### PR TITLE
Software page meta

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.3.6
+    image: rsd/frontend:0.3.7
     env_file:
       - ./frontend/.env.production.local
     # ports:

--- a/frontend/components/layout/AppFooter.tsx
+++ b/frontend/components/layout/AppFooter.tsx
@@ -11,9 +11,9 @@ export default function AppFooter () {
           <div className="text-xl mb-4">
             The Research Software Directory aims to promote the impact,
             the exchange and re-use of research software.
-            Please use our tools!&nbsp;<Link href="/about" passHref>
+            {/* Please use our tools!&nbsp;<Link href="/about" passHref>
               <a className="underline mr-2">Read more</a>
-            </Link>
+            </Link> */}
           </div>
           <a target="_blank" href="https://esciencecenter.nl" rel="noreferrer"
             className="hover:text-primary"

--- a/frontend/components/layout/UserMenu.tsx
+++ b/frontend/components/layout/UserMenu.tsx
@@ -56,7 +56,7 @@ export default function UserMenu(props:UserMenuType) {
         data-testid="user-menu-button"
         aria-controls="user-menu"
         aria-haspopup="true"
-        aria-expanded={open ? 'true' : undefined}
+        aria-expanded={open ? 'true' : 'false'}
         onClick={handleClick}
       >
         <Avatar

--- a/frontend/components/seo/CanonicalUrl.tsx
+++ b/frontend/components/seo/CanonicalUrl.tsx
@@ -1,0 +1,10 @@
+
+import Head from 'next/head'
+
+export default function CanoncialUrl({canonicalUrl}:{canonicalUrl: string }) {
+  return (
+    <Head>
+      <link rel="canonical" href={canonicalUrl}/>
+    </Head>
+  )
+}

--- a/frontend/components/seo/CitationMeta.tsx
+++ b/frontend/components/seo/CitationMeta.tsx
@@ -1,0 +1,17 @@
+import Head from 'next/head'
+
+export default function CitationMeta({title, author, publication_date, concept_doi}: {
+  title:string,author:string,publication_date:string|null,concept_doi:string
+}) {
+  // do not render citation meta tags if concept_doi is not present
+  if (!concept_doi) return null
+
+  return (
+    <Head>
+      <meta name="citation_title" content={title} />
+      <meta name="citation_author" content={author} />
+      <meta name="citation_publication_date" content={publication_date || new Date().toISOString()} />
+      <meta name="citation_doi" content={concept_doi} />
+    </Head>
+  )
+}

--- a/frontend/components/seo/OgMetaTags.tsx
+++ b/frontend/components/seo/OgMetaTags.tsx
@@ -1,0 +1,14 @@
+import Head from 'next/head'
+import {app} from '../../config/app'
+
+export default function OgMetaTags({title, description, url}:
+  { title:string,description:string,url:string }) {
+  return (
+    <Head>
+      <meta property="og:title" content={title} />
+      <meta property="og:description" content={description} />
+      <meta property="og:url" content={url} />
+      <meta property="og:site_name" content={app.title} />
+    </Head>
+  )
+}

--- a/frontend/components/seo/PageMeta.tsx
+++ b/frontend/components/seo/PageMeta.tsx
@@ -1,7 +1,5 @@
 import Head from 'next/head'
 
-import {SoftwareItem} from '../../types/SoftwareItem'
-
 export default function SoftwarePageMeta({title, description}:
   { title: string, description:string }) {
   return (

--- a/frontend/components/seo/PageMeta.tsx
+++ b/frontend/components/seo/PageMeta.tsx
@@ -1,0 +1,13 @@
+import Head from 'next/head'
+
+import {SoftwareItem} from '../../types/SoftwareItem'
+
+export default function SoftwarePageMeta({title, description}:
+  { title: string, description:string }) {
+  return (
+    <Head>
+      <title>{title}</title>
+      <meta name="description" content={description} />
+    </Head>
+  )
+}

--- a/frontend/components/software/MentionIsFeatured.tsx
+++ b/frontend/components/software/MentionIsFeatured.tsx
@@ -10,7 +10,9 @@ export default function MentionIsFeatured({mention}: { mention: Mention }) {
   return (
     <Link href={mention.url} passHref>
       <a data-testid="software-mention-is-featured"
-        target="_blank">
+        target="_blank"
+        rel="noreferrer"
+      >
         <article className="mb-8 md:flex">
           <ImageAsBackground className="flex-1 h-[17rem]" src={mention.image} alt={mention.title} />
           <div className="flex flex-col py-4 px-0 md:py-0 md:px-6 md:flex-1 lg:flex-[2] text-white">

--- a/frontend/components/software/MentionItem.tsx
+++ b/frontend/components/software/MentionItem.tsx
@@ -24,7 +24,7 @@ export default function MentionItem({item, pos}: {item: Mention, pos:number}) {
   if (item?.url) {
     return (
       <Link href={item.url} passHref>
-        <a className="hover:text-black" target="_blank">
+        <a className="hover:text-black" target="_blank" rel="noreferrer">
           {renderItemBody()}
         </a>
       </Link>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -4,6 +4,7 @@ import {app} from '../../../config/app'
 import PageMeta from '../../../components/seo/PageMeta'
 import OgMetaTags from '../../../components/seo/OgMetaTags'
 import CitationMeta from '../../../components/seo/CitationMeta'
+import CanoncialUrl from '../../../components/seo/CanonicalUrl'
 import AppHeader from '../../../components/layout/AppHeader'
 import AppFooter from '../../../components/layout/AppFooter'
 import PageContainer from '../../../components/layout/PageContainer'
@@ -105,6 +106,9 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
         title={software?.brand_name}
         description={software.short_statement}
         url={resolvedUrl}
+      />
+      <CanoncialUrl
+        canonicalUrl={resolvedUrl}
       />
       <PageSnackbarContext.Provider value={{options,setSnackbar}}>
         <AppHeader />

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -1,7 +1,9 @@
-import {useState} from 'react'
-import Head from 'next/head'
+import {useEffect, useState} from 'react'
 
 import {app} from '../../../config/app'
+import PageMeta from '../../../components/seo/PageMeta'
+import OgMetaTags from '../../../components/seo/OgMetaTags'
+import CitationMeta from '../../../components/seo/CitationMeta'
 import AppHeader from '../../../components/layout/AppHeader'
 import AppFooter from '../../../components/layout/AppFooter'
 import PageContainer from '../../../components/layout/PageContainer'
@@ -16,7 +18,6 @@ import MentionsSection from '../../../components/software/MentionsSection'
 import ContributorsSection from '../../../components/software/ContributorsSection'
 import TestimonialSection from '../../../components/software/TestimonialsSection'
 import RelatedToolsSection from '../../../components/software/RelatedToolsSection'
-
 import {
   getSoftwareItem,
   getCitationsForSoftware,
@@ -36,6 +37,8 @@ import {SoftwareCitationInfo} from '../../../types/SoftwareCitation'
 import {ScriptProps} from 'next/script'
 import {Contributor} from '../../../types/Contributor'
 import {Testimonial} from '../../../types/Testimonial'
+import {GetServerSidePropsContext} from 'next'
+import {getDisplayName} from '../../../utils/getDisplayName'
 
 interface SoftwareIndexData extends ScriptProps{
   slug: string,
@@ -50,9 +53,10 @@ interface SoftwareIndexData extends ScriptProps{
   relatedTools: RelatedTools[]
 }
 
-
 export default function SoftwareIndexPage(props:SoftwareIndexData) {
   const [options, setSnackbar] = useState(snackbarDefaults)
+  const [resolvedUrl, setResolvedUrl] = useState('')
+  const [author, setAuthor] = useState('')
   // extract data from props
   const {
     software, citationInfo, tagsInfo,
@@ -60,6 +64,19 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
     mentions, testimonials, contributors,
     relatedTools
   } = props
+
+  useEffect(() => {
+    if (typeof location != 'undefined') {
+      setResolvedUrl(location.href)
+    }
+  }, [])
+  useEffect(() => {
+    const contact = contributors.filter(item => item.is_contact_person)
+    if (contact.length > 0) {
+      const name = getDisplayName(contact[0])
+      setAuthor(name||'')
+    }
+  },[contributors])
 
   if (!software?.brand_name){
     return (
@@ -71,9 +88,24 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
 
   return (
     <>
-      <Head>
-        <title>{software?.brand_name} | {app.title}</title>
-      </Head>
+      {/* Page Head meta tags */}
+      <PageMeta
+        title={`${software?.brand_name} | ${app.title}`}
+        description={software.short_statement}
+      />
+      {/* Page Head meta tags */}
+      <CitationMeta
+        title={software?.brand_name}
+        author={author}
+        publication_date={software.created_at}
+        concept_doi={software.concept_doi}
+      />
+      {/* Page Head meta tags */}
+      <OgMetaTags
+        title={software?.brand_name}
+        description={software.short_statement}
+        url={resolvedUrl}
+      />
       <PageSnackbarContext.Provider value={{options,setSnackbar}}>
         <AppHeader />
         <PageContainer>
@@ -122,11 +154,11 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
 
 // fetching data server side
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
-export async function getServerSideProps(context:any) {
-  try{
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  try {
     const {params} = context
     // console.log('getServerSideProps...params...', params)
-    const software = await getSoftwareItem(params?.slug)
+    const software = await getSoftwareItem(params?.slug?.toString())
     // console.log('getServerSideProps...software...', software)
     if (typeof software == 'undefined'){
       // returning notFound triggers 404 page
@@ -134,7 +166,7 @@ export async function getServerSideProps(context:any) {
         notFound: true,
       }
     }
-    // fetch all info about software based on software.id in parallel
+    // fetch all info about software in parallel based on software.id
     const fetchData = [
       // citationInfo
       getCitationsForSoftware(software.id),
@@ -164,15 +196,8 @@ export async function getServerSideProps(context:any) {
       relatedTools
     ] = await Promise.all(fetchData)
 
-    // const citationInfo = await getCitationsForSoftware(software.id)
-    // const tagsInfo = await getTagsForSoftware(software.id)
-    // const licenseInfo = await getLicenseForSoftware(software.id)
-    // const softwareIntroCounts = await getContributorMentionCount(software.id)
-    // const mentions = await getMentionsForSoftware(software.id)
-    // const contributors = await getContributorsForSoftware(software.id)
-
-    return {
     // pass data to page component as props
+    return {
       props: {
         software,
         citationInfo,

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -45,7 +45,7 @@ export async function getSoftwareList(url:string){
 }
 
 // query for software item page based on slug
-export async function getSoftwareItem(slug:string){
+export async function getSoftwareItem(slug:string|undefined){
   try{
     // this request is always perfomed from backend
     const url = `${process.env.POSTGREST_URL}/software?select=*,repository_url!left(url)&slug=eq.${slug}`


### PR DESCRIPTION
# Add meta tags to software page

Closes #95 

Changes proposed in this pull request:

* Added meta tags according to task #95 
* Did few more SEO improvements based on Lighthouse feedback

How to test:
*  If you already runned the data-migration and have software entries in the database:
*  `docker-compose up`
* Visit software page, for example GGIR
* Open debugger (F12)
* Inspect Head of the page and confirm that meta tags are present

![image](https://user-images.githubusercontent.com/9204081/150414477-9210f4c4-5848-40dc-a0e7-2d48db371b90.png)


PR Checklist:

*   [x ] Link to a GitHub issue
