### PR TITLE
Software item mentions section

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.3.2
+    image: rsd/frontend:0.3.3
     env_file:
       - ./frontend/.env.production.local
     # ports:

--- a/frontend/components/layout/ImageAsBackground.tsx
+++ b/frontend/components/layout/ImageAsBackground.tsx
@@ -27,21 +27,4 @@ export default function ImageAsBackground({src, alt, className}:
       className={className}
     ></div>
   )
-  // image as div background scales better imho
-  // return (
-  //   <div className="flex-1">
-  //     <img
-  //       src={src}
-  //       alt={alt}
-  //       className={className}
-  //       style={{
-  //         width: '100%',
-  //         height: '100%',
-  //         maxHeight: '15rem',
-  //         maxWidth: '100%',
-  //         objectFit: 'cover'
-  //       }}
-  //       />
-  //   </div>
-  // )
 }

--- a/frontend/components/layout/ImageAsBackground.tsx
+++ b/frontend/components/layout/ImageAsBackground.tsx
@@ -1,0 +1,28 @@
+import styled from '@mui/system/styled'
+import {ReactNode} from 'react'
+import {Url} from 'url'
+
+export default function ImageAsBackground({src, alt, className}:
+  { src: string, alt: string, className:string }) {
+  // debugger
+  let imageUrl = src
+  if (!imageUrl) {
+    imageUrl = 'https://upload.wikimedia.org/wikipedia/commons/6/65/No-Image-Placeholder.svg'
+  }
+
+  return (
+    <div
+      role="img"
+      style={{
+        flex: 1,
+        backgroundImage: `url('${imageUrl}')`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center center',
+        backgroundRepeat: 'no-repeat',
+        backgroundColor:'#eee'
+      }}
+      aria-label={alt}
+      className={className}
+    ></div>
+  )
+}

--- a/frontend/components/layout/ImageAsBackground.tsx
+++ b/frontend/components/layout/ImageAsBackground.tsx
@@ -1,15 +1,18 @@
-import styled from '@mui/system/styled'
-import {ReactNode} from 'react'
-import {Url} from 'url'
+/* eslint-disable @next/next/no-img-element */
+import PhotoSizeSelectActualOutlinedIcon from '@mui/icons-material/PhotoSizeSelectActualOutlined'
 
 export default function ImageAsBackground({src, alt, className}:
   { src: string, alt: string, className:string }) {
   // debugger
   let imageUrl = src
   if (!imageUrl) {
-    imageUrl = 'https://upload.wikimedia.org/wikipedia/commons/6/65/No-Image-Placeholder.svg'
+    return (
+      <div className="flex-1 flex flex-col justify-center items-center text-grey-500 bg-grey-200">
+        <PhotoSizeSelectActualOutlinedIcon sx={{width: '5rem', height:'5rem'}} />
+        <div className="uppercase">no image avaliable</div>
+      </div>
+    )
   }
-
   return (
     <div
       role="img"
@@ -19,10 +22,26 @@ export default function ImageAsBackground({src, alt, className}:
         backgroundSize: 'cover',
         backgroundPosition: 'center center',
         backgroundRepeat: 'no-repeat',
-        backgroundColor:'#eee'
       }}
       aria-label={alt}
       className={className}
     ></div>
   )
+  // image as div background scales better imho
+  // return (
+  //   <div className="flex-1">
+  //     <img
+  //       src={src}
+  //       alt={alt}
+  //       className={className}
+  //       style={{
+  //         width: '100%',
+  //         height: '100%',
+  //         maxHeight: '15rem',
+  //         maxWidth: '100%',
+  //         objectFit: 'cover'
+  //       }}
+  //       />
+  //   </div>
+  // )
 }

--- a/frontend/components/layout/UserMenu.test.js
+++ b/frontend/components/layout/UserMenu.test.js
@@ -1,0 +1,24 @@
+import {render,screen, fireEvent} from '@testing-library/react'
+import {WrappedComponentWithProps} from '../../utils/jest/WrappedComponents'
+
+import UserMenu from './UserMenu'
+import {userMenuItems} from '../../config/userMenuItems'
+
+it('should render userMenu',()=>{
+  render(WrappedComponentWithProps(UserMenu))
+  const userMenu = screen.queryByTestId('user-menu-button')
+  expect(userMenu).toBeInTheDocument()
+  // screen.debug()
+})
+
+it('should have userMenu options',async()=>{
+  render(WrappedComponentWithProps(UserMenu, {menuOptions: userMenuItems}))
+  const menuButton = screen.queryByTestId('user-menu-button')
+  // click on the button to display menu options
+  fireEvent.click(menuButton)
+  // select all menu options
+  const menuOptions = screen.queryAllByTestId('user-menu-option')
+  // assert same length as defined in config/userMenuItems
+  expect(menuOptions.length).toEqual(userMenuItems.length)
+  // screen.debug()
+})

--- a/frontend/components/layout/UserMenu.tsx
+++ b/frontend/components/layout/UserMenu.tsx
@@ -39,6 +39,7 @@ export default function UserMenu(props:UserMenuType) {
         menuOptions.map(item=>{
           return (
             <MenuItem
+              data-testid="user-menu-option"
               key={item.label}
               onClick={()=>handleClose(item)}>
               {item.label}
@@ -52,6 +53,7 @@ export default function UserMenu(props:UserMenuType) {
   return (
     <>
       <Button
+        data-testid="user-menu-button"
         aria-controls="user-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : undefined}

--- a/frontend/components/software/MentionIsFeatured.tsx
+++ b/frontend/components/software/MentionIsFeatured.tsx
@@ -9,15 +9,17 @@ export default function MentionIsFeatured({mention}: { mention: Mention }) {
 
   return (
     <Link href={mention.url} passHref>
-      <a target="_blank">
+      <a data-testid="software-mention-is-featured"
+        target="_blank">
         <article className="mb-8 md:flex">
           <ImageAsBackground className="flex-1 h-[17rem]" src={mention.image} alt={mention.title} />
-          <div className="py-4 px-0 md:py-0 md:px-6 md:flex-[1] text-white">
+          <div className="flex flex-col py-4 px-0 md:py-0 md:px-6 md:flex-1 lg:flex-[2] text-white">
               <h3 className="text-[2rem] mb-4 text-primary leading-10">
                 {mention.title}
               </h3>
-            <div>{mention.author}</div>
+            <div>By {mention.author}</div>
             <div>{isoStrToLocalDateStr(mention.date)}</div>
+            {/* <div>Read the blog</div> */}
           </div>
         </article>
       </a>

--- a/frontend/components/software/MentionIsFeatured.tsx
+++ b/frontend/components/software/MentionIsFeatured.tsx
@@ -1,0 +1,26 @@
+import {Mention} from '../../utils/getSoftware'
+import Link from 'next/link'
+import {isoStrToLocalDateStr} from '../../utils/dateFn'
+import ImageAsBackground from '../layout/ImageAsBackground'
+
+export default function MentionIsFeatured({mention}: { mention: Mention }) {
+  // do not render if no data
+  if (!mention) return null
+
+  return (
+    <Link href={mention.url} passHref>
+      <a target="_blank">
+        <article className="mb-8 md:flex">
+          <ImageAsBackground className="flex-1 h-[17rem]" src={mention.image} alt={mention.title} />
+          <div className="py-4 px-0 md:py-0 md:px-6 md:flex-[1] text-white">
+              <h3 className="text-[2rem] mb-4 text-primary leading-10">
+                {mention.title}
+              </h3>
+            <div>{mention.author}</div>
+            <div>{isoStrToLocalDateStr(mention.date)}</div>
+          </div>
+        </article>
+      </a>
+    </Link>
+  )
+}

--- a/frontend/components/software/MentionItem.tsx
+++ b/frontend/components/software/MentionItem.tsx
@@ -1,0 +1,34 @@
+import Link from 'next/link'
+import LinkIcon from '@mui/icons-material/Link'
+
+import {Mention} from '../../utils/getSoftware'
+import {isoStrToLocalDateStr} from '../../utils/dateFn'
+
+export default function MentionItem({item, pos}: {item: Mention, pos:number}) {
+
+  function renderItemBody() {
+    return (
+      <div data-testid="software-mention-item-body" className="flex justify-start">
+        <div className="min-w-[1rem]">{pos}.</div>
+        <div className='pl-4 flex-1'>
+          <div>{item.title}</div>
+          <div>{isoStrToLocalDateStr(item.date)}</div>
+        </div>
+        <div className="flex justify-center items-center">
+          <LinkIcon />
+        </div>
+      </div>
+    )
+  }
+
+  if (item?.url) {
+    return (
+      <Link href={item.url} passHref>
+        <a className="hover:text-black" target="_blank">
+          {renderItemBody()}
+        </a>
+      </Link>
+    )
+  }
+  return renderItemBody()
+}

--- a/frontend/components/software/MentionsByType.tsx
+++ b/frontend/components/software/MentionsByType.tsx
@@ -1,0 +1,144 @@
+import Link from 'next/link'
+import Accordion from '@mui/material/Accordion'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import Typography from '@mui/material/Typography'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import Badge from '@mui/material/Badge'
+
+import {Mention} from '../../utils/getSoftware'
+import {mentionType,MentionType} from '../../types/MentionType'
+import {sortOnDateProp} from '../../utils/sortFn'
+import {isoStrToLocalDateStr} from '../../utils/dateFn'
+
+type MentionByType={
+  [key:string]: Mention[]
+}
+
+export default function MentionsByType({mentions}: { mentions: Mention[] }) {
+  const mentionByType = clasifyMentions(mentions)
+  const mentionTypes = Object.keys(mentionByType).sort()
+
+  return (
+    <section>
+      {mentionTypes.map((key) => {
+        // debugger
+        const items = mentionByType[key]
+        return renderMentionSectionForType(key as MentionType, items)
+      })}
+    </section>
+  )
+}
+
+function clasifyMentions(mentions: Mention[]) {
+  let mentionByType:MentionByType={}
+
+  mentions.forEach(item => {
+    // debugger
+    // remove array with software uuid
+    delete item.mention_for_software
+    // check if type prop exists
+    let mType = item?.type as string ?? 'default'
+    // change type for corporate blogs
+    if (item.is_corporate_blog === true) {
+      mType = 'corporateBlog'
+    }
+    if (mentionByType?.hasOwnProperty(item.type)) {
+      mentionByType[mType].push(item)
+    } else {
+      // create array for new type
+      mentionByType[mType] = []
+      // add item
+      mentionByType[mType].push(item)
+    }
+  })
+  return mentionByType
+}
+
+function renderMentionSectionForType(key: MentionType, items: Mention[]) {
+  // do not render accordion/section if no items
+  if (items.length===0) return null
+  return (
+    <Accordion
+      data-testid='software-mentions-by-type'
+      key={key}
+      sx={{
+        boxShadow: 0,
+        border: 'none',
+        backgroundColor: '#3a3e40'
+      }}>
+      <AccordionSummary
+        expandIcon={<ExpandMoreIcon />}
+        aria-controls={`panel1-content-${key}`}
+        id={`panel1-header-${key}`}
+        sx={{
+          position: 'sticky',
+          top: 0,
+          backgroundColor: '#222425',
+          padding: ['0rem', '0rem 1rem'],
+          '&:hover': {
+            opacity:0.95
+          }
+        }}
+      >
+        <Badge
+          badgeContent={items.length}
+          color="primary"
+          anchorOrigin={{
+            vertical: 'top',
+            horizontal: 'right',
+          }}
+          sx={{
+            '& .MuiBadge-badge': {
+              right: '-1rem',
+              top: '0.25rem',
+              border: '2px solid #fff',
+            },
+          }}
+        >
+          <Typography>{mentionType[key] ?? 'Title'}</Typography>
+        </Badge>
+      </AccordionSummary>
+      <AccordionDetails sx={{
+        // set max height to avoid large shifts
+        maxHeight: '30rem',
+        //avoid resizing when scrollbar appears
+        overflow: 'overlay',
+        padding:'0rem 0rem'
+      }}>
+        {renderMentionItemsForType(items)}
+      </AccordionDetails>
+    </Accordion>
+  )
+}
+
+function renderMentionItemsForType(items: Mention[]) {
+  if (items.length === 0) return null
+  return (
+    <ul>
+      {
+        items.sort((a, b) => {
+          // sort mentions on date, newest at the top
+          return sortOnDateProp(a,b,'date','desc')
+        }).map((item, pos) => {
+          return (
+            <li key={pos} className="p-4 hover:bg-grey-200 hover:text-black">
+              {item.url ?
+                <Link href={item.url} passHref>
+                  <a className="hover:text-black" target="_blank">
+                    <div>{item.title}</div>
+                    <div>{isoStrToLocalDateStr(item.date)}</div>
+                  </a>
+                </Link>
+                :<div>
+                  <div>{item.title}</div>
+                  <div>{isoStrToLocalDateStr(item.date)}</div>
+                </div>
+              }
+            </li>
+          )
+        })
+      }
+    </ul>
+  )
+}

--- a/frontend/components/software/MentionsByType.tsx
+++ b/frontend/components/software/MentionsByType.tsx
@@ -2,10 +2,10 @@ import Link from 'next/link'
 import Accordion from '@mui/material/Accordion'
 import AccordionSummary from '@mui/material/AccordionSummary'
 import AccordionDetails from '@mui/material/AccordionDetails'
-import Typography from '@mui/material/Typography'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import Badge from '@mui/material/Badge'
 
+import MentionIsFeatured from './MentionIsFeatured'
 import {Mention} from '../../utils/getSoftware'
 import {mentionType,MentionType} from '../../types/MentionType'
 import {sortOnDateProp} from '../../utils/sortFn'
@@ -16,13 +16,17 @@ type MentionByType={
 }
 
 export default function MentionsByType({mentions}: { mentions: Mention[] }) {
-  const mentionByType = clasifyMentions(mentions)
+  const {mentionByType, featuredMentions} = clasifyMentions(mentions)
   const mentionTypes = Object.keys(mentionByType).sort()
 
   return (
     <section>
+      {featuredMentions.map(item => {
+        return (
+          <MentionIsFeatured key={item.url} mention={item} />
+        )
+      })}
       {mentionTypes.map((key) => {
-        // debugger
         const items = mentionByType[key]
         return renderMentionSectionForType(key as MentionType, items)
       })}
@@ -31,28 +35,32 @@ export default function MentionsByType({mentions}: { mentions: Mention[] }) {
 }
 
 function clasifyMentions(mentions: Mention[]) {
-  let mentionByType:MentionByType={}
+  let mentionByType: MentionByType = {}
+  let featuredMentions:Mention[]=[]
 
   mentions.forEach(item => {
-    // debugger
     // remove array with software uuid
     delete item.mention_for_software
     // check if type prop exists
     let mType = item?.type as string ?? 'default'
-    // change type for corporate blogs
-    if (item.is_corporate_blog === true) {
-      mType = 'corporateBlog'
-    }
-    if (mentionByType?.hasOwnProperty(item.type)) {
+    // extract featured mentions
+    if (item.is_featured === true) {
+      mType = 'featured'
+      featuredMentions.push(item)
+    } else if (mentionByType?.hasOwnProperty(item.type)) {
       mentionByType[mType].push(item)
     } else {
       // create array for new type
       mentionByType[mType] = []
-      // add item
+      // and add this item
       mentionByType[mType].push(item)
     }
   })
-  return mentionByType
+
+  return {
+    mentionByType,
+    featuredMentions
+  }
 }
 
 function renderMentionSectionForType(key: MentionType, items: Mention[]) {
@@ -64,8 +72,18 @@ function renderMentionSectionForType(key: MentionType, items: Mention[]) {
       key={key}
       sx={{
         boxShadow: 0,
-        border: 'none',
-        backgroundColor: '#3a3e40'
+        borderTop: '1px solid',
+        borderColor: 'divider',
+        // custom color from legacy RSD
+        backgroundColor: '#3a3e40',
+        // remove line above the accordion
+        '&:before': {
+          height: '0px'
+        },
+        '&:last-child': {
+          borderBottom: '1px solid',
+          borderColor: 'divider',
+        }
       }}>
       <AccordionSummary
         expandIcon={<ExpandMoreIcon />}
@@ -75,7 +93,7 @@ function renderMentionSectionForType(key: MentionType, items: Mention[]) {
           position: 'sticky',
           top: 0,
           backgroundColor: '#222425',
-          padding: ['0rem', '0rem 1rem'],
+          padding: '0rem',
           '&:hover': {
             opacity:0.95
           }
@@ -84,19 +102,16 @@ function renderMentionSectionForType(key: MentionType, items: Mention[]) {
         <Badge
           badgeContent={items.length}
           color="primary"
-          anchorOrigin={{
-            vertical: 'top',
-            horizontal: 'right',
-          }}
           sx={{
             '& .MuiBadge-badge': {
               right: '-1rem',
               top: '0.25rem',
-              border: '2px solid #fff',
+              border: '2px solid',
+              borderColor: 'common.white'
             },
           }}
         >
-          <Typography>{mentionType[key] ?? 'Title'}</Typography>
+          <div className="text-xl">{mentionType[key] ?? 'Other mentions'}</div>
         </Badge>
       </AccordionSummary>
       <AccordionDetails sx={{

--- a/frontend/components/software/MentionsByType.tsx
+++ b/frontend/components/software/MentionsByType.tsx
@@ -1,67 +1,30 @@
-import Link from 'next/link'
 import Accordion from '@mui/material/Accordion'
 import AccordionSummary from '@mui/material/AccordionSummary'
 import AccordionDetails from '@mui/material/AccordionDetails'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import Badge from '@mui/material/Badge'
 
-import MentionIsFeatured from './MentionIsFeatured'
+import MentionItem from './MentionItem'
 import {Mention} from '../../utils/getSoftware'
 import {mentionType,MentionType} from '../../types/MentionType'
 import {sortOnDateProp} from '../../utils/sortFn'
-import {isoStrToLocalDateStr} from '../../utils/dateFn'
 
-type MentionByType={
+export type MentionByType={
   [key:string]: Mention[]
 }
 
-export default function MentionsByType({mentions}: { mentions: Mention[] }) {
-  const {mentionByType, featuredMentions} = clasifyMentions(mentions)
+export default function MentionsByType({mentionByType}: { mentionByType: MentionByType }) {
   const mentionTypes = Object.keys(mentionByType).sort()
-
   return (
-    <section>
-      {featuredMentions.map(item => {
-        return (
-          <MentionIsFeatured key={item.url} mention={item} />
-        )
-      })}
+    <>
       {mentionTypes.map((key) => {
         const items = mentionByType[key]
         return renderMentionSectionForType(key as MentionType, items)
       })}
-    </section>
+    </>
   )
 }
 
-function clasifyMentions(mentions: Mention[]) {
-  let mentionByType: MentionByType = {}
-  let featuredMentions:Mention[]=[]
-
-  mentions.forEach(item => {
-    // remove array with software uuid
-    delete item.mention_for_software
-    // check if type prop exists
-    let mType = item?.type as string ?? 'default'
-    // extract featured mentions
-    if (item.is_featured === true) {
-      mType = 'featured'
-      featuredMentions.push(item)
-    } else if (mentionByType?.hasOwnProperty(item.type)) {
-      mentionByType[mType].push(item)
-    } else {
-      // create array for new type
-      mentionByType[mType] = []
-      // and add this item
-      mentionByType[mType].push(item)
-    }
-  })
-
-  return {
-    mentionByType,
-    featuredMentions
-  }
-}
 
 function renderMentionSectionForType(key: MentionType, items: Mention[]) {
   // do not render accordion/section if no items
@@ -138,18 +101,7 @@ function renderMentionItemsForType(items: Mention[]) {
         }).map((item, pos) => {
           return (
             <li key={pos} className="p-4 hover:bg-grey-200 hover:text-black">
-              {item.url ?
-                <Link href={item.url} passHref>
-                  <a className="hover:text-black" target="_blank">
-                    <div>{item.title}</div>
-                    <div>{isoStrToLocalDateStr(item.date)}</div>
-                  </a>
-                </Link>
-                :<div>
-                  <div>{item.title}</div>
-                  <div>{isoStrToLocalDateStr(item.date)}</div>
-                </div>
-              }
+              <MentionItem pos={pos + 1} item={item} />
             </li>
           )
         })

--- a/frontend/components/software/MentionsSection.test.js
+++ b/frontend/components/software/MentionsSection.test.js
@@ -1,0 +1,42 @@
+import {render,screen} from '@testing-library/react'
+import {WrappedComponentWithProps} from '../../utils/jest/WrappedComponents'
+
+import MentionsSection from './MentionsSection'
+import mentionsData from './__mocks__/mentionSectionData.json'
+
+it('should NOT render mentions section when no data provided',()=>{
+  render(WrappedComponentWithProps(MentionsSection))
+  const title = screen.queryByTestId('software-mentions-section-title')
+  expect(title).not.toBeInTheDocument()
+  // screen.debug()
+})
+
+it('should render mention section title when data provided',()=>{
+  render(WrappedComponentWithProps(MentionsSection, {mentions: mentionsData}))
+  const title = screen.queryByTestId('software-mentions-section-title')
+  expect(title).toBeInTheDocument()
+  // screen.debug()
+})
+
+it('should render featured mention items (based on dummy data)',()=>{
+  render(WrappedComponentWithProps(MentionsSection, {mentions: mentionsData}))
+  const expectedItems = mentionsData.filter(item=>item.is_featured)
+  const featured = screen.queryAllByTestId('software-mention-is-featured')
+  expect(featured.length).toEqual(expectedItems.length)
+  // screen.debug()
+})
+
+it('should render 6 mention type sections (based on dummy data)',()=>{
+  render(WrappedComponentWithProps(MentionsSection, {mentions:mentionsData}))
+  const mentions = screen.queryAllByTestId('software-mentions-by-type')
+  expect(mentions.length).toEqual(6)
+  // screen.debug()
+})
+
+it('should render all not featured mention items (based on dummy data)',()=>{
+  render(WrappedComponentWithProps(MentionsSection, {mentions: mentionsData}))
+  const expectedItems = mentionsData.filter(item=>!item.is_featured)
+  const mentionItems = screen.queryAllByTestId('software-mention-item-body')
+  expect(mentionItems.length).toEqual(expectedItems.length)
+  // screen.debug()
+})

--- a/frontend/components/software/MentionsSection.tsx
+++ b/frontend/components/software/MentionsSection.tsx
@@ -12,7 +12,7 @@ const darkTheme = createTheme({
 
 export default function MentionsSection({mentions}: { mentions: Mention[] }) {
 
-  // render nothing if no data
+  // do not render section if no data
   if (mentions.length === 0) return null
 
   return (

--- a/frontend/components/software/MentionsSection.tsx
+++ b/frontend/components/software/MentionsSection.tsx
@@ -1,0 +1,29 @@
+import {createTheme, ThemeProvider} from '@mui/material/styles'
+
+import PageContainer from '../layout/PageContainer'
+import MentionsByType from './MentionsByType'
+import {Mention} from '../../utils/getSoftware'
+
+const darkTheme = createTheme({
+  palette: {
+    mode: 'dark',
+  },
+})
+
+export default function MentionsSection({mentions}: { mentions: Mention[] }) {
+
+  // render nothing if no data
+  if (mentions.length === 0) return null
+
+  return (
+    <ThemeProvider theme={darkTheme}>
+      <section className="bg-secondary">
+        <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
+          <h2 className="pb-8 text-[2rem] text-white">Mentions</h2>
+
+          <MentionsByType mentions={mentions} />
+        </PageContainer>
+      </section>
+    </ThemeProvider>
+  )
+}

--- a/frontend/components/software/__mocks__/mentionSectionData.json
+++ b/frontend/components/software/__mocks__/mentionSectionData.json
@@ -1,0 +1,128 @@
+[
+  {
+    "date": "2018-12-20T00:00:00",
+    "is_featured": true,
+    "title": "Portable HPC workflows with Snakemake, Conda, and Xenon",
+    "type": "blogPost",
+    "url": "https://blog.esciencecenter.nl/portable-hpc-workflows-with-snakemake-and-xenon-e971e5127391",
+    "image": "https://miro.medium.com/max/1200/1*Dkns3eBVvWMJHsR08BZaCQ.jpeg",
+    "author": "Jurriaan H. Spaaks"
+  },
+  {
+    "date": "2017-11-07T00:00:00",
+    "is_featured": false,
+    "title": "NLeSC/xenon-cli: v2.0.0",
+    "type": "computerProgram",
+    "url": "https://doi.org/10.5281/zenodo.597603",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2018-04-15T09:29:07",
+    "is_featured": false,
+    "title": "sv-callers",
+    "type": "computerProgram",
+    "url": "https://doi.org/10.5281/zenodo.1217112",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2018-04-11T00:00:00",
+    "is_featured": false,
+    "title": "sv-callers workflow",
+    "type": "computerProgram",
+    "url": "https://doi.org/10.5281/zenodo.1217112",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2017-11-13T00:00:00",
+    "is_featured": false,
+    "title": "PyXenon 2.2.0: Python interface to Xenon 2.2",
+    "type": "computerProgram",
+    "url": "https://doi.org/10.5281/zenodo.1045888",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2017-11-07T00:00:00",
+    "is_featured": false,
+    "title": "NLeSC/xenon-grpc: v2.0.0",
+    "type": "computerProgram",
+    "url": "https://doi.org/10.5281/zenodo.1043481",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2018-10-29T00:00:00",
+    "is_featured": false,
+    "title": "A portable and scalable workflow for detecting  structural variants in whole-genome sequencing data.",
+    "type": "conferencePaper",
+    "url": "https://doi.org/10.1109/eScience.2018.00064",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2016-12-30T00:00:00",
+    "is_featured": false,
+    "title": "Using modular 3D digital earth applications based on point clouds for the study of complex sites",
+    "type": "journalArticle",
+    "url": "https://doi.org/10.1080/17538947.2016.1205673",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2020-01-25T00:00:00",
+    "is_featured": false,
+    "title": "sv-callers: a highly portable parallel workflow for structural variant detection in whole-genome sequence data",
+    "type": "journalArticle",
+    "url": "https://doi.org/10.7717/peerj.8214",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2019-09-13T00:00:00",
+    "is_featured": false,
+    "title": "Xenon introduction & highly portable parallel [genomics] workflows based on Snakemake/Xenon.",
+    "type": "presentation",
+    "url": "https://www.dtls.nl/community/meetings/programmers-meetings/",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2019-06-19T00:00:00",
+    "is_featured": false,
+    "title": "Portable HPC workflows and software re-use",
+    "type": "presentation",
+    "url": "https://betterscientificsoftware.github.io/swe-cse-bof/2019-06-isc19-bof/",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2016-02-01T00:00:00",
+    "is_featured": false,
+    "title": "Tutorial Distributed Computing With Xenon 1.1.0",
+    "type": "report",
+    "url": "https://doi.org/10.5281/zenodo.1064100",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2017-10-16T00:00:00",
+    "is_featured": false,
+    "title": "Xenon - A Uniform Interface To Distributed Storage And Compute Resources",
+    "type": "report",
+    "url": "https://doi.org/10.5281/zenodo.1064695",
+    "image": null,
+    "author": null
+  },
+  {
+    "date": "2017-10-03T00:00:00",
+    "is_featured": false,
+    "title": "Xenon tutorial on readthedocs.io",
+    "type": "webpage",
+    "url": "https://xenonrse2017.readthedocs.io/en/latest/",
+    "image": null,
+    "author": null
+  }
+]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -11,6 +11,7 @@ import CitationSection from '../../../components/software/CitationSection'
 import PageSnackbar from '../../../components/snackbar/PageSnackbar'
 import PageSnackbarContext, {snackbarDefaults} from '../../../components/snackbar/PageSnackbarContext'
 import AboutSection from '../../../components/software/AboutSection'
+import MentionsSection from '../../../components/software/MentionsSection'
 
 import {
   getSoftwareItem,
@@ -18,17 +19,27 @@ import {
   getTagsForSoftware,
   getLicenseForSoftware,
   getContributorMentionCount,
-  Tag, License, ContributorMentionCount
+  getMentionsForSoftware,
+  Tag, License, ContributorMentionCount,Mention
 } from '../../../utils/getSoftware'
 import logger from '../../../utils/logger'
 import {SoftwareItem} from '../../../types/SoftwareItem'
 import {SoftwareCitationInfo} from '../../../types/SoftwareCitation'
+import {ScriptProps} from 'next/script'
 
-export default function SoftwareIndexPage({software, citationInfo, tagsInfo, licenseInfo, softwareIntroCounts}:
-  {
-    slug: string, software: SoftwareItem, citationInfo: SoftwareCitationInfo, tagsInfo: Tag[], licenseInfo: License[],
-    softwareIntroCounts: ContributorMentionCount
-  }) {
+interface SoftwareIndexData extends ScriptProps{
+  slug: string,
+  software: SoftwareItem,
+  citationInfo: SoftwareCitationInfo,
+  tagsInfo: Tag[],
+  licenseInfo: License[],
+  softwareIntroCounts: ContributorMentionCount,
+  mentions: Mention[]
+}
+
+
+export default function SoftwareIndexPage(props:SoftwareIndexData) {
+  const {software, citationInfo, tagsInfo, licenseInfo, softwareIntroCounts, mentions} = props
   const [options, setSnackbar] = useState(snackbarDefaults)
 
   if (!software?.brand_name){
@@ -75,6 +86,7 @@ export default function SoftwareIndexPage({software, citationInfo, tagsInfo, lic
           licenses={licenseInfo}
           repositories={software.repository_url}
         />
+        <MentionsSection mentions={mentions} />
         <AppFooter />
       </PageSnackbarContext.Provider>
       <PageSnackbar options={options} setOptions={setSnackbar} />
@@ -102,6 +114,7 @@ export async function getServerSideProps(context:any) {
     const tagsInfo = await getTagsForSoftware(software.id)
     const licenseInfo = await getLicenseForSoftware(software.id)
     const softwareIntroCounts = await getContributorMentionCount(software.id)
+    const mentions = await getMentionsForSoftware(software.id)
 
 
     return {
@@ -112,7 +125,8 @@ export async function getServerSideProps(context:any) {
         citationInfo,
         tagsInfo,
         licenseInfo,
-        softwareIntroCounts
+        softwareIntroCounts,
+        mentions
       }
     }
   }catch(e:any){

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -87,6 +87,8 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
           repositories={software.repository_url}
         />
         <MentionsSection mentions={mentions} />
+        {/* temporary spacer */}
+        <section className="py-12"></section>
         <AppFooter />
       </PageSnackbarContext.Provider>
       <PageSnackbar options={options} setOptions={setSnackbar} />

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -3,7 +3,7 @@
  * based on the article but extended with MUI properties
  * https://medium.com/@akarX23/a-full-setup-of-next-js-with-redux-tailwind-material-ui-pwa-and-docker-c33bdceadce5
  */
-const defaultTheme = require("tailwindcss/defaultTheme");
+const defaultTheme = require('tailwindcss/defaultTheme')
 // custom theme variables to be used in both themes
 const {colors,muiTypography} = require('./styles/themeConfig')
 
@@ -13,13 +13,14 @@ module.exports = {
   //   preflight: false,
   // },
   content: [
-    "./pages/**/*.{js,ts,jsx,tsx}",
-    "./components/**/*.{js,ts,jsx,tsx}",
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}',
   ],
   theme: {
     extend: {
-      screens:{
-        hd:"1920px"
+      screens: {
+        // 1920 - 64
+        hd:'1800px'
       },
       colors: {
         paper: colors.white,
@@ -40,4 +41,4 @@ module.exports = {
     extend: {},
   },
   plugins: [],
-};
+}

--- a/frontend/types/MentionType.ts
+++ b/frontend/types/MentionType.ts
@@ -1,0 +1,30 @@
+/**
+ * Based on database enum type from
+ * database/008-create-mention-table.sql
+ */
+
+export const mentionType = {
+  attachment: 'Attachment',
+  blogPost:'BlogPost',
+  book:'Book',
+  bookSection:'Book section',
+  computerProgram:'Computer program',
+  conferencePaper:'Conference paper',
+  document:'Document',
+  interview:'Interview',
+  journalArticle:'Journal article',
+  magazineArticle:'Magazine article',
+  manuscript:'Manuscript',
+  newspaperArticle:'Newspaper article',
+  note:'Note',
+  presentation:'Presentation',
+  radioBroadcast:'Radio broadcast',
+  report:'Report',
+  thesis:'Thesis',
+  videoRecording:'Video recording',
+  webpage : 'Webpage',
+  // additional type to split coportate blog?
+  corporateBlog : 'Corporate blog'
+}
+
+export type MentionType = keyof typeof mentionType

--- a/frontend/types/MentionType.ts
+++ b/frontend/types/MentionType.ts
@@ -5,26 +5,26 @@
 
 export const mentionType = {
   attachment: 'Attachment',
-  blogPost:'BlogPost',
-  book:'Book',
+  blogPost:'Blogposts',
+  book:'Books',
   bookSection:'Book section',
-  computerProgram:'Computer program',
-  conferencePaper:'Conference paper',
-  document:'Document',
-  interview:'Interview',
-  journalArticle:'Journal article',
-  magazineArticle:'Magazine article',
-  manuscript:'Manuscript',
-  newspaperArticle:'Newspaper article',
-  note:'Note',
-  presentation:'Presentation',
-  radioBroadcast:'Radio broadcast',
-  report:'Report',
+  computerProgram:'Computer programs',
+  conferencePaper:'Conference papers',
+  document:'Documents',
+  interview:'Interviews',
+  journalArticle:'Journal articles',
+  magazineArticle:'Magazine articles',
+  manuscript:'Manuscripts',
+  newspaperArticle:'Newspaper articles',
+  note:'Notes',
+  presentation:'Presentations',
+  radioBroadcast:'Radio broadcasts',
+  report:'Reports',
   thesis:'Thesis',
-  videoRecording:'Video recording',
-  webpage : 'Webpage',
-  // additional type to split coportate blog?
-  corporateBlog : 'Corporate blog'
+  videoRecording:'Video recordings',
+  webpage : 'Webpages',
+  // additional type for featured mentions
+  featured : 'Featured mentions'
 }
 
 export type MentionType = keyof typeof mentionType

--- a/frontend/utils/dateFn.test.js
+++ b/frontend/utils/dateFn.test.js
@@ -1,0 +1,69 @@
+import {daysDiff, isoStrToDate, olderThanXDays} from './dateFn'
+
+describe('dateFn.daysDiff',()=>{
+  it('calculates days in past diff > 2',()=>{
+    const today = new Date('2020-11-12')
+    const diff = daysDiff(today)
+    expect(diff).toBeGreaterThan(2)
+  })
+
+  it('calculates days today=0',()=>{
+    const today = new Date()
+    const diff = daysDiff(today)
+    expect(diff).toBe(0)
+  })
+
+  it('returns 0 if date in future',()=>{
+    const date = new Date('2022-11-25')
+    const diff = daysDiff(date)
+    expect(diff).toBe(0)
+  })
+
+  it('returns null if no date provided',()=>{
+    const diff = daysDiff()
+    expect(diff).toBe(undefined)
+  })
+
+})
+
+describe('dateFn.isoStrToDate',()=>{
+  it ('returns null on empty string',()=>{
+    const date = isoStrToDate('')
+    expect(date).toBeNull()
+  })
+  it ('converts to propper date',()=>{
+    // const testStr="1970-11-23T00:00"
+    const expected = new Date()
+    const received = isoStrToDate(expected.toISOString())
+    expect(expected).toEqual(received)
+  })
+})
+
+describe('dateFn.olderThanXDays',()=>{
+  it('returns false for today',()=>{
+    const today = new Date()
+    const value = olderThanXDays(today,7)
+    expect(value).toEqual(false)
+  })
+  it('returns false for exactly 7 days',()=>{
+    const atBoundary = new Date()
+    atBoundary.setDate(atBoundary.getDate()-7)
+    const value = olderThanXDays(atBoundary,7)
+    expect(value).toEqual(false)
+  })
+  it('returns true for undefined',()=>{
+    const value = olderThanXDays(undefined,7)
+    expect(value).toEqual(true)
+  })
+  it('returns true for 2000-01-01 date',()=>{
+    const oldDate = new Date('2000-01-01')
+    const value = olderThanXDays(oldDate,7)
+    expect(value).toEqual(true)
+  })
+  it('returns true for 9 days',()=>{
+    const atBoundary = new Date()
+    atBoundary.setDate(atBoundary.getDate()-9)
+    const value = olderThanXDays(atBoundary,7)
+    expect(value).toEqual(true)
+  })
+})

--- a/frontend/utils/dateFn.ts
+++ b/frontend/utils/dateFn.ts
@@ -1,0 +1,57 @@
+import logger from './logger'
+
+export function daysDiff(date:Date):number|undefined{
+  const today = new Date()
+  if (date){
+    // set time to noon (ignore that diff)
+    today.setHours(12,0,0)
+    date.setHours(12,0,0)
+    // diff in ms
+    const diffInMs = today.valueOf() - date.valueOf()
+    const dayInMs = 1000 * 60 * 60 * 24
+    if (diffInMs >= dayInMs) {
+      const daysDiff = Math.floor(diffInMs / dayInMs)
+      return daysDiff
+    } else {
+      return 0
+    }
+  }else{
+    return undefined
+  }
+}
+
+export function olderThanXDays(lastDate:Date, xDays=7):boolean{
+  const days = daysDiff(lastDate)
+  if (days === undefined) return true
+  if (days > xDays) return true
+  return false
+}
+
+export function isoStrToDate(isoString:string):Date|null{
+  try{
+    if (isoString){
+      const newDate = new Date(isoString)
+      return newDate
+    }
+    return null
+  }catch{
+    logger(`dateFn.isoStringToDate...FAILED for value:${isoString}`, 'warn')
+    return null
+  }
+}
+
+const defaultDateFormattingOptions:Intl.DateTimeFormatOptions = {
+  weekday: 'long',
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric'
+}
+
+export function isoStrToLocalDateStr(isoString: string, locale = 'en-US',
+  options = defaultDateFormattingOptions): string{
+  const date = isoStrToDate(isoString)
+  if (date){
+    return date.toLocaleDateString(locale,options)
+  }
+  return ''
+}

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -2,6 +2,7 @@ import {SoftwareItem} from '../types/SoftwareItem'
 import {SoftwareCitationInfo} from '../types/SoftwareCitation'
 import {extractCountFromHeader} from './extractCountFromHeader'
 import logger from './logger'
+import {MentionType} from '../types/MentionType'
 
 /**
  * postgREST api uri to retreive software index data.
@@ -181,7 +182,7 @@ export type ContributorMentionCount = {
 export async function getContributorMentionCount(uuid:string){
   try{
     // this request is always perfomed from backend
-    // the content is order by license ascending
+    // the content is order by id ascending
     const url = `${process.env.POSTGREST_URL}/count_software_contributors_mentions?id=eq.${uuid}`
     const resp = await fetch(url,{method:'GET'})
     if (resp.status===200){
@@ -194,6 +195,43 @@ export async function getContributorMentionCount(uuid:string){
     }
   }catch(e:any){
     logger(`getContributorMentionCount: ${e?.message}`,'error')
+    return undefined
+  }
+}
+
+/**
+ * MENTIONS
+ * @param uuid
+ */
+
+export type Mention = {
+  date: string,
+  is_corporate_blog: boolean,
+  title: string,
+  type: keyof typeof MentionType,
+  url: string,
+  // url to external image
+  image: string,
+  author: string,
+  mention_for_software?:any[]
+}
+
+export async function getMentionsForSoftware(uuid: string) {
+  try {
+    // this request is always perfomed from backend
+    // the content is order by type ascending
+    const url = `${process.env.POSTGREST_URL}/mention?select=date,is_corporate_blog,title,type,url,image,author,mention_for_software!inner(software)&mention_for_software.software=eq.${uuid}&order=type.asc`
+    const resp = await fetch(url, {method: 'GET'})
+    if (resp.status === 200) {
+      const data: ContributorMentionCount[] = await resp.json()
+      return data
+    } else if (resp.status === 404) {
+      logger(`getContributorMentionCount: 404 [${url}]`, 'error')
+      // query not found
+      return undefined
+    }
+  } catch (e: any) {
+    logger(`getContributorMentionCount: ${e?.message}`, 'error')
     return undefined
   }
 }

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -206,9 +206,9 @@ export async function getContributorMentionCount(uuid:string){
 
 export type Mention = {
   date: string,
-  is_corporate_blog: boolean,
+  is_featured: boolean,
   title: string,
-  type: keyof typeof MentionType,
+  type: MentionType,
   url: string,
   // url to external image
   image: string,
@@ -220,7 +220,7 @@ export async function getMentionsForSoftware(uuid: string) {
   try {
     // this request is always perfomed from backend
     // the content is order by type ascending
-    const url = `${process.env.POSTGREST_URL}/mention?select=date,is_corporate_blog,title,type,url,image,author,mention_for_software!inner(software)&mention_for_software.software=eq.${uuid}&order=type.asc`
+    const url = `${process.env.POSTGREST_URL}/mention?select=date,is_featured,title,type,url,image,author,mention_for_software!inner(software)&mention_for_software.software=eq.${uuid}&order=type.asc`
     const resp = await fetch(url, {method: 'GET'})
     if (resp.status === 200) {
       const data: ContributorMentionCount[] = await resp.json()

--- a/frontend/utils/sortFn.test.js
+++ b/frontend/utils/sortFn.test.js
@@ -2,58 +2,58 @@
 import {sortOnStrProp, sortOnDateProp, sortOnNumProp} from './sortFn'
 
 const toOrder=[
-  {id:1,name:"K",amount:100},
-  {id:1,name:"Z",amount:100},
-  {id:1,name:"b",amount:100},
-  {id:1,name:"a",amount:100},
-  {id:1,name:"N",amount:100},
-  {id:1,name:"T",amount:100},
+  {id:1,name:'K',amount:100},
+  {id:1,name:'Z',amount:100},
+  {id:1,name:'b',amount:100},
+  {id:1,name:'a',amount:100},
+  {id:1,name:'N',amount:100},
+  {id:1,name:'T',amount:100},
 ]
 
 const orderAsc=[
-  {id:1,name:"a",amount:100, datum: "2020-12-1"},
-  {id:1,name:"b",amount:99, datum: "2019-12-1"},
-  {id:1,name:"c",amount:98, datum: "2019-12-26"},
-  {id:1,name:"d",amount:96.5, datum: "2020-12-15"},
-  {id:1,name:"e",amount:94, datum: "2020-12-7"},
-  {id:1,name:"f",amount:89, datum: "2018-11-1"},
+  {id:1,name:'a',amount:100, datum: '2020-12-1'},
+  {id:1,name:'b',amount:99, datum: '2019-12-1'},
+  {id:1,name:'c',amount:98, datum: '2019-12-26'},
+  {id:1,name:'d',amount:96.5, datum: '2020-12-15'},
+  {id:1,name:'e',amount:94, datum: '2020-12-7'},
+  {id:1,name:'f',amount:89, datum: '2018-11-1'},
 ]
 
-describe("sortFn",()=>{
+describe('sortFn',()=>{
   it('order asc on prop name',()=>{
-    const resp = toOrder.sort((a,b)=>sortOnStrProp(a,b,"name"))
+    const resp = toOrder.sort((a,b)=>sortOnStrProp(a,b,'name'))
     const first = resp[0]
     const last = resp[resp.length-1]
-    expect(first.name).toEqual("a")
-    expect(last.name).toEqual("Z")
+    expect(first.name).toEqual('a')
+    expect(last.name).toEqual('Z')
   })
   it('order desc on prop name',()=>{
-    const resp = toOrder.sort((a,b)=>sortOnStrProp(a,b,"name","desc"))
+    const resp = toOrder.sort((a,b)=>sortOnStrProp(a,b,'name','desc'))
     const first = resp[0]
     const last = resp[resp.length-1]
-    expect(first.name).toEqual("Z")
-    expect(last.name).toEqual("a")
+    expect(first.name).toEqual('Z')
+    expect(last.name).toEqual('a')
   })
   it('order asc op amount',()=>{
-    const resp = orderAsc.sort((a,b)=>sortOnNumProp(a,b,"amount"))
+    const resp = orderAsc.sort((a,b)=>sortOnNumProp(a,b,'amount'))
     const first = resp[0]
     const last = resp[resp.length-1]
     expect(first.amount).toEqual(89)
     expect(last.amount).toEqual(100)
   })
   it('order asc op date',()=>{
-    const resp = orderAsc.sort((a,b)=>sortOnDateProp(a,b,"datum"))
+    const resp = orderAsc.sort((a,b)=>sortOnDateProp(a,b,'datum'))
     const first = resp[0]
     const last = resp[resp.length-1]
-    expect(first.datum).toEqual("2018-11-1")
-    expect(last.datum).toEqual("2020-12-15")
+    expect(first.datum).toEqual('2018-11-1')
+    expect(last.datum).toEqual('2020-12-15')
   })
 
   it('order desc op date',()=>{
-    const resp = orderAsc.sort((a,b)=>sortOnDateProp(a,b,"datum","desc"))
+    const resp = orderAsc.sort((a,b)=>sortOnDateProp(a,b,'datum','desc'))
     const first = resp[0]
     const last = resp[resp.length-1]
-    expect(first.datum).toEqual("2020-12-15")
-    expect(last.datum).toEqual("2018-11-1")
+    expect(first.datum).toEqual('2020-12-15')
+    expect(last.datum).toEqual('2018-11-1')
   })
 })

--- a/frontend/utils/sortFn.test.js
+++ b/frontend/utils/sortFn.test.js
@@ -1,0 +1,59 @@
+
+import {sortOnStrProp, sortOnDateProp, sortOnNumProp} from './sortFn'
+
+const toOrder=[
+  {id:1,name:"K",amount:100},
+  {id:1,name:"Z",amount:100},
+  {id:1,name:"b",amount:100},
+  {id:1,name:"a",amount:100},
+  {id:1,name:"N",amount:100},
+  {id:1,name:"T",amount:100},
+]
+
+const orderAsc=[
+  {id:1,name:"a",amount:100, datum: "2020-12-1"},
+  {id:1,name:"b",amount:99, datum: "2019-12-1"},
+  {id:1,name:"c",amount:98, datum: "2019-12-26"},
+  {id:1,name:"d",amount:96.5, datum: "2020-12-15"},
+  {id:1,name:"e",amount:94, datum: "2020-12-7"},
+  {id:1,name:"f",amount:89, datum: "2018-11-1"},
+]
+
+describe("sortFn",()=>{
+  it('order asc on prop name',()=>{
+    const resp = toOrder.sort((a,b)=>sortOnStrProp(a,b,"name"))
+    const first = resp[0]
+    const last = resp[resp.length-1]
+    expect(first.name).toEqual("a")
+    expect(last.name).toEqual("Z")
+  })
+  it('order desc on prop name',()=>{
+    const resp = toOrder.sort((a,b)=>sortOnStrProp(a,b,"name","desc"))
+    const first = resp[0]
+    const last = resp[resp.length-1]
+    expect(first.name).toEqual("Z")
+    expect(last.name).toEqual("a")
+  })
+  it('order asc op amount',()=>{
+    const resp = orderAsc.sort((a,b)=>sortOnNumProp(a,b,"amount"))
+    const first = resp[0]
+    const last = resp[resp.length-1]
+    expect(first.amount).toEqual(89)
+    expect(last.amount).toEqual(100)
+  })
+  it('order asc op date',()=>{
+    const resp = orderAsc.sort((a,b)=>sortOnDateProp(a,b,"datum"))
+    const first = resp[0]
+    const last = resp[resp.length-1]
+    expect(first.datum).toEqual("2018-11-1")
+    expect(last.datum).toEqual("2020-12-15")
+  })
+
+  it('order desc op date',()=>{
+    const resp = orderAsc.sort((a,b)=>sortOnDateProp(a,b,"datum","desc"))
+    const first = resp[0]
+    const last = resp[resp.length-1]
+    expect(first.datum).toEqual("2020-12-15")
+    expect(last.datum).toEqual("2018-11-1")
+  })
+})

--- a/frontend/utils/sortFn.ts
+++ b/frontend/utils/sortFn.ts
@@ -1,0 +1,42 @@
+/**
+ * Array sorting functions for array of objects.
+*/
+
+export function sortOnStrProp(itemA:any, itemB:any, prop:string, sortDir:'asc'|'desc'='asc'){
+  // ignore case
+  const nameA = itemA[prop].toUpperCase()
+  const nameB = itemB[prop].toUpperCase()
+
+  return sortItems(nameA,nameB,sortDir)
+}
+
+export function sortOnDateProp(itemA: any, itemB: any, prop: string, sortDir: 'asc' | 'desc' = 'asc'){
+  const dateA = new Date(itemA[prop]).getTime() || 0
+  const dateB = new Date(itemB[prop]).getTime() || 0
+
+  return sortItems(dateA,dateB,sortDir)
+}
+
+export function sortOnNumProp(itemA: any, itemB: any, prop: string, sortDir: 'asc' | 'desc' = 'asc'){
+  const valA = itemA[prop]
+  const valB = itemB[prop]
+  return sortItems(valA,valB,sortDir)
+}
+
+function sortItems(valA: any, valB: any, sortDir: 'asc' | 'desc' = 'asc'){
+  if (valA < valB) {
+    if (sortDir === 'asc'){
+      return -1
+    }
+    return 1
+  }
+
+  if (valA > valB) {
+    if (sortDir === 'asc'){
+      return 1
+    }
+    return -1
+  }
+  // values are equal
+  return 0
+}


### PR DESCRIPTION
# Mentions section of software item page

Changes proposed in this pull request:

*  Add mentions section to software item page. There are slight design differences compared to legacy version due to use of different component libraries. If needed, the design can be further improved.

How to test:

*  `docker-compose up`
*  visit one of the featured software items (they have more mentions), like Xenon: http://localhost/software/xenon. At the bottom of the page you should see mentions section with one 'featured' item and number of other mentions per type.
* Click on feature item will open new web page

The software item page with the mention section should look something like in the picture below.
![image](https://user-images.githubusercontent.com/9204081/149581767-4e48e924-9689-4688-9c62-026b6aa3a28a.png)






