### PR TITLE
Testimonials images database

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -42,7 +42,7 @@ public class Main {
 		});
 
 		app.post("/login/surfconext", ctx -> {
-			try{
+			try {
 				String returnPath = ctx.cookie("rsd_pathname");
 				String code = ctx.formParam("code");
 				String redirectUrl = CONFIG.getProperty("NEXT_PUBLIC_SURFCONEXT_REDIRECT");
@@ -51,13 +51,13 @@ public class Main {
 				String token = jwtCreator.createUserJwt(account);
 				setJwtCookie(ctx, token);
 				// redirect based on info
-				if (returnPath != null && !returnPath.trim().isEmpty()){
+				if (returnPath != null && !returnPath.trim().isEmpty()) {
 					returnPath = returnPath.trim();
 					ctx.redirect(returnPath);
-				}else{
+				} else {
 					ctx.redirect("/");
 				}
-			}catch (RuntimeException ex){
+			} catch (RuntimeException ex) {
 				ex.printStackTrace();
 				ctx.status(400);
 				ctx.redirect("/login/failed");
@@ -65,7 +65,7 @@ public class Main {
 		});
 
 		app.get("/refresh", ctx -> {
-			try{
+			try {
 				String tokenToVerify = ctx.cookie("rsd_token");
 				String signingSecret = CONFIG.getProperty("PGRST_JWT_SECRET");
 				JwtVerifier verifier = new JwtVerifier(signingSecret);
@@ -74,7 +74,7 @@ public class Main {
 				JwtCreator jwtCreator = new JwtCreator(signingSecret);
 				String token = jwtCreator.refreshToken(tokenToVerify);
 				setJwtCookie(ctx, token);
-			}catch (RuntimeException ex){
+			} catch (RuntimeException ex) {
 				ex.printStackTrace();
 				ctx.status(400);
 				ctx.json("{\"message\": \"failed to refresh token\"}");

--- a/backend-postgrest/tests/RSD-SaaS-auth.postman_collection.json
+++ b/backend-postgrest/tests/RSD-SaaS-auth.postman_collection.json
@@ -1356,7 +1356,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"name\" : \"eScience Center\",\n\t\"primary_maintainer\" : \"{{account_id}}\"\n}",
+					"raw": "{\n\t\"name\" : \"eScience Center\",\n\t\"slug\" : \"nlesc\",\n\t\"primary_maintainer\" : \"{{account_id}}\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"

--- a/backend-postgrest/tests/docker-compose.yml
+++ b/backend-postgrest/tests/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: database-test
     build: ../../database
-    image: rsd/database-test:0.0.3
+    image: rsd/database-test:0.0.4
     ports:
       # enable connection from outside
       - "5432:5432"
@@ -23,7 +23,7 @@ services:
   backend:
     container_name: backend-test
     build: ../
-    image: rsd/backend-postgrest-test:0.0.3
+    image: rsd/backend-postgrest-test:0.0.4
     ports:
       # enable connection from outside
       - "3500:3500"
@@ -45,7 +45,7 @@ services:
       context: .
       # dockerfile to use for build
       dockerfile: ./dockerfile
-    image: rsd/auth-test:0.0.2
+    image: rsd/auth-test:0.0.3
     env_file:
       # configuration
       - ../../frontend/.env.production.local

--- a/data-migration/docker-compose.yml
+++ b/data-migration/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: ../
       dockerfile: ./data-migration/dockerfile
-    image: rsd/data-migration:0.0.3
+    image: rsd/data-migration:0.0.4
     environment:
       PROPERTIES: "/usr/mymaven/.env.production.local"
     network_mode: "host"

--- a/database/002-create-software-table.sql
+++ b/database/002-create-software-table.sql
@@ -2,13 +2,13 @@ CREATE TABLE software (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
 	slug VARCHAR(100) UNIQUE NOT NULL,
 	brand_name VARCHAR(100) NOT NULL,
-	bullets VARCHAR(2000) NOT NULL,
+	bullets VARCHAR(2000),
 	concept_doi VARCHAR,
-	get_started_url VARCHAR NOT NULL,
+	get_started_url VARCHAR,
 	is_featured BOOLEAN DEFAULT FALSE NOT NULL,
 	is_published  BOOLEAN DEFAULT FALSE NOT NULL,
 	read_more VARCHAR,
-	short_statement VARCHAR(300) NOT NULL,
+	short_statement VARCHAR(300),
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL
 );

--- a/database/003-create-relations-for-software.sql
+++ b/database/003-create-relations-for-software.sql
@@ -112,18 +112,18 @@ BEGIN
 		contributor.id)
 	FROM contributor WHERE contributor.id = get_contributor_image.id INTO headers;
 
-PERFORM set_config('response.headers', headers, TRUE);
+	PERFORM set_config('response.headers', headers, TRUE);
 
-SELECT decode(contributor.avatar_data, 'base64') FROM contributor WHERE contributor.id = get_contributor_image.id INTO blob;
+	SELECT decode(contributor.avatar_data, 'base64') FROM contributor WHERE contributor.id = get_contributor_image.id INTO blob;
 
-IF FOUND
-	THEN RETURN(blob);
-ELSE RAISE SQLSTATE 'PT404'
-	USING
-		message = 'NOT FOUND',
-		detail = 'File not found',
-		hint = format('%s seems to be an invalid file id', get_contributor_image.id);
-END IF;
+	IF FOUND
+		THEN RETURN(blob);
+	ELSE RAISE SQLSTATE 'PT404'
+		USING
+			message = 'NOT FOUND',
+			detail = 'File not found',
+			hint = format('%s seems to be an invalid file id', get_contributor_image.id);
+	END IF;
 END
 $$;
 

--- a/database/003-create-relations-for-software.sql
+++ b/database/003-create-relations-for-software.sql
@@ -66,7 +66,7 @@ CREATE TABLE contributor (
 	given_names VARCHAR NOT NULL,
 	name_particle VARCHAR,
 	name_suffix VARCHAR,
-	avatar_data BYTEA,
+	avatar_data VARCHAR,
 	avatar_mime_type VARCHAR(100),
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL

--- a/database/003-create-relations-for-software.sql
+++ b/database/003-create-relations-for-software.sql
@@ -96,3 +96,34 @@ END
 $$;
 
 CREATE TRIGGER sanitise_update_contributor BEFORE UPDATE ON contributor FOR EACH ROW EXECUTE PROCEDURE sanitise_update_contributor();
+
+
+
+CREATE TABLE testimonial (
+	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+	software UUID REFERENCES software (id) NOT NULL,
+	affiliation VARCHAR(100),
+	person VARCHAR(100) NOT NULL,
+	text VARCHAR(500) NOT NULL
+);
+
+CREATE FUNCTION sanitise_insert_testimonial() RETURNS TRIGGER LANGUAGE plpgsql as
+$$
+BEGIN
+	NEW.id = gen_random_uuid();
+	return NEW;
+END
+$$;
+
+CREATE TRIGGER sanitise_insert_testimonial BEFORE INSERT ON testimonial FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_testimonial();
+
+
+CREATE FUNCTION sanitise_update_testimonial() RETURNS TRIGGER LANGUAGE plpgsql as
+$$
+BEGIN
+	NEW.id = OLD.id;
+	return NEW;
+END
+$$;
+
+CREATE TRIGGER sanitise_update_testimonial BEFORE UPDATE ON testimonial FOR EACH ROW EXECUTE PROCEDURE sanitise_update_testimonial();

--- a/database/005-create-project-table.sql
+++ b/database/005-create-project-table.sql
@@ -51,6 +51,28 @@ $$;
 CREATE TRIGGER sanitise_update_project BEFORE UPDATE ON project FOR EACH ROW EXECUTE PROCEDURE sanitise_update_project();
 
 
+CREATE FUNCTION sanitise_insert_image_for_project() RETURNS TRIGGER LANGUAGE plpgsql as
+$$
+BEGIN
+	NEW.id = gen_random_uuid();
+	return NEW;
+END
+$$;
+
+CREATE TRIGGER sanitise_insert_image_for_project BEFORE INSERT ON image_for_project FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_image_for_project();
+
+
+CREATE FUNCTION sanitise_update_image_for_project() RETURNS TRIGGER LANGUAGE plpgsql as
+$$
+BEGIN
+	NEW.id = OLD.id;
+	return NEW;
+END
+$$;
+
+CREATE TRIGGER sanitise_update_image_for_project BEFORE UPDATE ON image_for_project FOR EACH ROW EXECUTE PROCEDURE sanitise_update_image_for_project();
+
+
 CREATE OR REPLACE FUNCTION get_project_image(id UUID) RETURNS BYTEA STABLE LANGUAGE plpgsql AS
 $$
 DECLARE headers TEXT;

--- a/database/005-create-project-table.sql
+++ b/database/005-create-project-table.sql
@@ -77,14 +77,16 @@ CREATE FUNCTION get_project_image(id UUID) RETURNS BYTEA STABLE LANGUAGE plpgsql
 $$
 DECLARE headers TEXT;
 DECLARE blob BYTEA;
+DECLARE project_slug VARCHAR;
 
 BEGIN
+	SELECT slug FROM project WHERE project.id = get_project_image.id INTO project_slug;
 	SELECT format(
 		'[{"Content-Type": "%s"},'
 		'{"Content-Disposition": "inline; filename=\"%s\""},'
 		'{"Cache-Control": "max-age=259200"}]',
 		mime_type,
-		id)
+		project_slug)
 	FROM image_for_project WHERE project = id INTO headers;
 
 PERFORM set_config('response.headers', headers, TRUE);

--- a/database/005-create-project-table.sql
+++ b/database/005-create-project-table.sql
@@ -20,7 +20,7 @@ CREATE TABLE project (
 
 CREATE TABLE image_for_project (
 	project UUID references project (id) PRIMARY KEY,
-	data BYTEA,
+	data VARCHAR,
 	mime_type VARCHAR(100)
 );
 

--- a/database/005-create-project-table.sql
+++ b/database/005-create-project-table.sql
@@ -73,7 +73,7 @@ $$;
 CREATE TRIGGER sanitise_update_image_for_project BEFORE UPDATE ON image_for_project FOR EACH ROW EXECUTE PROCEDURE sanitise_update_image_for_project();
 
 
-CREATE OR REPLACE FUNCTION get_project_image(id UUID) RETURNS BYTEA STABLE LANGUAGE plpgsql AS
+CREATE FUNCTION get_project_image(id UUID) RETURNS BYTEA STABLE LANGUAGE plpgsql AS
 $$
 DECLARE headers TEXT;
 DECLARE blob BYTEA;

--- a/database/006-create-relations-for-projects.sql
+++ b/database/006-create-relations-for-projects.sql
@@ -53,17 +53,17 @@ BEGIN
 		team_member.id)
 	FROM team_member WHERE team_member.id = get_team_member_image.id INTO headers;
 
-PERFORM set_config('response.headers', headers, TRUE);
+	PERFORM set_config('response.headers', headers, TRUE);
 
-SELECT decode(team_member.avatar_data, 'base64') FROM team_member WHERE team_member.id = get_team_member_image.id INTO blob;
+	SELECT decode(team_member.avatar_data, 'base64') FROM team_member WHERE team_member.id = get_team_member_image.id INTO blob;
 
-IF FOUND
-	THEN RETURN(blob);
-ELSE RAISE SQLSTATE 'PT404'
-	USING
-		message = 'NOT FOUND',
-		detail = 'File not found',
-		hint = format('%s seems to be an invalid file id', get_team_member_image.id);
-END IF;
+	IF FOUND
+		THEN RETURN(blob);
+	ELSE RAISE SQLSTATE 'PT404'
+		USING
+			message = 'NOT FOUND',
+			detail = 'File not found',
+			hint = format('%s seems to be an invalid file id', get_team_member_image.id);
+	END IF;
 END
 $$;

--- a/database/006-create-relations-for-projects.sql
+++ b/database/006-create-relations-for-projects.sql
@@ -7,7 +7,7 @@ CREATE TABLE team_member (
 	given_names VARCHAR NOT NULL,
 	name_particle VARCHAR,
 	name_suffix VARCHAR,
-	avatar_data BYTEA,
+	avatar_data VARCHAR,
 	avatar_mime_type VARCHAR(100),
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL

--- a/database/006-create-relations-for-projects.sql
+++ b/database/006-create-relations-for-projects.sql
@@ -37,3 +37,33 @@ END
 $$;
 
 CREATE TRIGGER sanitise_update_team_member BEFORE UPDATE ON team_member FOR EACH ROW EXECUTE PROCEDURE sanitise_update_team_member();
+
+
+CREATE FUNCTION get_team_member_image(id UUID) RETURNS BYTEA STABLE LANGUAGE plpgsql AS
+$$
+DECLARE headers TEXT;
+DECLARE blob BYTEA;
+
+BEGIN
+	SELECT format(
+		'[{"Content-Type": "%s"},'
+		'{"Content-Disposition": "inline; filename=\"%s\""},'
+		'{"Cache-Control": "max-age=259200"}]',
+		team_member.avatar_mime_type,
+		team_member.id)
+	FROM team_member WHERE team_member.id = get_team_member_image.id INTO headers;
+
+PERFORM set_config('response.headers', headers, TRUE);
+
+SELECT decode(team_member.avatar_data, 'base64') FROM team_member WHERE team_member.id = get_team_member_image.id INTO blob;
+
+IF FOUND
+	THEN RETURN(blob);
+ELSE RAISE SQLSTATE 'PT404'
+	USING
+		message = 'NOT FOUND',
+		detail = 'File not found',
+		hint = format('%s seems to be an invalid file id', get_team_member_image.id);
+END IF;
+END
+$$;

--- a/database/011-create-organisation-table.sql
+++ b/database/011-create-organisation-table.sql
@@ -1,5 +1,6 @@
 CREATE TABLE organisation (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+	slug VARCHAR(100) UNIQUE NOT NULL,
 	primary_maintainer UUID REFERENCES account (id),
 	name VARCHAR NOT NULL,
 	ror_id VARCHAR,

--- a/database/011-create-organisation-table.sql
+++ b/database/011-create-organisation-table.sql
@@ -26,6 +26,7 @@ CREATE FUNCTION sanitise_update_organisation() RETURNS TRIGGER LANGUAGE plpgsql 
 $$
 BEGIN
 	NEW.id = OLD.id;
+	NEW.slug = OLD.slug;
 	NEW.created_at = OLD.created_at;
 	NEW.updated_at = LOCALTIMESTAMP;
 	return NEW;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.1
+    image: rsd/database:0.0.2
     ports:
     # enable connection from outside
       - "5432:5432"
@@ -47,7 +47,7 @@ services:
     build:
       context: .
       dockerfile: ./authentication/dockerfile
-    image: rsd/auth:0.0.4
+    image: rsd/auth:0.0.5
     # ports:
     #   - "7000:7000"
     expose:

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,58 +1,63 @@
 
 # upstream configuration
 upstream backend {
-  server backend:3500;
+	server backend:3500;
 }
 upstream authentication {
-  server auth:7000;
+	server auth:7000;
 }
 
 server {
-  listen       80;
-  server_name  localhost;
+	listen       80;
+	server_name  localhost;
 
-  charset utf-8;
+	charset utf-8;
 
-  # enable gzip file compression
-  gzip on;
-  gzip_proxied any;
-  gzip_comp_level 4;
-  gzip_types text/css application/javascript image/svg+xml;
+	# enable gzip file compression
+	gzip on;
+	gzip_proxied any;
+	gzip_comp_level 4;
+	gzip_types text/css application/javascript image/svg+xml;
 
 
-  # auth
-  location /auth/ {
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    proxy_pass http://authentication/;
-  }
+	# auth
+	location /auth/ {
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_pass http://authentication/;
+	}
 
-  # PostgREST backend API
-  # Note next has api/fe for citation files and images
-  location /api/v1/ {
-    # needed to increase size for the migration script
-    client_max_body_size 40M;
-    proxy_set_header Host $host;
-    proxy_set_header X-Real-IP $remote_addr;
-    default_type  application/json;
-    proxy_hide_header Content-Location;
-    add_header Content-Location  /api/$upstream_http_content_location;
-    proxy_set_header  Connection "";
-    proxy_http_version 1.1;
-    proxy_pass http://backend/;
-  }
+	# PostgREST backend API
+	# Note next has api/fe for citation files and images
+	location /api/v1/ {
+		# needed to increase size for the migration script
+		client_max_body_size 40M;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		default_type  application/json;
+		proxy_hide_header Content-Location;
+		add_header Content-Location  /api/$upstream_http_content_location;
+		proxy_set_header  Connection "";
+		proxy_http_version 1.1;
+		proxy_pass http://backend/;
+	}
 
-  # reverse proxy for next fontend server
-  location / {
-    proxy_pass http://frontend:3000;
-    proxy_http_version 1.1;
-    proxy_set_header Upgrade $http_upgrade;
-    proxy_set_header Connection 'upgrade';
-    proxy_set_header Host $host;
-    proxy_cache_bypass $http_upgrade;
-    # we need to remove this 404 handling
-    # because next's _next folder has own 404 handling
-    # try_files $uri $uri/ =404;
-  }
+	# reverse proxy for next fontend server
+	location / {
+		proxy_pass http://frontend:3000;
+		proxy_http_version 1.1;
+		proxy_set_header Upgrade $http_upgrade;
+		proxy_set_header Connection 'upgrade';
+		proxy_set_header Host $host;
+		proxy_cache_bypass $http_upgrade;
+		# we need to remove this 404 handling
+		# because next's _next folder has own 404 handling
+		# try_files $uri $uri/ =404;
+	}
 
+	location /image/ {
+		rewrite /image/(.+) /$1 break;
+		proxy_set_header Accept application/octet-stream;
+		proxy_pass http://backend/;
+	}
 }


### PR DESCRIPTION
# Testimonials, images and small database changes

Fixes #

Changes proposed in this pull request:

* An extra location is added to the NGINX config that adds the necessary header to get images so they can be requested normally by browsers
* Extra functions added to the database that provides the correct mime type for images
* Testimonials table and data-migration
* Small database improvements, including slug for organisations

How to test:

* Build and start
* Tests should still succeed
* Data migration should still succeed
* http://localhost/api/v1/software?slug=eq.ggir&select=*,testimonial(*) should show two testimonials
* http://localhost/api/v1/testimonial should show content
* http://localhost/image/rpc/get_project_image?id=valid-uuid should show an image, saving it should suggest as filename the slug of the project
* http://localhost/image/rpc/get_contributor_image?id=valid-uuid should show an image
* http://localhost/image/rpc/get_team_member_image?id=valid-uuid should show an image

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests

closes #76 
