### PR TITLE
160 organisations overview

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -62,3 +62,47 @@ FROM
 ORDER BY
 	display_name asc
 ;
+
+-- Participating organisations by software
+CREATE VIEW organisations_for_software AS
+SELECT
+	organisation.id as id,
+	organisation.slug,
+	organisation.primary_maintainer,
+	organisation.name,
+	organisation.ror_id,
+	organisation.is_tenant,
+	organisation.website,
+	logo_for_organisation.id as logo_id,
+	software_for_organisation.status,
+	software.id as software
+FROM
+	software
+INNER JOIN
+	software_for_organisation on software.id=software
+INNER JOIN
+	organisation on software_for_organisation.organisation = organisation.id
+LEFT JOIN
+	logo_for_organisation on logo_for_organisation.id = organisation.id
+;
+
+-- Software count by organisation
+CREATE VIEW software_count_by_organisation AS
+SELECT
+	organisation, count(organisation) as software_cnt
+FROM
+	software_for_organisation
+GROUP BY organisation
+;
+
+-- Organisations overview
+CREATE VIEW organisations_overview AS
+SELECT
+	organisation.id as id,slug,name,website,ror_id,logo_for_organisation.id as logo_id,software_cnt
+FROM
+	organisation
+LEFT JOIN
+	software_count_by_organisation on organisation = organisation.id
+LEFT JOIN
+	logo_for_organisation on organisation = logo_for_organisation.id
+;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.13
+    image: rsd/database:0.0.14
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -24,7 +24,7 @@ services:
   backend:
     container_name: backend
     build: ./backend-postgrest
-    image: rsd/backend-postgrest:0.0.2
+    image: rsd/backend-postgrest:0.0.3
     expose:
       - 3500
     environment:
@@ -66,7 +66,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.5.9
+    image: rsd/frontend:0.6.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -9,26 +9,15 @@ Based on the features in the legacy application and the current requirements we 
 ## Development
 
 - intall dependencies `yarn install`
-- create env.local and env.production.local file. Use env.local.example as template.
+- create env.local file. Use env.example from the project root as template.
 - run all app modules `docker-compose up`
-- open another terminal and run `yarn dev` to start application in development mode
+- open another terminal and run `yarn dev` to start frontend in development mode
 
 ### Environment variables
 
-For oAuth implementation we need env variables. Copy env.local.example file to `env.local` and provide values required for next-auth module. In addition we use few public env variables that exposed to the browser. These values are stored in .env file. See [next documentation page for more info](https://nextjs.org/docs/basic-features/environment-variables).
+For oAuth implementation we need env variables. Copy env.example file to `env.local` and provide the values See [next documentation page for more info](https://nextjs.org/docs/basic-features/environment-variables).
 
-- `env` file contains public env variables. If different values are required for production create env.production file
-- `env.development` development specific values, when running frontend using `yarn dev`.
 - `env.local` contains secrets when running frontend in local development (yarn dev). This file is not in the repo. You will need to create it and add secrets to it.
-- `env.local.example` this is example file. copy to env.local for local development and env.production.local
-- `env.production.local` file is used when running frontend with docker compose `docker-compose up`.
-
-## Docker compose frontend only
-
-Use `docker-compose up` to run solution in Docker container. The solution is avaliable at http://localhost:3000
-To rebuild the image run `docker-compose up --build`.
-
-The image version is defined in docker-compose.yml file. When you inrease version number in the docker-compose.yml file new build will triggered even if you run `docker-compose up` without build flag. Please keep the version numbers in `package.json` and in `docker-compose.yml` the same. At this point this requires manual change at both file, later we should look for the ways to automate it in the CI/CD pipelines.
 
 ## Folders
 
@@ -78,7 +67,7 @@ The integration is based on [this article](https://medium.com/@akarX23/a-full-se
 
 ## Authentication
 
-For authentication we use `next-auth`. For more information see [official documentation](https://next-auth.js.org/getting-started/example).
+For authentication we use custom module which integrates with our auth service. The frontend code is in `frontend/auth` folder and the auth service is in `authentication` folder.
 
 ## Unit testing
 
@@ -95,9 +84,8 @@ The setup is performed according to [official Next documentation](https://nextjs
 ```bash
 # install dependencies
 npm install --save-dev jest @testing-library/react @testing-library/jest-dom react-test-renderer
-# install jest-fetch-mock support fetch in Jest (node environment not browser)
-# and whatwg-fetch to address next-auth fetch requests on node js (node-fetch)
-npm i -D jest-fetch-mock whatwg-fetch
+# install whatwg-fetch to address next-auth fetch requests on node js (node-fetch)
+npm i -D whatwg-fetch
 
 ```
 
@@ -111,12 +99,6 @@ import "whatwg-fetch";
 // specific
 import "@testing-library/jest-dom/extend-expect";
 ```
-
-### Fetch mock
-
-I tried to use fetch mock. More [info about setup here](https://frontend-digest.com/testing-getserversideprops-in-nextjs-b339ebcf3401).
-
-**The fetch mock library does not integrate well with next-auth. When enabled it causes error in session provider of next-auth. Further investigation is required.**
 
 ## NextJS
 

--- a/frontend/components/form/Searchbox.tsx
+++ b/frontend/components/form/Searchbox.tsx
@@ -5,7 +5,7 @@ import SearchIcon from '@mui/icons-material/Search'
 import {useDebounce} from '../../utils/useDebouce'
 import ClearIcon from '@mui/icons-material/Clear'
 
-export default function Searchbox({onSearch,delay=400}:{onSearch:Function,delay?:number}) {
+export default function Searchbox({placeholder, onSearch, delay = 400}: { placeholder:string,onSearch:Function,delay?:number}) {
   const [state,setState]=useState({
     value:'',
     wait:true
@@ -27,7 +27,7 @@ export default function Searchbox({onSearch,delay=400}:{onSearch:Function,delay?
     <Input
       id="search-input"
       autoComplete='off'
-      placeholder='Search for software'
+      placeholder={placeholder}
       value={state.value}
       sx={{
         minWidth:['inherit','17.5rem','19.5rem']

--- a/frontend/components/form/Searchbox.tsx
+++ b/frontend/components/form/Searchbox.tsx
@@ -30,7 +30,7 @@ export default function Searchbox({placeholder, onSearch, delay = 400}: { placeh
       placeholder={placeholder}
       value={state.value}
       sx={{
-        minWidth:['inherit','17.5rem','19.5rem']
+        minWidth:['inherit','20.5rem','19.5rem']
       }}
       onChange={({target})=>{
         setState({

--- a/frontend/components/layout/ImageAsBackground.tsx
+++ b/frontend/components/layout/ImageAsBackground.tsx
@@ -1,14 +1,19 @@
 /* eslint-disable @next/next/no-img-element */
 import PhotoSizeSelectActualOutlinedIcon from '@mui/icons-material/PhotoSizeSelectActualOutlined'
 
-export default function ImageAsBackground({src, alt, className, bgSize='cover'}:
-  { src: string | null | undefined, alt: string, className: string, bgSize?:string }) {
+export default function ImageAsBackground({src, alt, className, bgSize='cover', noImgMsg='no image avaliable'}:
+  {src: string | null | undefined, alt: string, className: string, bgSize?:string, noImgMsg?:string }) {
 
   if (!src) {
     return (
-      <div className="flex-1 flex flex-col justify-center items-center text-grey-500 bg-grey-200">
-        <PhotoSizeSelectActualOutlinedIcon sx={{width: '5rem', height:'5rem'}} />
-        <div className="uppercase">no image avaliable</div>
+      <div className="flex-1 h-full flex flex-col justify-center items-center text-grey-500 bg-grey-50 rounded-md">
+        <PhotoSizeSelectActualOutlinedIcon
+          sx={{
+            width: '4rem',
+            height: '4rem'
+          }}
+        />
+        <div className="uppercase">{noImgMsg}</div>
       </div>
     )
   }

--- a/frontend/components/organisation/OrganisationCard.tsx
+++ b/frontend/components/organisation/OrganisationCard.tsx
@@ -1,0 +1,47 @@
+import Link from 'next/link'
+import {OrganisationForOverview} from '../../types/Organisation'
+import {getUrlFromLogoId} from '../../utils/editOrganisation'
+import ImageAsBackground from '../layout/ImageAsBackground'
+
+export default function OrganisationCard(organisation: OrganisationForOverview) {
+
+  function renderCount() {
+    const count = organisation.software_cnt ?? 0
+    let label = 'software packages'
+    if (organisation?.software_cnt === 1) label = 'software package'
+    return (
+      <div className="flex-1 flex flex-col px-8 py-4">
+        <div className="flex-1 flex items-center justify-center text-[4rem] text-primary">
+          {count}
+        </div>
+        <div className="flex items-center justify-center">
+          {label}
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <Link
+      href={`/organisation/${organisation.slug}`}
+      passHref>
+      <a>
+        <div className="flex flex-col border rounded-sm p-4 h-full min-h-[16rem]">
+          <h2 className='h-[4rem]'>{organisation.name}</h2>
+          <div className="flex-1 flex">
+            <div className="flex-1 flex items-center">
+              <ImageAsBackground
+                className="h-min-[3rem] h-max-[5rem] h-full"
+                src={getUrlFromLogoId(organisation.logo_id)}
+                alt={organisation.name}
+                bgSize="contain"
+                noImgMsg='no logo'
+              />
+            </div>
+            {renderCount()}
+          </div>
+        </div>
+      </a>
+    </Link>
+  )
+}

--- a/frontend/components/organisation/OrganisationCard.tsx
+++ b/frontend/components/organisation/OrganisationCard.tsx
@@ -1,25 +1,21 @@
+import {Avatar} from '@mui/material'
 import Link from 'next/link'
 import {OrganisationForOverview} from '../../types/Organisation'
 import {getUrlFromLogoId} from '../../utils/editOrganisation'
-import ImageAsBackground from '../layout/ImageAsBackground'
 
 export default function OrganisationCard(organisation: OrganisationForOverview) {
 
-  function renderCount() {
+  function getCountAndLabel() {
     const count = organisation.software_cnt ?? 0
     let label = 'software packages'
     if (organisation?.software_cnt === 1) label = 'software package'
-    return (
-      <div className="flex-1 flex flex-col px-8 py-4">
-        <div className="flex-1 flex items-center justify-center text-[4rem] text-primary">
-          {count}
-        </div>
-        <div className="flex items-center justify-center">
-          {label}
-        </div>
-      </div>
-    )
+    return {
+      count,
+      label
+    }
   }
+
+  const {count, label} = getCountAndLabel()
 
   return (
     <Link
@@ -30,15 +26,30 @@ export default function OrganisationCard(organisation: OrganisationForOverview) 
           <h2 className='h-[4rem]'>{organisation.name}</h2>
           <div className="flex-1 flex">
             <div className="flex-1 flex items-center">
-              <ImageAsBackground
-                className="h-min-[3rem] h-max-[5rem] h-full"
-                src={getUrlFromLogoId(organisation.logo_id)}
-                alt={organisation.name}
-                bgSize="contain"
-                noImgMsg='no logo'
-              />
+              <Avatar
+                alt={organisation.name ?? ''}
+                src={getUrlFromLogoId(organisation.logo_id) ?? ''}
+                sx={{
+                  width: '100%',
+                  height: '100%',
+                  fontSize: '3rem',
+                  '& img': {
+                    height:'auto'
+                  }
+                }}
+                variant="square"
+              >
+                {organisation.name.slice(0,3)}
+              </Avatar>
             </div>
-            {renderCount()}
+             <div className="flex-1 flex flex-col px-8 py-4">
+              <div className="flex-1 flex items-center justify-center text-[4rem] text-primary">
+                {count}
+              </div>
+              <div className="flex items-center justify-center">
+                {label}
+              </div>
+            </div>
           </div>
         </div>
       </a>

--- a/frontend/components/organisation/OrganisationGrid.tsx
+++ b/frontend/components/organisation/OrganisationGrid.tsx
@@ -1,0 +1,29 @@
+import {OrganisationForOverview} from '../../types/Organisation'
+import ContentInTheMiddle from '../layout/ContentInTheMiddle'
+import OrganisationCard from './OrganisationCard'
+
+// render software cards
+export default function OrganisationsGrid({organisations}:{organisations:OrganisationForOverview[]}){
+  // console.log("renderItems...software...", software)
+
+  if (organisations.length===0){
+    return (
+      <ContentInTheMiddle>
+        <h2>No content</h2>
+      </ContentInTheMiddle>
+    )
+  }
+
+  return (
+    <section className='grid grid-cols-1 gap-[0.125rem] sm:grid-cols-2 lg:grid-cols-3 hd:grid-cols-4 py-4 px-[0.0625rem]'>
+      {organisations.map(item=>{
+        return(
+          <OrganisationCard
+            key={item.id}
+            {...item}
+          />
+        )
+      })}
+    </section>
+  )
+}

--- a/frontend/config/menuItems.ts
+++ b/frontend/config/menuItems.ts
@@ -12,7 +12,8 @@ export type MenuItemType = {
 export const menuItems:MenuItemType[] = [
   // {path:"/", label:"Home"},
   {path:'/software', label:'Software'},
-  {path:'/projects', label:'Projects'},
+  {path: '/projects', label: 'Projects'},
+  {path: '/organisation', label: 'Organisations'},
   // will be done later
   // {path:"/about", label:"About"},
 ]

--- a/frontend/pages/logout.tsx
+++ b/frontend/pages/logout.tsx
@@ -1,45 +1,57 @@
 import {useEffect} from 'react'
+import {GetServerSidePropsContext} from 'next'
+import {useRouter} from 'next/router'
 import ContentInTheMiddle from '../components/layout/ContentInTheMiddle'
 import {getRsdTokenNode, removeRsdTokenNode} from '../auth'
 import Button from '@mui/material/Button'
-import {useAuth, defaultSession, Session} from '../auth'
 
-export default function Logout({session}:{session:Session}) {
-  const {setSession} = useAuth()
+type RedirectProps = {
+  destination: string,
+  statusCode?: number,
+  permanent: boolean
+}
+
+export default function Logout({redirect}: { redirect: RedirectProps }) {
+  const router = useRouter()
+  // in case we did reach frontend page somehow?!?
+  // we will redirect you (again)
   useEffect(() => {
-    setSession(session)
-  },[session,setSession])
+    router.replace(redirect.destination)
+  },[redirect.destination,router])
+
+  // this content should not be visible
   return (
     <ContentInTheMiddle>
       <div className="border p-12">
         <h1>You are logged out!</h1>
         <p className="py-8">
-          You can go now doing something else :-)
-         </p>
-         <Button onClick={() => window.location.href = '/'}>
+          You can now do something else :-)
+        </p>
+        <Button onClick={() => window.location.href = '/'}>
            Home
-         </Button>
+        </Button>
       </div>
     </ContentInTheMiddle>
   )
 }
 
-export function getServerSideProps(context: any) {
-  const {req, res} = context
+export function getServerSideProps(context: GetServerSidePropsContext) {
+  const {req,res} = context
   // get token
   const token = getRsdTokenNode(req)
-  // console.group('Logout')
-  // console.log('session...', session)
+  // get last visited path
+  // const redirect = req.cookies['rsd_pathname']
+  // console.log('redirect to...', redirect)
   // remove old cookie
   if (token) {
     // console.log('removeRsdTokenNode...')
     removeRsdTokenNode(res)
   }
-  // console.groupEnd()
+  // redirect to home
   return {
-    props: {
-      // return default
-      session: defaultSession
-    }
+    redirect: {
+      destination: '/',
+      permanent: false
+    },
   }
 }

--- a/frontend/pages/organisation/[slug]/index.tsx
+++ b/frontend/pages/organisation/[slug]/index.tsx
@@ -4,12 +4,8 @@ import {useRouter} from 'next/router'
 import DefaultLayout from '../../../components/layout/DefaultLayout'
 import PageTitle from '../../../components/layout/PageTitle'
 import IconButton from '@mui/material/IconButton'
-import EditIcon from '@mui/icons-material/Edit'
 import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 import {useAuth} from '../../../auth'
-
-import {getProjectItem} from '../../../utils/getProjects'
-import {ProjectItem} from '../../../types/ProjectItem'
 
 export default function OrganisationPage({organisation, slug}:{organisation:any, slug:string}) {
   const router = useRouter()
@@ -51,11 +47,9 @@ export default function OrganisationPage({organisation, slug}:{organisation:any,
 export async function getServerSideProps(context:any) {
   try{
     const {params} = context
-    console.log('getServerSideProps...params...', params)
-
+    // console.log('getServerSideProps...params...', params)
     return {
-    // will be passed to the page component as props
-    // see params in SoftwareIndexPage
+      // passed to the page component as props
       props: {
         organisation: null,
         slug: params?.slug

--- a/frontend/pages/organisation/[slug]/index.tsx
+++ b/frontend/pages/organisation/[slug]/index.tsx
@@ -1,0 +1,68 @@
+import Head from 'next/head'
+import {useRouter} from 'next/router'
+
+import DefaultLayout from '../../../components/layout/DefaultLayout'
+import PageTitle from '../../../components/layout/PageTitle'
+import IconButton from '@mui/material/IconButton'
+import EditIcon from '@mui/icons-material/Edit'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+import {useAuth} from '../../../auth'
+
+import {getProjectItem} from '../../../utils/getProjects'
+import {ProjectItem} from '../../../types/ProjectItem'
+
+export default function OrganisationPage({organisation, slug}:{organisation:any, slug:string}) {
+  const router = useRouter()
+  const {session: {status}} = useAuth()
+  // console.log("useSession.status...", status)
+  return (
+    <DefaultLayout>
+      <Head>
+        <title>Organisation | RSD</title>
+      </Head>
+      <PageTitle title="Under construction">
+        <div>
+          <IconButton
+            title="Go back"
+            onClick={()=>router.back()}>
+            <ArrowBackIcon />
+          </IconButton>
+          {/* <IconButton
+            title="Edit"
+            onClick={()=>router.push(`/projects/${slug}/edit`)}
+            disabled={status!=='authenticated'}
+          >
+            <EditIcon />
+          </IconButton> */}
+        </div>
+      </PageTitle>
+      <h2 className='my-4'>
+        Slug: {slug}
+      </h2>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Facilis quo corporis nostrum eum beatae aperiam hic dolorem ipsum laborum mollitia.
+      </p>
+    </DefaultLayout>
+  )
+}
+
+// fetching data server side
+// see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
+export async function getServerSideProps(context:any) {
+  try{
+    const {params} = context
+    console.log('getServerSideProps...params...', params)
+
+    return {
+    // will be passed to the page component as props
+    // see params in SoftwareIndexPage
+      props: {
+        organisation: null,
+        slug: params?.slug
+      },
+    }
+  }catch(e){
+    return {
+      notFound: true,
+    }
+  }}

--- a/frontend/pages/organisation/index.tsx
+++ b/frontend/pages/organisation/index.tsx
@@ -1,0 +1,114 @@
+import {MouseEvent, ChangeEvent} from 'react'
+import Head from 'next/head'
+import {useRouter} from 'next/router'
+import TablePagination from '@mui/material/TablePagination'
+
+import {app} from '../../config/app'
+import DefaultLayout from '../../components/layout/DefaultLayout'
+import PageTitle from '../../components/layout/PageTitle'
+import Searchbox from '../../components/form/Searchbox'
+import {ssrOrganisationUrl} from '../../utils/postgrestUrl'
+import {OrganisationForOverview} from '../../types/Organisation'
+import {rowsPerPageOptions} from '../../config/pagination'
+import {ssrSoftwareParams} from '../../utils/extractQueryParam'
+import {getOrganisationsList} from '../../utils/getOrganisations'
+import OrganisationsGrid from '../../components/organisation/OrganisationGrid'
+
+export default function OrganisationsIndexPage({count,page,rows,organisations=[]}:
+  {count:number,page:number,rows:number,organisations:OrganisationForOverview[]
+}) {
+  // use next router (hook is only for browser)
+  const router = useRouter()
+
+  // next/previous page button
+  function handlePageChange(
+    event: MouseEvent<HTMLButtonElement> | null,
+    newPage: number,
+  ){
+    const url = ssrOrganisationUrl({
+      query: router.query,
+      page: newPage
+    })
+    router.push(url)
+  }
+
+  // change number of cards per page
+  function handleItemsPerPage(
+    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+  ){
+    const url = ssrOrganisationUrl({
+      query: router.query,
+      // reset to first page
+      page: 0,
+      rows: parseInt(event.target.value),
+    })
+    router.push(url)
+  }
+
+  function handleSearch(searchFor:string){
+    const url = ssrOrganisationUrl({
+      query: router.query,
+      search: searchFor,
+      // start from first page
+      page: 0
+    })
+    router.push(url)
+  }
+
+  return (
+     <DefaultLayout>
+      <Head>
+        <title>Organisations | {app.title}</title>
+      </Head>
+      <PageTitle title="Organisations">
+        <div className="flex flex-wrap justify-end">
+          <div className="flex items-center">
+            <Searchbox
+              placeholder='Search for organisation'
+              onSearch={handleSearch}
+            />
+          </div>
+          <TablePagination
+            component="nav"
+            count={count}
+            page={page}
+            labelRowsPerPage="Per page"
+            onPageChange={handlePageChange}
+            rowsPerPage={rows}
+            rowsPerPageOptions={rowsPerPageOptions}
+            onRowsPerPageChange={handleItemsPerPage}
+          />
+        </div>
+      </PageTitle>
+      <OrganisationsGrid
+        organisations={organisations}
+      />
+    </DefaultLayout>
+  )
+}
+
+
+// fetching data server side
+// see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
+export async function getServerSideProps(context: any) {
+  // extract params from page-query
+  const {search, rows, page} = ssrSoftwareParams(context)
+
+  const {count, data} = await getOrganisationsList({
+    search,
+    rows,
+    page,
+    token: undefined
+  })
+
+  // will be passed as props to page
+  // see params of SoftwareIndexPage function
+  return {
+    props: {
+      count,
+      page,
+      rows,
+      organisations:data
+    }
+  }
+}

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -6,7 +6,7 @@ import TablePagination from '@mui/material/TablePagination'
 import {app} from '../../config/app'
 import DefaultLayout from '../../components/layout/DefaultLayout'
 import PageTitle from '../../components/layout/PageTitle'
-import Searchbox from '../../components/software/Searchbox'
+import Searchbox from '../../components/form/Searchbox'
 import FilterTechnologies from '../../components/software/FilterTechnologies'
 import SortSelection from '../../components/software/SortSelection'
 import SoftwareGrid from '../../components/software/SoftwareGrid'
@@ -88,7 +88,10 @@ export default function SoftwareIndexPage({count,page,rows,tags,software=[]}:
       <PageTitle title="Software">
         <div className="flex flex-wrap justify-end">
           <div className="flex items-center">
-            <Searchbox onSearch={handleSearch}></Searchbox>
+            <Searchbox
+              placeholder="Search for software"
+              onSearch={handleSearch}
+            />
             <FilterTechnologies
               items={tags}
               onSelect={handleFilters}

--- a/frontend/pages/user/profile.tsx
+++ b/frontend/pages/user/profile.tsx
@@ -1,19 +1,40 @@
+import {useRouter} from 'next/router'
 import {useAuth} from '../../auth'
 import DefaultLayout from '../../components/layout/DefaultLayout'
 import ProtectedContent from '../../auth/ProtectedContent'
+import PageTitle from '../../components/layout/PageTitle'
+import IconButton from '@mui/material/IconButton'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
 
 export default function UserProfilePage() {
   const {session} = useAuth()
+  const router = useRouter()
 
   return (
     <DefaultLayout>
       <ProtectedContent>
-        <h1>Profile page</h1>
-        <h2>User status: {session?.status}</h2>
-        <h2>Profile info</h2>
-        <pre>
-          {JSON.stringify(session,null,2)}
-        </pre>
+        <PageTitle title="UNDER CONSTRUCTION: user profile page">
+        <div>
+          <IconButton
+            title="Go back"
+            onClick={()=>router.back()}>
+            <ArrowBackIcon />
+          </IconButton>
+          {/* <IconButton
+            title="Edit"
+            onClick={()=>router.push(`/projects/${slug}/edit`)}
+            disabled={status!=='authenticated'}
+          >
+            <EditIcon />
+          </IconButton> */}
+        </div>
+      </PageTitle>
+      <h2 className='my-4'>
+        User status: {session?.status}
+      </h2>
+      <pre>
+        {JSON.stringify(session,null,2)}
+      </pre>
       </ProtectedContent>
     </DefaultLayout>
   )

--- a/frontend/pages/user/software.tsx
+++ b/frontend/pages/user/software.tsx
@@ -1,11 +1,40 @@
+import {useRouter} from 'next/router'
+
 import DefaultLayout from '../../components/layout/DefaultLayout'
 import ProtectedContent from '../../auth/ProtectedContent'
 
-export default function UserProfilePage() {
+import PageTitle from '../../components/layout/PageTitle'
+import IconButton from '@mui/material/IconButton'
+import ArrowBackIcon from '@mui/icons-material/ArrowBack'
+
+
+export default function UserSoftwarePage() {
+  const router = useRouter()
   return (
     <DefaultLayout>
       <ProtectedContent>
-        <h1>User software page</h1>
+        <PageTitle title="UNDER CONSTRUCTION: user software page">
+        <div>
+          <IconButton
+            title="Go back"
+            onClick={()=>router.back()}>
+            <ArrowBackIcon />
+          </IconButton>
+          {/* <IconButton
+            title="Edit"
+            onClick={()=>router.push(`/projects/${slug}/edit`)}
+            disabled={status!=='authenticated'}
+          >
+            <EditIcon />
+          </IconButton> */}
+        </div>
+      </PageTitle>
+      <h2 className='my-4'>
+        User software page
+      </h2>
+      <p>
+        Lorem ipsum dolor sit amet consectetur adipisicing elit. Facilis quo corporis nostrum eum beatae aperiam hic dolorem ipsum laborum mollitia.
+      </p>
       </ProtectedContent>
     </DefaultLayout>
   )

--- a/frontend/types/Organisation.ts
+++ b/frontend/types/Organisation.ts
@@ -1,7 +1,8 @@
 // object for organisation
+// based on organisation table
 export type Organisation = {
   id: string | null
-  slug?: string
+  slug?: string | null
   primary_maintainer?: string
   name: string
   ror_id?: string
@@ -43,10 +44,18 @@ export type SoftwareForOrganisation = {
 }
 
 // object returned from api
+// based on view organisations_for_software
 export type OrganisationsForSoftware={
-  software: string
-  organisation: Organisation
+  id: string
+  slug: string | null
+  primary_maintainer: string
+  name: string
+  ror_id: string
+  is_tenant: boolean
+  website: string | null
+  logo_id: string | null
   status: Status
+  software: string
 }
 
 export type ParticipatingOrganisationProps = {
@@ -55,3 +64,12 @@ export type ParticipatingOrganisationProps = {
   logo_url: string | null
 }
 
+export type OrganisationForOverview = {
+  id: string
+  slug: string | null
+  name: string
+  website: string
+  ror_id: string
+  logo_id: string
+  software_cnt: number | null
+}

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -1,0 +1,57 @@
+import {extractCountFromHeader} from './extractCountFromHeader'
+import {createJsonHeaders} from './fetchHelpers'
+import logger from './logger'
+
+
+export function organisationUrl({search, rows = 12, page = 0}:
+  { search: string | undefined, rows: number, page: number }) {
+  // by default order is on software count and name
+  let url = `${process.env.POSTGREST_URL}/organisations_overview?order=software_cnt.desc,name.asc`
+  if (search) {
+    url+=`&or=(name.ilike.*${search}*,website.ilike.*${search}*)`
+  }
+  if (rows) {
+    url +=`&limit=${rows}`
+  }
+  if (page) {
+    url +=`&offset=${page * rows}`
+  }
+  return url
+}
+
+export async function getOrganisationsList({search,rows,page,token}:
+  { search: string|undefined,rows:number,page:number,token: string|undefined}) {
+  try {
+    const url = organisationUrl({search,rows,page})
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+        // request record count to be returned
+        // note: it's returned in the header
+        'Prefer':'count=exact'
+      },
+    })
+
+    if (resp.status === 200) {
+      const json = await resp.json()
+      return {
+        count: extractCountFromHeader(resp.headers),
+        data: json
+      }
+    }
+    // otherwise request failed
+    logger(`getSoftwareList failed: ${resp.status} ${resp.statusText}`, 'warn')
+    // we log and return zero
+    return {
+      count: 0,
+      data: []
+    }
+  } catch (e: any) {
+    logger(`getOrganisationsList: ${e?.message}`, 'error')
+    return {
+      count: 0,
+      data: []
+    }
+  }
+}

--- a/frontend/utils/getPropsFromObject.ts
+++ b/frontend/utils/getPropsFromObject.ts
@@ -1,19 +1,24 @@
 import logger from './logger'
 
-export function getPropsFromObject(data:any, props: string[],useNull:boolean=true) {
-  let newData:any = {}
-  props.forEach((prop:any) => {
-    if (data.hasOwnProperty(prop)) {
-      if (useNull && data[prop] === '') {
-        newData[prop] = null
+export function getPropsFromObject(data: any, props: string[], useNull: boolean = true) {
+  try {
+    let newData:any = {}
+    props.forEach((prop:any) => {
+      if (data.hasOwnProperty(prop)) {
+        if (useNull && data[prop] === '') {
+          newData[prop] = null
+        } else {
+          newData[prop] = data[prop]
+        }
+      } else if (useNull===true) {
+        newData[prop]=null
       } else {
-        newData[prop] = data[prop]
+        logger(`Property [${prop}] not present in data object`, 'warn')
       }
-    } else if (useNull===true) {
-      newData[prop]=null
-    } else {
-      logger(`Property [${prop}] not present in data object`, 'warn')
-    }
-  })
-  return newData
+    })
+    return newData
+  } catch (e:any) {
+    logger(`getPropsFromObject: ${e.message}`,'error')
+    return {}
+  }
 }

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -59,35 +59,47 @@ type QueryParams={
 }
 
 export function ssrSoftwareUrl(params:QueryParams){
-  const {search,filter,rows,page,query} = params
-  let url='/software?'
-  if (search){
-    url+=`search=${encodeURIComponent(search)}`
-  } else if (search===''){
+  const view = 'software'
+  const url = ssrUrl(params, view)
+  return url
+}
+
+export function ssrOrganisationUrl(params: QueryParams) {
+  const view = 'organisation'
+  const url = ssrUrl(params,view)
+  return url
+}
+
+function ssrUrl(params: QueryParams, view:string) {
+  const {search, filter, rows, page, query} = params
+  let url = `/${view}?`
+  if (search) {
+    url += `search=${encodeURIComponent(search)}`
+  } else if (search === '') {
     //remove search query
-  } else if (query?.search){
-    url+=`search=${encodeURIComponent(query.search.toString())}`
+  } else if (query?.search) {
+    url += `search=${encodeURIComponent(query.search.toString())}`
   }
-  if (filter){
-    url+=`&filter=${encodeURIComponent(filter)}`
-  } else if (filter===null){
+  if (filter) {
+    url += `&filter=${encodeURIComponent(filter)}`
+  } else if (filter === null) {
     // remove filter
-  } else if(query?.filter){
-    url+=`&filter=${encodeURIComponent(query?.filter.toString())}`
+  } else if (query?.filter) {
+    url += `&filter=${encodeURIComponent(query?.filter.toString())}`
   }
-  if (page || page===0){
-    url+=`&page=${page}`
-  } else if (query?.page){
-    url+=`&page=${query.page}`
+  if (page || page === 0) {
+    url += `&page=${page}`
+  } else if (query?.page) {
+    url += `&page=${query.page}`
   } else {
-    url+='&page=0'
+    url += '&page=0'
   }
-  if (rows){
-    url+=`&rows=${rows}`
-  } else if (query?.rows){
-    url+=`&rows=${query?.rows}`
+  if (rows) {
+    url += `&rows=${rows}`
+  } else if (query?.rows) {
+    url += `&rows=${query?.rows}`
   } else {
-    url+='&rows=12'
+    url += '&rows=12'
   }
   return url
 }

--- a/frontend/utils/useParticipatingOrganisations.ts
+++ b/frontend/utils/useParticipatingOrganisations.ts
@@ -27,23 +27,18 @@ export function useParticipatingOrganisations({software, token, account}: UsePar
       // and sort! items on name
       const orgList = resp.map((item, pos) => {
         // extract only needed props
-        const organisation: EditOrganisation = getPropsFromObject(item.organisation, columsForUpdate)
-        // additional props for edit
-        organisation.position = pos + 1
-        organisation.logo_b64 = null
-        organisation.logo_mime_type = null
-        organisation.source = 'RSD' as 'RSD'
-        organisation.status = item.status
-        organisation.canEdit = item.organisation.primary_maintainer === account
-        // organisation logo
-        if (item.organisation?.logo_for_organisation &&
-          item.organisation?.logo_for_organisation?.length > 0) {
-          organisation.logo_id = item.organisation?.logo_for_organisation[0]?.id ?? null
-        } else {
-          organisation.logo_id = null
+        const organisation: EditOrganisation = {
+          ...item,
+          // additional props for edit type
+          position:pos + 1,
+          logo_b64:null,
+          logo_mime_type:null,
+          source:'RSD' as 'RSD',
+          status:item.status,
+          canEdit:item.primary_maintainer === account
         }
         return organisation
-      }).sort((a, b) => sortOnStrProp(a, b, 'name'))
+      })
       // update organisation list
       setOrganisations(orgList)
       // upadate loading state


### PR DESCRIPTION
# Add organisations overview

Closes #160

Changes proposed in this pull request:
* The organisations present in RSD are shown in an overview with the number of software packages registered in RSD      
* The overview is visible to all visitors (you do not have to be logged in)
* The organisation card shows name, logo and software packages count
* Clicking on the organisation redirects to organisation page. **The organisation page shows very simple "under construction" message at the moment**

How to test:

* `docker-compose down --volumes`: to remove old data and database structure
* `docker-compose build` to build all services
* `docker-compose up` to start the instance
*  data-migration is not required
*  Navigate to organisation page in the menu on the top. The overview will be empty at the moment
*  Login to RSD, in order to be able to add new software
*  Add an organisation to software and save software
*  Navigate to organisations overview, it should show the organisation you added with 1 software package
*  You can add more organisations to same software, add more software to RSD and reference already added organisations. The software package count should reflect the changes. You should have the overview similair to image below

![image](https://user-images.githubusercontent.com/9204081/159695462-b05872cf-c7e5-4eb0-b9b1-1e68de6ea36a.png)

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
