### PR TITLE
Participating organisations

### DIFF
--- a/frontend/components/layout/ImageAsBackground.tsx
+++ b/frontend/components/layout/ImageAsBackground.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable @next/next/no-img-element */
 import PhotoSizeSelectActualOutlinedIcon from '@mui/icons-material/PhotoSizeSelectActualOutlined'
 
-export default function ImageAsBackground({src, alt, className}:
-  { src: string, alt: string, className:string }) {
-  let imageUrl = src
-  if (!imageUrl) {
+export default function ImageAsBackground({src, alt, className, bgSize='cover'}:
+  { src: string | null | undefined, alt: string, className: string, bgSize?:string }) {
+
+  if (!src) {
     return (
       <div className="flex-1 flex flex-col justify-center items-center text-grey-500 bg-grey-200">
         <PhotoSizeSelectActualOutlinedIcon sx={{width: '5rem', height:'5rem'}} />
@@ -17,8 +17,8 @@ export default function ImageAsBackground({src, alt, className}:
       role="img"
       style={{
         flex: 1,
-        backgroundImage: `url('${imageUrl}')`,
-        backgroundSize: 'cover',
+        backgroundImage: `url('${src}')`,
+        backgroundSize: bgSize,
         backgroundPosition: 'center center',
         backgroundRepeat: 'no-repeat',
       }}

--- a/frontend/components/software/OrganisationsSection.tsx
+++ b/frontend/components/software/OrganisationsSection.tsx
@@ -1,0 +1,31 @@
+
+import {ParticipatingOrganisationProps} from '../../types/Organisation'
+import PageContainer from '../layout/PageContainer'
+import ParticipatingOrganisation from './ParticipatingOrganisation'
+
+export default function OrganisationsSection({organisations = []}: { organisations: ParticipatingOrganisationProps[] }) {
+  // do not render section if no data
+  if (organisations?.length === 0) return null
+
+  return (
+    <section>
+      <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
+        <h2
+          data-testid="software-contributors-section-title"
+          className="pb-8 text-[2rem] text-primary leading-10">
+          Participating organisations
+        </h2>
+        <section className="grid gap-8 auto-rows-[minmax(3rem,5rem)] md:grid-cols-4 xl:grid-cols-5">
+          {organisations.map((item, pos) => {
+            return (
+              <ParticipatingOrganisation
+                key={pos}
+                {...item}
+              />
+            )
+          })}
+        </section>
+      </PageContainer>
+    </section>
+  )
+}

--- a/frontend/components/software/ParticipatingOrganisation.tsx
+++ b/frontend/components/software/ParticipatingOrganisation.tsx
@@ -1,0 +1,60 @@
+
+import Avatar from '@mui/material/Avatar'
+import {ParticipatingOrganisationProps} from '../../types/Organisation'
+import ImageAsBackground from '../layout/ImageAsBackground'
+
+export default function OrganisationItem({name, website, logo_url}: ParticipatingOrganisationProps) {
+
+  function renderLogo() {
+    if (logo_url) {
+      return (
+        <ImageAsBackground
+          className="h-min-[3rem] h-max-[5rem] h-full"
+          src={logo_url}
+          alt={name}
+          bgSize="contain"
+        />
+      )
+    }
+    return (
+      <>
+      <Avatar
+        alt={name ?? ''}
+        src={logo_url ?? ''}
+        sx={{
+          width: '4rem',
+          height: '4rem',
+          fontSize: '2rem',
+          marginRight: '0.5rem',
+          '& img': {
+            height:'auto'
+          }
+        }}
+        variant="square"
+      >
+        {name.slice(0,3)}
+      </Avatar>
+      <span>{name}</span>
+      </>
+    )
+  }
+
+
+  if (website) {
+    return (
+      <a href={website} target="_blank"
+        title={name}
+        className="flex items-center" rel="noreferrer">
+        {renderLogo()}
+      </a>
+    )
+  }
+
+  return (
+    <div
+      title={name}
+      className="flex">
+      {renderLogo()}
+    </div>
+  )
+}

--- a/frontend/components/software/edit/organisations/index.tsx
+++ b/frontend/components/software/edit/organisations/index.tsx
@@ -6,7 +6,8 @@ import ContentLoader from '../../../layout/ContentLoader'
 import ConfirmDeleteModal from '../../../layout/ConfirmDeleteModal'
 import {
   EditOrganisation,
-  SearchOrganisation
+  SearchOrganisation,
+  SoftwareForOrganisation
 } from '../../../../types/Organisation'
 import {sortOnStrProp} from '../../../../utils/sortFn'
 import {
@@ -81,6 +82,10 @@ export default function SoftwareOganisations({session}:{session:Session}) {
         token: session.token
       })
       if (resp.status === 200) {
+        // update status received in message
+        addOrganisation.status = resp.message as SoftwareForOrganisation['status']
+        // assume logo is uploaded?!?
+        addOrganisation.logo_id = item.id
         addOrganisationToList(addOrganisation)
       } else {
         showErrorMessage(resp.message)

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -43,6 +43,9 @@ import {SoftwareCitationInfo} from '../../../types/SoftwareCitation'
 import {Contributor} from '../../../types/Contributor'
 import {Testimonial} from '../../../types/Testimonial'
 import {MentionForSoftware} from '../../../types/MentionType'
+import {ParticipatingOrganisationProps} from '../../../types/Organisation'
+import {getParticipatingOrganisations} from '../../../utils/editOrganisation'
+import OrganisationsSection from '../../../components/software/OrganisationsSection'
 
 interface SoftwareIndexData extends ScriptProps{
   slug: string
@@ -56,7 +59,8 @@ interface SoftwareIndexData extends ScriptProps{
   testimonials: Testimonial[]
   contributors: Contributor[]
   relatedTools: RelatedTools[]
-  isMaintainer: boolean
+  isMaintainer: boolean,
+  organisations: ParticipatingOrganisationProps[]
 }
 
 export default function SoftwareIndexPage(props:SoftwareIndexData) {
@@ -67,7 +71,8 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
     software, citationInfo, tagsInfo,
     licenseInfo, repositoryInfo, softwareIntroCounts,
     mentions, testimonials, contributors,
-    relatedTools, isMaintainer, slug
+    relatedTools, isMaintainer, slug,
+    organisations
   } = props
 
   useEffect(() => {
@@ -142,6 +147,13 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
         repository={repositoryInfo?.url}
         languages={repositoryInfo?.languages}
       />
+      <OrganisationsSection
+        organisations={organisations}
+      />
+      {/* <section>
+        <h2>Participating organisations</h2>
+        {JSON.stringify(organisations,null,2)}
+      </section> */}
       <MentionsSection
         mentions={mentions}
       />
@@ -207,7 +219,9 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       // relatedTools
       getRelatedToolsForSoftware({software:software.id,frontend:false,token}),
       // check if maintainer
-      isMaintainerOfSoftware({slug,account,token,frontend:false})
+      isMaintainerOfSoftware({slug, account, token, frontend: false}),
+      // get organisations
+      getParticipatingOrganisations({software:software.id,frontend:false,token})
     ]
     const [
       citationInfo,
@@ -219,7 +233,8 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       testimonials,
       contributors,
       relatedTools,
-      isMaintainer
+      isMaintainer,
+      organisations
     ] = await Promise.all(fetchData)
 
     // pass data to page component as props
@@ -236,6 +251,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
         contributors,
         relatedTools,
         isMaintainer,
+        organisations,
         slug
       }
     }

--- a/frontend/types/Organisation.ts
+++ b/frontend/types/Organisation.ts
@@ -49,3 +49,9 @@ export type OrganisationsForSoftware={
   status: Status
 }
 
+export type ParticipatingOrganisationProps = {
+  name: string
+  website: string | null
+  logo_url: string | null
+}
+


### PR DESCRIPTION
# Software page, participating organisation

Closes #88 

Changes proposed in this pull request:

*     Show participating organisations on the software page

How to test:

* `docker-compose down --volumes`: remove old database
* `docker-compose build`: build new solution
* `docker-compose up`: start solution
*  Login to RSD as professor1
*  Create new software
*  Navigate to organisation section and add organisations
*  Upload logos for some organisation, so you have some organisation with logo and some without the logo
*  View software page, you should see organisations listed. Each organisation has a link to their website that opens in separate tab
*  Logout, you should still be able to see organisations and logos on the software page

![image](https://user-images.githubusercontent.com/9204081/159227445-fafe68c5-c019-42a0-addc-0541b233607a.png)


**The organisations without logo are represented with an suqare containing first 3 letters and name**, as in the example bellow
![image](https://user-images.githubusercontent.com/9204081/159227828-8e5b4862-f2ce-4df0-8d32-77b3640d6877.png)


PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
