### PR TITLE
198 fix missing optional env variables create errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
   scrapers:
     container_name: scrapers
     build: ./scrapers
-    image: rsd/scrapers:0.0.4
+    image: rsd/scrapers:0.0.5
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
@@ -18,11 +18,13 @@ public class Utils {
 	}
 
 	public static String get(String uri, String... headers) {
-		HttpRequest request = HttpRequest.newBuilder()
+		HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
 				.GET()
-				.uri(URI.create(uri))
-				.headers(headers)
-				.build();
+				.uri(URI.create(uri));
+		if (headers != null && headers.length > 0 && headers.length % 2 == 0) {
+			httpRequestBuilder.headers(headers);
+		}
+		HttpRequest request = httpRequestBuilder.build();
 		HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
 		HttpResponse<String> response;
 		try {

--- a/scrapers/src/main/resources/releases.py
+++ b/scrapers/src/main/resources/releases.py
@@ -296,7 +296,7 @@ def get_citations(dois_data):
 if __name__ == "__main__":
 	print("Start scraping releases")
 	backend_url = os.environ.get('POSTGREST_URL')
-	number_releases_to_scrape = os.environ.get('MAX_REQUESTS_GITHUB')
+	number_releases_to_scrape = os.environ.get('MAX_REQUESTS_GITHUB', default='6')
 	jwt_secret = os.environ.get('PGRST_JWT_SECRET')
 	jwt_token = jwt.encode({"role": "rsd_admin", "exp": datetime.now() + timedelta(minutes = 10)}, jwt_secret, algorithm="HS256")
 	response_dois = requests.get('{}/software?select=id,slug,concept_doi,release(id)&concept_doi=not.is.null&order=releases_scraped_at.nullsfirst&limit={}'.format(backend_url, number_releases_to_scrape), headers={'Authorization': 'Bearer ' + jwt_token})

--- a/scrapers/src/main/resources/zotero.py
+++ b/scrapers/src/main/resources/zotero.py
@@ -173,7 +173,7 @@ def get_mentions(since_version=None, keys_data=None):
 if __name__ == "__main__":
 	print("Start scraping mentions")
 	backend_url = os.environ.get('POSTGREST_URL')
-	number_mentions_to_scrape = os.environ.get('MAX_REQUESTS_GITHUB')
+	number_mentions_to_scrape = os.environ.get('MAX_REQUESTS_GITHUB', default='6')
 	jwt_secret = os.environ.get('PGRST_JWT_SECRET')
 	jwt_token = jwt.encode({"role": "rsd_admin", "exp": datetime.now() + timedelta(minutes = 10)}, jwt_secret, algorithm="HS256")
 	zotero_library = os.environ.get('ZOTERO_LIBRARY')


### PR DESCRIPTION
# Fix bug: missing env variables generate errors

Changes proposed in this pull request:

* Scrapers don't generate errors if optional env variables are missing

How to test:

* From your `.env` file, comment out the variables `API_CREDENTIALS_GITHUB` and `MAX_REQUESTS_GITHUB`
* Rebuild the scraper module:
	* `docker-compose build scrapers`
	* `docker-compose up`
* Wait at least 6 minutes so that all scrapers have run at least once. 
* There should be no errors that have anything to do with the missing env variables

Closes #198

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests