### PR TITLE
Related tools section - Software page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.3.4
+    image: rsd/frontend:0.3.5
     env_file:
       - ./frontend/.env.production.local
     # ports:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,12 +3,14 @@ FROM node:16.13-buster-slim AS builder
 
 WORKDIR /app
 
-# copy all files
-# not excluded in .dockerignore
-COPY . .
-
+# copy
+COPY package.json yarn.lock ./
 # install
 RUN yarn install --frozen-lockfile
+
+# copy all other files
+# not excluded in .dockerignore
+COPY . .
 
 # test solution
 RUN yarn test

--- a/frontend/components/software/AboutSection.tsx
+++ b/frontend/components/software/AboutSection.tsx
@@ -19,14 +19,14 @@ export default function AboutSection({brand_name = '', bullets = '', read_more =
 
   return (
     <PageContainer className="flex flex-col px-4 py-12 lg:flex-row lg:pt-0 lg:pb-12">
-      <div className="flex-[3] pr-4">
+      <div className="flex-[3] 2xl:flex-[4] pr-12">
         <AboutStatement
           brand_name={brand_name}
           bullets={bullets}
           read_more={read_more}
         />
       </div>
-      <div className="flex-1 lg:pl-8">
+      <div className="flex-1">
         <AboutTags tags={tags || []} />
         <AboutLanguages languages={['Test 1', 'Test 2', 'Test 3']} />
         <AboutLicense license={license || []} />

--- a/frontend/components/software/CitationSection.tsx
+++ b/frontend/components/software/CitationSection.tsx
@@ -17,7 +17,7 @@ const darkTheme = createTheme({
 export default function CitationSection({citationInfo,concept_doi}:
   {citationInfo:SoftwareCitationInfo, concept_doi:string}) {
   const [version, setVersion]=useState('')
-  const [citation, setCitation]=useState<SoftwareCitationContent>()
+  const [citation, setCitation] = useState<SoftwareCitationContent>()
 
   useEffect(()=>{
     // select first option by default
@@ -26,6 +26,11 @@ export default function CitationSection({citationInfo,concept_doi}:
       setCitation(citationInfo?.release_content[0])
     }
   },[citationInfo])
+
+  // do not render section if no data
+  if (!citationInfo) return null
+  // do not render section if not citable
+  if (citationInfo.is_citable===false) return null
 
   // prepare release versions
   const versions = citationInfo?.release_content?.map((item,pos)=>{
@@ -39,11 +44,6 @@ export default function CitationSection({citationInfo,concept_doi}:
     setVersion(target?.value)
     setCitation(cite)
   }
-
-  // do not render section if no data
-  if (!citationInfo) return null
-  // do not render section if not citable
-  if (citationInfo.is_citable===false) return null
 
   // render section
   return (

--- a/frontend/components/software/RelatedToolsSection.tsx
+++ b/frontend/components/software/RelatedToolsSection.tsx
@@ -1,0 +1,43 @@
+import {SoftwareItem} from '../../types/SoftwareItem'
+import {RelatedTools} from '../../utils/getSoftware'
+import PageContainer from '../layout/PageContainer'
+
+import SoftwareGrid from './SoftwareGrid'
+
+
+export default function RelatedToolsSection({relatedTools=[]}: { relatedTools: RelatedTools[] }) {
+  // do not render if no data
+  if (relatedTools?.length === 0) return null
+
+  const relatedSoftware:SoftwareItem[] = relatedTools.map(item => {
+    return {
+      id: item.software.id,
+      slug: item.software.slug,
+      brand_name: item.software.brand_name,
+      bullets: null,
+      concept_doi: '',
+      get_started_url: '',
+      // we do not have featured software layout
+      is_featured: false,
+      is_published: true,
+      read_more: null,
+      short_statement: item.software.short_statement||'',
+      created_at: '',
+      updated_at: null,
+      repository_url:[]
+    }
+  })
+
+  return (
+    <section>
+      <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
+        <h2
+          data-testid="software-contributors-section-title"
+          className="pb-8 text-[2rem] text-primary">
+          Related tools
+        </h2>
+        <SoftwareGrid software={relatedSoftware as SoftwareItem[]} />
+      </PageContainer>
+    </section>
+  )
+}

--- a/frontend/components/software/RelatedToolsSection.tsx
+++ b/frontend/components/software/RelatedToolsSection.tsx
@@ -5,10 +5,11 @@ import PageContainer from '../layout/PageContainer'
 import SoftwareGrid from './SoftwareGrid'
 
 
-export default function RelatedToolsSection({relatedTools=[]}: { relatedTools: RelatedTools[] }) {
+export default function RelatedToolsSection({relatedTools=[]}: {relatedTools: RelatedTools[]}) {
   // do not render if no data
   if (relatedTools?.length === 0) return null
 
+  // prepare related software items to be used by SoftwareGrid
   const relatedSoftware:SoftwareItem[] = relatedTools.map(item => {
     return {
       id: item.software.id,
@@ -17,7 +18,7 @@ export default function RelatedToolsSection({relatedTools=[]}: { relatedTools: R
       bullets: null,
       concept_doi: '',
       get_started_url: '',
-      // we do not have featured software layout
+      // we do not use featured software layout
       is_featured: false,
       is_published: true,
       read_more: null,

--- a/frontend/components/software/SoftwareCard.tsx
+++ b/frontend/components/software/SoftwareCard.tsx
@@ -1,39 +1,15 @@
 import Link from 'next/link'
 import StarIcon from '@mui/icons-material/Star'
+import {getTimeAgoSince} from '../../utils/dateFn'
 
 export default function SoftwareCard({href,brand_name,short_statement,is_featured,updated_at}:
-  {href:string,brand_name:string,short_statement:string,is_featured:boolean,updated_at:string}) {
+  {href:string,brand_name:string,short_statement:string,is_featured:boolean,updated_at:string|null}) {
 
   const colors = is_featured ? 'bg-primary text-white' : 'bg-gray-200 text-gray-800'
   const today = new Date()
 
   function getInitals(){
     return brand_name.slice(0,2).toUpperCase()
-  }
-
-  function getTimeAgo(){
-    try{
-      const updated = new Date(updated_at)
-      if (today > updated){
-        const msDiff = today.getTime() - updated.getTime()
-        const hours = 1000 * 60 * 60
-        const hoursDiff = Math.floor(msDiff / hours)
-        if (hoursDiff > 24){
-          const daysDiff = Math.floor(hoursDiff/24)
-          if (daysDiff > 1) return `${hoursDiff} days ago`
-          return '1 day ago'
-        }else if (hoursDiff===1){
-          return '1 hour ago'
-        }else{
-          return `${hoursDiff} hours ago`
-        }
-      }else{
-        return 'right now'
-      }
-    }catch(e){
-      // on fail return nothing
-      return null
-    }
   }
 
   function renderFeatured(){
@@ -61,7 +37,7 @@ export default function SoftwareCard({href,brand_name,short_statement,is_feature
         </p>
         <div className="flex justify-between p-4 text-sm">
           <span className="last-update">
-            {getTimeAgo()}
+            {getTimeAgoSince(today,updated_at)}
           </span>
           {renderFeatured()}
         </div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -76,7 +76,6 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
       </Head>
       <PageSnackbarContext.Provider value={{options,setSnackbar}}>
         <AppHeader />
-
         <PageContainer>
           <SoftwareIntroSection
             brand_name={software.brand_name}
@@ -84,19 +83,14 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
             counts={softwareIntroCounts}
           />
         </PageContainer>
-
         <GetStartedSection
           get_started_url={software.get_started_url}
           repository_url={software.repository_url}
         />
-        {
-          citationInfo ?
-            <CitationSection
-              citationInfo={citationInfo}
-              concept_doi={software.concept_doi}
-            />
-            :null
-        }
+        <CitationSection
+          citationInfo={citationInfo}
+          concept_doi={software.concept_doi}
+        />
         <AboutSection
           brand_name={software.brand_name}
           bullets={software?.bullets ?? ''}
@@ -111,10 +105,13 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
         <TestimonialSection
           testimonials={testimonials}
         />
-        <ContributorsSection contributors={contributors} />
-
-        <RelatedToolsSection relatedTools={relatedTools}/>
-        {/* temporary spacer */}
+        <ContributorsSection
+          contributors={contributors}
+        />
+        <RelatedToolsSection
+          relatedTools={relatedTools}
+        />
+        {/* bottom spacer */}
         <section className="py-12"></section>
         <AppFooter />
       </PageSnackbarContext.Provider>

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -15,6 +15,7 @@ import AboutSection from '../../../components/software/AboutSection'
 import MentionsSection from '../../../components/software/MentionsSection'
 import ContributorsSection from '../../../components/software/ContributorsSection'
 import TestimonialSection from '../../../components/software/TestimonialsSection'
+import RelatedToolsSection from '../../../components/software/RelatedToolsSection'
 
 import {
   getSoftwareItem,
@@ -25,7 +26,9 @@ import {
   getMentionsForSoftware,
   getTestimonialsForSoftware,
   getContributorsForSoftware,
-  Tag, License, ContributorMentionCount, Mention,
+  getRelatedToolsForSoftware,
+  Tag, License, ContributorMentionCount,
+  Mention,RelatedTools
 } from '../../../utils/getSoftware'
 import logger from '../../../utils/logger'
 import {SoftwareItem} from '../../../types/SoftwareItem'
@@ -43,7 +46,8 @@ interface SoftwareIndexData extends ScriptProps{
   softwareIntroCounts: ContributorMentionCount,
   mentions: Mention[],
   testimonials: Testimonial[],
-  contributors: Contributor[]
+  contributors: Contributor[],
+  relatedTools: RelatedTools[]
 }
 
 
@@ -53,7 +57,8 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
   const {
     software, citationInfo, tagsInfo,
     licenseInfo, softwareIntroCounts,
-    mentions, testimonials, contributors
+    mentions, testimonials, contributors,
+    relatedTools
   } = props
 
   if (!software?.brand_name){
@@ -94,8 +99,8 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
         }
         <AboutSection
           brand_name={software.brand_name}
-          bullets={software.bullets}
-          read_more={software.read_more}
+          bullets={software?.bullets ?? ''}
+          read_more={software?.read_more ?? ''}
           tags={tagsInfo}
           licenses={licenseInfo}
           repositories={software.repository_url}
@@ -107,6 +112,8 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
           testimonials={testimonials}
         />
         <ContributorsSection contributors={contributors} />
+
+        <RelatedToolsSection relatedTools={relatedTools}/>
         {/* temporary spacer */}
         <section className="py-12"></section>
         <AppFooter />
@@ -145,7 +152,9 @@ export async function getServerSideProps(context:any) {
       // testimonials
       getTestimonialsForSoftware(software.id),
       // contributors
-      getContributorsForSoftware(software.id)
+      getContributorsForSoftware(software.id),
+      // relatedTools
+      getRelatedToolsForSoftware(software.id)
     ]
     const [
       citationInfo,
@@ -154,7 +163,8 @@ export async function getServerSideProps(context:any) {
       softwareIntroCounts,
       mentions,
       testimonials,
-      contributors
+      contributors,
+      relatedTools
     ] = await Promise.all(fetchData)
 
     // const citationInfo = await getCitationsForSoftware(software.id)
@@ -174,7 +184,8 @@ export async function getServerSideProps(context:any) {
         softwareIntroCounts,
         mentions,
         testimonials,
-        contributors
+        contributors,
+        relatedTools
       }
     }
   }catch(e:any){

--- a/frontend/types/SoftwareItem.ts
+++ b/frontend/types/SoftwareItem.ts
@@ -28,14 +28,14 @@ export type SoftwareItem = {
   id: string,
   slug: string,
   brand_name: string,
-  bullets: string,
+  bullets: string|null,
   concept_doi: string,
   get_started_url: string,
   is_featured: boolean,
   is_published: boolean,
-  read_more: string,
+  read_more: string|null,
   short_statement: string,
   created_at: string,
-  updated_at: string,
+  updated_at: string|null,
   repository_url: RepositoryUrl[]
 }

--- a/frontend/utils/dateFn.ts
+++ b/frontend/utils/dateFn.ts
@@ -55,3 +55,39 @@ export function isoStrToLocalDateStr(isoString: string, locale = 'en-US',
   }
   return ''
 }
+
+/**
+ * Get human readible time difference like: right now, X hours ago, X days ago etc..
+ * @param isoString
+ * @param since
+ * @returns
+ */
+export function getTimeAgoSince(since: Date, isoStringDate: string | null) {
+  try {
+    // if not provided we do not show
+    if (!isoStringDate) return null
+    // convert to date
+    const updated = isoStrToDate(isoStringDate)
+    if (!updated) return null
+
+    if (since > updated) {
+      const msDiff = since.getTime() - updated.getTime()
+      const hours = 1000 * 60 * 60
+      const hoursDiff = Math.floor(msDiff / hours)
+      if (hoursDiff > 24) {
+        const daysDiff = Math.floor(hoursDiff / 24)
+        if (daysDiff > 1) return `${hoursDiff} days ago`
+        return '1 day ago'
+      } else if (hoursDiff === 1) {
+        return '1 hour ago'
+      } else {
+        return `${hoursDiff} hours ago`
+      }
+    } else {
+      return 'right now'
+    }
+  } catch (e) {
+    // on fail return nothing
+    return null
+  }
+}

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -286,3 +286,37 @@ export async function getContributorsForSoftware(uuid: string) {
   }
 }
 
+/**
+ * RELATED TOOLS
+ */
+
+export type RelatedTools = {
+  origin:string,
+  software: {
+    id: string
+    slug: string
+    brand_name: string
+    short_statement: string|null
+  }
+}
+
+export async function getRelatedToolsForSoftware(uuid: string) {
+  try {
+    // this request is always perfomed from backend
+    // the content is order by family_names ascending
+    const select = 'origin,relation,software!software_for_software_relation_fkey(id,slug,brand_name,short_statement)'
+    const url = `${process.env.POSTGREST_URL}/software_for_software?select=${select}&&origin=eq.${uuid}&status=eq.approved`
+    const resp = await fetch(url, {method: 'GET'})
+    if (resp.status === 200) {
+      const data: RelatedTools[] = await resp.json()
+      return data
+    } else if (resp.status === 404) {
+      logger(`getContributorsForSoftware: 404 [${url}]`, 'error')
+      // query not found
+      return []
+    }
+  } catch (e: any) {
+    logger(`getContributorsForSoftware: ${e?.message}`, 'error')
+    return []
+  }
+}


### PR DESCRIPTION
# Related tools on software page

Closes #60 

Changes proposed in this pull request:

* Related tools section is added. This is final section 
* Minor improvements in page layout
* Minor refactor of SoftwareItemCard to be reused on this page too
* Improved caching in frontend dockerfile

How to test:

* `docker-compose up`
* visit the software without related tool section, like [GGIR](http://localhost/software/ggir), the section will not be visible
* visit an software page with related tool section, like [Xenon](http://localhost/software/xenon), the section should be visible and similair to picture below
![image](https://user-images.githubusercontent.com/9204081/150004688-54424f01-1cc0-4f0f-ad2f-86e27f53bbdf.png)

