### PR TITLE
Helmholtz login preparation

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Account.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Account.java
@@ -1,0 +1,6 @@
+package nl.esciencecenter.rsd.authentication;
+
+public interface Account {
+
+	AccountInfo account();
+}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AccountInfo.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AccountInfo.java
@@ -1,0 +1,6 @@
+package nl.esciencecenter.rsd.authentication;
+
+import java.util.UUID;
+
+public record AccountInfo(UUID account, String name) {
+}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
@@ -8,6 +8,7 @@ import com.google.gson.Gson;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 public class JwtCreator {
 
@@ -21,11 +22,12 @@ public class JwtCreator {
 		this.signingAlgorithm = Algorithm.HMAC256(this.signingSecret);
 	}
 
-	String createUserJwt(String account) {
+	String createUserJwt(UUID account, String name) {
 		return JWT.create()
 				.withClaim("iss", "rsd_auth")
 				.withClaim("role", "rsd_user")
-				.withClaim("account", account)
+				.withClaim("account", account.toString())
+				.withClaim("name", name)
 				.withExpiresAt(new Date(System.currentTimeMillis() + ONE_HOUR_IN_MILLISECONDS))
 				.sign(signingAlgorithm);
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Login.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Login.java
@@ -2,5 +2,5 @@ package nl.esciencecenter.rsd.authentication;
 
 public interface Login {
 
-	String account();
+	OpenIdInfo openidInfo();
 }

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -18,9 +18,10 @@ public class Main {
 				String returnPath = ctx.cookie("rsd_pathname");
 				String code = ctx.formParam("code");
 				String redirectUrl = Config.surfconextRedirect();
-				String account = new SurfconextLogin(code, redirectUrl).account();
+				OpenIdInfo surfconextInfo = new SurfconextLogin(code, redirectUrl).openidInfo();
+				AccountInfo accountInfo = new PostgrestAccount(surfconextInfo).account();
 				JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
-				String token = jwtCreator.createUserJwt(account);
+				String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
 				setJwtCookie(ctx, token);
 				// redirect based on returnPath
 				if (returnPath != null && !returnPath.trim().isEmpty()) {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OpenIdInfo.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OpenIdInfo.java
@@ -1,0 +1,6 @@
+package nl.esciencecenter.rsd.authentication;
+
+import java.util.UUID;
+
+public record OpenIdInfo(UUID sub, String name, String email, String organisation) {
+}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OpenIdInfo.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OpenIdInfo.java
@@ -1,6 +1,4 @@
 package nl.esciencecenter.rsd.authentication;
 
-import java.util.UUID;
-
-public record OpenIdInfo(UUID sub, String name, String email, String organisation) {
+public record OpenIdInfo(String sub, String name, String email, String organisation) {
 }

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
@@ -1,0 +1,98 @@
+package nl.esciencecenter.rsd.authentication;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Objects;
+import java.util.UUID;
+
+public class PostgrestAccount implements Account {
+
+	private final OpenIdInfo openIdInfo;
+
+	public PostgrestAccount(OpenIdInfo openIdInfo) {
+		this.openIdInfo = Objects.requireNonNull(openIdInfo);
+		Objects.requireNonNull(openIdInfo.sub());
+	}
+
+	@Override
+	public AccountInfo account() {
+		String backendUri = Config.backendBaseUrl();
+		String subject = openIdInfo.sub().toString();
+		URI queryUri = URI.create(backendUri + "/login_for_account?select=account,name&sub=eq." + subject);
+		JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
+		String token = jwtCreator.createAdminJwt();
+		String responseLogin = getAsAdmin(queryUri, token);
+		JsonArray accountsWithSub = JsonParser.parseString(responseLogin).getAsJsonArray();
+		if (accountsWithSub.size() > 1)
+			throw new RuntimeException("More than one login for subject " + subject + " exists");
+		else if (accountsWithSub.size() == 1) {
+			JsonObject accountInfo = accountsWithSub.get(0).getAsJsonObject();
+			UUID account = UUID.fromString(accountInfo.getAsJsonPrimitive("account").getAsString());
+			String name = accountInfo.getAsJsonPrimitive("name").getAsString();
+			return new AccountInfo(account, name);
+		}
+		else { // create account
+			URI createAccountEndpoint = URI.create(backendUri + "/account");
+			String newAccountId = JsonParser.parseString(postJsonAsAdmin(createAccountEndpoint, "{}", token)).getAsJsonArray().get(0).getAsJsonObject().getAsJsonPrimitive("id").getAsString();
+
+//			create login for account
+			JsonObject loginForAccountData = new JsonObject();
+			loginForAccountData.addProperty("account", newAccountId);
+			loginForAccountData.addProperty("sub", subject);
+			loginForAccountData.addProperty("name", openIdInfo.name());
+			loginForAccountData.addProperty("email", openIdInfo.email());
+			loginForAccountData.addProperty("home_organisation", openIdInfo.organisation());
+			URI createLoginUri = URI.create(backendUri + "/login_for_account");
+			postJsonAsAdmin(createLoginUri, loginForAccountData.toString(), token);
+
+			return new AccountInfo(UUID.fromString(newAccountId), openIdInfo.name());
+		}
+	}
+
+	private String getAsAdmin(URI uri, String token) {
+		HttpRequest request = HttpRequest.newBuilder()
+				.GET()
+				.uri(uri)
+				.header("Authorization", "bearer " + token)
+				.build();
+		HttpClient client = HttpClient.newHttpClient();
+		HttpResponse<String> response;
+		try {
+			response = client.send(request, HttpResponse.BodyHandlers.ofString());
+		} catch (IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+		if (response.statusCode() >= 300) {
+			throw new RuntimeException("Error fetching data from the endpoint: " + response.body());
+		}
+		return response.body();
+	}
+
+	private String postJsonAsAdmin(URI uri, String json, String token) {
+		HttpRequest request = HttpRequest.newBuilder()
+				.POST(HttpRequest.BodyPublishers.ofString(json))
+				.uri(uri)
+				.header("Content-Type", "application/json")
+				.header("Prefer", "return=representation")
+				.header("Authorization", "bearer " + token)
+				.build();
+		HttpClient client = HttpClient.newHttpClient();
+		HttpResponse<String> response;
+		try {
+			response = client.send(request, HttpResponse.BodyHandlers.ofString());
+		} catch (IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+		if (response.statusCode() >= 300) {
+			throw new RuntimeException("Error fetching data from the endpoint: " + response.body());
+		}
+		return response.body();
+	}
+}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
@@ -1,10 +1,7 @@
 package nl.esciencecenter.rsd.authentication;
 
 import com.auth0.jwt.JWT;
-import com.auth0.jwt.interfaces.Claim;
 import com.auth0.jwt.interfaces.DecodedJWT;
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
 import java.io.IOException;
@@ -14,35 +11,39 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.UUID;
 
 public class SurfconextLogin implements Login {
 
-	private final String CODE;
-	private final String REDIRECT_URL;
+	private final String code;
+	private final String redirectUrl;
 
 	public SurfconextLogin(String code, String redirectUrl) {
-		if (code == null) throw new IllegalArgumentException("The code should not be null");
-		if (redirectUrl == null) throw new IllegalArgumentException("The redirect url should not be null");
-		this.CODE = code;
-		this.REDIRECT_URL = redirectUrl;
+		this.code = Objects.requireNonNull(code);
+		this.redirectUrl = Objects.requireNonNull(redirectUrl);
 	}
 
-
 	@Override
-	public String account() {
+	public OpenIdInfo openidInfo() {
 		Map<String, String> form = createForm();
 		String tokenResponse = getTokensFromSurfconext(form);
 		String idToken = extractIdToken(tokenResponse);
-		String account = accountFromIdToken(idToken);
-		return account;
+
+		DecodedJWT idJwt = JWT.decode(idToken);
+		UUID subject = UUID.fromString(idJwt.getSubject());
+		String name = idJwt.getClaim("name").asString();
+		String email = idJwt.getClaim("email").asString();
+		String organisation = idJwt.getClaim("schac_home_organization").asString();
+		return new OpenIdInfo(subject, name, email, organisation);
 	}
 
 	private Map<String, String> createForm() {
 		Map<String, String> form = new HashMap<>();
-		form.put("code", CODE);
+		form.put("code", code);
 		form.put("grant_type", "authorization_code");
-		form.put("redirect_uri", REDIRECT_URL);
+		form.put("redirect_uri", redirectUrl);
 		form.put("scope", "openid");
 		form.put("client_id", Config.surfconextClientId());
 		form.put("client_secret", Config.surfconextClientSecret());
@@ -64,42 +65,6 @@ public class SurfconextLogin implements Login {
 		return JsonParser.parseString(response).getAsJsonObject().getAsJsonPrimitive("id_token").getAsString();
 	}
 
-	private String accountFromIdToken(String idToken) {
-		DecodedJWT idJwt = JWT.decode(idToken);
-		String subject = idJwt.getSubject();
-		return accountFromSubject(subject, idJwt);
-	}
-
-	private String accountFromSubject(String subject, DecodedJWT idToken) {
-		String backendUri = Config.backendBaseUrl();
-		URI queryUri = URI.create(backendUri + "/login_for_account?select=account,sub&sub=eq." + subject);
-		JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
-		String token = jwtCreator.createAdminJwt();
-		String responseLogin = getAsAdmin(queryUri, token);
-		JsonArray accountsWithSub = JsonParser.parseString(responseLogin).getAsJsonArray();
-		if (accountsWithSub.size() > 1)
-			throw new RuntimeException("More than one login for subject " + subject + " exists");
-		else if (accountsWithSub.size() == 1)
-			return accountsWithSub.get(0).getAsJsonObject().getAsJsonPrimitive("account").getAsString();
-		else { // create account
-			URI createAccountEndpoint = URI.create(backendUri + "/account");
-			String newAccountId = JsonParser.parseString(postJsonAsAdmin(createAccountEndpoint, "{}", token)).getAsJsonArray().get(0).getAsJsonObject().getAsJsonPrimitive("id").getAsString();
-
-//			create login for account
-			Map<String, Claim> claims = idToken.getClaims();
-			JsonObject loginForAccountData = new JsonObject();
-			loginForAccountData.addProperty("account", newAccountId);
-			loginForAccountData.addProperty("sub", subject);
-			loginForAccountData.addProperty("name", claims.get("name").asString());
-			loginForAccountData.addProperty("email", claims.get("email").asString());
-			loginForAccountData.addProperty("home_organisation", claims.get("schac_home_organization").asString());
-			URI createLoginUri = URI.create(backendUri + "/login_for_account");
-			postJsonAsAdmin(createLoginUri, loginForAccountData.toString(), token);
-
-			return newAccountId;
-		}
-	}
-
 	private String postForm(URI uri, String json) {
 		HttpRequest request = HttpRequest.newBuilder()
 				.POST(HttpRequest.BodyPublishers.ofString(json))
@@ -115,47 +80,6 @@ public class SurfconextLogin implements Login {
 		}
 		if (response.statusCode() >= 300) {
 			throw new RuntimeException("Error fetching data from " + uri.toString() + ": " + response.body());
-		}
-		return response.body();
-	}
-
-	private String postJsonAsAdmin(URI uri, String json, String token) {
-		HttpRequest request = HttpRequest.newBuilder()
-				.POST(HttpRequest.BodyPublishers.ofString(json))
-				.uri(uri)
-				.header("Content-Type", "application/json")
-				.header("Prefer", "return=representation")
-				.header("Authorization", "bearer " + token)
-				.build();
-		HttpClient client = HttpClient.newHttpClient();
-		HttpResponse<String> response;
-		try {
-			response = client.send(request, HttpResponse.BodyHandlers.ofString());
-		} catch (IOException | InterruptedException e) {
-			throw new RuntimeException(e);
-		}
-		if (response.statusCode() >= 300) {
-			throw new RuntimeException("Error fetching data from the endpoint: " + response.body());
-		}
-		return response.body();
-	}
-
-
-	private String getAsAdmin(URI uri, String token) {
-		HttpRequest request = HttpRequest.newBuilder()
-				.GET()
-				.uri(uri)
-				.header("Authorization", "bearer " + token)
-				.build();
-		HttpClient client = HttpClient.newHttpClient();
-		HttpResponse<String> response;
-		try {
-			response = client.send(request, HttpResponse.BodyHandlers.ofString());
-		} catch (IOException | InterruptedException e) {
-			throw new RuntimeException(e);
-		}
-		if (response.statusCode() >= 300) {
-			throw new RuntimeException("Error fetching data from the endpoint: " + response.body());
 		}
 		return response.body();
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
-import java.util.UUID;
 
 public class SurfconextLogin implements Login {
 
@@ -32,7 +31,7 @@ public class SurfconextLogin implements Login {
 		String idToken = extractIdToken(tokenResponse);
 
 		DecodedJWT idJwt = JWT.decode(idToken);
-		UUID subject = UUID.fromString(idJwt.getSubject());
+		String subject = idJwt.getSubject();
 		String name = idJwt.getClaim("name").asString();
 		String email = idJwt.getClaim("email").asString();
 		String organisation = idJwt.getClaim("schac_home_organization").asString();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
   auth:
     container_name: auth
     build: ./authentication
-    image: rsd/auth:0.0.7
+    image: rsd/auth:0.0.8
     expose:
       - 7000
     environment:


### PR DESCRIPTION
# Refactor authentication module

Changes proposed in this pull request:

* Refactor the authentication module so that it is easier to add Helmholtz AAI and other OpenID providers
	* A separate class for communicating with the PostgREST API that is independent of the OpenID provider
	* Record classes for transferring data without assumptions on the underlying protocols or OpenID processes
* Provide the name in the RSD token (that is transferred in a cookie when logging in successfully)

How to test:

* Rebuild the authentication module:
	* `docker-compose build auth`
	* `docker-compose up --scale scrapers=0`
* Login, this should be successful
* Inspect the cookie called `rsd_token`, verify that the JWT token has a `name` claim

PR Checklist:

*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests