### PR TITLE
#214 Fix mentions components

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.6.6
+    image: rsd/frontend:0.6.7
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/__tests__/OrganisationsIndex.test.tsx
+++ b/frontend/__tests__/OrganisationsIndex.test.tsx
@@ -5,6 +5,7 @@ import organisationsOverview from './__fixtures__/organisationsOverview.json'
 import {WrappedComponentWithProps} from '../utils/jest/WrappedComponents'
 
 import OrganisationIndexPage,{getServerSideProps} from '../pages/organisations/index'
+import {RsdUser} from '../auth'
 
 
 describe('pages/organisations/index.tsx', () => {
@@ -36,15 +37,18 @@ describe('pages/organisations/index.tsx', () => {
 
   it('renders heading with the title Organisations', async() => {
     render(WrappedComponentWithProps(
-      OrganisationIndexPage,{
-        count:200,
-        page:0,
-        rows:12,
-        organisations:organisationsOverview,
+      OrganisationIndexPage, {
+        props: {
+          count:200,
+          page:0,
+          rows:12,
+          organisations:organisationsOverview,
+        },
         // user session
         session:{
-          expires: 'test',
-          user: {name:'Test user'}
+          status: 'missing',
+          token: 'test-token',
+          user: {name:'Test user'} as RsdUser
         }
       }
     ))
@@ -56,15 +60,18 @@ describe('pages/organisations/index.tsx', () => {
 
   it('renders organisation name as card header h2', async() => {
     render(WrappedComponentWithProps(
-      OrganisationIndexPage,{
-        count:3,
-        page:0,
-        rows:12,
-        organisations:organisationsOverview,
+      OrganisationIndexPage, {
+        props:{
+          count:3,
+          page:0,
+          rows:12,
+          organisations: organisationsOverview,
+        },
         // user session
         session:{
-          expires: 'test',
-          user: {name:'Test user'}
+          status: 'missing',
+          token: 'test-token',
+          user: {name:'Test user'} as RsdUser
         }
       }
     ))

--- a/frontend/__tests__/ProjectItem.test.tsx
+++ b/frontend/__tests__/ProjectItem.test.tsx
@@ -60,7 +60,7 @@ describe('pages/projects/index.tsx', () => {
   it('renders Project title', async() => {
     render(WrappedComponentWithProps(
       ProjectItemPage,
-      mockedProps
+      {props: mockedProps}
     ))
     const heading = await screen.findByRole('heading',{
       name: mockedProps.project.title

--- a/frontend/__tests__/ProjectsIndex.test.tsx
+++ b/frontend/__tests__/ProjectsIndex.test.tsx
@@ -8,6 +8,7 @@ import projectsOverview from './__fixtures__/projectsOverview.json'
 import ProjectsIndexPage, {getServerSideProps} from '../pages/projects/index'
 import {prepareData} from '../utils/getProjects'
 import {RawProject} from '../types/Project'
+import {RsdUser} from '../auth'
 
 
 describe('pages/projects/index.tsx', () => {
@@ -41,15 +42,18 @@ describe('pages/projects/index.tsx', () => {
 
   it('renders heading with the title Projects', async() => {
     render(WrappedComponentWithProps(
-      ProjectsIndexPage,{
-        count:200,
-        page:0,
-        rows:12,
-        projects:projectsOverview,
-        // user session
+      ProjectsIndexPage, {
+        props: {
+          count:200,
+          page:0,
+          rows:12,
+          projects:projectsOverview,
+        },
+       // user session
         session:{
-          expires: 'test',
-          user: {name:'Test user'}
+          status: 'missing',
+          token: 'test-token',
+          user: {name:'Test user'} as RsdUser
         }
       }
     ))
@@ -61,15 +65,18 @@ describe('pages/projects/index.tsx', () => {
 
   it('renders project as card (based on title)', async() => {
     render(WrappedComponentWithProps(
-      ProjectsIndexPage,{
-        count:3,
-        page:0,
-        rows:12,
-        projects:projectsOverview,
+      ProjectsIndexPage, {
+        props: {
+          count:3,
+          page:0,
+          rows:12,
+          projects:projectsOverview,
+        },
         // user session
         session:{
-          expires: 'test',
-          user: {name:'Test user'}
+          status: 'missing',
+          token: 'test-token',
+          user: {name:'Test user'} as RsdUser
         }
       }
     ))

--- a/frontend/__tests__/SoftwareIndex.test.tsx
+++ b/frontend/__tests__/SoftwareIndex.test.tsx
@@ -5,6 +5,7 @@ import {mockResolvedValue} from '../utils/jest/mockFetch'
 
 // mock fetch response
 import softwareItem from './__fixtures__/softwareItem.json'
+import {RsdUser} from '../auth'
 const mockedResponse=[softwareItem]
 
 describe('pages/software/index.tsx', () => {
@@ -35,16 +36,19 @@ describe('pages/software/index.tsx', () => {
   })
   it('renders heading with the title Software', async() => {
     render(WrappedComponentWithProps(
-      SoftwareIndexPage,{
-        count:200,
-        page:0,
-        rows:12,
-        software:mockedResponse,
-        tags:[],
+      SoftwareIndexPage, {
+        props: {
+          count:200,
+          page:0,
+          rows:12,
+          software:mockedResponse,
+          tags:[],
+        },
         // user session
         session:{
-          expires: 'test',
-          user: {name:'Test user'}
+          status: 'missing',
+          token: 'test-token',
+          user: {name:'Test user'} as RsdUser
         }
       }
     ))
@@ -56,16 +60,19 @@ describe('pages/software/index.tsx', () => {
   })
   it('renders software card title',async()=>{
     render(WrappedComponentWithProps(
-      SoftwareIndexPage,{
-        count:200,
-        page:0,
-        rows:12,
-        software:mockedResponse,
-        tags:[],
+      SoftwareIndexPage, {
+        props: {
+          count:200,
+          page:0,
+          rows:12,
+          software:mockedResponse,
+          tags:[]
+        },
         // user session
         session:{
-          expires: 'test',
-          user: {name:'Test user'}
+          status: 'missing',
+          token: 'test-token',
+          user: {name:'Test user'} as RsdUser
         }
       }
     ))

--- a/frontend/__tests__/SoftwareItem.test.tsx
+++ b/frontend/__tests__/SoftwareItem.test.tsx
@@ -11,7 +11,7 @@ describe('pages/software/[slug]/index.tsx', () => {
   it('renders heading with software title', async() => {
     render(WrappedComponentWithProps(
       SoftwareItemPage,
-      softwareIndexData
+      {props: softwareIndexData}
     ))
     const title = await screen.findByText(softwareIndexData.software.brand_name)
     expect(title).toBeInTheDocument()
@@ -22,7 +22,7 @@ describe('pages/software/[slug]/index.tsx', () => {
     softwareIndexData.isMaintainer=true
     render(WrappedComponentWithProps(
       SoftwareItemPage,
-      softwareIndexData
+      {props: softwareIndexData}
     ))
     const editBtn = screen.getByTestId('edit-button')
     expect(editBtn).toBeInTheDocument()
@@ -33,7 +33,7 @@ describe('pages/software/[slug]/index.tsx', () => {
     softwareIndexData.isMaintainer=false
     render(WrappedComponentWithProps(
       SoftwareItemPage,
-      softwareIndexData
+      {props: softwareIndexData}
     ))
     const editBtn = screen.queryByTestId('edit-button')
     expect(editBtn).not.toBeInTheDocument()
@@ -42,7 +42,7 @@ describe('pages/software/[slug]/index.tsx', () => {
   it('render mentions count', () => {
     render(WrappedComponentWithProps(
       SoftwareItemPage,
-      softwareIndexData
+      {props: softwareIndexData}
     ))
     const expected = softwareIndexData.softwareIntroCounts.mention_cnt
     const mentions = screen.getByText(expected)
@@ -52,7 +52,7 @@ describe('pages/software/[slug]/index.tsx', () => {
   it('render contributor_cnt count', () => {
     render(WrappedComponentWithProps(
       SoftwareItemPage,
-      softwareIndexData
+      {props: softwareIndexData}
     ))
     const expected = softwareIndexData.softwareIntroCounts.contributor_cnt
     const contributor_cnt = screen.getByText(expected)

--- a/frontend/auth/ProtectedContent.test.tsx
+++ b/frontend/auth/ProtectedContent.test.tsx
@@ -1,7 +1,7 @@
 
 import {render,screen} from '@testing-library/react'
 import {Session} from './index'
-import {WrappedComponentWithPropsAndSession} from '../utils/jest/WrappedComponents'
+import {WrappedComponentWithProps} from '../utils/jest/WrappedComponents'
 
 import ProtectedContent from './ProtectedContent'
 
@@ -13,8 +13,7 @@ const session:Session = {
 
 it('renders loader when status loader', () => {
   session.status = 'loading'
-  render(WrappedComponentWithPropsAndSession({
-    Component: ProtectedContent,
+  render(WrappedComponentWithProps(ProtectedContent,{
     session
   }))
   const loader = screen.getByRole('progressbar')
@@ -28,8 +27,7 @@ it('renders content when authenticated', async() => {
       <h1>Authenticated</h1>
     </ProtectedContent>
   )
-  render(WrappedComponentWithPropsAndSession({
-    Component: Content,
+  render(WrappedComponentWithProps(Content,{
     session
   }))
   const header = await screen.findByText('Authenticated')
@@ -43,12 +41,9 @@ it('renders 403 when no maintainer', async() => {
       <h1>Authenticated</h1>
     </ProtectedContent>
   )
-  render(WrappedComponentWithPropsAndSession({
-    Component: Content,
+  render(WrappedComponentWithProps(Content,{
     session
   }))
   const b403 = await screen.findByText('403')
   expect(b403).toBeInTheDocument()
 })
-
-

--- a/frontend/components/layout/AppFooter.tsx
+++ b/frontend/components/layout/AppFooter.tsx
@@ -4,7 +4,7 @@ import Mail from '@mui/icons-material/Mail'
 
 export default function AppFooter () {
   return (
-    <footer className="flex flex-wrap bg-secondary text-white border-t border-neutral">
+    <footer className="flex flex-wrap bg-secondary text-white border-t border-grey-A400">
       <div className="grid grid-cols-1 gap-8 px-4 md:grid-cols-[_2fr,1fr] lg:container lg:mx-auto">
 
         <div className="pt-10 sm:pb-10">

--- a/frontend/components/layout/AppHeader.tsx
+++ b/frontend/components/layout/AppHeader.tsx
@@ -41,16 +41,16 @@ export default function AppHeader({editButton}:{editButton?:JSX.Element}){
 
   return (
     <header className="px-4 lg:container lg:mx-auto">
-      <div className="flex flex-col pt-4 md:flex-row md:items-center">
+      <div className="flex flex-col pt-4 pb-6 md:flex-row md:items-center">
         <Link href="/" passHref>
           <a><LogoRSD className="cursor-pointer scale-90 sm:scale-100"/></a>
         </Link>
-        <section className='flex flex-1 py-4'>
+        <section className="flex flex-1 text-lg">
           <div className="flex flex-1 md:justify-center md:items-center">
             {getMenuItems()}
           </div>
           <JavascriptSupportWarning />
-          <div className="flex-1 min-w-[8rem] text-right sm:flex-none">
+          <div className="flex-1 flex justify-end items-center min-w-[8rem] text-right sm:flex-none">
             {editButton ? editButton : null}
             {status==='authenticated' ? <AddMenu/> : null}
             {/*<ThemeSwitcher/>*/}

--- a/frontend/components/layout/DarkThemeSection.tsx
+++ b/frontend/components/layout/DarkThemeSection.tsx
@@ -1,12 +1,7 @@
-import {createTheme, ThemeProvider} from '@mui/material/styles'
+import {ThemeProvider} from '@mui/material/styles'
+import {loadMuiTheme} from '../../styles/rsdMuiTheme'
 
-import PageContainer from './PageContainer'
-
-const darkTheme = createTheme({
-  palette: {
-    mode: 'dark',
-  },
-})
+const darkTheme = loadMuiTheme('dark')
 
 export default function DarkThemeSection(props:any) {
 

--- a/frontend/components/layout/UserMenu.test.tsx
+++ b/frontend/components/layout/UserMenu.test.tsx
@@ -12,7 +12,9 @@ it('should render userMenu',()=>{
 })
 
 it('should have userMenu options',async()=>{
-  render(WrappedComponentWithProps(UserMenu, {menuOptions: userMenuItems}))
+  render(WrappedComponentWithProps(UserMenu, {
+    props: {menuOptions: userMenuItems}
+  }))
   const menuButton = screen.queryByTestId('user-menu-button')
   // click on the button to display menu options
   expect(menuButton).toBeInTheDocument()

--- a/frontend/components/software/CitationSection.test.tsx
+++ b/frontend/components/software/CitationSection.test.tsx
@@ -15,7 +15,9 @@ it('should NOT render citation section when no data provided',()=>{
 describe('with dummy data',()=>{
   beforeEach(()=>{
     // render citation section with parent context and dummy data
-    render(WrappedComponentWithProps(CitationSection,{citationInfo}))
+    render(WrappedComponentWithProps(CitationSection, {
+      props: {citationInfo}
+    }))
   })
 
   it('should render citation section with title: Cite this software',()=>{
@@ -63,5 +65,3 @@ describe('with dummy data',()=>{
     expect(downloadButton).toHaveAttribute('disabled')
   })
 })
-
-

--- a/frontend/components/software/MentionsByType.tsx
+++ b/frontend/components/software/MentionsByType.tsx
@@ -37,7 +37,7 @@ function renderMentionSectionForType(key: MentionType, items: MentionForSoftware
         borderTop: '1px solid',
         borderColor: 'divider',
         // custom color from legacy RSD
-        backgroundColor: '#3a3e40',
+        backgroundColor: 'secondary.light',
         // remove line above the accordion
         '&:before': {
           height: '0px'
@@ -54,7 +54,7 @@ function renderMentionSectionForType(key: MentionType, items: MentionForSoftware
         sx={{
           position: 'sticky',
           top: 0,
-          backgroundColor: '#222425',
+          backgroundColor: 'secondary.main',
           padding: '0rem',
           '&:hover': {
             opacity:0.95

--- a/frontend/components/software/MentionsByType.tsx
+++ b/frontend/components/software/MentionsByType.tsx
@@ -47,7 +47,13 @@ function renderMentionSectionForType(key: MentionType, items: MentionForSoftware
         }
       }}>
       <AccordionSummary
-        expandIcon={<ExpandMoreIcon />}
+        expandIcon={
+          <ExpandMoreIcon
+            sx={{
+              color: 'secondary.contrastText'
+            }}
+          />
+        }
         aria-controls={`panel1-content-${key}`}
         id={`panel1-header-${key}`}
         sx={{
@@ -69,7 +75,8 @@ function renderMentionSectionForType(key: MentionType, items: MentionForSoftware
               top: '0.25rem',
               border: '1px solid',
               borderColor: 'secondary.contrastText',
-              color: 'secondary.contrastText'
+              color: 'secondary.contrastText',
+              fontWeight: 500
             },
           }}
         >

--- a/frontend/components/software/MentionsByType.tsx
+++ b/frontend/components/software/MentionsByType.tsx
@@ -36,7 +36,6 @@ function renderMentionSectionForType(key: MentionType, items: MentionForSoftware
         boxShadow: 0,
         borderTop: '1px solid',
         borderColor: 'divider',
-        // custom color from legacy RSD
         backgroundColor: 'secondary.light',
         // remove line above the accordion
         '&:before': {
@@ -63,13 +62,14 @@ function renderMentionSectionForType(key: MentionType, items: MentionForSoftware
       >
         <Badge
           badgeContent={items.length}
-          color="primary"
+          color="secondary"
           sx={{
             '& .MuiBadge-badge': {
               right: '-1rem',
               top: '0.25rem',
-              border: '2px solid',
-              borderColor: 'common.white'
+              border: '1px solid',
+              borderColor: 'secondary.contrastText',
+              color: 'secondary.contrastText'
             },
           }}
         >
@@ -81,7 +81,7 @@ function renderMentionSectionForType(key: MentionType, items: MentionForSoftware
         maxHeight: '30rem',
         //avoid resizing when scrollbar appears
         overflow: 'overlay',
-        padding:'0rem 0rem'
+        padding: '0rem 0rem'
       }}>
         {renderMentionItemsForType(items)}
       </AccordionDetails>

--- a/frontend/components/software/MentionsSection.test.tsx
+++ b/frontend/components/software/MentionsSection.test.tsx
@@ -12,14 +12,18 @@ it('should NOT render mentions section when no data provided',()=>{
 })
 
 it('should render mention section title when data provided',()=>{
-  render(WrappedComponentWithProps(MentionsSection, {mentions: mentionsData}))
+  render(WrappedComponentWithProps(MentionsSection, {
+    props:{mentions: mentionsData}
+}))
   const title = screen.queryByTestId('software-mentions-section-title')
   expect(title).toBeInTheDocument()
   // screen.debug()
 })
 
 it('should render featured mention items (based on dummy data)',()=>{
-  render(WrappedComponentWithProps(MentionsSection, {mentions: mentionsData}))
+  render(WrappedComponentWithProps(MentionsSection, {
+    props: {mentions: mentionsData}
+  }))
   const expectedItems = mentionsData.filter(item=>item.is_featured)
   const featured = screen.queryAllByTestId('software-mention-is-featured')
   expect(featured.length).toEqual(expectedItems.length)
@@ -27,14 +31,18 @@ it('should render featured mention items (based on dummy data)',()=>{
 })
 
 it('should render 6 mention type sections (based on dummy data)',()=>{
-  render(WrappedComponentWithProps(MentionsSection, {mentions:mentionsData}))
+  render(WrappedComponentWithProps(MentionsSection, {
+    props: {mentions: mentionsData}
+  }))
   const mentions = screen.queryAllByTestId('software-mentions-by-type')
   expect(mentions.length).toEqual(6)
   // screen.debug()
 })
 
 it('should render all not featured mention items (based on dummy data)',()=>{
-  render(WrappedComponentWithProps(MentionsSection, {mentions: mentionsData}))
+  render(WrappedComponentWithProps(MentionsSection, {
+    props: {mentions: mentionsData}
+  }))
   const expectedItems = mentionsData.filter(item=>!item.is_featured)
   const mentionItems = screen.queryAllByTestId('software-mention-item-body')
   expect(mentionItems.length).toEqual(expectedItems.length)

--- a/frontend/components/software/MentionsSection.tsx
+++ b/frontend/components/software/MentionsSection.tsx
@@ -1,17 +1,11 @@
-import {createTheme, ThemeProvider} from '@mui/material/styles'
+import DarkThemeSection from '../layout/DarkThemeSection'
 
 import PageContainer from '../layout/PageContainer'
 import MentionIsFeatured from './MentionIsFeatured'
-import MentionsByType, {MentionByType} from './MentionsByType'
+import MentionsByType from './MentionsByType'
 import {sortOnDateProp} from '../../utils/sortFn'
 import {MentionForSoftware} from '../../types/Mention'
 import {clasifyMentionsByType} from '../../utils/editMentions'
-
-const darkTheme = createTheme({
-  palette: {
-    mode: 'dark',
-  },
-})
 
 export default function SoftwareMentionsSection({mentions}: { mentions: MentionForSoftware[] }) {
   // do not render section if no data
@@ -20,28 +14,24 @@ export default function SoftwareMentionsSection({mentions}: { mentions: MentionF
   const {mentionByType, featuredMentions} = clasifyMentionsByType(mentions)
 
   return (
-    <ThemeProvider theme={darkTheme}>
-      <section
-        className="bg-secondary"
-      >
-        <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
-          <h2
-            data-testid="software-mentions-section-title"
-            className="pb-8 text-[2rem] text-white">
-            Mentions
-          </h2>
-          <section>
-            {featuredMentions
-              .sort((a,b)=>sortOnDateProp(a,b,'date','desc'))
-              .map(item => {
-              return (
-                <MentionIsFeatured key={item.url} mention={item} />
-              )
-            })}
-            <MentionsByType mentionByType={mentionByType} />
-          </section>
-        </PageContainer>
-      </section>
-    </ThemeProvider>
+    <DarkThemeSection>
+      <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
+        <h2
+          data-testid="software-mentions-section-title"
+          className="pb-8 text-[2rem] text-white">
+          Mentions
+        </h2>
+        <section>
+          {featuredMentions
+            .sort((a,b)=>sortOnDateProp(a,b,'date','desc'))
+            .map(item => {
+            return (
+              <MentionIsFeatured key={item.url} mention={item} />
+            )
+          })}
+          <MentionsByType mentionByType={mentionByType} />
+        </section>
+      </PageContainer>
+    </DarkThemeSection>
   )
 }

--- a/frontend/components/software/add/AddSoftwareCard.test.tsx
+++ b/frontend/components/software/add/AddSoftwareCard.test.tsx
@@ -1,12 +1,14 @@
 import {render,screen,fireEvent,waitFor,waitForElementToBeRemoved} from '@testing-library/react'
-import {WrappedComponentWithProps,WrappedComponentWithPropsAndSession} from '../../../utils/jest/WrappedComponents'
+import {WrappedComponentWithProps} from '../../../utils/jest/WrappedComponents'
 
+import {Session} from '../../../auth/'
 import AddSoftwareCard from './AddSoftwareCard'
 import {addConfig} from './addConfig'
 import {getSlugFromString} from '../../../utils/getSlugFromString'
 
 // mock addSoftware
 import * as editSoftware from '../../../utils/editSoftware'
+
 const mockAddSoftware = jest.spyOn(editSoftware, 'addSoftware')
   .mockImplementation((props) => Promise.resolve({status: 201, message: props}))
 // mock validSoftwareItem
@@ -34,7 +36,7 @@ it('render card with title', async () => {
 
 it('card has textbox with Name that can be entered', async() => {
   render(WrappedComponentWithProps(AddSoftwareCard))
-  const name = screen.getByRole('textbox', {name: 'Name'})
+  const name = screen.getByRole<HTMLInputElement>('textbox', {name: 'Name'})
   expect(name).toBeInTheDocument()
 
   // accepts test value
@@ -45,7 +47,7 @@ it('card has textbox with Name that can be entered', async() => {
 
 it('card has textbox with Short description that can be entered', async() => {
   render(WrappedComponentWithProps(AddSoftwareCard))
-  const desc = screen.getByRole('textbox', {name: 'Short description'})
+  const desc = screen.getByRole<HTMLInputElement>('textbox', {name: 'Short description'})
   expect(desc).toBeInTheDocument()
   // accepts test value
   const inputValue = 'Test software description'
@@ -78,21 +80,20 @@ it('validate, save and redirect', async () => {
   // test values
   const inputName = 'Test software name'
   const inputValue = 'Test software description'
-  const session = {
+  const session:Session = {
     user: null,
     token: 'TEST_TOKEN',
     status: 'authenticated'
   }
   // render
-  render(WrappedComponentWithPropsAndSession({
-    Component: AddSoftwareCard,
+  render(WrappedComponentWithProps(AddSoftwareCard,{
     session
   }))
 
-  const name = screen.getByRole('textbox', {name: 'Name'})
+  const name = screen.getByRole<HTMLInputElement>('textbox', {name: 'Name'})
   expect(name).toBeInTheDocument()
 
-  const desc = screen.getByRole('textbox', {name: 'Short description'})
+  const desc = screen.getByRole<HTMLInputElement>('textbox', {name: 'Short description'})
   expect(desc).toBeInTheDocument()
 
   fireEvent.change(name, {target: {value: inputName}})
@@ -144,4 +145,3 @@ it('validate, save and redirect', async () => {
     expect(mockReplace).toHaveBeenCalledWith(expected)
   })
 })
-

--- a/frontend/config/menuItems.ts
+++ b/frontend/config/menuItems.ts
@@ -12,5 +12,5 @@ export type MenuItemType = {
 export const menuItems:MenuItemType[] = [
   {path:'/software', label:'Software'},
   {path: '/projects', label: 'Projects'},
-  {path: '/organisations', label: 'Organizations'}
+  {path: '/organisations', label: 'Organisations'}
 ]

--- a/frontend/config/menuItems.ts
+++ b/frontend/config/menuItems.ts
@@ -10,10 +10,7 @@ export type MenuItemType = {
 // routes defined for nav/menu
 // used in components/AppHeader
 export const menuItems:MenuItemType[] = [
-  // {path:"/", label:"Home"},
   {path:'/software', label:'Software'},
   {path: '/projects', label: 'Projects'},
-  {path: '/organisations', label: 'Organisations'},
-  // will be done later
-  // {path:"/about", label:"About"},
+  {path: '/organisations', label: 'Organizations'}
 ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.6.4",
+  "version": "0.6.7",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -4,7 +4,7 @@ import App, {AppContext, AppProps} from 'next/app'
 import Head from 'next/head'
 import {ThemeProvider} from '@mui/material/styles'
 import {CacheProvider, EmotionCache} from '@emotion/react'
-import {rsdMuiTheme} from '../styles/rsdMuiTheme'
+import {loadMuiTheme} from '../styles/rsdMuiTheme'
 import createEmotionCache from '../styles/createEmotionCache'
 // loading bar at the top of the screen
 import nprogress from 'nprogress'
@@ -36,9 +36,9 @@ nprogress.configure({showSpinner: false})
 
 function RsdApp(props: MuiAppProps) {
   const {Component, emotionCache = clientSideEmotionCache, pageProps, session} = props
-
   const [options, setSnackbar] = useState(snackbarDefaults)
-
+  //currently we support only default (light) and dark RSD theme for MUI
+  const muiTheme = loadMuiTheme('default')
 
   useEffect(()=>{
     router.events.on('routeChangeStart', ()=>{
@@ -63,8 +63,8 @@ function RsdApp(props: MuiAppProps) {
         <title>Research Software Directory</title>
         <meta name="viewport" content="initial-scale=1, width=device-width" />
       </Head>
-        {/* CssBaseline from MUI-5*/}
-      <ThemeProvider theme={rsdMuiTheme}>
+      {/* MUI Theme provider */}
+      <ThemeProvider theme={muiTheme}>
         {/* CssBaseline from MUI-5*/}
         {/* <CssBaseline /> */}
         <AuthProvider session={session}>

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react'
 import Document, {Html, Head, Main, NextScript} from 'next/document'
 import createEmotionServer from '@emotion/server/create-instance'
-import {rsdMuiTheme} from '../styles/rsdMuiTheme'
 import createEmotionCache from '../styles/createEmotionCache'
 
 export default class MyDocument extends Document {
@@ -9,20 +8,21 @@ export default class MyDocument extends Document {
     return (
       <Html lang="en">
         <Head>
-          {/* PWA primary color */}
-          <meta name="theme-color" content={rsdMuiTheme.palette.primary.main} />
+          {/* Theme color for the browser, if it supports it, is REMOVED 2022-04-10 by Dusan */}
+          {/* <meta name="theme-color" content={rsdMuiTheme.palette.primary.main} /> */}
           {/* Roboto fonts */}
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:100,300,400&display=swap"
           />
           <link href="https://fonts.googleapis.com/css2?family=Work+Sans:wght@700&display=swap" rel="stylesheet" />
+          {/* add support for gracefull fallback for aos animations when js is disabled */}
           <noscript dangerouslySetInnerHTML={{__html: `
-                <style type="text/css">
-                  [data-aos] {
-                  opacity: 1 !important;
-                  transform: translate(0) scale(1) !important;
-                }
-                </style>
-              `}} />
+            <style type="text/css">
+              [data-aos] {
+              opacity: 1 !important;
+              transform: translate(0) scale(1) !important;
+            }
+            </style>
+          `}} />
         </Head>
         <body className="dark">
           <Main />

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,4 +1,4 @@
-import {useContext, useEffect, useState} from 'react'
+import {useEffect, useState} from 'react'
 import AOS from 'aos'
 import AppFooter from '~/components/layout/AppFooter'
 import ThemeSwitcher from '~/components/layout/ThemeSwitcher'
@@ -52,7 +52,7 @@ export default function Home() {
           data-testid="Landing Page"
           className="sticky top-0 px-5 md:px-10 z-10 backdrop-filter backdrop-blur-xl bg-white dark:bg-black bg-opacity-60 dark:bg-opacity-60">
 
-          <div className=" w-fudocker ll max-w-screen-xl mx-auto flex py-6 items-center">
+          <div className="w-full max-w-screen-xl mx-auto flex py-6 items-center">
             <Link href="/" passHref>
               <a className="hover:shadow-2xl">
                 <LogoApp className="hidden xl:block"/>
@@ -100,6 +100,7 @@ export default function Home() {
               opacity-50 md:opacity-100
                 ">
             <Image src="/images/illustration.webp" width="847" height="760"
+              alt="rsd-illustration"
             />
             </div>
           </div>

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -64,7 +64,7 @@ export default function Home() {
                 <a href="#whyrsd">Why RSD</a>
                 <Link href="/software">Software</Link>
                 <Link href="/projects">Projects</Link>
-                <Link href="/organisations">Organizations</Link>
+                <Link href="/organisations">Organisations</Link>
                 {/*<Link href="/about">About us</Link>*/}
               </div>
             </div>

--- a/frontend/pages/projects/[slug]/index.tsx
+++ b/frontend/pages/projects/[slug]/index.tsx
@@ -13,10 +13,10 @@ import PageMeta from '../../../components/seo/PageMeta'
 import OgMetaTags from '../../../components/seo/OgMetaTags'
 import CanoncialUrl from '../../../components/seo/CanonicalUrl'
 import {
-  getLinksForProject, getParticipatingOrganisations,
-  getProjectItem, getTagsForProject, getTopicsForProject,
-  getImpactForProject, getOutputForProject, getRelatedProjects,
-  getRelatedToolsForProject, getTeamForProject,
+  getLinksForProject, getImpactForProject,
+  getOutputForProject, getParticipatingOrganisations,
+  getProjectItem, getRelatedProjects, getRelatedToolsForProject,
+  getTagsForProject, getTeamForProject, getTopicsForProject
 } from '../../../utils/getProjects'
 import {Project, ProjectLink, RelatedProject} from '../../../types/Project'
 import ProjectInfo from '../../../components/projects/ProjectInfo'
@@ -65,7 +65,8 @@ export default function ProjectPage(props: ProjectPageProps) {
       </ContentInTheMiddle>
     )
   }
-  // console.log('ProjectItemPage...topics...', topics)
+  // console.log('ProjectItemPage...relatedTools...', relatedTools)
+  // console.log('ProjectItemPage...impact...', impact)
   return (
     <>
       {/* Page Head meta tags */}
@@ -163,7 +164,7 @@ export async function getServerSideProps(context:any) {
       getTeamForProject({project: project.id, token, frontend: false}),
       getRelatedToolsForProject({project: project.id, token, frontend: false}),
       getRelatedProjects({project: project.id, token, frontend: false}),
-      getLinksForProject({project: project.id, token, frontend: false}),
+      getLinksForProject({project: project.id, token, frontend: false})
     ]
 
     const [
@@ -194,7 +195,7 @@ export async function getServerSideProps(context:any) {
         team,
         relatedTools,
         relatedProjects,
-        links,
+        links
       },
     }
   } catch (e:any) {

--- a/frontend/styles/README.md
+++ b/frontend/styles/README.md
@@ -6,16 +6,22 @@ The global.css file is imported in page/\_document.tsx. It is applied to all pag
 
 ## CSS Baseline
 
-MUI provides baseline styles as CSSBaseline component. Tese are applied in page/\_document.tsx file.
-For more information [see documentation](https://mui.com/components/css-baseline/).
+MUI provides baseline styles as CSSBaseline component. These are applied in page/\_document.tsx file.
+For more information [see documentation](https://mui.com/components/css-baseline/). However in this project we currently apply tailwind base classes rather than MUI's.
 
 ## MUI theme and global styles
 
-You can change all theme values in the rsdTheme.ts file.
+Initially we defined two themes: default and dark theme. The definitions are stored in themeDark and themeDefault javascript files. The definition are loaded by getThemeConfig(theme) method in themeConfig.js file.
 
-For more information [see documentation](https://mui.com/customization/theming/)
-For default theme values [see this page](https://mui.com/customization/default-theme/)
-Tip: to see all theme values you can use (uncomment) the console.log() at the bottom of rsdTheme.ts.
+The same color definitions are loaded into tailwind configuration (tailwind.config.js)
+
+For more information see comments in these files:
+
+- themeConfig.js
+- themeDefault.js
+- tailwind.config.js
+
+For general information about MUI themes [see documentation](https://mui.com/customization/theming/)
 
 ## MUI Theme properties
 
@@ -282,7 +288,7 @@ const rsdTheme = {
 
 ## Tailwind theme
 
-Below you see the default theme configuration.
+Below you see default theme configuration of tailwind. We combine material-ui and tailwind and we need to keep color definitions in sync. For more info see themeConfig.js and tailwind.config.js
 
 ```javascript
 const colors = require("../colors");

--- a/frontend/styles/rsdMuiTheme.ts
+++ b/frontend/styles/rsdMuiTheme.ts
@@ -7,14 +7,14 @@
  */
 
 import {createTheme} from '@mui/material/styles'
-// import colors and breakpoints from shared themeConfig file
-// these values are applied to both MUI-5 and Tailwind themes
-import {colors, muiTypography} from './themeConfig'
+// import default colors, typography and getThemeMethod for loading theme configuration
+import {colors,muiTypography,getThemeConfig} from './themeConfig'
+
+type MuiColorSchema = typeof colors
+type MuiTypography = typeof muiTypography
 
 /**
  * EXAMPLE of extendings MUI-5 theme interface
- * Alter styles module declaration to extend breakpoints.
- * We add hd (1920) to better cover 2k/4k screens.
  * See https://mui.com/customization/breakpoints/
  */
 // declare module '@mui/material/styles' {
@@ -23,256 +23,152 @@ import {colors, muiTypography} from './themeConfig'
 //   }
 // }
 
-const rsdMuiTheme = createTheme({
-  palette: {
-    primary: {
-      main: colors.primary,
-      contrastText: colors.contrastText
-    },
-    secondary: {
-      main: colors.secondary,
-      contrastText: colors.contrastText
-    },
-    error: {
-      main: colors.error,
-      contrastText: colors.contrastText
-    },
-    common: {
-      black: colors.black,
-      white: colors.white,
-    },
-    warning: {
-      main: colors.warning,
-      contrastText: colors.contrastText
-    },
-    info: {
-      main: colors.info,
-      contrastText: colors.contrastText
-    },
-    success: {
-      main: colors.success,
-      contrastText: colors.contrastText
-    },
-    grey: colors.grey,
-    text: {
-      primary: colors.textPrimary,
-      secondary: colors.textSecondary,
-      disabled: colors.textDisabled,
-    },
-    divider: colors.divider,
-    background: {
-      paper: colors.white,
-      default: colors.white,
-    },
-  },
-  shape:{
-    borderRadius: 2
-  },
-  typography:{
-    button:{
-      fontWeight: 400,
-      letterSpacing: '0.125rem',
-    },
-    // change headers fontSize and weight
-    h1: {
-      fontWeight: 300,
-      fontSize: '4rem',
-      lineHeight: 1.3,
-    },
-    h2: {
-      fontWeight: 100,
-      fontSize: '2rem',
-      lineHeight: 1.25,
-    },
-    h3: {
-      fontWeight: 300,
-      fontSize: '1.5rem',
-      lineHeight: 1.125,
-    },
-    ...muiTypography
-  },
-  // overriding defaults
-  // in Mui components
-  // see https://mui.com/customization/theme-components/
-  components: {
-    // MuiButton:{
-    //   styleOverrides:{
-    //     root:{
-    //       // remove upper text transform from buttons
-    //       textTransform:'inherit'
-    //     }
-    //   }
-    // },
-    MuiListItemText:{
-      styleOverrides:{
-        primary:{
-          // cut off large menu items with ...
-          overflow:'hidden',
-          textOverflow: 'ellipsis'
-        }
-      }
-    },
-    MuiPaper:{
-      styleOverrides:{
-        root:{
-          overflow:'auto'
-        }
-      }
-    },
-    MuiTablePagination:{
-      styleOverrides:{
-        selectRoot:{
-          marginRight:'0.5rem'
-        },
-        displayedRows:{
-          minWidth:'6.5rem',
-          textAlign:'right',
-          '@media(max-width: 640px)':{
-            minWidth:'inherit',
-          }
-        },
-        toolbar:{
-          '@media(max-width: 640px)':{
-            paddingLeft:'0rem'
-          }
-        },
-        actions:{
-          '@media(max-width: 640px)':{
-            marginLeft:'0.5rem'
-          }
-        }
-      }
-    }
-  },
-})
-
-
-const rsdDarkMuiTheme = createTheme({
-  palette: {
-    primary: {
-      main: colors.primary,
-      contrastText: colors.contrastText
-    },
-    secondary: {
-      main: colors.secondary,
-      contrastText: colors.contrastText
-    },
-    error: {
-      main: colors.error,
-      contrastText: colors.contrastText
-    },
-    common: {
-      black: colors.black,
-      white: colors.white,
-    },
-    warning: {
-      main: colors.warning,
-      contrastText: colors.contrastText
-    },
-    info: {
-      main: colors.info,
-      contrastText: colors.contrastText
-    },
-    success: {
-      main: colors.success,
-      contrastText: colors.contrastText
-    },
-    grey: colors.grey,
-    text: {
-      primary: colors.textPrimary,
-      secondary: colors.textSecondary,
-      disabled: colors.textDisabled,
-    },
-    divider: colors.divider,
-    background: {
-      paper: colors.white,
-      default: colors.white,
-    },
-  },
-  shape:{
-    borderRadius: 2
-  },
-  typography:{
-    button:{
-      fontWeight: 400,
-      letterSpacing: '0.125rem',
-    },
-    // change headers fontSize and weight
-    h1: {
-      fontWeight: 300,
-      fontSize: '4rem',
-      lineHeight: 1.3,
-    },
-    h2: {
-      fontWeight: 100,
-      fontSize: '2rem',
-      lineHeight: 1.25,
-    },
-    h3: {
-      fontWeight: 300,
-      fontSize: '1.5rem',
-      lineHeight: 1.125,
-    },
-    ...muiTypography
-  },
-  // overriding defaults
-  // in Mui components
-  // see https://mui.com/customization/theme-components/
-  components: {
-    // MuiButton:{
-    //   styleOverrides:{
-    //     root:{
-    //       // remove upper text transform from buttons
-    //       textTransform:'inherit'
-    //     }
-    //   }
-    // },
-    MuiListItemText:{
-      styleOverrides:{
-        primary:{
-          // cut off large menu items with ...
-          overflow:'hidden',
-          textOverflow: 'ellipsis'
-        }
-      }
-    },
-    MuiPaper:{
-      styleOverrides:{
-        root:{
-          overflow:'auto'
-        }
-      }
-    },
-    MuiTablePagination:{
-      styleOverrides:{
-        selectRoot:{
-          marginRight:'0.5rem'
-        },
-        displayedRows:{
-          minWidth:'6.5rem',
-          textAlign:'right',
-          '@media(max-width: 640px)':{
-            minWidth:'inherit',
-          }
-        },
-        toolbar:{
-          '@media(max-width: 640px)':{
-            paddingLeft:'0rem'
-          }
-        },
-        actions:{
-          '@media(max-width: 640px)':{
-            marginLeft:'0.5rem'
-          }
-        }
-      }
-    }
-  },
-})
-
-export {
-  rsdMuiTheme,
-  rsdDarkMuiTheme
+export type ThemeConfig = {
+  colors: MuiColorSchema
+  muiTypography: MuiTypography
 }
-// show all theme values
-// console.log("rsdTheme:", JSON.stringify(rsdTheme))
+
+export type RsdThemes = 'dark' | 'default'
+
+/**
+ * Call this method to switch MuiTheme
+ * @param theme
+ * @returns Theme
+ */
+export function loadMuiTheme(theme:RsdThemes) {
+  // get theme colors and typography
+  const config: ThemeConfig = getThemeConfig(theme)
+  // create Mui Theme
+  const muiTheme = applyThemeConfig({
+    ...config
+  })
+  if (theme === 'dark') {
+    muiTheme.palette.mode = 'dark'
+  }
+  return muiTheme
+}
+
+function applyThemeConfig({colors,muiTypography}:ThemeConfig) {
+  return createTheme({
+    palette: {
+      primary: {
+        main: colors.primary,
+        contrastText: colors.contrastText
+      },
+      secondary: {
+        main: colors.secondary,
+        contrastText: colors.contrastText
+      },
+      error: {
+        main: colors.error,
+        contrastText: colors.contrastText
+      },
+      common: {
+        black: colors.black,
+        white: colors.white,
+      },
+      warning: {
+        main: colors.warning,
+        contrastText: colors.contrastText
+      },
+      info: {
+        main: colors.info,
+        contrastText: colors.contrastText
+      },
+      success: {
+        main: colors.success,
+        contrastText: colors.contrastText
+      },
+      grey: colors.grey,
+      text: {
+        primary: colors.textPrimary,
+        secondary: colors.textSecondary,
+        disabled: colors.textDisabled,
+      },
+      divider: colors.divider,
+      background: {
+        paper: colors.paper,
+        default: colors.background,
+      },
+    },
+    shape: {
+      borderRadius: 2
+    },
+    typography: {
+      button: {
+        fontWeight: 400,
+        letterSpacing: '0.125rem',
+      },
+      // change headers fontSize and weight
+      h1: {
+        fontWeight: 300,
+        fontSize: '4rem',
+        lineHeight: 1.3,
+      },
+      h2: {
+        fontWeight: 100,
+        fontSize: '2rem',
+        lineHeight: 1.25,
+      },
+      h3: {
+        fontWeight: 300,
+        fontSize: '1.5rem',
+        lineHeight: 1.125,
+      },
+      ...muiTypography
+    },
+    // overriding defaults
+    // in Mui components
+    // see https://mui.com/customization/theme-components/
+    components: {
+      // MuiButton:{
+      //   styleOverrides:{
+      //     root:{
+      //       // remove upper text transform from buttons
+      //       textTransform:'inherit'
+      //     }
+      //   }
+      // },
+      MuiListItemText: {
+        styleOverrides: {
+          primary: {
+            // cut off large menu items with ...
+            overflow: 'hidden',
+            textOverflow: 'ellipsis'
+          }
+        }
+      },
+      MuiPaper: {
+        styleOverrides: {
+          root: {
+            overflow: 'auto'
+          }
+        }
+      },
+      MuiTablePagination: {
+        styleOverrides: {
+          selectRoot: {
+            marginRight: '0.5rem'
+          },
+          displayedRows: {
+            minWidth: '6.5rem',
+            textAlign: 'right',
+            '@media(max-width: 640px)': {
+              minWidth: 'inherit',
+            }
+          },
+          toolbar: {
+            '@media(max-width: 640px)': {
+              paddingLeft: '0rem'
+            }
+          },
+          actions: {
+            '@media(max-width: 640px)': {
+              marginLeft: '0.5rem'
+            }
+          }
+        }
+      }
+    },
+  })
+}

--- a/frontend/styles/themeConfig.js
+++ b/frontend/styles/themeConfig.js
@@ -1,68 +1,43 @@
 /**
- * Colors for both themes
- * Tailwind and MUI-5 based on MUI-5 definitions
+ * Theme configuration
+ * It supports loading MUI theme application during the runtime.
+ * It requires color and typography configuration. To add theme:
+ * 1. Use themeDefault.js as a template and adapt the colors.
+ * 2. Add theme enumerator value to RsdThemes types in rsdMuiTheme.ts file
+ * 3. Call getThemeConfig with provided enumerator to load theme dynamically
+ * 4. Use MUI theme provider to provide the theme to child components.
+ * You can use multiple theme providers/overwrite current theme,
+ * the last assigned theme is applied to its children.
  */
+const defaultTheme = require('./themeDefault')
+const darkTheme = require('./themeDark')
+// example eScience theme loading
+// const escienceTheme = require('./themeEscience')
 
-const colors = {
-  primary:'#60a5fa',
-  secondary:'#000',
-  textPrimary:'rgba(34,36,37,1)',
-  textSecondary:'rgba(34,36,37,0.87)',
-  textDisabled:'rgba(34,36,37,0.45)',
-  divider:'#ddd',
-  contrastText:'#fff',
-  error:'#e53935',
-  warning:'#ed6c02',
-  info:'#0288d1',
-  success:'#2e7d32',
-  black:'#000',
-  white:'#fff',
-  grey: {
-    50: '#fafafa',
-    100: '#f5f5f5',
-    200: '#eeeeee',
-    300: '#e0e0e0',
-    400: '#bdbdbd',
-    500: '#9e9e9e',
-    600: '#757575',
-    700: '#616161',
-    800: '#424242',
-    900: '#212121',
-    A100: '#f5f5f5',
-    A200: '#eeeeee',
-    A400: '#bdbdbd',
-    A700: '#616161',
-  },
-  neutral: '#90909060',
-}
-
-/**
- * Breakpoints to use in both themes
- * Note! Tailwind uses string and MUI-5 numeric values
- */
-// const breakpoints = {
-//   xs: 640,
-//   sm: 768,
-//   md: 1024,
-//   lg: 1280,
-//   xl: 1920
-// }
-
-const muiTypography={
-  // Note! if you change the fonts here ensure you update
-  // pages/_document.tsx file to import proper fontFamily
-  // Currently we import the fonst from Google Fonts
-  // legacy RSD uses these fonts
-  fontFamily: 'Roboto,Helvetica,arial,sans-serif',
-  // set default fontsize to 1rem for MUI-5
-  // fontSize:14,
-  fontWeightLight: 100,
-  fontWeightRegular: 300,
-  fontWeightMedium: 300,
-  fontWeightBold: 400,
+function getThemeConfig(theme) {
+  // console.log('themeConfig.getThemeConfig...', theme)
+  switch (theme) {
+    // example escience theme type
+    // case 'escience':
+    //   return {
+    //     colors: escienceTheme.colors,
+    //     muiTypography: escienceTheme.muiTypography
+    //   }
+    case 'dark':
+      return {
+        colors: darkTheme.colors,
+        muiTypography: darkTheme.muiTypography
+      }
+    default:
+      return {
+        colors: defaultTheme.colors,
+        muiTypography: defaultTheme.muiTypography
+      }
+  }
 }
 
 module.exports={
-  colors,
-  muiTypography
+  colors: defaultTheme.colors,
+  muiTypography: defaultTheme.muiTypography,
+  getThemeConfig
 }

--- a/frontend/styles/themeDark.js
+++ b/frontend/styles/themeDark.js
@@ -1,0 +1,69 @@
+/**
+ * Colors for both themes
+ * Tailwind and MUI-5 based on MUI-5 definitions
+ */
+
+const colors = {
+  primary:'#60a5fa',
+  secondary:'#000',
+  textPrimary:'rgba(200,200,200,1)',
+  textSecondary:'rgba(34,36,37,0.87)',
+  textDisabled:'rgba(34,36,37,0.45)',
+  divider:'#ddd',
+  contrastText:'#000',
+  error:'#e53935',
+  warning:'#ed6c02',
+  info:'#0288d1',
+  success:'#2e7d32',
+  black:'#fff',
+  white: '#fafafa',
+  background: '#000',
+  paper: '#000',
+  grey: {
+    50: '#fafafa',
+    100: '#f5f5f5',
+    200: '#eeeeee',
+    300: '#e0e0e0',
+    400: '#bdbdbd',
+    500: '#9e9e9e',
+    600: '#757575',
+    700: '#616161',
+    800: '#424242',
+    900: '#212121',
+    A100: '#f5f5f5',
+    A200: '#eeeeee',
+    A400: '#bdbdbd',
+    A700: '#616161',
+  }
+}
+
+/**
+ * Breakpoints to use in both themes
+ * Note! Tailwind uses string and MUI-5 numeric values
+ */
+// const breakpoints = {
+//   xs: 640,
+//   sm: 768,
+//   md: 1024,
+//   lg: 1280,
+//   xl: 1920
+// }
+
+const muiTypography={
+  // Note! if you change the fonts here ensure you update
+  // pages/_document.tsx file to import proper fontFamily
+  // Currently we import the fonst from Google Fonts
+  // legacy RSD uses these fonts
+  fontFamily: 'Roboto,Helvetica,arial,sans-serif',
+  // set default fontsize to 1rem for MUI-5
+  // fontSize:14,
+  fontWeightLight: 100,
+  fontWeightRegular: 300,
+  fontWeightMedium: 300,
+  fontWeightBold: 400,
+}
+
+module.exports={
+  colors,
+  muiTypography
+}

--- a/frontend/styles/themeDark.js
+++ b/frontend/styles/themeDark.js
@@ -10,7 +10,7 @@ const colors = {
   textSecondary:'rgba(34,36,37,0.87)',
   textDisabled:'rgba(34,36,37,0.45)',
   divider:'#ddd',
-  contrastText:'#000',
+  contrastText:'#fff',
   error:'#e53935',
   warning:'#ed6c02',
   info:'#0288d1',

--- a/frontend/styles/themeDefault.js
+++ b/frontend/styles/themeDefault.js
@@ -1,0 +1,70 @@
+/**
+ * Colors for both themes
+ * Tailwind and MUI-5 based on MUI-5 definitions
+ */
+
+const colors = {
+  primary:'#60a5fa',
+  secondary:'#000',
+  textPrimary:'rgba(34,36,37,1)',
+  textSecondary:'rgba(34,36,37,0.87)',
+  textDisabled:'rgba(34,36,37,0.45)',
+  divider:'#ddd',
+  contrastText:'#fff',
+  error:'#e53935',
+  warning:'#ed6c02',
+  info:'#0288d1',
+  success:'#2e7d32',
+  black:'#000',
+  white: '#fff',
+  background: '#fff',
+  paper: '#fff',
+  grey: {
+    50: '#fafafa',
+    100: '#f5f5f5',
+    200: '#eeeeee',
+    300: '#e0e0e0',
+    400: '#bdbdbd',
+    500: '#9e9e9e',
+    600: '#757575',
+    700: '#616161',
+    800: '#424242',
+    900: '#212121',
+    A100: '#f5f5f5',
+    A200: '#eeeeee',
+    // tailwind neutral is A400 in MUI
+    A400: '#909090',
+    A700: '#616161',
+  }
+}
+
+/**
+ * Breakpoints to use in both themes
+ * Note! Tailwind uses string and MUI-5 numeric values
+ */
+// const breakpoints = {
+//   xs: 640,
+//   sm: 768,
+//   md: 1024,
+//   lg: 1280,
+//   xl: 1920
+// }
+
+const muiTypography={
+  // Note! if you change the fonts here ensure you update
+  // pages/_document.tsx file to import proper fontFamily
+  // Currently we import the fonts from Google Fonts
+  // legacy RSD uses these fonts
+  fontFamily: 'Roboto,Helvetica,arial,sans-serif',
+  // set default fontsize to 1rem for MUI-5
+  // fontSize:14,
+  fontWeightLight: 100,
+  fontWeightRegular: 300,
+  fontWeightMedium: 300,
+  fontWeightBold: 400,
+}
+
+module.exports={
+  colors,
+  muiTypography
+}

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -64,16 +64,19 @@ module.exports = {
         'rsd-titles': ['Work Sans']
       },
       colors: {
-        neutral: colors.neutral,
-        paper: colors.white,
+        // in order to have optimal theme integration with material ui components
+        // please keep the color names (props) in sync with MUI definitions
+        // the list of all theme properties can be found in README.md
         primary: colors.primary,
         secondary: colors.secondary,
+        divider: colors.divider,
         error: colors.error,
         warning: colors.warning,
         info: colors.info,
         success: colors.success,
-        grey: colors.grey
-
+        background: colors.background,
+        paper: colors.paper,
+        grey: colors.grey,
       },
       fontWeight:{
         regular: muiTypography.fontWeightRegular

--- a/frontend/utils/jest/WrappedComponents.tsx
+++ b/frontend/utils/jest/WrappedComponents.tsx
@@ -4,31 +4,22 @@
  */
 
 // import {SessionProvider} from 'next-auth/react'
-import {rsdMuiTheme} from '../../styles/rsdMuiTheme'
+import {loadMuiTheme,RsdThemes} from '../../styles/rsdMuiTheme'
 import {ThemeProvider} from '@mui/material/styles'
 import {AuthProvider, defaultSession, Session} from '../../auth'
 
-export function WrappedComponentWithProps(Component: any, props?: any, session?: Session) {
-  if (session) {
-    return (
-      <ThemeProvider theme={rsdMuiTheme}>
-        <AuthProvider session={session}>
-          <Component {...props} />
-        </AuthProvider>
-      </ThemeProvider>
-    )
-  }
-  return (
-    <ThemeProvider theme={rsdMuiTheme}>
-      <AuthProvider session={defaultSession}>
-        <Component { ...props }/>
-      </AuthProvider>
-    </ThemeProvider>
-  )
+type WrapProps = {
+  props?: any
+  session?: Session
+  theme?: RsdThemes
 }
 
-export function WrappedComponentWithPropsAndSession({Component, props = {}, session}:
-  { Component: any, props?: any, session?: Session }) {
+export function WrappedComponentWithProps(Component: any, options?: WrapProps) {
+  const theme = options?.theme ?? 'default'
+  const session = options?.session ?? defaultSession
+  const props = options?.props ?? {}
+
+  const rsdMuiTheme = loadMuiTheme(theme)
   if (session) {
     return (
       <ThemeProvider theme={rsdMuiTheme}>

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -65,7 +65,7 @@ export function ssrSoftwareUrl(params:QueryParams){
 }
 
 export function ssrOrganisationUrl(params: QueryParams) {
-  const view = 'organisation'
+  const view = 'organisations'
   const url = ssrUrl(params,view)
   return url
 }


### PR DESCRIPTION
# Fix mentions component to load colors from the theme

Closes #214 
Closes #218
Closes #62

Changes proposed in this pull request:
* The mentions section on software and project page uses secondary theme color. Previously the color was hard coded
* The change required refactoring on mui theme loading and updating of existing tests
* The Organization title in the header is changed to Organisation to be in line with other titles and labels currently used in RSD

How to test:
* `docker-compose down --volumes`: remove old instances
* `docker-compose build`: build solution (you could also build only frontend if you have most recent db structure)
* `docker-compose up`: start solution
* run data migration: cd data-migration && docker-compose up
* navigate to xenon software page with mentions, the mention section should look like this
![image](https://user-images.githubusercontent.com/9204081/163169728-5af0f518-85a5-468c-9332-851d89bc0fb5.png)
* navigate to 3D-e-Chem project and the impact and output section should look like this
![image](https://user-images.githubusercontent.com/9204081/163170111-167a3dad-ea64-46b8-a0da-fd11293484c0.png)

PR Checklist:

*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
