### PR TITLE
Software citation download

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.3.5
+    image: rsd/frontend:0.3.6
     env_file:
       - ./frontend/.env.production.local
     # ports:

--- a/frontend/components/software/CitationDownload.tsx
+++ b/frontend/components/software/CitationDownload.tsx
@@ -1,11 +1,12 @@
 import {useState} from 'react'
+import {useRouter} from 'next/router'
 import {SelectChangeEvent} from '@mui/material/Select'
 import Button from '@mui/material/Button'
 import DownloadIcon from '@mui/icons-material/Download'
 
 import CiteDropdown from './CiteDropdown'
 import {SoftwareCitationContent} from '../../types/SoftwareCitation'
-import {citationFormats} from './citationFormats'
+import {citationFormats, CitationFormatType} from './citationFormats'
 
 function getAvailableFormats(citation:SoftwareCitationContent){
   const valid = citationFormats.map((item,pos)=>{
@@ -22,18 +23,36 @@ function getAvailableFormats(citation:SoftwareCitationContent){
   return valid
 }
 
-export default function CitationFormat({citation}:{citation:SoftwareCitationContent}) {
-  const [format,setFormat]=useState({v:'',f:'',e:'',t:''})
-
+export default function CitationFormat({citation}: { citation: SoftwareCitationContent }) {
+  const router = useRouter()
+  const [format,setFormat]=useState({v:'',f:'',e:'',t:'',n:''})
   const options = getAvailableFormats(citation)
 
+  function getFileName(option: CitationFormatType) {
+    const {slug} = router.query
+    switch (option.format) {
+      case 'bibtex':
+      case 'endnote':
+      case 'ris':
+        return `${slug}.${option.ext}`
+      case 'codemeta':
+        return 'codemeta.json'
+      case 'cff':
+        return 'CITATION.cff'
+      default:
+        return `${option.format}.${option.ext}`
+    }
+  }
+
   function onFormatChange({target}:{target:SelectChangeEvent['target']}){
-    if (target?.value){
+    if (target?.value) {
+      debugger
       setFormat({
         v: target?.value,
         f: options[parseInt(target.value)].format,
         t: options[parseInt(target.value)].contentType,
-        e: options[parseInt(target.value)].ext
+        e: options[parseInt(target.value)].ext,
+        n: getFileName(options[parseInt(target.value)])
       })
     }
   }
@@ -57,8 +76,8 @@ export default function CitationFormat({citation}:{citation:SoftwareCitationCont
         }}
       >
         <DownloadIcon sx={{mr:1}}/>
-        <a href={`/api/fe/cite/${citation.id}?f=${format.f}&e=${format.e}&t=${format.t}`}
-          download={`citation.${format.e}`}
+        <a href={`/api/fe/cite/${citation.id}?f=${format.f}&t=${format.t}&n=${format.n}`}
+          download={format.n}
         >
           Download file
         </a>

--- a/frontend/components/software/ContributorsSection.tsx
+++ b/frontend/components/software/ContributorsSection.tsx
@@ -46,7 +46,7 @@ export default function ContributorsSection({contributors}: { contributors: Cont
             <ContactPersonCard person={contact} />
           </div>
           <div className="2xl:flex-[3]">
-            <ContributorsList contributors={contributors} />
+            <ContributorsList contributors={contributorList} />
           </div>
         </section>
       </PageContainer>

--- a/frontend/components/software/citationFormats.ts
+++ b/frontend/components/software/citationFormats.ts
@@ -9,3 +9,5 @@ export const citationFormats = [
   {label:'CodeMeta',format:'codemeta',contentType:'application/json',ext:'json'},
   {label:'Citation File Format',format:'cff',contentType:'text/yaml',ext:'cff'}
 ]
+
+export type CitationFormatType = typeof citationFormats[0]

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -4,6 +4,6 @@ module.exports = {
   eslint: {
     // Run ESLint in these directories during production builds (next build)
     // by default next runs linter only in pages/, components/, and lib/
-    dirs: ["components","config","pages","styles","types","utils"]
+    dirs: ['components','config','pages','styles','types','utils']
   },
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/api/fe/cite/[id].ts
+++ b/frontend/pages/api/fe/cite/[id].ts
@@ -23,7 +23,7 @@ export default async function handler(
     const id = req.query?.id.toString()
     const format = req.query?.f.toString()
     const type = req.query?.t.toString()
-    const ext = req.query?.e.toString()
+    const name = req.query?.n.toString()
 
     // make request to postgREST api
     const url = `${process.env.POSTGREST_URL}/release_content?select=${format}&id=eq.${id}`
@@ -34,7 +34,7 @@ export default async function handler(
       const data:any[] = await resp.json()
       const content = data[0][format]
       // add reponse headers
-      res.setHeader('Content-Disposition',`attachment; filename=citation.${ext}`)
+      res.setHeader('Content-Disposition',`attachment; filename=${name}`)
       res.setHeader('Content-Type',type)
       // send content
       res.status(200).send(content)


### PR DESCRIPTION
# Use citation file naming conventions

Fixes #85 

Changes proposed in this pull request:
* Downloaded citation files follow the naming convention implemented in legacy RSD

How to test:

* `docker compose up` to start app
* navigate to software, for example [Xenon](http://localhost/software/xenon)
* select software version you want to cite
* select citation format
* click on `download file` button
* the file name should follow convention specified in #85 
  - BibTex: {slug}.bib
  - EndNote: {slug}.enw
  - RIS: {slug}.ris
  - CodeMeta: codemeta.json
  - CIFF: CITATION.ciff (name in capitals)
- citation files should contain "proper" content (but that might be more difficult to confirm)
![image](https://user-images.githubusercontent.com/9204081/150161857-3dc4b6cb-a713-426d-9471-2188b428082d.png)

PR Checklist:

*   [x] Link to a GitHub issue