### PR TITLE
188 no empty project images migration

### DIFF
--- a/data-migration/docker-compose.yml
+++ b/data-migration/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: ../
       dockerfile: ./data-migration/Dockerfile
-    image: rsd/data-migration:0.0.11
+    image: rsd/data-migration:0.0.12
     env_file:
       # use main env file
       - ../.env

--- a/data-migration/src/main/java/nl/esciencecenter/rsd/migration/Main.java
+++ b/data-migration/src/main/java/nl/esciencecenter/rsd/migration/Main.java
@@ -484,7 +484,9 @@ public class Main {
 			String slug = projectsFromLegacyRSD.get("slug").getAsString();
 			JsonObject imageToSave = new JsonObject();
 			imageToSave.addProperty("project", slugToId.get(slug));
-			imageToSave.add("data", imageFromLegacyRSD.get("data"));
+			JsonElement imageDataJson = imageFromLegacyRSD.get("data");
+			if (imageDataJson == null || imageDataJson.isJsonNull() || imageDataJson.getAsString().isBlank()) return;
+			imageToSave.add("data", imageDataJson);
 			imageToSave.add("mime_type", imageFromLegacyRSD.get("mimeType"));
 			allImagesToSave.add(imageToSave);
 		});

--- a/database/005-create-project-table.sql
+++ b/database/005-create-project-table.sql
@@ -20,8 +20,8 @@ CREATE TABLE project (
 
 CREATE TABLE image_for_project (
 	project UUID references project (id) PRIMARY KEY,
-	data VARCHAR,
-	mime_type VARCHAR(100)
+	data VARCHAR NOT NULL,
+	mime_type VARCHAR(100) NOT NULL
 );
 
 CREATE FUNCTION sanitise_insert_project() RETURNS TRIGGER LANGUAGE plpgsql as

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.18
+    image: rsd/database:0.0.19
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"

--- a/frontend/utils/dateFn.ts
+++ b/frontend/utils/dateFn.ts
@@ -29,7 +29,14 @@ export function olderThanXDays(lastDate:Date, xDays=7):boolean{
 
 export function isoStrToDate(isoString:string):Date|null{
   try{
-    if (isoString){
+    if (isoString) {
+      if (isoString.endsWith('Z') === false) {
+        // quickfix for missing Z at the end of isoString
+        // TODO! investigate why api does not delivers Z
+        isoString += 'Z'
+        const newDate = new Date(isoString)
+        return newDate
+      }
       const newDate = new Date(isoString)
       return newDate
     }
@@ -77,7 +84,6 @@ export function getTimeAgoSince(since: Date, isoStringDate: string | null) {
     // convert to date
     const updated = isoStrToDate(isoStringDate)
     if (!updated) return null
-
     if (since > updated) {
       const msDiff = since.getTime() - updated.getTime()
       const hours = 1000 * 60 * 60
@@ -87,13 +93,15 @@ export function getTimeAgoSince(since: Date, isoStringDate: string | null) {
         if (daysDiff > 30) {
           const monthDiff = Math.floor(daysDiff / 30)
           return `${monthDiff} months ago`
-        }else if (daysDiff > 7) {
+        } else if (daysDiff > 7) {
           const weeksDiff = Math.floor(daysDiff / 7)
           return `${weeksDiff} weeks ago`
         } else if (daysDiff > 1) return `${daysDiff} days ago`
         return '1 day ago'
       } else if (hoursDiff === 1) {
         return '1 hour ago'
+      } else if (hoursDiff === 0) {
+        return 'right now'
       } else {
         return `${hoursDiff} hours ago`
       }


### PR DESCRIPTION
# Don't store empty images for projects when migrating

Changes proposed in this pull request:

* Adapt the migration script so that empty images for projects from the legacy RSD are not saved in the database when migrating. These images were not stored as `null` but as empty strings instead in the legacy RSD database.
* Enforce in the database that image data and mime types are not null.

How to test:

* The database structure has changed:
	* `docker-compose down --volumes`
	* `docker-compose build database`
	* `docker-compose up database`
* Build and run the new migration script:
	* `cd data-migration && docker-compose build && docker-compose up`
* The following query should return zero rows:
	* `SELECT * FROM image_for_project WHERE LENGTH(data) = 0 OR LENGTH(mime_type) = 0;`

Closes #188

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests