### PR TITLE
Organisation parent child structure

### DIFF
--- a/database/011-create-organisation-table.sql
+++ b/database/011-create-organisation-table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE organisation (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	slug VARCHAR(100) UNIQUE,
+	slug VARCHAR(100),
 	parent UUID REFERENCES organisation (id),
 	primary_maintainer UUID REFERENCES account (id),
 	name VARCHAR UNIQUE NOT NULL,
@@ -8,8 +8,11 @@ CREATE TABLE organisation (
 	website VARCHAR UNIQUE,
 	is_tenant BOOLEAN DEFAULT FALSE NOT NULL,
 	created_at TIMESTAMP NOT NULL,
-	updated_at TIMESTAMP NOT NULL
+	updated_at TIMESTAMP NOT NULL,
+	UNIQUE (slug, parent)
 );
+
+CREATE UNIQUE INDEX unique_slug_for_top_level_org_idx ON organisation (slug, (parent IS NULL)) WHERE parent IS NULL;
 
 CREATE FUNCTION sanitise_insert_organisation() RETURNS TRIGGER LANGUAGE plpgsql as
 $$


### PR DESCRIPTION
# Organisation parent child structure

Changes proposed in this pull request:

* Organisations can now have one parent organisation
* Function for listing all parents and slugs of an organisation
* Function for mapping a full slug into an organisation id

How to test:

* This change affects the database structure, so we need to rebuild everything. We only need the database container:
* `docker-compose down --volumes`
* `docker-compose build database`
* `docker-compose up databasse`
* Run the following queries one by one and observe if the results match with what you expect:
```sql
INSERT INTO organisation VALUES
(NULL, 'parent', NULL, NULL, 'Parent organisation', NULL, NULL, FALSE, NULL, NULL);

INSERT INTO organisation VALUES
(NULL, 'child1', (SELECT id FROM organisation WHERE slug = 'parent'), NULL, 'Child 1 organisation', NULL, NULL, FALSE, NULL, NULL);

INSERT INTO organisation VALUES
(NULL, 'child2', (SELECT id FROM organisation WHERE slug = 'child1'), NULL, 'Child 2 organisation', NULL, NULL, FALSE, NULL, NULL);

INSERT INTO organisation VALUES
(NULL, 'child3', (SELECT id FROM organisation WHERE slug = 'parent'), NULL, 'Child 3 organisation', NULL, NULL, FALSE, NULL, NULL);

-- make a note of the id's, use this later too when inserting more values
SELECT * FROM organisation;


SELECT * FROM list_parent_organisations((SELECT id FROM organisation WHERE slug = 'child2'));
SELECT * FROM list_parent_organisations((SELECT id FROM organisation WHERE slug = 'child3'));


-- should throw an error
INSERT INTO organisation VALUES
(NULL, 'parent', NULL, NULL, 'Parent organisation duplicate', NULL, NULL, FALSE, NULL, NULL);

-- should throw an error
INSERT INTO organisation VALUES
(NULL, 'child1', (SELECT id FROM organisation WHERE slug = 'parent'), NULL, 'Child 1 organisation duplicate', NULL, NULL, FALSE, NULL, NULL);


SELECT * FROM slug_to_organisation('parent');
SELECT * FROM slug_to_organisation('parent/child1');
SELECT * FROM slug_to_organisation('parent/child2');
SELECT * FROM slug_to_organisation('parent/child3');

INSERT INTO organisation VALUES
(NULL, 'child4', (SELECT id FROM organisation WHERE slug = 'child1'), NULL, 'Child 4 organisation', NULL, NULL, FALSE, NULL, NULL);

SELECT * FROM slug_to_organisation('parent/child1/child4');

-- should return NULL
SELECT * FROM slug_to_organisation('bla/parent');

```


PR Checklist:

*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests