### PR TITLE
Auto fill in contributors from Zenodo concept DOI

### DIFF
--- a/frontend/components/software/edit/contributors/AutoFillContributors.tsx
+++ b/frontend/components/software/edit/contributors/AutoFillContributors.tsx
@@ -1,0 +1,18 @@
+import Button from '@mui/material/Button'
+
+import {contributorInformation as config} from '../editSoftwareConfig'
+
+export default function AutoFillContributors(
+  {onClick}: { onClick: () => void }
+) {
+  return (
+    <section className="flex items-center mb-4">
+      <Button
+        variant="outlined"
+        onClick={onClick}
+      >
+        { config.findContributor.autofill }
+      </Button>
+    </section>
+  )
+}

--- a/frontend/components/software/edit/editSoftwareConfig.ts
+++ b/frontend/components/software/edit/editSoftwareConfig.ts
@@ -161,7 +161,7 @@ export const contributorInformation = {
     help: '16 digits, pattern 0000-0000-0000-0000',
     validation: {
       pattern: {
-        value: /\d{4}-\d{4}-\d{4}-\d{4}/,
+        value: /\d{4}-\d{4}-\d{4}-\d{3}[0-9X]/,
         message: 'Invalid pattern, not a 0000-0000-0000-0000'
       }
     }

--- a/frontend/components/software/edit/editSoftwareConfig.ts
+++ b/frontend/components/software/edit/editSoftwareConfig.ts
@@ -104,7 +104,8 @@ export const contributorInformation = {
     validation: {
       // custom validation rule, not in use by react-hook-form
       minLength: 2,
-    }
+    },
+    autofill: 'Add contributors from DOI data',
   },
   is_contact_person: {
     label: 'Contact person',

--- a/frontend/components/software/edit/editSoftwareContext.tsx
+++ b/frontend/components/software/edit/editSoftwareContext.tsx
@@ -6,6 +6,7 @@ type SoftwareInfo = {
   id?: string,
   slug?: string,
   brand_name?: string,
+  concept_doi?: string,
 }
 
 export type EditSoftwareState = {
@@ -26,7 +27,8 @@ export const initialState = {
   software: {
     id: '',
     slug: '',
-    brand_name:''
+    brand_name:'',
+    concept_doi: '',
   },
   isDirty: false,
   isValid: true,
@@ -87,7 +89,8 @@ const EditSoftwareContext = createContext<{ pageState: EditSoftwareState, dispat
     software: {
       id: '',
       slug: '',
-      brand_name: ''
+      brand_name: '',
+      concept_doi: '',
     },
     isDirty: false,
     isValid: true,

--- a/frontend/components/software/edit/information/RepositoryPlatform.tsx
+++ b/frontend/components/software/edit/information/RepositoryPlatform.tsx
@@ -138,7 +138,7 @@ export default function RepositoryPlatform(props: RepositoryPlatformProps) {
               // always use value here to ensure sync with Controller
               value={value ?? ''}
               onChange={({target}: { target: any }) => {
-                debugger
+                // debugger
                 // change value in form
                 onChange(target.value)
                 // update local state

--- a/frontend/components/software/edit/information/index.tsx
+++ b/frontend/components/software/edit/information/index.tsx
@@ -55,7 +55,8 @@ export default function SoftwareInformation({slug,token}:{slug:string,token: str
           software: {
             slug,
             id: editSoftware?.id ?? '',
-            brand_name: editSoftware?.brand_name ?? ''
+            brand_name: editSoftware?.brand_name ?? '',
+            concept_doi: editSoftware?.concept_doi ?? '',
           },
           loading:false
         }

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -351,7 +351,7 @@ export async function deleteOrganisation({uuid,logo_id, token}:
         id: logo_id,
         token
       })
-      debugger
+      // debugger
       if (resp.status !== 200) {
         return resp
       }
@@ -365,7 +365,7 @@ export async function deleteOrganisation({uuid,logo_id, token}:
         ...createJsonHeaders(token)
       }
     })
-    debugger
+    // debugger
     return extractReturnMessage(resp)
   } catch (e: any) {
     return {

--- a/frontend/utils/editProject.ts
+++ b/frontend/utils/editProject.ts
@@ -363,7 +363,7 @@ export async function createOrganisationAndAddToProject({project,organisation,ro
         session
       })
     } else {
-      debugger
+      // debugger
       return resp
     }
   } catch(e:any) {

--- a/frontend/utils/getContributorsFromDoi.test.ts
+++ b/frontend/utils/getContributorsFromDoi.test.ts
@@ -1,0 +1,430 @@
+
+import {mockResolvedValueOnce} from './jest/mockFetch'
+import {getContributorsFromDoi} from './getContributorsFromDoi'
+
+const exampleCreator = {
+  'name': 'Doe, John',
+  'nameType': 'Personal',
+  'givenName': 'John',
+  'familyName': 'Doe',
+  'affiliation': [
+    {
+      'name': 'Example organisation'
+    },
+    {
+      'name': 'Second example organisation'
+    }
+  ],
+  'nameIdentifiers': [
+    {
+      'schemeUri': 'https://orcid.org',
+      'nameIdentifier': 'https://orcid.org/0000-0000-0000-0000',
+      'nameIdentifierScheme': 'ORCID'
+    },
+    {
+      'schemeUri': 'TEST',
+      'nameIdentifier': 'TEST',
+      'nameIdentifierScheme': 'TEST'
+    }
+  ]
+}
+
+const exampleResponse = {
+  'id': 'https://doi.org/10.0000/zenodo.0000000',
+  'doi': '10.0000/ZENODO.0000000',
+  'url': 'https://zenodo.org/record/0000000',
+  'types': {
+    'ris': 'COMP',
+    'bibtex': 'misc',
+    'citeproc': 'article',
+    'schemaOrg': 'SoftwareSourceCode',
+    'resourceTypeGeneral': 'Software'
+  },
+  'creators': [
+    exampleCreator,
+  ],
+  'titles': [
+    {
+      'title': 'Example Title v0.0.0'
+    }
+  ],
+  'publisher': 'Zenodo',
+  'container': {},
+  'subjects': [],
+  'contributors': [],
+  'dates': [
+    {
+      'date': '2021-10-16',
+      'dateType': 'Issued'
+    }
+  ],
+  'publicationYear': 2021,
+  'identifiers': [
+    {
+      'identifier': 'https://zenodo.org/record/0000000',
+      'identifierType': 'URL'
+    }
+  ],
+  'sizes': [
+    '8461 Bytes'
+  ],
+  'formats': [],
+  'version': 'v0.0.0',
+  'rightsList': [
+    {
+      'rights': 'Open Access',
+      'rightsUri': 'info:eu-repo/semantics/openAccess',
+      'schemeUri': 'https://spdx.org/licenses/',
+      'rightsIdentifier': 'cc-by-4.0',
+      'rightsIdentifierScheme': 'SPDX'
+    }
+  ],
+  'descriptions': [
+    {
+      'description': 'Example description',
+      'descriptionType': 'Abstract',
+    }
+  ],
+  'geoLocations': [],
+  'fundingReferences': [],
+  'relatedIdentifiers': [
+    {
+      'relationType': 'IsSupplementTo',
+      'relatedIdentifier': 'https://github.com/github/software/tree/v0.0.0',
+      'relatedIdentifierType': 'URL'
+    },
+  ],
+  'relatedItems': [],
+  'schemaVersion': 'http://datacite.org/schema/kernel-4',
+  'providerId': 'cern',
+  'clientId': 'cern.zenodo',
+  'agency': 'datacite',
+  'state': 'findable'
+}
+
+// taken from (and slightly modified):
+// https://github.com/inveniosoftware/datacite/blob/b15db91e1231135e5f2dba0cadca0c72ede037cf/tests/data/datacite-v4.1-full-example.json
+const dataciteFullExample = {
+  'identifier': {
+    'identifier': '10.1234/example-full',
+    'identifierType': 'DOI'
+  },
+  'creators': [
+    {
+      'creatorName': 'Miller, Elizabeth',
+      'nameType': 'Personal',
+      'givenName': 'Elizabeth',
+      'familyName': 'Miller',
+      'nameIdentifiers': [
+        {
+          'nameIdentifier': '0000-0000-0000-0000',
+          'nameIdentifierScheme': 'ORCID',
+          'schemeURI': 'http://orcid.org/'
+        },
+        {
+          'nameIdentifier': '0000-0000-0000-0001',
+          'nameIdentifierScheme': 'ORCID',
+          'schemeURI': 'http://orcid.org/'
+        }
+      ],
+      'affiliation': ['DataCite', 'CERN', 'TIND']
+    }
+  ],
+  'titles': [
+    {
+      'title': 'Full DataCite XML Example',
+      'lang': 'en-us'
+    },
+    {
+      'title': 'Demonstration of DataCite Properties.',
+      'titleType': 'Subtitle',
+      'lang': 'en-us'
+    }
+  ],
+  'publisher': 'DataCite',
+  'publicationYear': '2014',
+  'subjects': [
+    {
+      'subject': '000 computer science',
+      'subjectScheme': 'dewey',
+      'valueURI': 'https://cern.ch',
+      'schemeURI': 'http://dewey.info/',
+      'lang': 'en-us'
+    }
+  ],
+  'contributors': [
+    {
+      'contributorName': 'Starr, Joan',
+      'nameType': 'Personal',
+      'contributorType': 'ProjectLeader',
+      'givenName': 'Joan',
+      'familyName': 'Starr',
+      'nameIdentifiers': [
+        {
+          'nameIdentifier': '1000-0000-0000-000X',
+          'nameIdentifierScheme': 'ORCID',
+          'schemeURI': 'http://orcid.org/'
+        }
+      ],
+      'affiliation': ['California Digital Library']
+    }
+  ],
+  'dates': [
+    {
+      'date': '2014-10-17',
+      'dateType': 'Updated',
+      'dateInformation': 'Date of the first publishing.'
+    }
+  ],
+  'language': 'en-us',
+  'resourceType': {
+    'resourceTypeGeneral': 'Software',
+    'resourceType': 'XML'
+  },
+  'alternateIdentifiers': [
+    {
+      'alternateIdentifier': 'http://schema.datacite.org/schema/meta/kernel-4.1/example/datacite-example-full-v4.1.xml',
+      'alternateIdentifierType': 'URL'
+    }
+  ],
+  'relatedIdentifiers': [
+    {
+      'relatedIdentifier': 'http://data.datacite.org/application/citeproc+json/10.1234/example-full',
+      'relatedIdentifierType': 'URL',
+      'relationType': 'HasMetadata',
+      'relatedMetadataScheme': 'citeproc+json',
+      'schemeURI': 'https://github.com/citation-style-language/schema/raw/master/csl-data.json'
+    },
+    {
+      'relatedIdentifier': 'arXiv:0706.0001',
+      'relatedIdentifierType': 'arXiv',
+      'relationType': 'IsReviewedBy'
+    },
+    {
+      'relatedIdentifier': 'arXiv:0706.0002',
+      'relatedIdentifierType': 'arXiv',
+      'relationType': 'IsDescribedBy',
+      'resourceTypeGeneral': 'Text'
+    },
+    {
+      'relatedIdentifier': 'arXiv:0706.0003',
+      'relatedIdentifierType': 'arXiv',
+      'relationType': 'Describes'
+    },
+    {
+      'relatedIdentifier': 'arXiv:0706.0004',
+      'relatedIdentifierType': 'arXiv',
+      'relationType': 'IsVersionOf'
+    },
+    {
+      'relatedIdentifier': 'arXiv:0706.0005',
+      'relatedIdentifierType': 'arXiv',
+      'relationType': 'HasVersion'
+    },
+    {
+      'relatedIdentifier': 'arXiv:0706.0006',
+      'relatedIdentifierType': 'arXiv',
+      'relationType': 'IsRequiredBy'
+    },
+    {
+      'relatedIdentifier': 'arXiv:0706.0007',
+      'relatedIdentifierType': 'arXiv',
+      'relationType': 'Requires'
+    }
+  ],
+  'sizes': [
+    '3KB'
+  ],
+  'formats': [
+    'application/xml'
+  ],
+  'version': '4.1',
+  'rightsList': [
+    {
+      'rights': 'CC0 1.0 Universal',
+      'rightsURI': 'http://creativecommons.org/publicdomain/zero/1.0/',
+      'lang': 'en-us'
+    }
+  ],
+  'descriptions': [
+    {
+      'descriptionType': 'Abstract',
+      'lang': 'en-us',
+      'description': 'XML example of all DataCite Metadata Schema v4.1 properties.'
+    }
+  ],
+  'fundingReferences': [
+    {
+      'funderName': 'European Commission',
+      'funderIdentifier': {
+        'funderIdentifier': 'http://doi.org/10.13039/501100000780',
+        'funderIdentifierType': 'Crossref Funder ID'
+      },
+      'awardNumber': {
+        'awardNumber': '282625',
+        'awardURI': 'http://cordis.europa.eu/project/rcn/100180_en.html'
+      },
+      'awardTitle': 'MOTivational strength of ecosystem services and alternative ways to express the value of BIOdiversity'
+    },
+    {
+      'funderName': 'European Commission',
+      'funderIdentifier': {
+        'funderIdentifier': 'http://doi.org/10.13039/501100000780',
+        'funderIdentifierType': 'Crossref Funder ID'
+      },
+      'awardNumber': {
+        'awardNumber': '284382',
+        'awardURI': 'http://cordis.europa.eu/project/rcn/100603_en.html'
+      },
+      'awardTitle': 'Institutionalizing global genetic-resource commons. Global Strategies for accessingand using essential public knowledge assets in the life science'
+    }
+  ],
+  'geoLocations': [
+    {
+      'geoLocationPoint': {
+        'pointLongitude': 31.233,
+        'pointLatitude': -67.302
+      },
+      'geoLocationBox': {
+        'westBoundLongitude': -71.032,
+        'eastBoundLongitude': -68.211,
+        'southBoundLatitude': 41.090,
+        'northBoundLatitude': 42.893
+      },
+      'geoLocationPlace': 'Atlantic Ocean',
+      'geoLocationPolygons': [
+        {
+          'polygonPoints': [
+            {
+              'pointLongitude': -71.032,
+              'pointLatitude': 41.090
+            },
+            {
+              'pointLongitude': -68.211,
+              'pointLatitude': 42.893
+            },
+            {
+              'pointLongitude': -72.032,
+              'pointLatitude': 39.090
+            },
+            {
+              'pointLongitude': -71.032,
+              'pointLatitude': 41.090
+            }
+          ]
+        },
+        {
+          'polygonPoints': [
+            {
+              'pointLongitude': -72.032,
+              'pointLatitude': 42.090
+            },
+            {
+              'pointLongitude': -69.211,
+              'pointLatitude': 43.893
+            },
+            {
+              'pointLongitude': -73.032,
+              'pointLatitude': 41.090
+            },
+            {
+              'pointLongitude': -72.032,
+              'pointLatitude': 42.090
+            }
+          ],
+          'inPolygonPoint': {
+            'pointLongitude': -52.032,
+            'pointLatitude': 12.090
+          }
+        }
+      ]
+    }
+  ]
+}
+
+const exampleResponseInvalidPersons = {
+  'id': 'https://doi.org/10.0000/zenodo.0000000',
+  'doi': '10.0000/ZENODO.0000000',
+  'url': 'https://zenodo.org/record/0000000',
+  'creators': [
+    {
+      'name': 'Test',
+      'givenName': 'Test'
+    },
+    {
+      'name': 'Test',
+      'familyName': 'test',
+    },
+    {
+      'name': 'Test'
+    }
+  ],
+  'contributors': [
+    {
+      'name': 'Test',
+      'givenName': 'Test'
+    },
+    {
+      'name': 'Test',
+      'familyName': 'test',
+    },
+    {
+      'name': 'Test'
+    }
+  ]
+}
+
+it('returns expected contributors', async () => {
+  mockResolvedValueOnce(exampleResponse)
+
+  const resp = await getContributorsFromDoi('0', 'DOI')
+
+  expect(resp).toEqual(
+    [
+      {
+        'affiliation': 'Example organisation',
+        'email_address': '',
+        'family_names': 'Doe',
+        'given_names': 'John',
+        'is_contact_person': false,
+        'orcid': '0000-0000-0000-0000',
+        'software': '0'
+      }
+    ]
+  )
+})
+
+it('returns authors and contributors', async () => {
+  mockResolvedValueOnce(dataciteFullExample)
+
+  const resp = await getContributorsFromDoi('0', 'DOI')
+
+  expect(resp).toEqual(
+    [
+      {
+        'affiliation': 'DataCite',
+        'email_address': '',
+        'family_names': 'Miller',
+        'given_names': 'Elizabeth',
+        'is_contact_person': false,
+        'orcid': '0000-0000-0000-0000',
+        'software': '0'
+      },
+      {
+        'affiliation': 'California Digital Library',
+        'email_address': '',
+        'family_names': 'Starr',
+        'given_names': 'Joan',
+        'is_contact_person': false,
+        'orcid': '1000-0000-0000-000X',
+        'software': '0'
+      }
+    ]
+  )
+})
+
+it('should skip invalid persons', async () => {
+  mockResolvedValueOnce(exampleResponseInvalidPersons)
+  const resp = await getContributorsFromDoi('0', 'DOI')
+  expect(resp).toEqual([])
+})

--- a/frontend/utils/getContributorsFromDoi.ts
+++ b/frontend/utils/getContributorsFromDoi.ts
@@ -1,0 +1,206 @@
+import {Contributor} from '~/types/Contributor'
+import {createJsonHeaders} from './fetchHelpers'
+import logger from './logger'
+
+const exampleCreator = {
+  'name': 'Doe, John',
+  'nameType': 'Personal',
+  'givenName': 'John',
+  'familyName': 'Doe',
+  'affiliation': [
+    {
+      'name': 'Example organisation'
+    }
+  ],
+  'nameIdentifiers': [
+    {
+      'schemeUri': 'https://orcid.org',
+      'nameIdentifier': 'https://orcid.org/0000-0000-0000-0000',
+      'nameIdentifierScheme': 'ORCID'
+    }
+  ]
+}
+
+const exampleResponse = {
+  'id': 'https://doi.org/10.0000/zenodo.0000000',
+  'doi': '10.0000/ZENODO.0000000',
+  'url': 'https://zenodo.org/record/0000000',
+  'types': {
+    'ris': 'COMP',
+    'bibtex': 'misc',
+    'citeproc': 'article',
+    'schemaOrg': 'SoftwareSourceCode',
+    'resourceTypeGeneral': 'Software'
+  },
+  'creators': [
+    exampleCreator,
+  ],
+  'titles': [
+    {
+      'title': 'Example Title v0.0.0'
+    }
+  ],
+  'publisher': 'Zenodo',
+  'container': {},
+  'subjects': [],
+  'contributors': [],
+  'dates': [
+    {
+      'date': '2021-10-16',
+      'dateType': 'Issued'
+    }
+  ],
+  'publicationYear': 2021,
+  'identifiers': [
+    {
+      'identifier': 'https://zenodo.org/record/0000000',
+      'identifierType': 'URL'
+    }
+  ],
+  'sizes': [
+    '8461 Bytes'
+  ],
+  'formats': [],
+  'version': 'v0.0.0',
+  'rightsList': [
+    {
+      'rights': 'Open Access',
+      'rightsUri': 'info:eu-repo/semantics/openAccess',
+      'schemeUri': 'https://spdx.org/licenses/',
+      'rightsIdentifier': 'cc-by-4.0',
+      'rightsIdentifierScheme': 'SPDX'
+    }
+  ],
+  'descriptions': [
+    {
+      'description': 'Example description',
+      'descriptionType': 'Abstract',
+    }
+  ],
+  'geoLocations': [],
+  'fundingReferences': [],
+  'relatedIdentifiers': [
+    {
+      'relationType': 'IsSupplementTo',
+      'relatedIdentifier': 'https://github.com/github/software/tree/v0.0.0',
+      'relatedIdentifierType': 'URL'
+    },
+  ],
+  'relatedItems': [],
+  'schemaVersion': 'http://datacite.org/schema/kernel-4',
+  'providerId': 'cern',
+  'clientId': 'cern.zenodo',
+  'agency': 'datacite',
+  'state': 'findable'
+}
+
+export type DataciteRecord = typeof exampleResponse
+export type DatacitePerson = typeof exampleCreator
+
+const baseUrl = 'https://api.datacite.org/application/vnd.datacite.datacite+json/'
+const orcidPattern = /^\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$/
+const orcidUrlPattern = /^https?\:\/\/orcid\.org\/\d{4}-\d{4}-\d{4}-\d{3}[0-9X]$/
+
+export async function getDoiInfo(doiId: string) {
+  try {
+    const url = `${baseUrl}${doiId}`
+
+    // make request
+    const resp = await fetch(url, {
+      headers: {
+        // pass json request in the header
+        ...createJsonHeaders(undefined),
+      }
+    })
+
+    if (resp.status === 200) {
+      const json: any = await resp.json()
+      return json
+    }
+
+    logger(`getting DOI info FAILED: ${resp.status}: ${resp.statusText}`,'warn')
+    return null
+  } catch (e: any) {
+    logger(`getting DOI info: ${e?.message}`, 'error')
+    return null
+  }
+}
+
+export async function getContributorsFromDoi(
+  softwareId: string | undefined, doiId: string | undefined
+) {
+  if (!doiId || !softwareId) {
+    return []
+  }
+
+  const doiData = await getDoiInfo(doiId)
+
+  if (!doiData) {
+    return []
+  }
+
+  const contributors: Contributor[] = []
+  let allPersons: DatacitePerson[] = []
+
+  if ('creators' in doiData) {
+    allPersons = allPersons.concat(doiData['creators'])
+  }
+
+  if ('contributors' in doiData) {
+    allPersons = allPersons.concat(doiData['contributors'])
+  }
+
+  for (const person of allPersons) {
+    const affiliation = person.affiliation
+    const nameIds = person.nameIdentifiers
+    let useAffiliation = ''
+    let useOrcid = ''
+
+    // check minimum needed attributes
+    if (!('givenName' in person) || !('familyName' in person)) {
+      continue
+    }
+
+    if (affiliation && affiliation.length > 0) {
+      const first = affiliation[0]
+
+      // DataCite schema says "free text", but API returns "name" attribute
+      if (typeof(first) === 'string') {
+        useAffiliation = first
+      } else if (typeof(first) === 'object' && 'name' in first) {
+        useAffiliation = first.name
+      }
+    }
+
+    if (nameIds && nameIds.length > 0) {
+      for (const id of nameIds) {
+        if (id.nameIdentifierScheme !== 'ORCID') {
+          continue
+        }
+
+        if (id.nameIdentifier.match(orcidUrlPattern) !== null) {
+          const l = id.nameIdentifier.length
+          useOrcid = id.nameIdentifier.substring(l - 19, l)
+          break
+        }
+
+        if (id.nameIdentifier.match(orcidPattern) !== null) {
+          useOrcid = id.nameIdentifier
+          break
+        }
+      }
+    }
+
+    contributors.push({
+      given_names: person.givenName,
+      family_names: person.familyName,
+      email_address: '',
+      software: softwareId,
+      affiliation: useAffiliation,
+      is_contact_person: false,
+      orcid: useOrcid,
+    })
+  }
+
+  return contributors
+}


### PR DESCRIPTION
# Auto fill in contributors from Zenodo concept DOI

Fixes #201
See also https://github.com/research-software-directory/Helmholtz/issues/9

Changes proposed in this pull request:

* Add possibility to fill in contributors by using the Zenodo concept DOI (and using the DataCite API)
* fix ORCID identifier pattern (see https://support.orcid.org/hc/en-us/articles/360053289173-Why-does-my-ORCID-iD-have-an-X)

How to test:

* create a new software entry with a given DOI (including creators or contributors)
* switch to "Contributors" tab and click on button "Add contributors from DOI data"

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
