### PR TITLE
Database improvements

### DIFF
--- a/database/002-create-software-table.sql
+++ b/database/002-create-software-table.sql
@@ -1,4 +1,4 @@
-CREATE TYPE description_type as ENUM (
+CREATE TYPE description_type AS ENUM (
 	'link',
 	'markdown'
 );
@@ -20,7 +20,7 @@ CREATE TABLE software (
 	updated_at TIMESTAMP NOT NULL
 );
 
-CREATE FUNCTION sanitise_insert_software() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_software() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -33,7 +33,7 @@ $$;
 CREATE TRIGGER sanitise_insert_software BEFORE INSERT ON software FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_software();
 
 
-CREATE FUNCTION sanitise_update_software() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_software() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;

--- a/database/002-create-software-table.sql
+++ b/database/002-create-software-table.sql
@@ -5,7 +5,7 @@ CREATE TYPE description_type as ENUM (
 
 CREATE TABLE software (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	slug VARCHAR(100) UNIQUE NOT NULL,
+	slug VARCHAR(100) UNIQUE NOT NULL CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
 	brand_name VARCHAR(100) NOT NULL,
 	concept_doi VARCHAR,
 	description VARCHAR,

--- a/database/003-create-relations-for-software.sql
+++ b/database/003-create-relations-for-software.sql
@@ -20,7 +20,7 @@ CREATE TABLE license_for_software (
 	updated_at TIMESTAMP NOT NULL
 );
 
-CREATE FUNCTION sanitise_insert_license_for_software() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_license_for_software() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -33,7 +33,7 @@ $$;
 CREATE TRIGGER sanitise_insert_license_for_software BEFORE INSERT ON license_for_software FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_license_for_software();
 
 
-CREATE FUNCTION sanitise_update_license_for_software() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_license_for_software() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;
@@ -63,7 +63,7 @@ CREATE TABLE contributor (
 	updated_at TIMESTAMP NOT NULL
 );
 
-CREATE FUNCTION sanitise_insert_contributor() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_contributor() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -76,7 +76,7 @@ $$;
 CREATE TRIGGER sanitise_insert_contributor BEFORE INSERT ON contributor FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_contributor();
 
 
-CREATE FUNCTION sanitise_update_contributor() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_contributor() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;
@@ -127,7 +127,7 @@ CREATE TABLE testimonial (
 	position INTEGER
 );
 
-CREATE FUNCTION sanitise_insert_testimonial() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_testimonial() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -138,7 +138,7 @@ $$;
 CREATE TRIGGER sanitise_insert_testimonial BEFORE INSERT ON testimonial FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_testimonial();
 
 
-CREATE FUNCTION sanitise_update_testimonial() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_testimonial() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;

--- a/database/004-create-tags-for-software.sql
+++ b/database/004-create-tags-for-software.sql
@@ -1,4 +1,4 @@
-CREATE TYPE tag as ENUM (
+CREATE TYPE tag AS ENUM (
 	'Big data',
 	'GPU',
 	'High performance computing',

--- a/database/005-create-project-table.sql
+++ b/database/005-create-project-table.sql
@@ -24,7 +24,7 @@ CREATE TABLE image_for_project (
 	mime_type VARCHAR(100) NOT NULL
 );
 
-CREATE FUNCTION sanitise_insert_project() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_project() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -37,7 +37,7 @@ $$;
 CREATE TRIGGER sanitise_insert_project BEFORE INSERT ON project FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_project();
 
 
-CREATE FUNCTION sanitise_update_project() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_project() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;

--- a/database/005-create-project-table.sql
+++ b/database/005-create-project-table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE project (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	slug VARCHAR(100) UNIQUE NOT NULL,
+	slug VARCHAR(100) UNIQUE NOT NULL CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
 	call_url VARCHAR,
 	code_url VARCHAR,
 	data_management_plan_url VARCHAR,

--- a/database/006-create-relations-for-projects.sql
+++ b/database/006-create-relations-for-projects.sql
@@ -13,7 +13,7 @@ CREATE TABLE team_member (
 	updated_at TIMESTAMP NOT NULL
 );
 
-CREATE FUNCTION sanitise_insert_team_member() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_team_member() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -26,7 +26,7 @@ $$;
 CREATE TRIGGER sanitise_insert_team_member BEFORE INSERT ON team_member FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_team_member();
 
 
-CREATE FUNCTION sanitise_update_team_member() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_team_member() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;

--- a/database/007-create-topics-for-projects.sql
+++ b/database/007-create-topics-for-projects.sql
@@ -1,4 +1,4 @@
-CREATE TYPE topic as ENUM (
+CREATE TYPE topic AS ENUM (
 	'Astronomy',
 	'Chemistry',
 	'Climate and weather',

--- a/database/008-create-mention-table.sql
+++ b/database/008-create-mention-table.sql
@@ -1,4 +1,4 @@
-CREATE TYPE mention_type as ENUM (
+CREATE TYPE mention_type AS ENUM (
 	'attachment',
 	'blogPost',
 	'book',
@@ -36,7 +36,7 @@ CREATE TABLE mention (
 	updated_at TIMESTAMP NOT NULL
 );
 
-CREATE FUNCTION sanitise_insert_mention() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_mention() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -49,7 +49,7 @@ $$;
 CREATE TRIGGER sanitise_insert_mention BEFORE INSERT ON mention FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_mention();
 
 
-CREATE FUNCTION sanitise_update_mention() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_mention() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;

--- a/database/009-create-release-table.sql
+++ b/database/009-create-release-table.sql
@@ -8,7 +8,7 @@ CREATE TABLE release (
 );
 
 
-CREATE FUNCTION sanitise_insert_release() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_release() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -21,7 +21,7 @@ $$;
 CREATE TRIGGER sanitise_insert_release BEFORE INSERT ON release FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_release();
 
 
-CREATE FUNCTION sanitise_update_release() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_release() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;
@@ -35,7 +35,7 @@ CREATE TRIGGER sanitise_update_release BEFORE UPDATE ON release FOR EACH ROW EXE
 
 
 
-CREATE TYPE citability as ENUM (
+CREATE TYPE citability AS ENUM (
 	'doi-only',
 	'full'
 );
@@ -58,7 +58,7 @@ CREATE TABLE release_content (
 );
 
 
-CREATE FUNCTION sanitise_insert_release_content() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_release_content() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -69,7 +69,7 @@ $$;
 CREATE TRIGGER sanitise_insert_release_content BEFORE INSERT ON release_content FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_release_content();
 
 
-CREATE FUNCTION sanitise_update_release_content() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_release_content() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;

--- a/database/010-create-account-table.sql
+++ b/database/010-create-account-table.sql
@@ -4,7 +4,7 @@ CREATE TABLE account (
 	updated_at TIMESTAMP NOT NULL
 );
 
-CREATE FUNCTION sanitise_insert_account() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_account() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -17,7 +17,7 @@ $$;
 CREATE TRIGGER sanitise_insert_account BEFORE INSERT ON account FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_account();
 
 
-CREATE FUNCTION sanitise_update_account() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_account() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;
@@ -42,7 +42,7 @@ CREATE TABLE login_for_account (
 	updated_at TIMESTAMP NOT NULL
 );
 
-CREATE FUNCTION sanitise_insert_login_for_account() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_insert_login_for_account() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -55,7 +55,7 @@ $$;
 CREATE TRIGGER sanitise_insert_login_for_account BEFORE INSERT ON login_for_account FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_login_for_account();
 
 
-CREATE FUNCTION sanitise_update_login_for_account() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_login_for_account() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;

--- a/database/011-create-organisation-table.sql
+++ b/database/011-create-organisation-table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE organisation (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	slug VARCHAR(100),
+	slug VARCHAR(100) NOT NULL CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
 	parent UUID REFERENCES organisation (id),
 	primary_maintainer UUID REFERENCES account (id),
 	name VARCHAR NOT NULL,

--- a/database/011-create-organisation-table.sql
+++ b/database/011-create-organisation-table.sql
@@ -30,7 +30,8 @@ BEGIN
 END
 $$;
 
-CREATE TRIGGER check_cycle_organisations BEFORE UPDATE OF parent ON organisation FOR EACH ROW EXECUTE PROCEDURE check_cycle_organisations();
+-- z_ prefix so that if is executed after the sanitise_update_organisation trigger
+CREATE TRIGGER z_check_cycle_organisations BEFORE UPDATE OF parent ON organisation FOR EACH ROW EXECUTE PROCEDURE check_cycle_organisations();
 
 CREATE FUNCTION sanitise_insert_organisation() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$

--- a/database/012-inter-relation-tables.sql
+++ b/database/012-inter-relation-tables.sql
@@ -1,4 +1,4 @@
-CREATE TYPE relation_status as ENUM (
+CREATE TYPE relation_status AS ENUM (
 	'requested_by_origin',
 	'requested_by_relation',
 	'approved'
@@ -10,7 +10,7 @@ CREATE TABLE software_for_software (
 	PRIMARY KEY (origin, relation)
 );
 
-CREATE FUNCTION sanitise_update_software_for_software() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_software_for_software() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.origin = OLD.origin;
@@ -29,7 +29,7 @@ CREATE TABLE software_for_project (
 	PRIMARY KEY (software, project)
 );
 
-CREATE FUNCTION sanitise_update_software_for_project() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_software_for_project() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.software = OLD.software;
@@ -48,7 +48,7 @@ CREATE TABLE project_for_project (
 	PRIMARY KEY (origin, relation)
 );
 
-CREATE FUNCTION sanitise_update_project_for_project() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_project_for_project() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.origin = OLD.origin;
@@ -67,7 +67,7 @@ CREATE TABLE software_for_organisation (
 	PRIMARY KEY (software, organisation)
 );
 
-CREATE FUNCTION sanitise_update_software_for_organisation() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_software_for_organisation() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.software = OLD.software;
@@ -86,7 +86,7 @@ CREATE TABLE project_for_organisation (
 	PRIMARY KEY (project, organisation)
 );
 
-CREATE FUNCTION sanitise_update_project_for_organisation() RETURNS TRIGGER LANGUAGE plpgsql as
+CREATE FUNCTION sanitise_update_project_for_organisation() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.project = OLD.project;

--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -60,7 +60,7 @@ CREATE POLICY maintainer_all_rights ON software TO rsd_user
 CREATE FUNCTION insert_maintainer_new_software() RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS
 $$
 BEGIN
-	IF (SELECT current_setting('request.jwt.claims', FALSE)::json->>'account' IS NULL) THEN RETURN NULL;
+	IF (SELECT current_setting('request.jwt.claims', TRUE)::json->>'account' IS NULL) THEN RETURN NULL;
 	END IF;
 	INSERT INTO maintainer_for_software VALUES (uuid(current_setting('request.jwt.claims', FALSE)::json->>'account'), NEW.id);
 	RETURN NULL;
@@ -145,7 +145,7 @@ CREATE POLICY maintainer_all_rights ON project TO rsd_user
 CREATE FUNCTION insert_maintainer_new_project() RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS
 $$
 BEGIN
-	IF (SELECT current_setting('request.jwt.claims', FALSE)::json->>'account' IS NULL) THEN RETURN NULL;
+	IF (SELECT current_setting('request.jwt.claims', TRUE)::json->>'account' IS NULL) THEN RETURN NULL;
 	END IF;
 	INSERT INTO maintainer_for_project VALUES (uuid(current_setting('request.jwt.claims', FALSE)::json->>'account'), NEW.id);
 	RETURN NULL;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.19
+    image: rsd/database:0.0.20
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"


### PR DESCRIPTION
# Database improvements

Changes proposed in this pull request:

* Enforce slug rules in the database:
	* Only lower case letters, digits and dashes
	* Not two dashes in a row, starting or ending with a dash
* Add a trigger that prevents an organisation to become an (in)direct parent of itself

How to test:

* Rebuild the database module:
	* `docker-compose down --volumes && docker-compose build database && docker-compose up database`
* Execute the following statements to test the slug rules:
```sql
-- the following should be correct
INSERT INTO software (slug, brand_name) VALUES ('abc', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('1234567890asdfghjkl', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('ab-c', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('a-bc', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('a-b-c', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('1-2-3', 'my sw');

-- the following statements should all throw an error stating:
-- 'SQL Error [23514]: ERROR: new row for relation "software" violates check constraint "software_slug_check"'
INSERT INTO software (slug, brand_name) VALUES ('ab-c-', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('-abc', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('-', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('-ab-c', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('ab--c', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('ABC', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('/abc', 'my sw');
INSERT INTO software (slug, brand_name) VALUES ('abc/', 'my sw');
```
* Execute the following statements to test the cycle detection trigger:
```sql
-- these should run without an error
INSERT INTO organisation (slug, name, parent) VALUES ('parent', 'Parent', NULL);
INSERT INTO organisation (slug, name, parent) VALUES ('child1', 'Child 1', (SELECT id FROM organisation WHERE slug = 'parent'));
INSERT INTO organisation (slug, name, parent) VALUES ('grandchild1', 'Grand child 1', (SELECT id FROM organisation WHERE slug = 'child1'));

-- these should throw an error
UPDATE organisation SET parent = (SELECT id FROM organisation WHERE slug = 'parent') WHERE slug = 'parent';
UPDATE organisation SET parent = (SELECT id FROM organisation WHERE slug = 'child1') WHERE slug = 'parent';
UPDATE organisation SET parent = (SELECT id FROM organisation WHERE slug = 'grandchild1') WHERE slug = 'parent';

-- these should run without an error
UPDATE organisation SET parent = (SELECT id FROM organisation WHERE slug = 'parent') WHERE slug = 'grandchild1';
UPDATE organisation SET parent = NULL WHERE slug = 'grandchild1';
```
* Create test cases that might have been forgotten

Closes #183
Closes #184

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests