### PR TITLE
Migrate organisations

### DIFF
--- a/data-migration/docker-compose.yml
+++ b/data-migration/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: ../
       dockerfile: ./data-migration/dockerfile
-    image: rsd/data-migration:0.0.10
+    image: rsd/data-migration:0.0.11
     env_file:
       # use main env file
       - ../.env

--- a/data-migration/src/main/java/nl/esciencecenter/rsd/migration/Main.java
+++ b/data-migration/src/main/java/nl/esciencecenter/rsd/migration/Main.java
@@ -14,6 +14,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
@@ -736,7 +737,13 @@ public class Main {
 			}
 			existingNames.add(name);
 
-			String slug = name.toLowerCase().replace(' ', '-');
+			String slug = Normalizer.normalize(name, Normalizer.Form.NFD);
+			slug = slug
+					.strip()
+					.toLowerCase()
+					.replaceAll("[^a-z0-9 -]", "")
+					.replace(' ', '-')
+					.replaceAll("-+", "-");
 
 			if (existingSlugs.contains(slug)) {
 				System.out.println("Warning, double slug found (" + slug + "), skipping");

--- a/database/011-create-organisation-table.sql
+++ b/database/011-create-organisation-table.sql
@@ -4,7 +4,7 @@ CREATE TABLE organisation (
 	primary_maintainer UUID REFERENCES account (id),
 	name VARCHAR UNIQUE NOT NULL,
 	ror_id VARCHAR UNIQUE,
-	website VARCHAR UNIQUE NOT NULL,
+	website VARCHAR UNIQUE,
 	is_tenant BOOLEAN DEFAULT FALSE NOT NULL,
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -16,7 +16,7 @@ GROUP BY
 -- COUNT contributors per software
 CREATE VIEW count_software_countributors AS
 SELECT
-	software, count(contributor.id) as contributor_cnt
+	software, count(contributor.id) AS contributor_cnt
 FROM
 	contributor
 GROUP BY
@@ -26,7 +26,7 @@ GROUP BY
 -- COUNT mentions per software
 CREATE VIEW count_software_mentions AS
 SELECT
-	software, count(mention) as mention_cnt
+	software, count(mention) AS mention_cnt
 FROM
 	mention_for_software
 GROUP BY
@@ -36,27 +36,27 @@ GROUP BY
 -- JOIN contributors and mentions counts per software
 CREATE VIEW count_software_contributors_mentions AS
 SELECT
-	software.id, contributor_cnt, mention_cnt from software
+	software.id, contributor_cnt, mention_cnt FROM software
 LEFT JOIN
 	count_software_countributors ON software.id=count_software_countributors.software
 LEFT JOIN
-	count_software_mentions on software.id=count_software_mentions.software
+	count_software_mentions ON software.id=count_software_mentions.software
 WHERE
 	software.is_published
 ;
 
 -- Software maintainer by software slug
-CREATE VIEW maintainer_for_software_by_slug as
+CREATE VIEW maintainer_for_software_by_slug AS
 SELECT
 	maintainer,software,slug from maintainer_for_software
 LEFT JOIN
-	software on software.id=maintainer_for_software.software
+	software ON software.id=maintainer_for_software.software
 ;
 
 -- UNIQUE contributor display_names
-CREATE VIEW unique_countributors as
+CREATE VIEW unique_countributors AS
 SELECT distinct
-	(CONCAT(given_names,' ',family_names)) as display_name, affiliation, orcid, given_names, family_names, email_address, avatar_mime_type
+	(CONCAT(given_names,' ',family_names)) AS display_name, affiliation, orcid, given_names, family_names, email_address, avatar_mime_type
 FROM
 	contributor
 ORDER BY
@@ -66,43 +66,40 @@ ORDER BY
 -- Participating organisations by software
 CREATE VIEW organisations_for_software AS
 SELECT
-	organisation.id as id,
+	organisation.id AS id,
 	organisation.slug,
 	organisation.primary_maintainer,
 	organisation.name,
 	organisation.ror_id,
 	organisation.is_tenant,
 	organisation.website,
-	logo_for_organisation.id as logo_id,
+	logo_for_organisation.id AS logo_id,
 	software_for_organisation.status,
-	software.id as software
+	software.id AS software
 FROM
 	software
 INNER JOIN
-	software_for_organisation on software.id=software
+	software_for_organisation ON software.id=software
 INNER JOIN
-	organisation on software_for_organisation.organisation = organisation.id
+	organisation ON software_for_organisation.organisation = organisation.id
 LEFT JOIN
-	logo_for_organisation on logo_for_organisation.id = organisation.id
-;
+	logo_for_organisation ON logo_for_organisation.id = organisation.id;
 
 -- Software count by organisation
 CREATE VIEW software_count_by_organisation AS
 SELECT
-	organisation, count(organisation) as software_cnt
+	organisation, count(organisation) AS software_cnt
 FROM
 	software_for_organisation
-GROUP BY organisation
-;
+GROUP BY organisation;
 
 -- Organisations overview
 CREATE VIEW organisations_overview AS
 SELECT
-	organisation.id as id,slug,name,website,ror_id,logo_for_organisation.id as logo_id,software_cnt
+	organisation.id AS id,slug,name,website,ror_id,logo_for_organisation.id AS logo_id,software_cnt
 FROM
 	organisation
 LEFT JOIN
-	software_count_by_organisation on organisation = organisation.id
+	software_count_by_organisation ON organisation = organisation.id
 LEFT JOIN
-	logo_for_organisation on organisation = logo_for_organisation.id
-;
+	logo_for_organisation ON organisation.id = logo_for_organisation.id;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.14
+    image: rsd/database:0.0.15
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -6,7 +6,7 @@ import logger from './logger'
 export function organisationUrl({search, rows = 12, page = 0}:
   { search: string | undefined, rows: number, page: number }) {
   // by default order is on software count and name
-  let url = `${process.env.POSTGREST_URL}/organisations_overview?order=software_cnt.desc,name.asc`
+  let url = `${process.env.POSTGREST_URL}/organisations_overview?order=software_cnt.desc.nullslast,name.asc`
   if (search) {
     url+=`&or=(name.ilike.*${search}*,website.ilike.*${search}*)`
   }
@@ -14,7 +14,7 @@ export function organisationUrl({search, rows = 12, page = 0}:
     url +=`&limit=${rows}`
   }
   if (page) {
-    url +=`&offset=${page * rows}`
+    url += `&offset=${page * rows}`
   }
   return url
 }
@@ -22,7 +22,8 @@ export function organisationUrl({search, rows = 12, page = 0}:
 export async function getOrganisationsList({search,rows,page,token}:
   { search: string|undefined,rows:number,page:number,token: string|undefined}) {
   try {
-    const url = organisationUrl({search,rows,page})
+    const url = organisationUrl({search, rows, page})
+
     const resp = await fetch(url, {
       method: 'GET',
       headers: {
@@ -33,7 +34,7 @@ export async function getOrganisationsList({search,rows,page,token}:
       },
     })
 
-    if (resp.status === 200) {
+    if ([200,206].includes(resp.status)) {
       const json = await resp.json()
       return {
         count: extractCountFromHeader(resp.headers),


### PR DESCRIPTION
# Migrate organisations

Changes proposed in this pull request:

* Organisations are migrated from the legacy RSD to the SaaS version
* The script makes a relation between all software and projects to the eScience Center
* Small bugfix for a view so that logo ids are also returned for organisations without software packages

How to test:

* This change affects the database structure, so we need to rebuild everything:
* `docker-compose down --volumes`
* `docker-compose build`
* `docker-compose up`
* Go to the `data-migration` directory
* Build and run the migration script: `docker compose build && docker-compose up`
* At http://localhost/organisation you should see an overview of all organisations and their software package count
* Every software page you see should have in the "Participating organisations" section the Netherlands eScience Center

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests

closes #167