### PR TITLE
Commit activity scraper

### DIFF
--- a/database/003-create-relations-for-software.sql
+++ b/database/003-create-relations-for-software.sql
@@ -3,7 +3,9 @@ CREATE TABLE repository_url (
 	software UUID references software (id) NOT NULL,
 	url VARCHAR NOT NULL,
 	license VARCHAR,
-	license_scraped_at TIMESTAMP
+	license_scraped_at TIMESTAMP,
+	commit_history JSONB,
+	commit_history_scraped_at TIMESTAMP
 );
 
 

--- a/scrapers/jobs.cron
+++ b/scrapers/jobs.cron
@@ -1,2 +1,3 @@
 */6 * * * * /usr/local/openjdk-17/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.MainProgrammingLanguages > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-3-59/6 * * * * /usr/local/openjdk-17/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.MainLicenses > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+2-59/6 * * * * /usr/local/openjdk-17/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.MainLicenses > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+4-59/6 * * * * /usr/local/openjdk-17/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.MainCommits > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/AggregateContributionsPerWeekSIDecorator.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/AggregateContributionsPerWeekSIDecorator.java
@@ -1,0 +1,45 @@
+package nl.esciencecenter.rsd.scraper;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import java.util.Objects;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+public class AggregateContributionsPerWeekSIDecorator implements SoftwareInfo {
+
+	private final SoftwareInfo origin;
+
+	public AggregateContributionsPerWeekSIDecorator(SoftwareInfo origin) {
+		this.origin = Objects.requireNonNull(origin);
+	}
+
+	@Override
+	public String languages() {
+		return origin.languages();
+	}
+
+	@Override
+	public String license() {
+		return origin.license();
+	}
+
+	@Override
+	public String contributions() {
+		JsonArray commitsPerContributor = JsonParser.parseString(origin.contributions()).getAsJsonArray();
+		SortedMap<Long, Long> commitsPerWeek = new TreeMap<>();
+		for (JsonElement jsonElement : commitsPerContributor) {
+			JsonArray weeks = jsonElement.getAsJsonObject().getAsJsonArray("weeks");
+			for (JsonElement week : weeks) {
+				long weekTimestamp = week.getAsJsonObject().getAsJsonPrimitive("w").getAsLong();
+				long commitsInWeek = week.getAsJsonObject().getAsJsonPrimitive("c").getAsLong();
+				long countedCommits = commitsPerWeek.getOrDefault(weekTimestamp, 0L);
+				commitsPerWeek.put(weekTimestamp, commitsInWeek + countedCommits);
+			}
+		}
+		return new Gson().toJson(commitsPerWeek);
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/FilterUrlOnlySIRDecorator.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/FilterUrlOnlySIRDecorator.java
@@ -14,16 +14,24 @@ public class FilterUrlOnlySIRDecorator implements SoftwareInfoRepository {
 	}
 
 	@Override
-	public Collection<RepositoryUrlData> repositoryUrldata() {
-		Collection<RepositoryUrlData> data = origin.repositoryUrldata();
+	public Collection<ProgrammingLanguageData> repositoryUrlData() {
+		Collection<ProgrammingLanguageData> data = origin.repositoryUrlData();
 		return data.stream()
 				.filter(repositoryUrlData -> repositoryUrlData.url().startsWith(urlFilter))
 				.toList();
 	}
 
 	@Override
-	public Collection<LicenseData> licenseData() {
-		Collection<LicenseData> data = origin.licenseData();
+	public Collection<RepositoryUrlData> licenseData() {
+		Collection<RepositoryUrlData> data = origin.licenseData();
+		return data.stream()
+				.filter(repositoryUrlData -> repositoryUrlData.url().startsWith(urlFilter))
+				.toList();
+	}
+
+	@Override
+	public Collection<RepositoryUrlData> commitData() {
+		Collection<RepositoryUrlData> data = origin.commitData();
 		return data.stream()
 				.filter(repositoryUrlData -> repositoryUrlData.url().startsWith(urlFilter))
 				.toList();

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/GithubSI.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/GithubSI.java
@@ -17,7 +17,6 @@ public class GithubSI implements SoftwareInfo {
 
 	@Override
 	public String languages() {
-		Objects.requireNonNull(repo);
 		return Config.apiCredentialsGithub()
 				.map(apiCredentials -> Utils.get(baseApiUrl + "/repos/" + repo + "/languages", "Authorization", "Basic " + Utils.base64Encode(apiCredentials)))
 				.orElseGet(() -> Utils.get(baseApiUrl + "/repos/" + repo + "/languages"));
@@ -25,11 +24,17 @@ public class GithubSI implements SoftwareInfo {
 
 	@Override
 	public String license() {
-		Objects.requireNonNull(repo);
 		String repoData = Config.apiCredentialsGithub()
 				.map(apiCredentials -> Utils.get(baseApiUrl + "/repos/" + repo, "Authorization", "Basic " + Utils.base64Encode(apiCredentials)))
 				.orElseGet(() -> Utils.get(baseApiUrl + "/repos/" + repo));
 		JsonElement jsonLicense = JsonParser.parseString(repoData).getAsJsonObject().get("license");
 		return jsonLicense.isJsonNull() ? null : jsonLicense.getAsJsonObject().getAsJsonPrimitive("spdx_id").getAsString();
+	}
+
+	@Override
+	public String contributions() {
+		return Config.apiCredentialsGithub()
+				.map(apiCredentials -> Utils.get(baseApiUrl + "/repos/" + repo + "/stats/contributors", "Authorization", "Basic " + Utils.base64Encode(apiCredentials)))
+				.orElseGet(() -> Utils.get(baseApiUrl + "/repos/" + repo + "/stats/contributors"));
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/LicenseData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/LicenseData.java
@@ -1,6 +1,0 @@
-package nl.esciencecenter.rsd.scraper;
-
-import java.time.LocalDateTime;
-
-public record LicenseData(String id, String software, String url, LocalDateTime lastUpdated) {
-}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainCommits.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainCommits.java
@@ -1,0 +1,45 @@
+package nl.esciencecenter.rsd.scraper;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+
+public class MainCommits {
+
+	public static void main(String[] args) {
+		System.out.println("Start scraping commits");
+		SoftwareInfoRepository existingCommitsSorted = new OrderByDateSIRDecorator(new FilterUrlOnlySIRDecorator(new PostgrestSIR(Config.backendBaseUrl()), "https://github.com"));
+		Collection<RepositoryUrlData> dataToScrape = existingCommitsSorted.commitData();
+		JsonArray allDataToSave = new JsonArray();
+		String scrapedAt = LocalDateTime.now().toString();
+		int countRequests = 0;
+		int maxRequests = Config.maxRequestsGithub();
+		for (RepositoryUrlData commitData : dataToScrape) {
+			try {
+				String repoUrl = commitData.url();
+				countRequests += 1;
+				if (countRequests > maxRequests) break;
+				String repo = repoUrl.replace("https://github.com/", "");
+				if (repo.endsWith("/")) repo = repo.substring(0, repo.length() - 1);
+
+				String scrapedCommits = new AggregateContributionsPerWeekSIDecorator(new GithubSI("https://api.github.com", repo)).contributions();
+				JsonObject newData = new JsonObject();
+				newData.addProperty("id", commitData.id());
+//				we have to add all existing columns, otherwise PostgREST will not do the UPSERT
+				newData.addProperty("software", commitData.software());
+				newData.addProperty("url", commitData.url());
+				newData.addProperty("license", commitData.license());
+				newData.addProperty("license_scraped_at", commitData.licenseScrapedAt() == null ? null : commitData.licenseScrapedAt().toString());
+				newData.addProperty("commit_history", scrapedCommits);
+				newData.addProperty("commit_history_scraped_at", scrapedAt);
+				allDataToSave.add(newData);
+			} catch (RuntimeException e) {
+				e.printStackTrace();
+			}
+		}
+		new PostgrestSIR(Config.backendBaseUrl() + "/repository_url").save(allDataToSave.toString());
+		System.out.println("Done scraping commits");
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainCommits.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainCommits.java
@@ -36,6 +36,7 @@ public class MainCommits {
 				newData.addProperty("commit_history_scraped_at", scrapedAt);
 				allDataToSave.add(newData);
 			} catch (RuntimeException e) {
+				System.out.println("Exception when handling data from url " + commitData.url() + ":");
 				e.printStackTrace();
 			}
 		}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainLicenses.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainLicenses.java
@@ -32,6 +32,8 @@ public class MainLicenses {
 				newData.addProperty("url", licenseData.url());
 				newData.addProperty("license", scrapedLicense);
 				newData.addProperty("license_scraped_at", scrapedAt);
+				newData.addProperty("commit_history", licenseData.commitHistory());
+				newData.addProperty("commit_history_scraped_at", licenseData.commitHistoryScrapedAt() == null ? null : licenseData.commitHistoryScrapedAt().toString());
 				allDataToSave.add(newData);
 			} catch (RuntimeException e) {
 				e.printStackTrace();

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainLicenses.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainLicenses.java
@@ -36,6 +36,7 @@ public class MainLicenses {
 				newData.addProperty("commit_history_scraped_at", licenseData.commitHistoryScrapedAt() == null ? null : licenseData.commitHistoryScrapedAt().toString());
 				allDataToSave.add(newData);
 			} catch (RuntimeException e) {
+				System.out.println("Exception when handling data from url " + licenseData.url() + ":");
 				e.printStackTrace();
 			}
 		}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainLicenses.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainLicenses.java
@@ -11,12 +11,12 @@ public class MainLicenses {
 	public static void main(String[] args) {
 		System.out.println("Start scraping licenses");
 		SoftwareInfoRepository existingLicensesSorted = new OrderByDateSIRDecorator(new FilterUrlOnlySIRDecorator(new PostgrestSIR(Config.backendBaseUrl()), "https://github.com"));
-		Collection<LicenseData> dataToScrape = existingLicensesSorted.licenseData();
+		Collection<RepositoryUrlData> dataToScrape = existingLicensesSorted.licenseData();
 		JsonArray allDataToSave = new JsonArray();
 		String scrapedAt = LocalDateTime.now().toString();
 		int countRequests = 0;
 		int maxRequests = Config.maxRequestsGithub();
-		for (LicenseData licenseData : dataToScrape) {
+		for (RepositoryUrlData licenseData : dataToScrape) {
 			try {
 				String repoUrl = licenseData.url();
 				countRequests += 1;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainProgrammingLanguages.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainProgrammingLanguages.java
@@ -11,13 +11,13 @@ public class MainProgrammingLanguages {
 	public static void main(String[] args) {
 		System.out.println("Start scraping programming languages");
 		SoftwareInfoRepository existingLanguagesSorted = new OrderByDateSIRDecorator(new FilterUrlOnlySIRDecorator(new PostgrestSIR(Config.backendBaseUrl()), "https://github.com"));
-		Collection<RepositoryUrlData> dataToScrape = existingLanguagesSorted.repositoryUrldata();
+		Collection<ProgrammingLanguageData> dataToScrape = existingLanguagesSorted.repositoryUrlData();
 		JsonArray allDataToSave = new JsonArray();
 		int countRequests = 0;
 		int maxRequests = Config.maxRequestsGithub();
-		for (RepositoryUrlData repositoryUrlData : dataToScrape) {
+		for (ProgrammingLanguageData programmingLanguageData : dataToScrape) {
 			try {
-				String repoUrl = repositoryUrlData.url();
+				String repoUrl = programmingLanguageData.url();
 				if (!repoUrl.startsWith("https://github.com/")) continue;
 				countRequests += 1;
 				if (countRequests > maxRequests) break;
@@ -26,7 +26,7 @@ public class MainProgrammingLanguages {
 
 				String scrapedJsonData = new GithubSI("https://api.github.com", repo).languages();
 				JsonObject newData = new JsonObject();
-				newData.addProperty("repository_url", repositoryUrlData.id());
+				newData.addProperty("repository_url", programmingLanguageData.id());
 				newData.addProperty("languages", scrapedJsonData);
 				allDataToSave.add(newData);
 			} catch (RuntimeException e) {

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainProgrammingLanguages.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/MainProgrammingLanguages.java
@@ -30,6 +30,7 @@ public class MainProgrammingLanguages {
 				newData.addProperty("languages", scrapedJsonData);
 				allDataToSave.add(newData);
 			} catch (RuntimeException e) {
+				System.out.println("Exception when handling data from url " + programmingLanguageData.url() + ":");
 				e.printStackTrace();
 			}
 		}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/OrderByDateSIRDecorator.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/OrderByDateSIRDecorator.java
@@ -13,18 +13,26 @@ public class OrderByDateSIRDecorator implements SoftwareInfoRepository {
 	}
 
 	@Override
-	public Collection<RepositoryUrlData> repositoryUrldata() {
-		Collection<RepositoryUrlData> data = origin.repositoryUrldata();
+	public Collection<ProgrammingLanguageData> repositoryUrlData() {
+		Collection<ProgrammingLanguageData> data = origin.repositoryUrlData();
 		return data.stream()
-				.sorted(Comparator.comparing(RepositoryUrlData::lastUpdated, Comparator.nullsFirst(Comparator.naturalOrder())))
+				.sorted(Comparator.comparing(ProgrammingLanguageData::lastUpdated, Comparator.nullsFirst(Comparator.naturalOrder())))
 				.toList();
 	}
 
 	@Override
-	public Collection<LicenseData> licenseData() {
-		Collection<LicenseData> data = origin.licenseData();
+	public Collection<RepositoryUrlData> licenseData() {
+		Collection<RepositoryUrlData> data = origin.licenseData();
 		return data.stream()
-				.sorted(Comparator.comparing(LicenseData::lastUpdated, Comparator.nullsFirst(Comparator.naturalOrder())))
+				.sorted(Comparator.comparing(RepositoryUrlData::licenseScrapedAt, Comparator.nullsFirst(Comparator.naturalOrder())))
+				.toList();
+	}
+
+	@Override
+	public Collection<RepositoryUrlData> commitData() {
+		Collection<RepositoryUrlData> data = origin.licenseData();
+		return data.stream()
+				.sorted(Comparator.comparing(RepositoryUrlData::commitHistoryScrapedAt, Comparator.nullsFirst(Comparator.naturalOrder())))
 				.toList();
 	}
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/PostgrestSIR.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/PostgrestSIR.java
@@ -19,9 +19,9 @@ public class PostgrestSIR implements SoftwareInfoRepository {
 	}
 
 	@Override
-	public Collection<RepositoryUrlData> repositoryUrldata() {
+	public Collection<ProgrammingLanguageData> repositoryUrlData() {
 		JsonArray data = JsonParser.parseString(Utils.getAsAdmin(baseUrl + "/repository_url?select=id,url,programming_languages(updated_at)")).getAsJsonArray();
-		Collection<RepositoryUrlData> result = new ArrayList<>();
+		Collection<ProgrammingLanguageData> result = new ArrayList<>();
 		for (JsonElement element : data) {
 			JsonObject jsonObject = element.getAsJsonObject();
 			String id = jsonObject.getAsJsonPrimitive("id").getAsString();
@@ -31,25 +31,39 @@ public class PostgrestSIR implements SoftwareInfoRepository {
 			if (!programmingLanguages.isEmpty()) {
 				updatedAt = LocalDateTime.parse(programmingLanguages.get(0).getAsJsonObject().getAsJsonPrimitive("updated_at").getAsString());
 			}
-			result.add(new RepositoryUrlData(id, url, updatedAt));
+			result.add(new ProgrammingLanguageData(id, url, updatedAt));
 		}
 		return result;
 	}
 
 	@Override
-	public Collection<LicenseData> licenseData() {
-		JsonArray data = JsonParser.parseString(Utils.getAsAdmin(baseUrl + "/repository_url?select=id,software,url,license_scraped_at)")).getAsJsonArray();
-		Collection<LicenseData> result = new ArrayList<>();
+	public Collection<RepositoryUrlData> licenseData() {
+		JsonArray data = JsonParser.parseString(Utils.getAsAdmin(baseUrl + "/repository_url")).getAsJsonArray();
+		Collection<RepositoryUrlData> result = new ArrayList<>();
 		for (JsonElement element : data) {
 			JsonObject jsonObject = element.getAsJsonObject();
 			String id = jsonObject.getAsJsonPrimitive("id").getAsString();
 			String software = jsonObject.getAsJsonPrimitive("software").getAsString();
 			String url = jsonObject.getAsJsonPrimitive("url").getAsString();
-			JsonElement jsonScrapedAt = jsonObject.get("license_scraped_at");
-			LocalDateTime updatedAt = jsonScrapedAt.isJsonNull() ? null : LocalDateTime.parse(jsonScrapedAt.getAsString());
-			result.add(new LicenseData(id, software, url, updatedAt));
+
+			JsonElement jsonLicence = jsonObject.get("license");
+			String license = jsonLicence.isJsonNull() ? null : jsonLicence.getAsString();
+			JsonElement jsonLicenseScrapedAt = jsonObject.get("license_scraped_at");
+			LocalDateTime licensScrapedAt = jsonLicenseScrapedAt.isJsonNull() ? null : LocalDateTime.parse(jsonLicenseScrapedAt.getAsString());
+
+			JsonElement jsonCommits = jsonObject.get("commit_history");
+			String commits = jsonCommits.isJsonNull() ? null : jsonCommits.getAsString();
+			JsonElement jsonCommitsScrapedAt = jsonObject.get("commit_history_scraped_at");
+			LocalDateTime commitsScrapedAt = jsonCommitsScrapedAt.isJsonNull() ? null : LocalDateTime.parse(jsonCommitsScrapedAt.getAsString());
+
+			result.add(new RepositoryUrlData(id, software, url, license, licensScrapedAt, commits, commitsScrapedAt));
 		}
 		return result;
+	}
+
+	@Override
+	public Collection<RepositoryUrlData> commitData() {
+		return licenseData();
 	}
 
 	@Override

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ProgrammingLanguageData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ProgrammingLanguageData.java
@@ -1,0 +1,6 @@
+package nl.esciencecenter.rsd.scraper;
+
+import java.time.LocalDateTime;
+
+public record ProgrammingLanguageData(String id, String url, LocalDateTime lastUpdated) {
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/RepositoryUrlData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/RepositoryUrlData.java
@@ -2,5 +2,6 @@ package nl.esciencecenter.rsd.scraper;
 
 import java.time.LocalDateTime;
 
-public record RepositoryUrlData(String id, String url, LocalDateTime lastUpdated) {
+public record RepositoryUrlData(String id, String software, String url, String license, LocalDateTime licenseScrapedAt,
+								String commitHistory, LocalDateTime commitHistoryScrapedAt) {
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/SoftwareInfo.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/SoftwareInfo.java
@@ -5,4 +5,6 @@ public interface SoftwareInfo {
 	String languages();
 
 	String license();
+
+	String contributions();
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/SoftwareInfoRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/SoftwareInfoRepository.java
@@ -4,9 +4,11 @@ import java.util.Collection;
 
 public interface SoftwareInfoRepository {
 
-	Collection<RepositoryUrlData> repositoryUrldata();
+	Collection<ProgrammingLanguageData> repositoryUrlData();
 
-	Collection<LicenseData> licenseData();
+	Collection<RepositoryUrlData> licenseData();
+
+	Collection<RepositoryUrlData> commitData();
 
 	void save(String data);
 }


### PR DESCRIPTION
# Commit history scraper

Changes proposed in this pull request:

* Add a commit history scraper, which scrapes the full commit history, e.g. from https://api.github.com/repos/research-software-directory/RSD-as-a-service/stats/contributors, and saves the data as a single JSON string aggregated per week

How to test:

* The database structure has changed, so we need to rebuild everything:
* `docker-compose down --volumes`
* `docker-compose build`
* `docker-compose up`
* Run the data migration script
* At 4, 10, 16, etc. minutes past the hour the commit history scraper should run and print two lines to the console
* Check https://localhost/api/v1/repository_url to see that data is indeed scraped and saved
* (The existing programming languages scraper should run at 0, 6, 12, etc. minutes past the hour)
* (The existing license scraper should run at 2, 8, 14, etc. minutes past the hour)

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests

Closes #91 