### PR TITLE
Fix missing permissions for db initialization scripts

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,2 +1,2 @@
 FROM postgres:14.2
-COPY *.sql /docker-entrypoint-initdb.d/
+COPY --chown=postgres:postgres *.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
# Fix missing permissions for db initialization scripts

Fixes #178 

Changes proposed in this pull request:

* move file ownership for db initialization scripts to user `postgres` and group `postgres`

How to test:

* Clean-up first:  `docker-compose down -v` 
* Build database image:  `docker-compose build database`
* Start database container: `docker-compose up database`

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
