### PR TITLE
Updated howfairis github action to 0.2.1

### DIFF
--- a/.github/workflows/fair_software.yml
+++ b/.github/workflows/fair_software.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       # https://github.com/fair-software/howfairis-github-action
       - name: Measure compliance with fair-software.eu recommendations
-        uses: fair-software/howfairis-github-action@0.2.0
+        uses: fair-software/howfairis-github-action@0.2.1
         env:
           PYCHARM_HOSTED: "Trick colorama into displaying colored output"
         with:


### PR DESCRIPTION
# Bump patch version for fair-software github action

Fixes #N/A

Changes proposed in this pull request:

* Bumped patch version of https://github.com/marketplace/actions/fair-software

How to test:

* before merging use the workflow dispatch trigger to start the fair-software workflow. It should fail with a "gcc can't be found" type of error. This error has been fixed in 0.2.1 of said github action. Not sure if you get the option to run the updated workflow via its `workflow_dispatch`, but if not, just merge and check afterwards; roll back if needed.

PR Checklist:

*   [ ] Link to a GitHub issue _nope_
*   [ ] Update documentation _nope_
*   [ ] Tests _nope_
