### PR TITLE
Software contributors and testimonials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.3.3
+    image: rsd/frontend:0.3.4
     env_file:
       - ./frontend/.env.production.local
     # ports:

--- a/frontend/components/software/ContactPersonCard.tsx
+++ b/frontend/components/software/ContactPersonCard.tsx
@@ -1,0 +1,54 @@
+/* eslint-disable @next/next/no-img-element */
+import EmailIcon from '@mui/icons-material/Email'
+import Avatar from '@mui/material/Avatar'
+
+import {Contributor} from '../../types/Contributor'
+import {getDisplayName, getDisplayInitials} from '../../utils/getDisplayName'
+
+
+export default function ContactPersonCard({person}: { person: Contributor|null }) {
+  // what to render if no contact person?
+  if (!person) return null
+  const displayName = getDisplayName(person)
+  return (
+    <article className="flex flex-col bg-white max-w-md">
+      <h4 className="text-center font-medium px-6 py-4 uppercase bg-primary text-white md:text-left">Contact person</h4>
+      <div className="flex flex-col p-6 md:flex-row 2xl:flex-col">
+        {/* <div className="self-center md:mr-8 2xl:mr-0"> */}
+        <Avatar
+          alt={displayName ?? 'Unknown'}
+          src={person.avatar_url ?? ''}
+          sx={{
+            width: '7rem',
+            height: '7rem',
+            fontSize: '2rem',
+            alignSelf: 'center',
+            marginRight:['0rem','2rem']
+          }}
+        >
+          {displayName ?
+            getDisplayInitials(person)
+            :null
+          }
+        </Avatar>
+        {/* </div> */}
+        <div className="flex-1 flex flex-col items-center py-4 md:items-start lg:pt-8">
+          <h5 className="text-primary text-2xl">{displayName}</h5>
+          <h6 className="py-2">Placeholder for ogranisation name</h6>
+          <a className="flex items-center md:items-start"
+            href={`mailto:${person.email_address}`}>
+            {/* <div className="flex items-center" style={{opacity:'inherit'}}> */}
+              <EmailIcon sx={{
+                mr: 1,
+                '&:hover': {
+                  opacity: 'inherit'
+                }
+              }} color="primary" />
+              Mail {person.given_names}
+            {/* </div> */}
+          </a>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/components/software/ContactPersonCard.tsx
+++ b/frontend/components/software/ContactPersonCard.tsx
@@ -34,7 +34,9 @@ export default function ContactPersonCard({person}: { person: Contributor|null }
         {/* </div> */}
         <div className="flex-1 flex flex-col items-center py-4 md:items-start lg:pt-8">
           <h5 className="text-primary text-2xl">{displayName}</h5>
-          <h6 className="py-2">Placeholder for ogranisation name</h6>
+          <h6 className="py-2">
+            {person?.affiliation ?? 'Organisation unknown'}
+          </h6>
           <a className="flex items-center md:items-start"
             href={`mailto:${person.email_address}`}>
             {/* <div className="flex items-center" style={{opacity:'inherit'}}> */}

--- a/frontend/components/software/ContributorsList.tsx
+++ b/frontend/components/software/ContributorsList.tsx
@@ -31,7 +31,7 @@ export default function ContributorsList({contributors}: { contributors: Contrib
                   {displayName}
                 </div>
                 <div>
-                  Placeholder for ogranisation name
+                  {item?.affiliation ?? 'Organisation unknown'}
                 </div>
               </div>
             </div>

--- a/frontend/components/software/ContributorsList.tsx
+++ b/frontend/components/software/ContributorsList.tsx
@@ -1,0 +1,45 @@
+import Avatar from '@mui/material/Avatar'
+import {Contributor} from '../../types/Contributor'
+import {getDisplayName, getDisplayInitials} from '../../utils/getDisplayName'
+
+export default function ContributorsList({contributors}: { contributors: Contributor[] }) {
+  // do not render component if no data
+  if (contributors?.length === 0) return null
+
+  return (
+    // <div className="flex mt-12 justify-between 2xl:justify-start 2xl:mt-0 lg:flex-[2] lg:flex flex-wrap lg:mr-8">
+    <div className="md:grid md:grid-cols-2 hd:grid-cols-3 gap-4 mt-12 2xl:mt-0">
+      {contributors.map(item => {
+        const displayName = getDisplayName(item)
+        if (displayName) {
+          return (
+            <div key={displayName} className="flex py-4 pr-4 md:pr-8 2xl:pr-12 2xl:pb-8">
+              <Avatar
+                alt={displayName ?? 'Unknown'}
+                src={item.avatar_url ?? ''}
+                sx={{
+                  width: '3rem',
+                  height: '3rem',
+                  fontSize: '1rem',
+                  marginRight: '1rem'
+                }}
+              >
+                {getDisplayInitials(item)}
+              </Avatar>
+              <div>
+                <div className="text-primary text-xl">
+                  {displayName}
+                </div>
+                <div>
+                  Placeholder for ogranisation name
+                </div>
+              </div>
+            </div>
+          )
+        }
+        return null
+      })
+      }
+    </div>
+  )
+}

--- a/frontend/components/software/ContributorsSection.tsx
+++ b/frontend/components/software/ContributorsSection.tsx
@@ -5,17 +5,17 @@ import ContactPersonCard from './ContactPersonCard'
 
 function clasifyContributors(contributors: Contributor[]) {
   const contributorList:Contributor[] = []
-  let contact:Contributor|null=null
+  let contact: Contributor | null = null
 
   contributors.forEach(item => {
     // construct file name
     if (item.avatar_mime_type) {
-      // preferably
-      // construct image path using id and mime type, example: 2023dbe4-f49c-4af9-b37e-13eacf5809a1.png
-      // item.avatar_url = `/image/contributor/${item.id}.${item.avatar_mime_type.split('/')[1]}`
-      // currently we use posgrest + nginx approach
-      // image/rpc/get_contributor_image?id=15c8d47f-f8f0-45ff-861c-1e57640ebd56
+      // construct image path
+      // currently we use posgrest + nginx approach image/rpc/get_contributor_image?id=15c8d47f-f8f0-45ff-861c-1e57640ebd56
+      // NOTE! the images will fail when running frontend in development due to origin being localhost:3000 instead of localhost
       item.avatar_url = `/image/rpc/get_contributor_image?id=${item.id}`
+      // debugger
+      // console.log('image',item.avatar_url)
     } else {
       item.avatar_url=null
     }

--- a/frontend/components/software/ContributorsSection.tsx
+++ b/frontend/components/software/ContributorsSection.tsx
@@ -1,0 +1,50 @@
+import {Contributor} from '../../types/Contributor'
+import PageContainer from '../layout/PageContainer'
+import ContributorsList from './ContributorsList'
+import ContactPersonCard from './ContactPersonCard'
+
+function clasifyContributors(contributors: Contributor[]) {
+  const contributorList:Contributor[] = []
+  let contact:Contributor|null=null
+
+  contributors.forEach(item => {
+    // construct file name
+    if (item.avatar_mime_type) {
+      item.avatar_url = `/images/contributor/${item.id}.${item.avatar_mime_type.split('/')[1]}`
+    } else {
+      item.avatar_url=null
+    }
+    if (item.is_contact_person === true) {
+      contact = item
+    } else {
+      contributorList.push(item)
+    }
+  })
+  return {
+    contributorList,
+    contact
+  }
+}
+
+export default function ContributorsSection({contributors}: { contributors: Contributor[] }) {
+  const {contact, contributorList} = clasifyContributors(contributors)
+  return (
+    <section className="bg-grey-200">
+      <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
+        <h2
+          data-testid="software-contributors-section-title"
+          className="pb-8 text-[2rem] text-primary">
+          Contributors
+        </h2>
+        <section className="2xl:flex 2xl:flex-row-reverse">
+          <div className="2xl:flex-1 lg:self-start">
+            <ContactPersonCard person={contact} />
+          </div>
+          <div className="2xl:flex-[3]">
+            <ContributorsList contributors={contributors} />
+          </div>
+        </section>
+      </PageContainer>
+    </section>
+  )
+}

--- a/frontend/components/software/ContributorsSection.tsx
+++ b/frontend/components/software/ContributorsSection.tsx
@@ -10,7 +10,12 @@ function clasifyContributors(contributors: Contributor[]) {
   contributors.forEach(item => {
     // construct file name
     if (item.avatar_mime_type) {
-      item.avatar_url = `/images/contributor/${item.id}.${item.avatar_mime_type.split('/')[1]}`
+      // preferably
+      // construct image path using id and mime type, example: 2023dbe4-f49c-4af9-b37e-13eacf5809a1.png
+      // item.avatar_url = `/image/contributor/${item.id}.${item.avatar_mime_type.split('/')[1]}`
+      // currently we use posgrest + nginx approach
+      // image/rpc/get_contributor_image?id=15c8d47f-f8f0-45ff-861c-1e57640ebd56
+      item.avatar_url = `/image/rpc/get_contributor_image?id=${item.id}`
     } else {
       item.avatar_url=null
     }

--- a/frontend/components/software/MentionItem.tsx
+++ b/frontend/components/software/MentionItem.tsx
@@ -15,7 +15,7 @@ export default function MentionItem({item, pos}: {item: Mention, pos:number}) {
           <div>{isoStrToLocalDateStr(item.date)}</div>
         </div>
         <div className="flex justify-center items-center">
-          <LinkIcon />
+          {item?.url ? <LinkIcon /> : null}
         </div>
       </div>
     )

--- a/frontend/components/software/TestimonialItem.tsx
+++ b/frontend/components/software/TestimonialItem.tsx
@@ -1,0 +1,44 @@
+import styled from '@mui/system/styled'
+import {Testimonial} from '../../types/Testimonial'
+
+const TestimonialContent = styled('div')(({theme}) => ({
+  position:'relative',
+  backgroundColor: `${theme.palette.primary.main}`,
+  color: `${theme.palette.common.white}`,
+  padding: '2.5rem',
+  fontSize:'1.5rem',
+  '&::after': {
+    content: '""',
+    width: 0,
+    height: 0,
+    border: '0 solid transparent',
+    position: 'absolute',
+    left: '4.5rem',
+    top: '100%',
+    borderTopWidth: 0,
+    borderBottomWidth: '1.5rem',
+    borderRight: '16px solid #00A3E3'
+  }
+}))
+
+const GivenBy = styled('div')(({theme}) => ({
+  margin: '20px 0 4em',
+  paddingLeft:'6rem'
+}))
+
+export default function TestimonialItem({item}: { item: Testimonial }) {
+
+  return (
+    <div>
+      <TestimonialContent>
+        <blockquote className="before:content-['\201C'] after:content-['\201C']">
+          {item.text}
+        </blockquote>
+        {/* &quot;  &quot; */}
+      </TestimonialContent>
+      <GivenBy>
+        – {item.person}, {item.affiliation}
+      </GivenBy>
+    </div>
+  )
+}

--- a/frontend/components/software/TestimonialsSection.tsx
+++ b/frontend/components/software/TestimonialsSection.tsx
@@ -1,0 +1,26 @@
+
+import {Testimonial} from '../../types/Testimonial'
+import PageContainer from '../layout/PageContainer'
+import TestimonialItem from './TestimonialItem'
+
+export default function TestimonialSection({testimonials = []}: { testimonials: Testimonial[] }) {
+  // do not render section if no data
+  if (testimonials?.length === 0) return null
+
+  return (
+    <section>
+      <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
+        <h2
+          data-testid="software-contributors-section-title"
+          className="pb-8 text-[2rem] text-primary">
+          Testimonials
+        </h2>
+        <section>
+          {testimonials.map((item, pos) => {
+            return (<TestimonialItem key={pos} item={item} />)
+          })}
+        </section>
+      </PageContainer>
+    </section>
+  )
+}

--- a/frontend/config/app.ts
+++ b/frontend/config/app.ts
@@ -1,0 +1,4 @@
+
+export const app = {
+  title:'Research Software Directory'
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,12 +1,13 @@
 import Head from 'next/head'
 
+import {app} from '../config/app'
 import DefaultLayout from '../components/layout/DefaultLayout'
 
 export default function Home(){
   return (
     <>
       <Head>
-        <title>Home page | Research Software Directory</title>
+        <title>Home page | {app.title}</title>
       </Head>
       <DefaultLayout>
         <h1>Home page</h1>

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -14,6 +14,7 @@ import PageSnackbarContext, {snackbarDefaults} from '../../../components/snackba
 import AboutSection from '../../../components/software/AboutSection'
 import MentionsSection from '../../../components/software/MentionsSection'
 import ContributorsSection from '../../../components/software/ContributorsSection'
+import TestimonialSection from '../../../components/software/TestimonialsSection'
 
 import {
   getSoftwareItem,
@@ -22,6 +23,7 @@ import {
   getLicenseForSoftware,
   getContributorMentionCount,
   getMentionsForSoftware,
+  getTestimonialsForSoftware,
   getContributorsForSoftware,
   Tag, License, ContributorMentionCount, Mention,
 } from '../../../utils/getSoftware'
@@ -30,6 +32,7 @@ import {SoftwareItem} from '../../../types/SoftwareItem'
 import {SoftwareCitationInfo} from '../../../types/SoftwareCitation'
 import {ScriptProps} from 'next/script'
 import {Contributor} from '../../../types/Contributor'
+import {Testimonial} from '../../../types/Testimonial'
 
 interface SoftwareIndexData extends ScriptProps{
   slug: string,
@@ -38,14 +41,20 @@ interface SoftwareIndexData extends ScriptProps{
   tagsInfo: Tag[],
   licenseInfo: License[],
   softwareIntroCounts: ContributorMentionCount,
-  mentions: Mention[]
+  mentions: Mention[],
+  testimonials: Testimonial[],
   contributors: Contributor[]
 }
 
 
 export default function SoftwareIndexPage(props:SoftwareIndexData) {
-  const {software, citationInfo, tagsInfo, licenseInfo, softwareIntroCounts, mentions ,contributors} = props
   const [options, setSnackbar] = useState(snackbarDefaults)
+  // extract data from props
+  const {
+    software, citationInfo, tagsInfo,
+    licenseInfo, softwareIntroCounts,
+    mentions, testimonials, contributors
+  } = props
 
   if (!software?.brand_name){
     return (
@@ -91,9 +100,12 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
           licenses={licenseInfo}
           repositories={software.repository_url}
         />
-        <MentionsSection mentions={mentions} />
-        {/* temporary spacer */}
-        <section className="py-12"></section>
+        <MentionsSection
+          mentions={mentions}
+        />
+        <TestimonialSection
+          testimonials={testimonials}
+        />
         <ContributorsSection contributors={contributors} />
         {/* temporary spacer */}
         <section className="py-12"></section>
@@ -130,6 +142,8 @@ export async function getServerSideProps(context:any) {
       getContributorMentionCount(software.id),
       // mentions
       getMentionsForSoftware(software.id),
+      // testimonials
+      getTestimonialsForSoftware(software.id),
       // contributors
       getContributorsForSoftware(software.id)
     ]
@@ -139,6 +153,7 @@ export async function getServerSideProps(context:any) {
       licenseInfo,
       softwareIntroCounts,
       mentions,
+      testimonials,
       contributors
     ] = await Promise.all(fetchData)
 
@@ -158,6 +173,7 @@ export async function getServerSideProps(context:any) {
         licenseInfo,
         softwareIntroCounts,
         mentions,
+        testimonials,
         contributors
       }
     }

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -3,6 +3,7 @@ import Head from 'next/head'
 import {useRouter} from 'next/router'
 import TablePagination from '@mui/material/TablePagination'
 
+import {app} from '../../config/app'
 import DefaultLayout from '../../components/layout/DefaultLayout'
 import PageTitle from '../../components/layout/PageTitle'
 import Searchbox from '../../components/software/Searchbox'
@@ -81,7 +82,7 @@ export default function SoftwareIndexPage({count,page,rows,tags,software=[]}:
   return (
     <DefaultLayout>
       <Head>
-        <title>Software | RSD</title>
+        <title>Software | {app.title}</title>
       </Head>
       <PageTitle title="Software">
         <div className="flex flex-wrap justify-end">

--- a/frontend/types/Contributor.ts
+++ b/frontend/types/Contributor.ts
@@ -1,0 +1,35 @@
+/**
+ * Table definitions in 003-create-relations-for-software.sql
+ * Based on record from contributor table
+ * {
+      "id": "b9de8c9b-f130-4203-bdaf-0b909a52eece",
+      "software": "4598d493-598f-4e65-884e-3d84e5e58183",
+      "is_contact_person": false,
+      "email_address": null,
+      "family_names": "Hua Zhao",
+      "given_names": "Jing",
+      "name_particle": null,
+      "name_suffix": null,
+      "avatar_data": null,
+      "avatar_mime_type": null,
+      "created_at": "2022-01-14T16:19:06.70371",
+      "updated_at": "2022-01-14T16:19:06.70371"
+    }
+ */
+
+export type Contributor = {
+  id: string
+  software: string
+  is_contact_person: boolean
+  email_address: string | null
+  family_names: string
+  given_names: string
+  name_particle: string | null
+  name_suffix: string | null
+  // avatar_data: string | null
+  // construct url based on id and mime-type
+  avatar_url: string|null
+  avatar_mime_type: string | null,
+  created_at: string
+  updated_at: string
+}

--- a/frontend/types/Contributor.ts
+++ b/frontend/types/Contributor.ts
@@ -29,7 +29,9 @@ export type Contributor = {
   // avatar_data: string | null
   // construct url based on id and mime-type
   avatar_url: string|null
-  avatar_mime_type: string | null,
+  avatar_mime_type: string | null
+  // NOTE! it should be added later
+  affiliation:string
   created_at: string
   updated_at: string
 }

--- a/frontend/types/Testimonial.ts
+++ b/frontend/types/Testimonial.ts
@@ -1,0 +1,11 @@
+// Based on record from testimonial table
+// 003-create-relations-for-software.sql
+const testimonial = {
+  'id': '5969556c-55ac-4912-812a-1be0f9c5d759',
+  'software': '87d793ed-9aff-4f87-aa07-586ca42b9e2a',
+  'affiliation': 'Professor of Private Law, Maastricht University',
+  'person': 'Gijs van Dijck',
+  'text': 'It’s quite amazing to see how, thanks to this tool, a student can, in some ways, outperform the expert.'
+}
+
+export type Testimonial = typeof testimonial

--- a/frontend/utils/getDisplayName.ts
+++ b/frontend/utils/getDisplayName.ts
@@ -1,0 +1,42 @@
+import {Contributor} from '../types/Contributor'
+
+export function getDisplayName(contributor: Contributor) {
+  let displayName = null
+  // start with given names (first name)
+  if (contributor.given_names) {
+    displayName = contributor.given_names
+  }
+  // add particle, eg. van
+  if (contributor.name_particle) {
+    displayName += ` ${contributor.name_particle}`
+  }
+  // then family names
+  if (contributor.family_names) {
+    displayName += ` ${contributor.family_names}`
+  }
+  // end with suffix? no prefix
+  if (contributor.name_suffix) {
+    displayName += ` ${contributor.name_suffix}`
+  }
+  return displayName
+}
+
+export function getDisplayInitials(contributor: Contributor) {
+  let displayInitials = ''
+  // start with given names (first name)
+  if (contributor.given_names) {
+    // take first char
+    displayInitials = contributor.given_names[0]
+  }
+  // add particle, eg. van
+  if (contributor.name_particle) {
+    // split on space and take first chars
+    displayInitials += `${contributor.name_particle.split(' ').map(i=>i[0])}`
+  }
+  // then family names
+  if (contributor.family_names) {
+    // take first char
+    displayInitials += `${contributor.family_names[0]}`
+  }
+  return displayInitials
+}

--- a/frontend/utils/getDisplayName.ts
+++ b/frontend/utils/getDisplayName.ts
@@ -31,7 +31,7 @@ export function getDisplayInitials(contributor: Contributor) {
   // add particle, eg. van
   if (contributor.name_particle) {
     // split on space and take first chars
-    displayInitials += `${contributor.name_particle.split(' ').map(i=>i[0])}`
+    displayInitials += `${contributor.name_particle.split(' ').map(i=>i[0]).join('')}`
   }
   // then family names
   if (contributor.family_names) {

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -3,6 +3,7 @@ import {SoftwareCitationInfo} from '../types/SoftwareCitation'
 import {extractCountFromHeader} from './extractCountFromHeader'
 import logger from './logger'
 import {MentionType} from '../types/MentionType'
+import {Contributor} from '../types/Contributor'
 
 /**
  * postgREST api uri to retreive software index data.
@@ -235,3 +236,29 @@ export async function getMentionsForSoftware(uuid: string) {
     return undefined
   }
 }
+
+/**
+ * CONTRIBUTORS
+ */
+
+export async function getContributorsForSoftware(uuid: string) {
+  try {
+    // this request is always perfomed from backend
+    // the content is order by type ascending
+    const columns = 'id,software,is_contact_person,email_address,family_names,given_names,name_particle,name_suffix,avatar_mime_type'
+    const url = `${process.env.POSTGREST_URL}/contributor?select=${columns}&software=eq.${uuid}&order=family_names.asc`
+    const resp = await fetch(url, {method: 'GET'})
+    if (resp.status === 200) {
+      const data: Contributor[] = await resp.json()
+      return data
+    } else if (resp.status === 404) {
+      logger(`getContributorsForSoftware: 404 [${url}]`, 'error')
+      // query not found
+      return undefined
+    }
+  } catch (e: any) {
+    logger(`getContributorsForSoftware: ${e?.message}`, 'error')
+    return undefined
+  }
+}
+

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -4,6 +4,7 @@ import {extractCountFromHeader} from './extractCountFromHeader'
 import logger from './logger'
 import {MentionType} from '../types/MentionType'
 import {Contributor} from '../types/Contributor'
+import {Testimonial} from '../types/Testimonial'
 
 /**
  * postgREST api uri to retreive software index data.
@@ -227,13 +228,36 @@ export async function getMentionsForSoftware(uuid: string) {
       const data: ContributorMentionCount[] = await resp.json()
       return data
     } else if (resp.status === 404) {
-      logger(`getContributorMentionCount: 404 [${url}]`, 'error')
+      logger(`getMentionsForSoftware: 404 [${url}]`, 'error')
       // query not found
       return undefined
     }
   } catch (e: any) {
-    logger(`getContributorMentionCount: ${e?.message}`, 'error')
+    logger(`getMentionsForSoftware: ${e?.message}`, 'error')
     return undefined
+  }
+}
+
+/**
+ * TESTIMONIALS
+ */
+export async function getTestimonialsForSoftware(uuid: string) {
+  try {
+    // this request is always perfomed from backend
+    // the content is NOT ordered
+    const url = `${process.env.POSTGREST_URL}/testimonial?software=eq.${uuid}`
+    const resp = await fetch(url, {method: 'GET'})
+    if (resp.status === 200) {
+      const data: Testimonial[] = await resp.json()
+      return data
+    } else if (resp.status === 404) {
+      logger(`getTestimonialsForSoftware: 404 [${url}]`, 'error')
+      // query not found
+      return []
+    }
+  } catch (e: any) {
+    logger(`getTestimonialsForSoftware: ${e?.message}`, 'error')
+    return []
   }
 }
 
@@ -244,7 +268,7 @@ export async function getMentionsForSoftware(uuid: string) {
 export async function getContributorsForSoftware(uuid: string) {
   try {
     // this request is always perfomed from backend
-    // the content is order by type ascending
+    // the content is order by family_names ascending
     const columns = 'id,software,is_contact_person,email_address,family_names,given_names,name_particle,name_suffix,avatar_mime_type'
     const url = `${process.env.POSTGREST_URL}/contributor?select=${columns}&software=eq.${uuid}&order=family_names.asc`
     const resp = await fetch(url, {method: 'GET'})


### PR DESCRIPTION
# Contributors and testimonials sections of software item page

In this PR I created all components for contributors and testimonials. There are slight improvements (imho) compared to legacy version.
* Contributors
  * All contributor have avatar
  * If no image provided contributor initials are shown the avatar area
* Testimonials: all testimonials are listed. In the legacy version only first/top testimonial was shown 

How to test:

* `docker compose up`
* visit software page, example: http://localhost/software/xenon

New contributor section should look like screenshot below
![image](https://user-images.githubusercontent.com/9204081/149923846-a703426e-2114-46c4-91fc-20bb8401fe6c.png)

Testimonial section for [GGIR](http://localhost/software/ggir) has 2 entries now
![image](https://user-images.githubusercontent.com/9204081/149945550-faffb9c7-8a54-491a-b954-b2a1ca5dc62f.png)

