### PR TITLE
feat: programming languages GitHub scraper

### DIFF
--- a/database/013-software-scraped-data.sql
+++ b/database/013-software-scraped-data.sql
@@ -1,0 +1,30 @@
+CREATE TABLE programming_languages (
+	repository_url UUID PRIMARY KEY REFERENCES repository_url (id),
+	languages JSONB NOT NULL,
+	created_at TIMESTAMP NOT NULL,
+	updated_at TIMESTAMP NOT NULL
+);
+
+CREATE FUNCTION sanitise_insert_programming_languages() RETURNS TRIGGER LANGUAGE plpgsql AS
+$$
+BEGIN
+	NEW.created_at = LOCALTIMESTAMP;
+	NEW.updated_at = NEW.created_at;
+	return NEW;
+END
+$$;
+
+CREATE TRIGGER sanitise_insert_programming_languages BEFORE INSERT ON programming_languages FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_programming_languages();
+
+
+CREATE FUNCTION sanitise_update_programming_languages() RETURNS TRIGGER LANGUAGE plpgsql AS
+$$
+BEGIN
+	NEW.repository_url = OLD.repository_url;
+	NEW.created_at = OLD.created_at;
+	NEW.updated_at = LOCALTIMESTAMP;
+	return NEW;
+END
+$$;
+
+CREATE TRIGGER sanitise_update_programming_languages BEFORE UPDATE ON programming_languages FOR EACH ROW EXECUTE PROCEDURE sanitise_update_programming_languages();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.2
+    image: rsd/database:0.0.3
     ports:
     # enable connection from outside
       - "5432:5432"
@@ -93,6 +93,19 @@ services:
       - "frontend"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+    networks:
+      - net
+
+  scrapers:
+    container_name: scrapers
+    build: ./scrapers
+    image: rsd/scrapers:0.0.1
+    env_file:
+      - ./frontend/.env.production.local
+    depends_on:
+      - "database"
+      - "backend"
+      - "nginx"
     networks:
       - net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,6 @@ services:
     depends_on:
       - "database"
       - "backend"
-      - "nginx"
     networks:
       - net
 

--- a/frontend/.env.local.example
+++ b/frontend/.env.local.example
@@ -14,7 +14,7 @@
 # ---- PUBLIC ENV VARIABLES -------------
 
 # postgREST api
-# cosumed by services: authentication,frontend,auth-tests
+# cosumed by services: authentication,frontend,auth-tests, scrapers
 # env.local: http://localhost/api/v1, env.production.local: http://backend:3500
 POSTGREST_URL=http://backend:3500
 
@@ -31,6 +31,11 @@ NEXT_PUBLIC_SURFCONEXT_REDIRECT=http://localhost/auth/login/surfconext
 # cosumed by: frontend/utils/surfConext
 NEXT_PUBLIC_SURFCONEXT_WELL_KNOWN_URL=https://connect.test.surfconext.nl/.well-known/openid-configuration
 
+# max requests to the GitHub API per run, runs 10 times per hour
+# optional, comment out if not available, a default of 6 will be used
+# consumed by: scrapers
+MAX_REQUESTS_GITHUB=6
+
 
 # ---- SECRETS ------ SECRETS -----------
 
@@ -39,5 +44,9 @@ NEXT_PUBLIC_SURFCONEXT_WELL_KNOWN_URL=https://connect.test.surfconext.nl/.well-k
 AUTH_SURFCONEXT_CLIENT_SECRET=
 
 # POSTGREST JWT SECRET
-# cosumed by services: authentication, frontend (auth-node), auth-tests
+# cosumed by services: authentication, frontend (auth-node), auth-tests, scrapers
 PGRST_JWT_SECRET=
+
+# optional, comment out if not available, should be of the form username:token
+# consumed by: scrapers
+API_CREDENTIALS_GITHUB=

--- a/scrapers/dockerfile
+++ b/scrapers/dockerfile
@@ -1,0 +1,15 @@
+FROM maven:3.8.3-openjdk-17 AS builder
+WORKDIR /usr/mymaven
+RUN mkdir --parents ./src/main
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY ./src/main ./src/main
+RUN mvn package --offline
+
+FROM openjdk:17.0-jdk-slim-bullseye
+RUN apt-get update && apt-get --yes install cron
+COPY jobs.cron /etc/cron.d/jobs.cron
+RUN crontab /etc/cron.d/jobs.cron
+WORKDIR /usr/myjava
+COPY --from=builder /usr/mymaven/target/*-jar-with-dependencies.jar scrapers.jar
+CMD printenv > /etc/environment && cron -f

--- a/scrapers/jobs.cron
+++ b/scrapers/jobs.cron
@@ -1,0 +1,1 @@
+*/6 * * * * /usr/local/openjdk-17/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.language.Main > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1

--- a/scrapers/pom.xml
+++ b/scrapers/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>nl.research-software</groupId>
+	<artifactId>scrapers</artifactId>
+	<version>1.0-SNAPSHOT</version>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>17</maven.compiler.source>
+		<maven.compiler.target>17</maven.compiler.target>
+	</properties>
+
+	<build>
+		<plugins>
+			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.2.0</version>
+			</plugin>
+
+			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-assembly-plugin</artifactId>
+				<version>3.3.0</version>
+
+				<configuration>
+					<descriptorRefs>
+						<descriptorRef>jar-with-dependencies</descriptorRef>
+					</descriptorRefs>
+				</configuration>
+
+				<executions>
+					<execution>
+						<phase>package</phase>
+						<goals>
+							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+
+	<dependencies>
+		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>3.18.2</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.8.9</version>
+		</dependency>
+	</dependencies>
+</project>

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Config.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Config.java
@@ -1,0 +1,29 @@
+package nl.esciencecenter.rsd.scraper;
+
+import java.util.Optional;
+
+public class Config {
+
+	private static final long TEN_MINUTES_IN_MILLISECONDS = 600_000L; // 10 * 60 * 1000
+
+	public static String jwtSigningSecert() {
+		return System.getenv("PGRST_JWT_SECRET");
+	}
+
+	public static long jwtExpirationTime() {
+		return TEN_MINUTES_IN_MILLISECONDS;
+	}
+
+	public static String backendBaseUrl() {
+		return System.getenv("POSTGREST_URL");
+	}
+
+	public static int maxRequestsGithub() {
+		String valueAsString = System.getenv("MAX_REQUESTS_GITHUB");
+		return valueAsString == null ? 6 : Integer.parseInt(valueAsString);
+	}
+
+	public static Optional<String> apiCredentialsGithub() {
+		return Optional.ofNullable(System.getenv("API_CREDENTIALS_GITHUB"));
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
@@ -1,0 +1,90 @@
+package nl.esciencecenter.rsd.scraper;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+import java.util.Date;
+
+public class Utils {
+
+	public static String base64Encode(String s) {
+		return Base64.getEncoder().encodeToString(s.getBytes());
+	}
+
+	public static String get(String uri, String... headers) {
+		HttpRequest request = HttpRequest.newBuilder()
+				.GET()
+				.uri(URI.create(uri))
+				.headers(headers)
+				.build();
+		HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+		HttpResponse<String> response;
+		try {
+			response = client.send(request, HttpResponse.BodyHandlers.ofString());
+		} catch (IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+		if (response.statusCode() >= 300) {
+			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+		}
+		return response.body();
+	}
+
+	public static String getAsAdmin(String uri) {
+		String jwtString = adminJwt();
+		HttpRequest request = HttpRequest.newBuilder()
+				.GET()
+				.uri(URI.create(uri))
+				.header("Authorization", "Bearer " + jwtString)
+				.build();
+		HttpClient client = HttpClient.newHttpClient();
+		HttpResponse<String> response;
+		try {
+			response = client.send(request, HttpResponse.BodyHandlers.ofString());
+		} catch (IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+		if (response.statusCode() >= 300) {
+			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+		}
+		return response.body();
+	}
+
+	public static String postAsAdmin(String uri, String json, String... extraHeaders) {
+		String jwtString = adminJwt();
+		HttpRequest request = HttpRequest.newBuilder()
+				.POST(HttpRequest.BodyPublishers.ofString(json))
+				.uri(URI.create(uri))
+				.header("Content-Type", "application/json")
+				.header("Authorization", "Bearer " + jwtString)
+				.headers(extraHeaders)
+				.build();
+		HttpClient client = HttpClient.newHttpClient();
+		HttpResponse<String> response;
+		try {
+			response = client.send(request, HttpResponse.BodyHandlers.ofString());
+		} catch (IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+		if (response.statusCode() >= 300) {
+			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+		}
+		return response.body();
+	}
+
+	private static String adminJwt() {
+		String signingSecret = Config.jwtSigningSecert();
+		Algorithm signingAlgorithm = Algorithm.HMAC256(signingSecret);
+		String jwtString = JWT.create()
+				.withClaim("role", "rsd_admin")
+				.withExpiresAt(new Date(System.currentTimeMillis() + Config.jwtExpirationTime()))
+				.sign(signingAlgorithm);
+		return jwtString;
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/FilterUrlOnlyPLRDecorator.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/FilterUrlOnlyPLRDecorator.java
@@ -1,0 +1,28 @@
+package nl.esciencecenter.rsd.scraper.language;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class FilterUrlOnlyPLRDecorator implements ProgrammingLanguagesRepository {
+
+	private final ProgrammingLanguagesRepository origin;
+	private final String urlFilter;
+
+	public FilterUrlOnlyPLRDecorator(ProgrammingLanguagesRepository origin, String urlFilter) {
+		this.origin = Objects.requireNonNull(origin);
+		this.urlFilter = Objects.requireNonNull(urlFilter);
+	}
+
+	@Override
+	public Collection<RepositoryUrlData> data() {
+		Collection<RepositoryUrlData> data = origin.data();
+		return data.stream()
+				.filter(repositoryUrlData -> repositoryUrlData.url().startsWith(urlFilter))
+				.toList();
+	}
+
+	@Override
+	public void save(String data) {
+		origin.save(data);
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/GithubPL.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/GithubPL.java
@@ -1,0 +1,28 @@
+package nl.esciencecenter.rsd.scraper.language;
+
+import nl.esciencecenter.rsd.scraper.Config;
+import nl.esciencecenter.rsd.scraper.Utils;
+
+import java.util.Objects;
+
+public class GithubPL implements ProgrammingLanguages {
+
+	private final String baseApiUrl;
+
+	public GithubPL(String baseApiUrl) {
+		this.baseApiUrl = Objects.requireNonNull(baseApiUrl);
+	}
+
+	@Override
+	public String data(String repo) {
+		Objects.requireNonNull(repo);
+		return Config.apiCredentialsGithub()
+				.map(apiCredentials -> Utils.get(baseApiUrl + "/repos/" + repo + "/languages", "Authorization", "Basic " + Utils.base64Encode(apiCredentials)))
+				.orElseGet(() -> Utils.get(baseApiUrl + "/repos/" + repo + "/languages"));
+	}
+
+	@Override
+	public void save(String data) {
+		throw new UnsupportedOperationException();
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/Main.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/Main.java
@@ -1,0 +1,40 @@
+package nl.esciencecenter.rsd.scraper.language;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import nl.esciencecenter.rsd.scraper.Config;
+
+import java.util.Collection;
+
+public class Main {
+
+
+	public static void main(String[] args) {
+		System.out.println("Start scraping programming languages");
+		ProgrammingLanguagesRepository existingLanguagesSorted = new OrderByDatePLRDecorator(new FilterUrlOnlyPLRDecorator(new PostgrestPLR(Config.backendBaseUrl() + "/repository_url?select=id,url,programming_languages(languages,updated_at)"), "https://github.com"));
+		Collection<RepositoryUrlData> dataToScrape = existingLanguagesSorted.data();
+		JsonArray allDataToSave = new JsonArray();
+		int countRequests = 0;
+		int maxRequests = Config.maxRequestsGithub();
+		for (RepositoryUrlData repositoryUrlData : dataToScrape) {
+			try {
+				String repoUrl = repositoryUrlData.url();
+				if (!repoUrl.startsWith("https://github.com/")) continue;
+				countRequests += 1;
+				if (countRequests > maxRequests) break;
+				String repo = repoUrl.replace("https://github.com/", "");
+				if (repo.endsWith("/")) repo = repo.substring(0, repo.length() - 1);
+
+				String scrapedJsonData = new GithubPL("https://api.github.com").data(repo);
+				JsonObject newData = new JsonObject();
+				newData.addProperty("repository_url", repositoryUrlData.id());
+				newData.addProperty("languages", scrapedJsonData);
+				allDataToSave.add(newData);
+			} catch (RuntimeException e) {
+				e.printStackTrace();
+			}
+		}
+		new PostgrestPLR(Config.backendBaseUrl() + "/programming_languages").save(allDataToSave.toString());
+		System.out.println("Done scraping programming languages");
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/OrderByDatePLRDecorator.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/OrderByDatePLRDecorator.java
@@ -1,0 +1,27 @@
+package nl.esciencecenter.rsd.scraper.language;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Objects;
+
+public class OrderByDatePLRDecorator implements ProgrammingLanguagesRepository {
+
+	private final ProgrammingLanguagesRepository origin;
+
+	public OrderByDatePLRDecorator(ProgrammingLanguagesRepository origin) {
+		this.origin = Objects.requireNonNull(origin);
+	}
+
+	@Override
+	public Collection<RepositoryUrlData> data() {
+		Collection<RepositoryUrlData> data = origin.data();
+		return data.stream()
+				.sorted(Comparator.comparing(RepositoryUrlData::lastUpdated, Comparator.nullsFirst(Comparator.naturalOrder())))
+				.toList();
+	}
+
+	@Override
+	public void save(String data) {
+		origin.save(data);
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/PostgrestPLR.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/PostgrestPLR.java
@@ -1,0 +1,46 @@
+package nl.esciencecenter.rsd.scraper.language;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import nl.esciencecenter.rsd.scraper.Utils;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Objects;
+
+public class PostgrestPLR implements ProgrammingLanguagesRepository {
+
+	private final String baseUrl;
+
+	public PostgrestPLR(String baseUrl) {
+		this.baseUrl = Objects.requireNonNull(baseUrl);
+	}
+
+	@Override
+	public Collection<RepositoryUrlData> data() {
+		JsonArray data = JsonParser.parseString(Utils.getAsAdmin(baseUrl)).getAsJsonArray();
+		Collection<RepositoryUrlData> result = new ArrayList<>();
+		for (JsonElement element : data) {
+			JsonObject jsonObject = element.getAsJsonObject();
+			String id = jsonObject.getAsJsonPrimitive("id").getAsString();
+			String url = jsonObject.getAsJsonPrimitive("url").getAsString();
+			String programmingLanguagesData = null;
+			LocalDateTime updatedAt = null;
+			JsonArray programmingLanguages = jsonObject.getAsJsonArray("programming_languages");
+			if (!programmingLanguages.isEmpty()) {
+				programmingLanguagesData = programmingLanguages.get(0).getAsJsonObject().getAsJsonPrimitive("languages").getAsString();
+				updatedAt = LocalDateTime.parse(programmingLanguages.get(0).getAsJsonObject().getAsJsonPrimitive("updated_at").getAsString());
+			}
+			result.add(new RepositoryUrlData(id, url, programmingLanguagesData, updatedAt));
+		}
+		return result;
+	}
+
+	@Override
+	public void save(String data) {
+		Utils.postAsAdmin(baseUrl, data, "Prefer", "resolution=merge-duplicates");
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/ProgrammingLanguages.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/ProgrammingLanguages.java
@@ -1,0 +1,8 @@
+package nl.esciencecenter.rsd.scraper.language;
+
+public interface ProgrammingLanguages {
+
+	String data(String repo);
+
+	void save(String data);
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/ProgrammingLanguagesRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/ProgrammingLanguagesRepository.java
@@ -1,0 +1,10 @@
+package nl.esciencecenter.rsd.scraper.language;
+
+import java.util.Collection;
+
+public interface ProgrammingLanguagesRepository {
+
+	Collection<RepositoryUrlData> data();
+
+	void save(String data);
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/RepositoryUrlData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/language/RepositoryUrlData.java
@@ -1,0 +1,6 @@
+package nl.esciencecenter.rsd.scraper.language;
+
+import java.time.LocalDateTime;
+
+public record RepositoryUrlData(String id, String url, String jsonData, LocalDateTime lastUpdated) {
+}


### PR DESCRIPTION
# Programming languages GitHub scraper

Changes proposed in this pull request:

* Add a scraper that scrapes the GitHub API to collect the programming languages used in repositories. It runs a cron job in a Docker container that runs every 6 minutes. The amount of requests is makes is configurable and it supports using a GitHub authentication token to increase the rate limit. 

How to test:

Since the database structure has changed, we have to delete and build everything
* Copy the new version of the file `frontend/.env.local.example` to `frontend/.env.production.local`
* Optionally fill in the new values
* Dont't forget to fill in the existing secrets again
* `docker-compose down --volumes`
* `docker-compose build`
* `docker-compose up`
* Every six minutes, you should see that the amount of data on https://localhost/api/v1/programming_languages has increased. 
* Repositories without data will be scraped first, then in order of last updated.

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests

Closes #90