### PR TITLE
Auth fix account creation

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
@@ -5,7 +5,6 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.gson.Gson;
 
-import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 
@@ -39,7 +38,7 @@ public class JwtCreator {
 	String refreshToken(String token) {
 		DecodedJWT oldJwt = JWT.decode(token);
 		String payloadEncoded = oldJwt.getPayload();
-		String payloadDecoded = new String(Base64.getUrlDecoder().decode(payloadEncoded));
+		String payloadDecoded = Main.decode(payloadEncoded);
 		Gson gson = new Gson();
 		Map claimsMap = gson.fromJson(payloadDecoded, Map.class);
 		return JWT.create()

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
@@ -1,0 +1,34 @@
+package nl.esciencecenter.rsd.authentication;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
+import java.util.Date;
+
+public class JwtCreator {
+
+	static final long ONE_HOUR_IN_MILLISECONDS = 3600_000L; // 60 * 60 * 1000
+	final String SIGNING_SECRET;
+
+	public JwtCreator(String signingSecret) {
+		if (signingSecret == null) throw new IllegalArgumentException("The signing secret should not be null");
+		this.SIGNING_SECRET = signingSecret;
+	}
+
+	String createUserJwt(String account) {
+		Algorithm signingAlgorithm = Algorithm.HMAC256(SIGNING_SECRET);
+		return JWT.create()
+				.withClaim("role", "rsd_user")
+				.withClaim("account", account)
+				.withExpiresAt(new Date(System.currentTimeMillis() + ONE_HOUR_IN_MILLISECONDS))
+				.sign(signingAlgorithm);
+	}
+
+	String createAdminJwt() {
+		Algorithm signingAlgorithm = Algorithm.HMAC256(SIGNING_SECRET);
+		return JWT.create()
+				.withClaim("role", "rsd_admin")
+				.withExpiresAt(new Date(System.currentTimeMillis() + ONE_HOUR_IN_MILLISECONDS))
+				.sign(signingAlgorithm);
+	}
+}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
@@ -2,33 +2,49 @@ package nl.esciencecenter.rsd.authentication;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.google.gson.Gson;
 
+import java.util.Base64;
 import java.util.Date;
+import java.util.Map;
 
 public class JwtCreator {
 
 	static final long ONE_HOUR_IN_MILLISECONDS = 3600_000L; // 60 * 60 * 1000
 	final String SIGNING_SECRET;
+	final Algorithm SIGNING_ALGORITHM;
 
 	public JwtCreator(String signingSecret) {
 		if (signingSecret == null) throw new IllegalArgumentException("The signing secret should not be null");
 		this.SIGNING_SECRET = signingSecret;
+		this.SIGNING_ALGORITHM = Algorithm.HMAC256(SIGNING_SECRET);
 	}
 
 	String createUserJwt(String account) {
-		Algorithm signingAlgorithm = Algorithm.HMAC256(SIGNING_SECRET);
 		return JWT.create()
 				.withClaim("role", "rsd_user")
 				.withClaim("account", account)
 				.withExpiresAt(new Date(System.currentTimeMillis() + ONE_HOUR_IN_MILLISECONDS))
-				.sign(signingAlgorithm);
+				.sign(SIGNING_ALGORITHM);
 	}
 
 	String createAdminJwt() {
-		Algorithm signingAlgorithm = Algorithm.HMAC256(SIGNING_SECRET);
 		return JWT.create()
 				.withClaim("role", "rsd_admin")
 				.withExpiresAt(new Date(System.currentTimeMillis() + ONE_HOUR_IN_MILLISECONDS))
-				.sign(signingAlgorithm);
+				.sign(SIGNING_ALGORITHM);
+	}
+
+	String refreshToken(String token) {
+		DecodedJWT oldJwt = JWT.decode(token);
+		String payloadEncoded = oldJwt.getPayload();
+		String payloadDecoded = new String(Base64.getUrlDecoder().decode(payloadEncoded));
+		Gson gson = new Gson();
+		Map claimsMap = gson.fromJson(payloadDecoded, Map.class);
+		return JWT.create()
+				.withPayload(claimsMap)
+				.withExpiresAt(new Date(System.currentTimeMillis() + ONE_HOUR_IN_MILLISECONDS))
+				.sign(SIGNING_ALGORITHM);
 	}
 }

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtVerifier.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtVerifier.java
@@ -15,6 +15,7 @@ public class JwtVerifier {
 	}
 
 	boolean verify(String token) {
+		if (token == null) return false;
 		Algorithm signingAlgorithm = Algorithm.HMAC256(SIGNING_SECRET);
 		JWTVerifier verifier = JWT.require(signingAlgorithm).build();
 		try {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtVerifier.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtVerifier.java
@@ -14,15 +14,10 @@ public class JwtVerifier {
 		this.SIGNING_SECRET = signingSecret;
 	}
 
-	boolean verify(String token) {
-		if (token == null) return false;
+	void verify(String token) {
+		if (token == null) throw new JWTVerificationException("Token was null");
 		Algorithm signingAlgorithm = Algorithm.HMAC256(SIGNING_SECRET);
 		JWTVerifier verifier = JWT.require(signingAlgorithm).build();
-		try {
-			verifier.verify(token);
-			return true;
-		} catch (JWTVerificationException e) {
-			return false;
-		}
+		verifier.verify(token);
 	}
 }

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtVerifier.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtVerifier.java
@@ -1,0 +1,27 @@
+package nl.esciencecenter.rsd.authentication;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+
+public class JwtVerifier {
+
+	final String SIGNING_SECRET;
+
+	public JwtVerifier(String signingSecret) {
+		if (signingSecret == null) throw new IllegalArgumentException("The signing secret should not be null");
+		this.SIGNING_SECRET = signingSecret;
+	}
+
+	boolean verify(String token) {
+		Algorithm signingAlgorithm = Algorithm.HMAC256(SIGNING_SECRET);
+		JWTVerifier verifier = JWT.require(signingAlgorithm).build();
+		try {
+			verifier.verify(token);
+			return true;
+		} catch (JWTVerificationException e) {
+			return false;
+		}
+	}
+}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -60,19 +60,17 @@ public class Main {
 			String tokenToVerify = ctx.cookie("rsd_token");
 			String signingSecret = CONFIG.getProperty("PGRST_JWT_SECRET");
 			JwtVerifier verifier = new JwtVerifier(signingSecret);
-			boolean isTokenValid = verifier.verify(tokenToVerify);
-			if (!isTokenValid) {
-				ctx.status(400);
-			} else {
-				JwtCreator jwtCreator = new JwtCreator(signingSecret);
-				String token = jwtCreator.refreshToken(tokenToVerify);
-				setJwtCookie(ctx, token);
-			}
+			verifier.verify(tokenToVerify);
+
+			JwtCreator jwtCreator = new JwtCreator(signingSecret);
+			String token = jwtCreator.refreshToken(tokenToVerify);
+			setJwtCookie(ctx, token);
 		});
 
 		app.exception(JWTVerificationException.class, (ex, ctx) -> {
 			ex.printStackTrace();
-			ctx.result("Invalid JWT!");
+			ctx.status(400);
+			ctx.json("{\"Message\": \"invalid JWT\"}");
 		});
 	}
 

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -6,6 +6,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import io.javalin.Javalin;
+import io.javalin.http.Context;
 
 import java.io.FileReader;
 import java.io.IOException;
@@ -46,7 +47,7 @@ public class Main {
 			String account = new SurfconextLogin(code, redirectUrl).account();
 			JwtCreator jwtCreator = new JwtCreator(CONFIG.getProperty("PGRST_JWT_SECRET"));
 			String token = jwtCreator.createUserJwt(account);
-			ctx.cookie("rsd_token", token);
+			setJwtCookie(ctx, token);
 			ctx.result(token);
 		});
 
@@ -65,7 +66,7 @@ public class Main {
 			} else {
 				JwtCreator jwtCreator = new JwtCreator(signingSecret);
 				String token = jwtCreator.refreshToken(tokenToVerify);
-				ctx.cookie("rsd_token", token);
+				setJwtCookie(ctx, token);
 			}
 		});
 
@@ -73,6 +74,10 @@ public class Main {
 			ex.printStackTrace();
 			ctx.result("Invalid JWT!");
 		});
+	}
+
+	static void setJwtCookie(Context ctx, String token) {
+		ctx.header("Set-Cookie", "rsd_token=" + token + "; Secure; HttpOnly; Path=/; SameSite=Lax");
 	}
 
 	static String decode(String base64UrlEncoded) {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -21,7 +21,7 @@ public class Main {
 	public static void main(String[] args) throws IOException {
 		CONFIG.load(new FileReader(args[0]));
 		Javalin app = Javalin.create().start(7000);
-		app.get("/", ctx -> ctx.result("Hello World!"));
+		app.get("/", ctx -> ctx.json("{\"Module\": \"rsd/auth\", \"Status\": \"live\"}"));
 
 		app.get("/login", ctx -> {
 			Algorithm signingAlgorithm = Algorithm.HMAC256(CONFIG.getProperty("PGRST_JWT_SECRET"));


### PR DESCRIPTION
# Auth fix account creation

Changes proposed in this pull request:

* The redirect url for SURFconext is now read from the env files instead of being hardcoded
* Fix accounts not being created because no rsd_admin token was sent to PostgREST
* Tokens are now sent as cookies
* Add endpoint to refresh tokens

How to test:

* Build the authentication service. 
* Start the database, backend and authentication services. 
* Go to http://localhost:7000/login/surfconext and follow the link. After signing in, you should see a JWT on the screen. The same JWT should be in a cookie with name "rsd_token". This cookie should have the Secure and HttpOnly values to true and the SameSite value to Lax. 
* Then go to http://localhost:7000/refresh. Your cookie should be replaced with a new one. The token should have the same content, except that is it valid again for one more hour (and the signature was updated)

PR Checklist:

*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
