### PR TITLE
252 edit project team

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,6 +36,7 @@ RSD_AUTH_URL=http://auth:7000
 # consumed by services: frontend (api/fe)
 # provide a list of supported OpenID auth providers
 # the values should be separated by semicolon (;)
+# if env value is not provided default provider is set to be SURFCONEXT
 RSD_AUTH_PROVIDERS=SURFCONEXT;HELMHOLTZAAI
 
 # SURFCONEXT - TEST ENVIRONMENT

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -531,3 +531,30 @@ INNER JOIN
 ;
 END
 $$;
+
+-- UNIQUE LIST OF TEAM MEMBERS
+-- used in Find
+CREATE OR REPLACE FUNCTION unique_team_members() RETURNS TABLE (
+	display_name TEXT,
+	affiliation VARCHAR,
+	orcid VARCHAR,
+	given_names VARCHAR,
+	family_names VARCHAR,
+	email_address VARCHAR
+) LANGUAGE plpgsql STABLE AS
+$$
+BEGIN
+	RETURN QUERY
+		SELECT DISTINCT
+			(CONCAT(c.given_names,' ',c.family_names)) AS display_name,
+			c.affiliation,
+			c.orcid,
+			c.given_names,
+			c.family_names,
+			c.email_address
+		FROM
+			team_member c
+		ORDER BY
+			display_name ASC;
+END
+$$;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.25
+    image: rsd/database:0.0.26
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -75,7 +75,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.7.3
+    image: rsd/frontend:0.7.4
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/form/ControlledAffiliation.tsx
+++ b/frontend/components/form/ControlledAffiliation.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react'
 import {Controller} from 'react-hook-form'
 
 import {AutocompleteOption} from '~/types/AutocompleteOptions'
@@ -7,30 +8,44 @@ import TextField from '@mui/material/TextField'
 type ControlledFreeSoloProps = {
   name: string,
   label: string,
-  affiliations: string,
+  affiliation: string | null,
+  institution: string[] | null,
   control: any,
   rules: any,
   helperTextMessage: string
 }
 
 export default function ControlledAffiliation({
-  name, control, affiliations, label, rules, helperTextMessage
+  name, control, affiliation, institution, label, rules, helperTextMessage
 }: ControlledFreeSoloProps) {
+  const [open, setOpen] = useState(false)
+
   let allRules = {required: false}
   if (rules) {
     allRules=rules
   }
-  // ORCID api returns all affitiations as string (;) separated
-  // in that case we create dropdown with affiliation options
-  const options: AutocompleteOption<string>[] = affiliations.split(';').map(item => ({
-    key: item.trim(),
-    label: item.trim(),
-    data: item.trim()
-  }))
 
+  let defaultValue = ''
+
+  // ORCID api returns institution as string[]
+  // in that case we create dropdown with options
+  let options:AutocompleteOption<string>[]=[]
+  if (institution) {
+    options = institution.map(item => ({
+      key: item.trim(),
+      label: item.trim(),
+      data: item.trim()
+    }))
+    // select first item
+    defaultValue = options[0].label
+  }
+  // debugger
   // default is null or first option
-  let defaultValue = null
-  if (options.length > 1) defaultValue = options[0]
+
+  if (affiliation) {
+    // one string value
+    defaultValue = affiliation
+  }
 
   return (
     <Controller
@@ -46,7 +61,7 @@ export default function ControlledAffiliation({
             <TextField
               label={label}
               variant="standard"
-              value={value}
+              value={value ?? ''}
               onChange={({target}) => {
               // use null instead of empty string
                 if (target.value === '') {
@@ -72,6 +87,13 @@ export default function ControlledAffiliation({
               freeSolo={true}
               multiple={false}
               options={options}
+              open={open}
+              onOpen={() => {
+                setOpen(true)
+              }}
+              onClose={() => {
+                setOpen(false)
+              }}
               onInputChange={(e, value) => {
                 // debugger
                 onChange(value)
@@ -105,6 +127,7 @@ export default function ControlledAffiliation({
                     label={label}
                     variant="standard"
                     helperText={helperTextMessage}
+                    onFocus={()=>setOpen(true)}
                   />
                 )
               }}

--- a/frontend/components/form/ControlledAffiliation.tsx
+++ b/frontend/components/form/ControlledAffiliation.tsx
@@ -1,0 +1,117 @@
+import {Controller} from 'react-hook-form'
+
+import {AutocompleteOption} from '~/types/AutocompleteOptions'
+import Autocomplete from '@mui/material/Autocomplete'
+import TextField from '@mui/material/TextField'
+
+type ControlledFreeSoloProps = {
+  name: string,
+  label: string,
+  affiliations: string,
+  control: any,
+  rules: any,
+  helperTextMessage: string
+}
+
+export default function ControlledAffiliation({
+  name, control, affiliations, label, rules, helperTextMessage
+}: ControlledFreeSoloProps) {
+  let allRules = {required: false}
+  if (rules) {
+    allRules=rules
+  }
+  // ORCID api returns all affitiations as string (;) separated
+  // in that case we create dropdown with affiliation options
+  const options: AutocompleteOption<string>[] = affiliations.split(';').map(item => ({
+    key: item.trim(),
+    label: item.trim(),
+    data: item.trim()
+  }))
+
+  // default is null or first option
+  let defaultValue = null
+  if (options.length > 1) defaultValue = options[0]
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      rules={allRules}
+      defaultValue={defaultValue}
+      render={({field}) => {
+        const {onChange, value} = field
+        // use text input if no options
+        if (options.length < 2) {
+          return (
+            <TextField
+              label={label}
+              variant="standard"
+              value={value}
+              onChange={({target}) => {
+              // use null instead of empty string
+                if (target.value === '') {
+                  onChange(null)
+                } else {
+                  onChange(target.value)
+                }
+              }}
+              helperText={helperTextMessage}
+            />
+          )
+        } else {
+          // ORCID affitiations
+          // NOTE! we save only string value in controller
+          // and we convert it back to option here
+          const option = {
+            key: value,
+            label: value,
+            data: value
+          }
+          return (
+            <Autocomplete
+              freeSolo={true}
+              multiple={false}
+              options={options}
+              onInputChange={(e, value) => {
+                // debugger
+                onChange(value)
+              }}
+              onChange={(e, item, reason) => {
+                // here we pass items react-hook-form controller
+                // and mui autocompletes
+                // debugger
+                if (typeof item === 'string' || item === null) {
+                  onChange(item)
+                } else {
+                  onChange(item?.label)
+                }
+              }}
+              value={option}
+              getOptionLabel={(option) => option.label ? option.label : ''}
+              isOptionEqualToValue={(
+                option: AutocompleteOption<string>,
+                value: AutocompleteOption<string>) => {
+                if (value) {
+                  // debugger
+                  // we compare key values
+                  return option.key === value?.key
+                }
+                return false
+              }}
+              renderInput={(params) => {
+                return (
+                  <TextField
+                    {...params}
+                    label={label}
+                    variant="standard"
+                    helperText={helperTextMessage}
+                  />
+                )
+              }}
+            />
+          )
+        }
+      }}
+    />
+  )
+}

--- a/frontend/components/form/ControlledAffiliation.tsx
+++ b/frontend/components/form/ControlledAffiliation.tsx
@@ -37,10 +37,10 @@ export default function ControlledAffiliation({
       data: item.trim()
     }))
     // select first item
-    defaultValue = options[0].label
+    if (options.length > 0) {
+      defaultValue = options[0].label
+    }
   }
-  // debugger
-  // default is null or first option
 
   if (affiliation) {
     // one string value

--- a/frontend/components/keyword/FindKeyword.test.tsx
+++ b/frontend/components/keyword/FindKeyword.test.tsx
@@ -1,4 +1,4 @@
-import {render, screen, fireEvent, waitFor, waitForElementToBeRemoved} from '@testing-library/react'
+import {render, screen, fireEvent, waitFor, waitForElementToBeRemoved, act} from '@testing-library/react'
 import FindKeyword, {Keyword} from './FindKeyword'
 
 /**
@@ -43,7 +43,10 @@ it('calls seach Fn and renders the loader', async () => {
   fireEvent.change(searchInput, {target: {value: searchFor}})
 
   // need to advance all timers for debounce etc...
-  jest.runAllTimers()
+  // Note! it needs to be wrapped in act
+  act(() => {
+    jest.runAllTimers()
+  })
 
   await waitFor(() => {
     // validate that searchFn is called once
@@ -83,7 +86,11 @@ it('offer Add option when search has no results', async() => {
   fireEvent.change(searchInput, {target: {value: searchFor}})
 
   // need to advance all timers for debounce etc...
-  jest.runAllTimers()
+  // Note! it needs to be wrapped in act
+  act(() => {
+    jest.runAllTimers()
+  })
+
   // then wait for loader to be removed
   await waitForElementToBeRemoved(() => screen.getByTestId('circular-loader'))
   // wait for listbox and add option
@@ -115,7 +122,11 @@ it('DOES NOT offer Add option when search return result that match', async () =>
   fireEvent.change(searchInput, {target: {value: searchFor}})
 
   // need to advance all timers for debounce etc...
-  jest.runAllTimers()
+  // Note! it needs to be wrapped in act
+  act(() => {
+    jest.runAllTimers()
+  })
+
   // then wait for loader to be removed
   await waitForElementToBeRemoved(() => screen.getByTestId('circular-loader'))
   // wait for listbox and add option
@@ -146,7 +157,11 @@ it('calls onCreate method with string value to add new option', async() => {
   fireEvent.change(searchInput, {target: {value: searchFor}})
 
   // need to advance all timers for debounce etc...
-  jest.runAllTimers()
+  // Note! it needs to be wrapped in act
+  act(() => {
+    jest.runAllTimers()
+  })
+
   // then wait for loader to be removed
   await waitForElementToBeRemoved(() => screen.getByTestId('circular-loader'))
   // wait for listbox and add option
@@ -181,7 +196,11 @@ it('calls onAdd method to add option to selection', async() => {
   fireEvent.change(searchInput, {target: {value: searchFor}})
 
   // need to advance all timers for debounce etc...
-  jest.runAllTimers()
+  // Note! it needs to be wrapped in act
+  act(() => {
+    jest.runAllTimers()
+  })
+
   // then wait for loader to be removed
   await waitForElementToBeRemoved(() => screen.getByTestId('circular-loader'))
   // wait for listbox and add option

--- a/frontend/components/projects/edit/editProjectSteps.tsx
+++ b/frontend/components/projects/edit/editProjectSteps.tsx
@@ -7,7 +7,6 @@ import AccessibilityNewIcon from '@mui/icons-material/AccessibilityNew'
 import ShareIcon from '@mui/icons-material/Share'
 import PersonAddIcon from '@mui/icons-material/PersonAdd'
 
-import {Session} from '~/auth'
 import ProjectInformation from './information'
 import ProjectTeam from './team'
 import ProjectOrganisations from './organisations'

--- a/frontend/components/projects/edit/team/FindMember.tsx
+++ b/frontend/components/projects/edit/team/FindMember.tsx
@@ -1,0 +1,135 @@
+import {HTMLAttributes, useState} from 'react'
+
+import AsyncAutocompleteSC, {AutocompleteOption} from '~/components/form/AsyncAutocompleteSC'
+import FindContributorItem from '~/components/software/edit/contributors/FindContributorItem'
+import {SearchTeamMember, TeamMember} from '~/types/Project'
+import {splitName} from '~/utils/getDisplayName'
+import {cfgTeamMembers} from './config'
+import {searchForMember} from './searchForMember'
+
+type Name = {
+  given_names: string
+  family_names?: string
+}
+
+type FindMemberProps = {
+  project: string,
+  token: string,
+  onAdd: (item: TeamMember) => void
+}
+
+export default function FindMember({onAdd,project,token}:FindMemberProps) {
+  const [options, setOptions] = useState<AutocompleteOption<SearchTeamMember>[]>([])
+  const [status, setStatus] = useState<{
+    loading: boolean,
+    foundFor: string | undefined
+  }>({
+    loading: false,
+    foundFor: undefined
+  })
+
+  async function searchMember(searchFor: string) {
+    setStatus({loading:true,foundFor:undefined})
+    const resp = await searchForMember({
+      searchFor,
+      token,
+      frontend:true
+    })
+    // set options
+    setOptions(resp ?? [])
+    // stop loading
+    setStatus({
+      loading: false,
+      foundFor: searchFor
+    })
+  }
+
+  function addMember(selected:AutocompleteOption<SearchTeamMember>) {
+    if (selected && selected.data) {
+      onAdd({
+        ...selected.data,
+        id: null,
+        project,
+        is_contact_person: false,
+        role: null,
+      })
+    }
+  }
+
+  function createMember(newInputValue: string) {
+    const name = splitName(newInputValue)
+    // add new person
+    onAdd({
+      id: null,
+      project,
+      is_contact_person: false,
+      ...name,
+      email_address: null,
+      affiliation: null,
+      role: null,
+      orcid: null,
+      avatar_data: null,
+      avatar_mime_type: null,
+      avatar_b64: null
+    })
+  }
+
+  function renderAddOption(props: HTMLAttributes<HTMLLIElement>,
+    option: AutocompleteOption<SearchTeamMember>) {
+    // if more than one option we add border at the bottom
+    // we assume that first option is Add "new item"
+    if (options.length > 1) {
+      if (props?.className) {
+        props.className+=' mb-2 border-b'
+      } else {
+        props.className='mb-2 border-b'
+      }
+    }
+    return (
+      <li {...props} key={option.key}>
+        {/* if new option (has input) show label and count  */}
+        <strong>{`Add "${option.label}"`}</strong>
+      </li>
+    )
+  }
+
+  function renderOption(props: HTMLAttributes<HTMLLIElement>,
+    option: AutocompleteOption<SearchTeamMember>) {
+    // console.log('renderOption...', option)
+    // when value is not not found option returns input prop
+    if (option?.input) {
+      // if input is over minLength
+      if (option?.input.length > cfgTeamMembers.find.validation.minLength) {
+        // we offer an option to create this entry
+        return renderAddOption(props,option)
+      } else {
+        return null
+      }
+    }
+
+    return (
+      <li {...props} key={option.key}>
+        <FindContributorItem option={option} />
+      </li>
+    )
+  }
+
+  return (
+    <section className="flex items-center">
+      <AsyncAutocompleteSC
+        status={status}
+        options={options}
+        onSearch={searchMember}
+        onAdd={addMember}
+        onCreate={createMember}
+        onRenderOption={renderOption}
+        config={{
+          freeSolo: true,
+          minLength: cfgTeamMembers.find.validation.minLength,
+          label: cfgTeamMembers.find.label,
+          help: cfgTeamMembers.find.help
+        }}
+      />
+    </section>
+  )
+}

--- a/frontend/components/projects/edit/team/FindMember.tsx
+++ b/frontend/components/projects/edit/team/FindMember.tsx
@@ -108,7 +108,7 @@ export default function FindMember({onAdd,project,token}:FindMemberProps) {
     }
 
     return (
-      <li {...props} key={option.key}>
+      <li {...props} key={Math.random().toString()}>
         <FindContributorItem option={option} />
       </li>
     )

--- a/frontend/components/projects/edit/team/FindMember.tsx
+++ b/frontend/components/projects/edit/team/FindMember.tsx
@@ -127,7 +127,9 @@ export default function FindMember({onAdd,project,token}:FindMemberProps) {
           freeSolo: true,
           minLength: cfgTeamMembers.find.validation.minLength,
           label: cfgTeamMembers.find.label,
-          help: cfgTeamMembers.find.help
+          help: cfgTeamMembers.find.help,
+          // clear selected item
+          reset: true
         }}
       />
     </section>

--- a/frontend/components/projects/edit/team/TeamMemberList.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberList.tsx
@@ -1,0 +1,104 @@
+
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import ListItemText from '@mui/material/ListItemText'
+import ListItemAvatar from '@mui/material/ListItemAvatar'
+
+import DeleteIcon from '@mui/icons-material/Delete'
+import EditIcon from '@mui/icons-material/Edit'
+import IconButton from '@mui/material/IconButton'
+
+import {TeamMember} from '~/types/Project'
+import ContributorAvatar from '~/components/software/ContributorAvatar'
+import {combineRoleAndAffiliation, getDisplayInitials, getDisplayName} from '~/utils/getDisplayName'
+
+type TeamMemberProps = {
+  pos: number,
+  item: TeamMember,
+  onEdit: (pos: number) => void,
+  onDelete: (pos: number) => void,
+}
+
+type TeamMemberListProps = {
+  members: TeamMember[],
+  onEdit: (member: TeamMember, pos: number) => void
+  onDelete: (pos:number) => void
+}
+
+export default function TeamMemberList({members,onEdit,onDelete}: TeamMemberListProps) {
+  // console.group('TeamMemberList')
+  // console.log('members...', members)
+  // console.groupEnd()
+  return (
+    <List sx={{
+      width: '100%',
+    }}>
+      {members.map((item, pos) => {
+        return (
+          <TeamMemberItem
+            key={item.id ?? pos}
+            pos={pos}
+            item={item}
+            onEdit={() => {
+              onEdit(members[pos], pos)
+            }}
+            onDelete={()=>onDelete(pos)}
+          />
+        )
+      })}
+    </List>
+  )
+}
+
+function TeamMemberItem({pos, item, onEdit, onDelete}: TeamMemberProps) {
+  const displayName = getDisplayName(item)
+  const displayInitials = getDisplayInitials(item)
+  const primaryText = item.is_contact_person ?
+    <><span>{displayName}</span><span className="text-primary"> (contact person)</span></>
+    : displayName
+
+  return (
+    <ListItem
+      secondaryAction={
+        <>
+          <IconButton
+            edge="end"
+            aria-label="edit"
+            sx={{marginRight: '1rem'}}
+            onClick={() => {
+              // alert(`Edit...${item.id}`)
+              onEdit(pos)
+            }}
+          >
+            <EditIcon />
+          </IconButton>
+          <IconButton
+            edge="end"
+            aria-label="delete"
+            onClick={() => {
+              onDelete(pos)
+            }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </>
+      }
+      sx={{
+        // this makes space for buttons
+        paddingRight:'6.5rem',
+        '&:hover': {
+          backgroundColor:'grey.100'
+        }
+      }}
+      >
+        <ListItemAvatar>
+          <ContributorAvatar
+            avatarUrl={item.avatar_url ?? ''}
+            displayName={displayName ?? ''}
+            displayInitials={displayInitials}
+          />
+        </ListItemAvatar>
+        <ListItemText primary={primaryText} secondary={combineRoleAndAffiliation(item)} />
+    </ListItem>
+  )
+}

--- a/frontend/components/projects/edit/team/TeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberModal.tsx
@@ -1,0 +1,309 @@
+import {useEffect,useState} from 'react'
+import {
+  Button, Dialog, DialogActions, DialogContent,
+  DialogTitle, useMediaQuery
+} from '@mui/material'
+import SaveIcon from '@mui/icons-material/Save'
+import DeleteIcon from '@mui/icons-material/Delete'
+import {useForm} from 'react-hook-form'
+
+import logger from '~/utils/logger'
+import {getDisplayInitials, getDisplayName} from '~/utils/getDisplayName'
+import {TeamMember} from '~/types/Project'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import ControlledTextField from '~/components/form/ControlledTextField'
+import ControlledSwitch from '~/components/form/ControlledSwitch'
+import ContributorAvatar from '~/components/software/ContributorAvatar'
+import {cfgTeamMembers as config} from './config'
+
+type TeamMemberModalProps = {
+  open: boolean,
+  onCancel: () => void,
+  onSubmit: ({data, pos}: { data: TeamMember, pos?: number }) => void,
+  member?: TeamMember,
+  pos?: number
+}
+
+export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}: TeamMemberModalProps) {
+  const {showErrorMessage} = useSnackbar()
+  const smallScreen = useMediaQuery('(max-width:600px)')
+  const [b64Image, setB64Image]=useState<string>()
+  const {handleSubmit, watch, formState, reset, control, register, setValue} = useForm<TeamMember>({
+    mode: 'onChange',
+    defaultValues: {
+      ...member,
+      avatar_b64:null
+    }
+  })
+
+  // extract
+  const {isValid, isDirty} = formState
+  const formData = watch()
+
+  useEffect(() => {
+    if (member) {
+      reset(member)
+    }
+  }, [member,reset])
+
+  function handleCancel() {
+    // reset form
+    reset()
+    // remove image upload
+    setB64Image(undefined)
+    // hide
+    onCancel()
+  }
+
+  function handleFileUpload({target}:{target: any}) {
+    try {
+      let file = target.files[0]
+      if (typeof file == 'undefined') return
+      // check file size
+      if (file.size > 2097152) {
+        // file is to large > 2MB
+        showErrorMessage('The file is too large. Please select image < 2MB.')
+        return
+      }
+      let reader = new FileReader()
+      reader.onloadend = function () {
+        if (reader.result) {
+          // write to new avatar b64
+          setValue('avatar_b64', reader.result as string)
+          setValue('avatar_mime_type', file.type,{shouldDirty: true})
+        }
+      }
+      reader.readAsDataURL(file)
+    } catch (e:any) {
+      logger(`handleFileUpload: ${e.message}`,'error')
+    }
+  }
+
+  function getAvatarUrl() {
+    if (formData?.avatar_b64 && formData?.avatar_b64?.length > 10) {
+      return formData?.avatar_b64
+    }
+    if (formData?.avatar_url && formData?.avatar_url.length > 10) {
+      return formData?.avatar_url
+    }
+    return ''
+  }
+
+  return (
+     <Dialog
+      // use fullScreen modal for small screens (< 600px)
+      fullScreen={smallScreen}
+      open={open}
+      onClose={handleCancel}
+    >
+      <DialogTitle sx={{
+        fontSize: '1.5rem',
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        color: 'primary.main',
+        fontWeight: 500
+      }}>
+        Contributor
+      </DialogTitle>
+      <form
+        id="team-member-modal"
+        onSubmit={handleSubmit((data: TeamMember) => onSubmit({data, pos}))}
+        autoComplete="off"
+      >
+        {/* hidden inputs */}
+        <input type="hidden"
+          {...register('id')}
+        />
+        <input type="hidden"
+          {...register('project')}
+        />
+        <input type="hidden"
+          {...register('avatar_mime_type')}
+        />
+        <input type="hidden"
+          {...register('avatar_b64')}
+        />
+        <DialogContent sx={{
+          width: ['100%', '37rem'],
+        }}>
+          <section className="grid grid-cols-[1fr,2fr] gap-8">
+            <div>
+              <label htmlFor="upload-avatar-image"
+                  style={{cursor:'pointer'}}
+                  title="Click to upload an image"
+                >
+                <ContributorAvatar
+                  size={8}
+                  avatarUrl={getAvatarUrl()}
+                  displayName={getDisplayName(member ?? {}) ?? ''}
+                  displayInitials={getDisplayInitials(member ?? {}) ?? ''}
+                />
+              </label>
+              <input
+                id="upload-avatar-image"
+                type="file"
+                accept="image/*"
+                onChange={handleFileUpload}
+                style={{display:'none'}}
+              />
+              <div className="flex pt-4">
+                <Button
+                  title="Remove image"
+                  // color='primary'
+                  disabled={!formData.avatar_b64 && !formData.avatar_url}
+                  onClick={() => {
+                    if (formData?.avatar_b64) {
+                      setValue('avatar_b64', null)
+                    }
+                    if (formData.avatar_url) {
+                      setValue('avatar_url', null)
+                    }
+                    setValue('avatar_mime_type',null,{shouldDirty: true})
+                  }}
+                >
+                  remove <DeleteIcon/>
+                </Button>
+              </div>
+            </div>
+            <div>
+              <ControlledTextField
+                control={control}
+                options={{
+                  name: 'given_names',
+                  label: config.given_names.label,
+                  useNull: true,
+                  defaultValue: member?.given_names,
+                  helperTextMessage: config.given_names.help,
+                  // helperTextCnt: `${formData?.given_names?.length || 0}/${config.given_names.validation.maxLength.value}`,
+                }}
+                rules={config.given_names.validation}
+              />
+              <div className="py-4"></div>
+              <ControlledTextField
+                control={control}
+                options={{
+                  name: 'family_names',
+                  label: config.family_names.label,
+                  useNull: true,
+                  defaultValue: member?.family_names,
+                  helperTextMessage: config.family_names.help,
+                  // helperTextCnt: `${formData?.family_names?.length || 0}/${config.family_names.validation.maxLength.value}`,
+                }}
+                rules={config.family_names.validation}
+              />
+            </div>
+          </section>
+          <div className="py-4"></div>
+          <section className="py-4 grid grid-cols-[1fr,1fr] gap-8">
+            <ControlledTextField
+              control={control}
+              options={{
+                name: 'email_address',
+                label: config.email_address.label,
+                type: 'email',
+                useNull: true,
+                defaultValue: member?.email_address,
+                helperTextMessage: config.email_address.help,
+                // helperTextCnt: `${formData?.email_address?.length || 0}/${config.email_address.validation.maxLength.value}`,
+              }}
+              rules={config.email_address.validation}
+            />
+
+            <ControlledTextField
+                options={{
+                  name: 'orcid',
+                  label: config.orcid.label,
+                  useNull: true,
+                  defaultValue: member?.orcid,
+                  helperTextMessage: config.orcid.help,
+                  // helperTextCnt: `${formData?.orcid?.length || 0}/${config.orcid.validation.maxLength.value}`,
+                }}
+                control={control}
+                rules={config.orcid.validation}
+              />
+
+            <ControlledTextField
+              control={control}
+              options={{
+                name: 'role',
+                label: config.role.label,
+                useNull: true,
+                defaultValue: member?.role,
+                helperTextMessage: config.role.help,
+                // helperTextCnt: `${formData?.role?.length || 0}/${config.role.validation.maxLength.value}`,
+              }}
+              rules={config.role.validation}
+            />
+
+            <ControlledTextField
+              control={control}
+              options={{
+                name: 'affiliation',
+                label: config.affiliation.label,
+                useNull: true,
+                defaultValue: member?.affiliation,
+                helperTextMessage: config.affiliation.help,
+                // helperTextCnt: `${formData?.affiliation?.length || 0}/${config.affiliation.validation.maxLength.value}`,
+              }}
+              rules={config.affiliation.validation}
+            />
+
+          </section>
+          <section>
+            <ControlledSwitch
+              name="is_contact_person"
+              label="Contact person"
+              control={control}
+              defaultValue={member?.is_contact_person ?? false}
+            />
+          </section>
+        </DialogContent>
+        <DialogActions sx={{
+          padding: '1rem 1.5rem',
+          borderTop: '1px solid',
+          borderColor: 'divider'
+        }}>
+          <Button
+            tabIndex={1}
+            onClick={handleCancel}
+            color="secondary"
+            sx={{marginRight:'2rem'}}
+          >
+            Cancel
+          </Button>
+          <Button
+            tabIndex={0}
+            type="submit"
+            variant="contained"
+            sx={{
+              // overwrite tailwind preflight.css for submit type
+              '&[type="submit"]:not(.Mui-disabled)': {
+                backgroundColor:'primary.main'
+              }
+            }}
+            endIcon={
+              <SaveIcon />
+            }
+            disabled={isSaveDisabled()}
+          >
+            Save
+          </Button>
+        </DialogActions>
+      </form>
+    </Dialog>
+  )
+
+  function isSaveDisabled() {
+    // if pos is undefined we are creating
+    // new entry, but we might already have required
+    // information (first name - last name). In this
+    // case we only check if form is valid
+    if (typeof pos == 'undefined') {
+      if (isValid === false) return true
+    } else {
+      if (isValid === false) return true
+      if (isDirty === false) return true
+    }
+    return false
+  }
+}

--- a/frontend/components/projects/edit/team/TeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberModal.tsx
@@ -14,6 +14,7 @@ import useSnackbar from '~/components/snackbar/useSnackbar'
 import ControlledTextField from '~/components/form/ControlledTextField'
 import ControlledSwitch from '~/components/form/ControlledSwitch'
 import ContributorAvatar from '~/components/software/ContributorAvatar'
+import ControlledAffiliation from '~/components/form/ControlledAffiliation'
 import {cfgTeamMembers as config} from './config'
 
 type TeamMemberModalProps = {
@@ -103,7 +104,7 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
         color: 'primary.main',
         fontWeight: 500
       }}>
-        Contributor
+        Team member
       </DialogTitle>
       <form
         id="team-member-modal"
@@ -234,20 +235,14 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
               }}
               rules={config.role.validation}
             />
-
-            <ControlledTextField
+            <ControlledAffiliation
+              name= 'affiliation'
+              label={config.affiliation.label}
+              affiliations={member?.affiliation ?? ''}
               control={control}
-              options={{
-                name: 'affiliation',
-                label: config.affiliation.label,
-                useNull: true,
-                defaultValue: member?.affiliation,
-                helperTextMessage: config.affiliation.help,
-                // helperTextCnt: `${formData?.affiliation?.length || 0}/${config.affiliation.validation.maxLength.value}`,
-              }}
               rules={config.affiliation.validation}
+              helperTextMessage={config.affiliation.help}
             />
-
           </section>
           <section>
             <ControlledSwitch

--- a/frontend/components/projects/edit/team/TeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberModal.tsx
@@ -238,7 +238,8 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
             <ControlledAffiliation
               name= 'affiliation'
               label={config.affiliation.label}
-              affiliations={member?.affiliation ?? ''}
+              affiliation={member?.affiliation ?? ''}
+              institution={member?.institution ?? null}
               control={control}
               rules={config.affiliation.validation}
               helperTextMessage={config.affiliation.help}

--- a/frontend/components/projects/edit/team/config.ts
+++ b/frontend/components/projects/edit/team/config.ts
@@ -1,0 +1,74 @@
+
+export const cfgTeamMembers = {
+  title: 'Team Members',
+  find: {
+    title: 'Add member',
+    subtitle: 'We search by name in RSD and ORCID databases',
+    label: 'Find or add team memeber',
+    help: 'At least 3 letters, use pattern {First name} {Last name}',
+    validation: {
+      // custom validation rule, not in use by react-hook-form
+      minLength: 2,
+    }
+  },
+  is_contact_person: {
+    label: 'Contact person',
+    help: 'Is this contributor main contact person'
+  },
+  given_names: {
+    label: 'First name / Given name(s)',
+    help: '',
+    validation: {
+      required: 'Name is required',
+      minLength: {value: 1, message: 'Minimum length is 1'},
+      maxLength: {value: 200, message: 'Maximum length is 200'},
+    }
+  },
+  family_names: {
+    label: 'Last name / Family name(s)',
+    help: 'Family names including "de/van/van den"',
+    validation: {
+      required: 'Family name is required',
+      minLength: {value: 2, message: 'Minimum length is 2'},
+      maxLength: {value: 200, message: 'Maximum length is 200'},
+    }
+  },
+  email_address: {
+    label: 'Email',
+    help: 'Contact person should have an email',
+    validation: {
+      minLength: {value: 5, message: 'Minimum length is 5'},
+      maxLength: {value: 100, message: 'Maximum length is 100'},
+      pattern: {
+        value: /^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+        message: 'Invalid email address'
+      }
+    }
+  },
+  affiliation: {
+    label: 'Affiliation',
+    help: 'Where the contributor works currently?',
+    validation: {
+      minLength: {value: 2, message: 'Minimum length is 2'},
+      maxLength: {value: 200, message: 'Maximum length is 200'},
+    }
+  },
+  role: {
+    label: 'Role',
+    help: 'For this software',
+    validation: {
+      minLength: {value: 2, message: 'Minimum length is 2'},
+      maxLength: {value: 200, message: 'Maximum length is 200'},
+    }
+  },
+  orcid: {
+    label: 'ORCID',
+    help: '16 digits, pattern 0000-0000-0000-0000',
+    validation: {
+      pattern: {
+        value: /\d{4}-\d{4}-\d{4}-\d{4}/,
+        message: 'Invalid pattern, not a 0000-0000-0000-0000'
+      }
+    }
+  }
+}

--- a/frontend/components/projects/edit/team/config.ts
+++ b/frontend/components/projects/edit/team/config.ts
@@ -47,7 +47,7 @@ export const cfgTeamMembers = {
   },
   affiliation: {
     label: 'Affiliation',
-    help: 'Where the contributor works currently?',
+    help: 'Select or type in the current affiliation?',
     validation: {
       minLength: {value: 2, message: 'Minimum length is 2'},
       maxLength: {value: 200, message: 'Maximum length is 200'},

--- a/frontend/components/projects/edit/team/config.ts
+++ b/frontend/components/projects/edit/team/config.ts
@@ -66,7 +66,7 @@ export const cfgTeamMembers = {
     help: '16 digits, pattern 0000-0000-0000-0000',
     validation: {
       pattern: {
-        value: /\d{4}-\d{4}-\d{4}-\d{4}/,
+        value: /\d{4}-\d{4}-\d{4}-\d{3}[0-9X]/,
         message: 'Invalid pattern, not a 0000-0000-0000-0000'
       }
     }

--- a/frontend/components/projects/edit/team/editTeamMembers.ts
+++ b/frontend/components/projects/edit/team/editTeamMembers.ts
@@ -1,0 +1,158 @@
+import {TeamMemberProps} from '~/types/Contributor'
+import {TeamMember} from '~/types/Project'
+import {createJsonHeaders, extractReturnMessage} from '~/utils/fetchHelpers'
+import {getAvatarUrl} from '~/utils/getProjects'
+import {getPropsFromObject} from '~/utils/getPropsFromObject'
+import logger from '~/utils/logger'
+
+export type ModalProps = {
+  open: boolean
+  pos?: number
+}
+
+export type DeleteModalProps = ModalProps & {
+  displayName?: string | null
+}
+
+export type ModalStates<T> = {
+  edit: T,
+  delete: DeleteModalProps
+}
+
+
+export async function createTeamMember({data, token}:
+  { data: TeamMember, token: string }) {
+
+  const resp = await postTeamMember({
+    member: prepareMemberData(data),
+    token
+  })
+
+  if (resp.status === 201) {
+    const member = removeBase64Data(data)
+    member.id = resp.message
+    return {
+      status: 201,
+      message: member
+    }
+  }
+
+  return resp
+}
+
+export async function updateTeamMember({data, token}:
+  { data: TeamMember, token: string }) {
+
+  const member = prepareMemberData(data)
+  const resp = await patchTeamMember({member, token})
+
+  if (resp.status === 200) {
+    // if we uploaded new image we remove
+    // data and construct avatar_url
+    const returned = removeBase64Data(data)
+    return {
+      status: 200,
+      message: returned
+    }
+  } else {
+    return resp
+  }
+}
+
+export function prepareMemberData(data: TeamMember) {
+  const member = getPropsFromObject(data, TeamMemberProps)
+  // do we need to save new base64 image
+  if (data?.avatar_b64 &&
+    data?.avatar_b64.length > 10 &&
+    data?.avatar_mime_type !== null) {
+    // split base64 to use only encoded content
+    member.avatar_data = data?.avatar_b64.split(',')[1]
+  }
+  return member
+}
+
+export function removeBase64Data(member: TeamMember) {
+  if (member.avatar_b64 &&
+    member?.avatar_b64.length > 10) {
+    // clean it from memory data
+    member.avatar_b64 = null
+    // and we use avatar url instead
+    member.avatar_url = getAvatarUrl(member)
+  }
+  return member
+}
+
+export async function postTeamMember({member, token}:
+  { member: TeamMember, token: string }) {
+  try {
+    const url = '/api/v1/team_member'
+
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token),
+        'Prefer': 'return=headers-only'
+      },
+      body: JSON.stringify(member)
+    })
+    debugger
+    if (resp.status === 201) {
+      // we need to return id of created record
+      // it can be extracted from header.location
+      const id = resp.headers.get('location')?.split('.')[1]
+      return {
+        status: 201,
+        message: id
+      }
+    } else {
+      return extractReturnMessage(resp)
+    }
+  } catch (e: any) {
+    logger(`addTeamMember: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}
+
+export async function patchTeamMember({member, token}:
+  {member: TeamMember, token: string }) {
+  try {
+    const url = `/api/v1/team_member?id=eq.${member.id}`
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        ...createJsonHeaders(token),
+      },
+      body: JSON.stringify(member)
+    })
+    return extractReturnMessage(resp)
+  } catch (e: any) {
+    logger(`patchTeamMember: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}
+
+
+export async function deleteTeamMemberById({ids, token}: { ids: string[], token: string }) {
+  try {
+    const url = `/api/v1/team_member?id=in.("${ids.join('","')}")`
+    const resp = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        ...createJsonHeaders(token),
+      }
+    })
+    return extractReturnMessage(resp, ids.toString())
+  } catch (e: any) {
+    logger(`deleteTeamMemberById: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}

--- a/frontend/components/projects/edit/team/editTeamMembers.ts
+++ b/frontend/components/projects/edit/team/editTeamMembers.ts
@@ -29,8 +29,8 @@ export async function createTeamMember({data, token}:
   })
 
   if (resp.status === 201) {
+    data.id = resp.message
     const member = removeBase64Data(data)
-    member.id = resp.message
     return {
       status: 201,
       message: member
@@ -95,7 +95,7 @@ export async function postTeamMember({member, token}:
       },
       body: JSON.stringify(member)
     })
-    debugger
+
     if (resp.status === 201) {
       // we need to return id of created record
       // it can be extracted from header.location

--- a/frontend/components/projects/edit/team/index.tsx
+++ b/frontend/components/projects/edit/team/index.tsx
@@ -192,8 +192,8 @@ export default function ProjectTeam({slug, session}: { slug: string, session: Se
 
   return (
     <>
-      <EditSection className='xl:grid xl:grid-cols-[1fr,1fr] xl:px-0 xl:gap-[3rem]'>
-        <div className="py-4 xl:pl-[3rem]">
+      <EditSection className='md:flex md:flex-col-reverse md:justify-end xl:pl-[3rem] xl:grid xl:grid-cols-[1fr,1fr] xl:px-0 xl:gap-[3rem]'>
+        <div className="py-4">
           <h2 className="flex pr-4 pb-4 justify-between">
             <span>{cfgTeamMembers.title}</span>
             <span>{members?.length}</span>

--- a/frontend/components/projects/edit/team/index.tsx
+++ b/frontend/components/projects/edit/team/index.tsx
@@ -1,21 +1,66 @@
-import {useEffect} from 'react'
+import {useEffect, useState} from 'react'
 
+import {Session} from '~/auth'
+import {getTeamForProject} from '~/utils/getProjects'
+import {getDisplayName} from '~/utils/getDisplayName'
+import {sortOnStrProp} from '~/utils/sortFn'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
 import ContentLoader from '~/components/layout/ContentLoader'
 import EditSection from '~/components/layout/EditSection'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
+import {TeamMember} from '~/types/Project'
 import useProjectContext from '../useProjectContext'
+import {cfgTeamMembers} from './config'
+import TeamMemberList from './TeamMemberList'
+import FindMember from './FindMember'
+import {
+  createTeamMember, deleteTeamMemberById,
+  ModalProps, ModalStates, updateTeamMember
+} from './editTeamMembers'
+import TeamMemberModal from './TeamMemberModal'
 
-export default function ProjectTeam() {
-  const {loading, setLoading} = useProjectContext()
+type EditMemberModal = ModalProps & {
+  member?: TeamMember
+}
+
+export default function ProjectTeam({slug, session}: { slug: string, session: Session }) {
+  const {showErrorMessage} = useSnackbar()
+  const {step, project, loading, setLoading} = useProjectContext()
+  const [members, setMembers] = useState<TeamMember[]>([])
+  const [modal, setModal] = useState<ModalStates<EditMemberModal>>({
+    edit: {
+      open: false
+    },
+    delete: {
+      open: false,
+      displayName: null
+    }
+  })
 
   useEffect(() => {
     let abort = false
-    setTimeout(() => {
-      if (abort) return
-      if (loading) setLoading(false)
-    }, 1000)
-    return ()=>{abort=true}
-  },[loading,setLoading])
+    async function getMembers() {
+      setLoading(true)
+      const members = await getTeamForProject({
+        project: project.id,
+        token: session.token,
+        frontend: true
+      })
+      // debugger
+      // set member to form
+      setMembers(members)
+      setLoading(false)
+    }
+    if (slug && session.token && project.id) {
+      getMembers()
+    }
+    return () => { abort = true }
+    // exclude functions to avoid endless reloading of effect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    slug, session.token, project.id
+  ])
 
   if (loading) {
     return (
@@ -23,18 +68,181 @@ export default function ProjectTeam() {
     )
   }
 
+  // console.group('ProjectTeam')
+  // console.log('loading...', loading)
+  // console.log('project...', project)
+  // console.log('members...', members)
+  // console.groupEnd()
+
+  function hideModals() {
+    // hide modals
+    setModal({
+      edit: {
+        open:false
+      },
+      delete: {
+        open:false
+      }
+    })
+  }
+
+  function updateLocalState(member: TeamMember, pos?: number) {
+    if (typeof pos != 'undefined') {
+      // update
+      const newMembersList = [
+        ...members.slice(0, pos),
+        ...members.slice(pos+1),
+        member
+      ].sort((a, b) => sortOnStrProp(a, b, 'given_names'))
+      setMembers(newMembersList)
+    } else {
+      // append
+      const newMembersList = [
+        ...members,
+        member
+      ].sort((a, b) => sortOnStrProp(a, b, 'given_names'))
+      setMembers(newMembersList)
+    }
+  }
+
+  function onEditMember(member: TeamMember,pos?:number) {
+    if (member) {
+      // show modal and pass data
+      setModal({
+        edit: {
+          open: true,
+          pos,
+          member
+        },
+        delete: {
+          open:false
+        }
+      })
+    }
+  }
+
+  function onDeleteMember(pos:number) {
+    const member = members[pos]
+    if (member) {
+      setModal({
+        edit: {
+          open:false
+        },
+        delete: {
+          pos,
+          open: true,
+          displayName: getDisplayName(member)
+        }
+      })
+    }
+  }
+
+  async function deleteMember(pos: number) {
+    hideModals()
+    const member = members[pos]
+    if (member) {
+      const resp = await deleteTeamMemberById({
+        ids: [member?.id ?? ''],
+        token: session.token
+      })
+      if (resp.status === 200) {
+        const newMembersList = [
+          ...members.slice(0, pos),
+          ...members.slice(pos+1)
+        ]
+        setMembers(newMembersList)
+      } else {
+        showErrorMessage(`Failed to remove member. ${resp.message}`)
+      }
+    }
+  }
+
+  async function onSubmitMember({data,pos}:{data: TeamMember, pos?: number}) {
+    hideModals()
+    if (!data.project) {
+      // add project id
+      data.project = project.id
+    }
+    if (data?.id && typeof pos != 'undefined') {
+      const resp = await updateTeamMember({
+        data,
+        token: session.token
+      })
+      if (resp.status === 200) {
+        // updated record delivered in message
+        const member = resp.message
+        updateLocalState(member,pos)
+      } else {
+        showErrorMessage(`Failed to update member. ${resp.message}`)
+      }
+    } else {
+      const resp = await createTeamMember({
+        data,
+        token: session.token
+      })
+      if (resp.status === 201) {
+        // updated record delivered in message
+        const member = resp.message
+        updateLocalState(member)
+      } else {
+        showErrorMessage(`Failed to add member. ${resp.message}`)
+      }
+    }
+  }
+
   return (
-    <EditSection className='xl:grid xl:grid-cols-[3fr,1fr] xl:px-0 xl:gap-[3rem]'>
-      <div className="py-4 xl:pl-[3rem]">
-        <EditSectionTitle
-          title="Team members"
-        />
-      </div>
-      <div className="py-4 min-w-[21rem] xl:my-0">
-        <EditSectionTitle
-          title="Find team members"
-        />
-      </div>
-    </EditSection>
+    <>
+      <EditSection className='xl:grid xl:grid-cols-[1fr,1fr] xl:px-0 xl:gap-[3rem]'>
+        <div className="py-4 xl:pl-[3rem]">
+          <h2 className="flex pr-4 pb-4 justify-between">
+            <span>{cfgTeamMembers.title}</span>
+            <span>{members?.length}</span>
+          </h2>
+          <TeamMemberList
+            members={members}
+            onEdit={onEditMember}
+            onDelete={onDeleteMember}
+          />
+        </div>
+        <div className="py-4 min-w-[21rem] xl:my-0">
+          <EditSectionTitle
+            title={cfgTeamMembers.find.title}
+            subtitle={cfgTeamMembers.find.subtitle}
+          />
+          <FindMember
+            project={project.id}
+            token={session.token}
+            onAdd={onEditMember}
+          />
+        </div>
+      </EditSection>
+
+      <TeamMemberModal
+        open={modal.edit.open}
+        pos={modal.edit.pos}
+        member={modal.edit.member}
+        onCancel={() => {
+          setModal({
+            edit:{open:false},
+            delete:{open:false}
+          })
+        }}
+        onSubmit={onSubmitMember}
+      />
+      <ConfirmDeleteModal
+        open={modal.delete.open}
+        title="Remove team member"
+        body={
+          <p>Are you sure you want to remove <strong>{modal.delete.displayName ?? 'No name'}</strong>?</p>
+        }
+        onCancel={() => {
+          setModal({
+            edit:{open:false},
+            delete:{open:false}
+          })
+        }}
+        onDelete={()=>deleteMember(modal.delete.pos ?? 0)}
+      />
+    </>
   )
 }

--- a/frontend/components/projects/edit/team/searchForMember.ts
+++ b/frontend/components/projects/edit/team/searchForMember.ts
@@ -1,0 +1,79 @@
+import {AutocompleteOption} from '~/types/AutocompleteOptions'
+import {SearchTeamMember} from '~/types/Project'
+import {createJsonHeaders} from '~/utils/fetchHelpers'
+import {getORCID} from '~/utils/getORCID'
+import logger from '../../../../utils/logger'
+
+export type Keyword = {
+  id: string,
+  keyword: string,
+  cnt: number | null
+}
+
+export type NewKeyword = {
+  id: null,
+  keyword: string
+}
+
+export async function searchForMember({searchFor,token,frontend=true}:
+  {searchFor: string,token:string,frontend?:boolean}) {
+  try {
+    const [rsdContributor, orcidOptions] = await Promise.all([
+      findRSDMember({searchFor, token, frontend}),
+      getORCID({searchFor})
+    ])
+
+    const options = [
+      ...rsdContributor,
+      ...orcidOptions
+    ]
+
+    return options
+
+  } catch (e: any) {
+    logger(`searchForMember: ${e?.message}`, 'error')
+    return []
+  }
+}
+
+
+// this is always frontend call
+export async function findRSDMember({searchFor, token, frontend}:
+  { searchFor: string, token?: string, frontend?: boolean }) {
+  try {
+    let url = `${process.env.POSTGREST_URL}/rpc/unique_team_members?display_name=ilike.*${searchFor}*&limit=20`
+    if (frontend) {
+      url = `/api/v1/rpc/unique_team_members?display_name=ilike.*${searchFor}*&limit=20`
+    }
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+      }
+    })
+
+    if (resp.status === 200) {
+      const data: SearchTeamMember[] = await resp.json()
+      const options: AutocompleteOption<SearchTeamMember>[] = data.map(item => {
+        return {
+          key: item.display_name ?? '',
+          label: item.display_name ?? '',
+          data: {
+            ...item,
+            source: 'RSD'
+          }
+        }
+      })
+      return options
+    } else if (resp.status === 404) {
+      logger('findRSDMember ERROR: 404 Not found', 'error')
+      // query not found
+      return []
+    }
+    logger(`findRSDMember ERROR: ${resp?.status} ${resp?.statusText}`, 'error')
+    return []
+  } catch (e: any) {
+    logger(`findRSDMember: ${e?.message}`, 'error')
+    return []
+  }
+}

--- a/frontend/components/software/ContributorsList.tsx
+++ b/frontend/components/software/ContributorsList.tsx
@@ -1,8 +1,7 @@
 
 import {Contributor} from '../../types/Contributor'
 import ContributorAvatar from './ContributorAvatar'
-import {getDisplayName, getDisplayInitials} from '../../utils/getDisplayName'
-import {combineRoleAndAffiliation} from '../../utils/editContributors'
+import {getDisplayName, getDisplayInitials,combineRoleAndAffiliation} from '../../utils/getDisplayName'
 
 export default function ContributorsList({contributors}: { contributors: Contributor[] }) {
   // do not render component if no data

--- a/frontend/components/software/SoftwareCard.tsx
+++ b/frontend/components/software/SoftwareCard.tsx
@@ -35,15 +35,23 @@ export default function SoftwareCard({href,brand_name,short_statement,is_feature
 
   return (
     <Link href={href} passHref>
-      <a>
-        <article className={`flex flex-col h-[17rem] ${colors} hover:bg-secondary hover:text-white`}>
-          <div className="flex min-h-[6rem]">
-            <h2 className="p-4 flex-1">{brand_name}</h2>
-            <div className="flex w-[4rem] h-[4rem] justify-center items-center bg-white text-gray-800 text-[1.5rem]">
+      <a className="flex flex-col h-full">
+        <article className={`flex-1 flex flex-col ${colors} hover:bg-secondary hover:text-white`}>
+          <div className="flex relative">
+            <h2
+              title={brand_name}
+              className="p-4 flex-1 mr-[4rem] overflow-hidden text-ellipsis whitespace-nowrap"
+            >
+              {brand_name}
+            </h2>
+            <div
+              className="flex w-[4rem] h-[4rem] justify-center items-center bg-white text-gray-800 text-[1.5rem]"
+              style={{position:'absolute',right:0,top:0}}
+            >
               {getInitals()}
             </div>
           </div>
-          <p className="flex-1 p-4">
+          <p className="flex-1 p-4 overflow-auto max-h-[9.75rem]">
             {short_statement}
           </p>
           <div className="flex justify-between p-4 text-sm">

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -236,7 +236,8 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
             <ControlledAffiliation
               name='affiliation'
               label={config.affiliation.label}
-              affiliations={contributor?.affiliation ?? ''}
+              affiliation={contributor?.affiliation ?? ''}
+              institution={contributor?.institution ?? null}
               control={control}
               rules={config.affiliation.validation}
               helperTextMessage={config.affiliation.help}

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -15,6 +15,7 @@ import ContributorAvatar from '../../ContributorAvatar'
 import {contributorInformation as config} from '../editSoftwareConfig'
 import {getDisplayInitials, getDisplayName} from '../../../../utils/getDisplayName'
 import logger from '../../../../utils/logger'
+import ControlledAffiliation from '~/components/form/ControlledAffiliation'
 
 type EditContributorModalProps = {
   open: boolean,
@@ -232,20 +233,14 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
               }}
               rules={config.role.validation}
             />
-
-            <ControlledTextField
+            <ControlledAffiliation
+              name='affiliation'
+              label={config.affiliation.label}
+              affiliations={contributor?.affiliation ?? ''}
               control={control}
-              options={{
-                name: 'affiliation',
-                label: config.affiliation.label,
-                useNull: true,
-                defaultValue: contributor?.affiliation,
-                helperTextMessage: config.affiliation.help,
-                // helperTextCnt: `${formData?.affiliation?.length || 0}/${config.affiliation.validation.maxLength.value}`,
-              }}
               rules={config.affiliation.validation}
+              helperTextMessage={config.affiliation.help}
             />
-
           </section>
           <section>
             <ControlledSwitch

--- a/frontend/components/software/edit/contributors/FindContributor.tsx
+++ b/frontend/components/software/edit/contributors/FindContributor.tsx
@@ -1,12 +1,11 @@
 import {HTMLAttributes, useState} from 'react'
 
-import AsyncAutocomplete from '../../../form/AsyncAutocomplete'
 import {Contributor, SearchContributor} from '../../../../types/Contributor'
 import {searchForContributor} from '../../../../utils/editContributors'
-import {AutocompleteOption} from '../../../../types/AutocompleteOptions'
 import FindContributorItem from './FindContributorItem'
 import {splitName} from '../../../../utils/getDisplayName'
 import {contributorInformation as config} from '../editSoftwareConfig'
+import AsyncAutocompleteSC,{AutocompleteOption} from '~/components/form/AsyncAutocompleteSC'
 
 export type Name = {
   given_names: string
@@ -54,11 +53,41 @@ export default function FindContributor({onAdd, onCreate}:
     onCreate(name)
   }
 
-  function renderOption(props: HTMLAttributes<HTMLLIElement>,
-    option: AutocompleteOption<SearchContributor>,
-    state: object) {
+  function renderAddOption(props: HTMLAttributes<HTMLLIElement>,
+    option: AutocompleteOption<SearchContributor>) {
+    // if more than one option we add border at the bottom
+    // we assume that first option is Add "new item"
+    if (options.length > 1) {
+      if (props?.className) {
+        props.className+=' mb-2 border-b'
+      } else {
+        props.className='mb-2 border-b'
+      }
+    }
     return (
       <li {...props} key={option.key}>
+        {/* if new option (has input) show label and count  */}
+        <strong>{`Add "${option.label}"`}</strong>
+      </li>
+    )
+  }
+
+  function renderOption(props: HTMLAttributes<HTMLLIElement>,
+    option: AutocompleteOption<SearchContributor>) {
+    // console.log('renderOption...', option)
+    // when value is not not found option returns input prop
+    if (option?.input) {
+      // if input is over minLength
+      if (option?.input.length > config.findContributor.validation.minLength) {
+        // we offer an option to create this entry
+        return renderAddOption(props,option)
+      } else {
+        return null
+      }
+    }
+
+    return (
+      <li {...props} key={Math.random().toString()}>
         <FindContributorItem option={option} />
       </li>
     )
@@ -66,7 +95,7 @@ export default function FindContributor({onAdd, onCreate}:
 
   return (
     <section className="flex items-center">
-      <AsyncAutocomplete
+      <AsyncAutocompleteSC
         status={status}
         options={options}
         onSearch={searchContributor}

--- a/frontend/components/software/edit/contributors/FindContributor.tsx
+++ b/frontend/components/software/edit/contributors/FindContributor.tsx
@@ -106,7 +106,9 @@ export default function FindContributor({onAdd, onCreate}:
           freeSolo: true,
           minLength: config.findContributor.validation.minLength,
           label: config.findContributor.label,
-          help: config.findContributor.help
+          help: config.findContributor.help,
+          // clear selected item
+          reset: true
         }}
       />
     </section>

--- a/frontend/components/software/edit/contributors/FindContributorItem.tsx
+++ b/frontend/components/software/edit/contributors/FindContributorItem.tsx
@@ -4,25 +4,43 @@ import {SearchContributor} from '../../../../types/Contributor'
 export default function FindContributorItem({option}: { option: AutocompleteOption<SearchContributor> }) {
 
   function renderSecondRow() {
-    if (option.data?.affiliation && option.data?.orcid) {
+    const {affiliation,orcid,institution} = option.data
+    // debugger
+    if (affiliation && orcid) {
       return (
-        <div className="grid grid-cols-[4fr,3fr] gap-2">
-          <div>{option.data?.affiliation}</div>
+        <div className="grid grid-cols-[3fr,2fr] gap-2">
+          <div>{affiliation}</div>
+          <div className="pl-4 text-right">{orcid}</div>
+        </div>
+      )
+    }
+    if (institution && institution.length > 0 && orcid) {
+      return (
+        <div className="grid grid-cols-[3fr,2fr] gap-2">
+          {institution.join('; ')}
+          <div className="pl-4 text-right">{orcid}</div>
+        </div>
+      )
+    }
+    if (orcid) {
+      return (
+        <div className="grid grid-cols-[3fr,2fr] gap-2">
+          <div className="flex-1"></div>
           <div className="pl-4 text-right">{option.data?.orcid}</div>
         </div>
       )
     }
-    if (option.data?.affiliation) {
+    if (affiliation) {
       return (
         <div className="flex-1">
           {option.data?.affiliation}
         </div>
       )
     }
-    if (option.data?.orcid) {
+    if (institution) {
       return (
-        <div className="flex-1 text-right">
-          {option.data?.orcid}
+        <div className="flex-1">
+          {institution.join('; ')}
         </div>
       )
     }

--- a/frontend/components/software/edit/contributors/SoftwareContributorsList.tsx
+++ b/frontend/components/software/edit/contributors/SoftwareContributorsList.tsx
@@ -9,9 +9,8 @@ import IconButton from '@mui/material/IconButton'
 
 import {Contributor} from '../../../../types/Contributor'
 import ContributorAvatar from '../../ContributorAvatar'
-import {getDisplayInitials, getDisplayName} from '../../../../utils/getDisplayName'
+import {combineRoleAndAffiliation, getDisplayInitials, getDisplayName} from '../../../../utils/getDisplayName'
 import {Alert, AlertTitle} from '@mui/material'
-import {combineRoleAndAffiliation} from '../../../../utils/editContributors'
 
 
 export default function SoftwareContributorsList({contributors, onEdit, onDelete}:

--- a/frontend/components/software/edit/contributors/index.tsx
+++ b/frontend/components/software/edit/contributors/index.tsx
@@ -21,7 +21,7 @@ import EditSoftwareSection from '../../../layout/EditSection'
 import editSoftwareContext from '../editSoftwareContext'
 import EditSectionTitle from '../../../layout/EditSectionTitle'
 import {contributorInformation as config} from '../editSoftwareConfig'
-import {ModalProps,ModalStates} from '../editSoftwareTypes'
+import {ModalProps, ModalStates} from '../editSoftwareTypes'
 
 type EditContributorModal = ModalProps & {
   contributor?: Contributor
@@ -110,9 +110,7 @@ export default function SoftwareContributors({token}: {token: string }) {
       software?.id !== '') {
       item.software = software?.id
     }
-    // extract props into new object
-    const contributor: Contributor = getPropsFromObject(item, ContributorProps)
-    loadContributorIntoModal(contributor)
+    loadContributorIntoModal(item)
   }
 
   function loadContributorIntoModal(contributor: Contributor,pos?:number) {

--- a/frontend/components/software/edit/contributors/index.tsx
+++ b/frontend/components/software/edit/contributors/index.tsx
@@ -209,7 +209,7 @@ export default function SoftwareContributors({token}: {token: string }) {
         const resp = await deleteContributorsById({ids, token})
         if (resp.status === 200) {
           // show notification
-          showSuccessMessage(`Removed ${getDisplayName(contributor)} from ${pageState.software.brand_name}`)
+          // showSuccessMessage(`Removed ${getDisplayName(contributor)} from ${pageState.software.brand_name}`)
           removeFromContributorList(pos)
         } else {
           showErrorMessage(`Failed to remove ${getDisplayName(contributor)}. Error: ${resp.message}`)

--- a/frontend/components/software/edit/editSoftwareConfig.ts
+++ b/frontend/components/software/edit/editSoftwareConfig.ts
@@ -148,7 +148,7 @@ export const contributorInformation = {
   },
   affiliation: {
     label: 'Affiliation',
-    help: 'Where the contributor works currently?',
+    help: 'Select or type in the current affiliation?',
     validation: {
       minLength: {value: 2, message: 'Minimum length is 2'},
       maxLength: {value: 200, message: 'Maximum length is 200'},

--- a/frontend/components/software/edit/editSoftwareSteps.tsx
+++ b/frontend/components/software/edit/editSoftwareSteps.tsx
@@ -30,7 +30,7 @@ export const editSoftwareMenu:EditSoftwarePageStep[] = [
     status: 'Required information'
   },
   {
-    formId: 'contributors',
+    // formId: 'contributors',
     label: 'Contributors',
     icon: <Filter2Icon />,
     component: (props?) => <SoftwareContributors {...props} />,

--- a/frontend/components/software/edit/information/index.tsx
+++ b/frontend/components/software/edit/information/index.tsx
@@ -108,7 +108,7 @@ export default function SoftwareInformation({slug,token}:{slug:string,token: str
       getFieldState,
       projectState:editSoftware
     })
-    debugger
+    // debugger
     // save all changes
     const resp = await updateSoftwareInfo({
       software: formData,

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/types/Contributor.ts
+++ b/frontend/types/Contributor.ts
@@ -44,8 +44,7 @@ export type SearchContributor = {
   source: 'RSD'|'ORCID'
 }
 
-
-export const TeamMemberProps = [
+export const Person = [
   'id',
   'is_contact_person',
   'email_address',
@@ -57,7 +56,13 @@ export const TeamMemberProps = [
   'avatar_mime_type'
 ]
 
+
+export const TeamMemberProps = [
+  ...Person,
+  'project'
+]
+
 export const ContributorProps = [
-  ...TeamMemberProps,
+  ...Person,
   'software'
 ]

--- a/frontend/types/Contributor.ts
+++ b/frontend/types/Contributor.ts
@@ -10,6 +10,8 @@ export type NewContributor = {
   email_address: string | null
   // NOTE! added on 2022-02-11
   affiliation?: string | null
+  // ORCID delivers array of institutions
+  institution?: string[] | null
   // NOTE! added on 2022-02-11
   role?: string | null
   // NOTE! added on 2022-02-11
@@ -39,6 +41,8 @@ export type SearchContributor = {
   email_address: string | null
   // NOTE! added on 2022-02-11
   affiliation?: string | null
+  // ORCID delivers array of institutions
+  institution?: string[] | null
   display_name?: string | null,
   orcid?: string
   source: 'RSD'|'ORCID'

--- a/frontend/types/Project.ts
+++ b/frontend/types/Project.ts
@@ -1,5 +1,5 @@
 import {OrganisationRole, SearchOrganisation, Status} from './Organisation'
-import {AutocompleteOption} from './AutocompleteOptions'
+import {SearchContributor} from './Contributor'
 
 export type NewProject = {
   slug: string
@@ -125,6 +125,9 @@ export type TeamMember = {
   given_names: string,
   email_address: string | null,
   affiliation?: string | null,
+  // ORCID delivers array of institutions
+  // selected one is moved to affiliation
+  institution?: string[] | null,
   role: string | null,
   orcid?: string | null,
   // base64 image in table
@@ -136,20 +139,7 @@ export type TeamMember = {
   avatar_b64?: string | null
 }
 
-export type SearchTeamMember = {
-  given_names: string
-  family_names: string
-  email_address: string | null
-  affiliation?: string | null
-  display_name?: string | null,
-  orcid?: string
-  source: 'RSD' | 'ORCID'
-}
-
-export type EditTeamMembers = {
-  members: TeamMember[]
-  edit: TeamMember | null
-}
+export type SearchTeamMember = SearchContributor
 
 export const ProjectTableProps = [
   'id', 'slug', 'title', 'subtitle', 'is_published',

--- a/frontend/types/Project.ts
+++ b/frontend/types/Project.ts
@@ -117,6 +117,40 @@ export type ResearchDomainForProject = {
   research_domain: string
 }
 
+export type TeamMember = {
+  id: string | null,
+  project: string,
+  is_contact_person: boolean,
+  family_names: string,
+  given_names: string,
+  email_address: string | null,
+  affiliation?: string | null,
+  role: string | null,
+  orcid?: string | null,
+  // base64 image in table
+  avatar_data?: string | null
+  avatar_mime_type?: string | null
+  // image_url to use
+  avatar_url?: string | null
+  // uploaded raw image data
+  avatar_b64?: string | null
+}
+
+export type SearchTeamMember = {
+  given_names: string
+  family_names: string
+  email_address: string | null
+  affiliation?: string | null
+  display_name?: string | null,
+  orcid?: string
+  source: 'RSD' | 'ORCID'
+}
+
+export type EditTeamMembers = {
+  members: TeamMember[]
+  edit: TeamMember | null
+}
+
 export const ProjectTableProps = [
   'id', 'slug', 'title', 'subtitle', 'is_published',
   'description', 'date_start', 'date_end', 'image_caption',

--- a/frontend/utils/editContributors.ts
+++ b/frontend/utils/editContributors.ts
@@ -240,12 +240,3 @@ export async function deleteContributorsById({ids,token}:{ids:string[],token:str
     }
   }
 }
-
-
-export function combineRoleAndAffiliation(item:Contributor){
-  if (item?.role && item?.affiliation) return `${item?.role}, ${item?.affiliation}`
-
-  if (item?.role) return item?.role
-
-  return item?.affiliation ?? ''
-}

--- a/frontend/utils/getDisplayName.ts
+++ b/frontend/utils/getDisplayName.ts
@@ -42,3 +42,14 @@ export function splitName(name: string) {
     family_names: names.slice(1).join(' ')
   }
 }
+
+
+export function combineRoleAndAffiliation({role, affiliation}:
+  { role?: string | null, affiliation?: string | null }) {
+
+  if (role && affiliation) return `${role}, ${affiliation}`
+
+  if (role) return role
+
+  return affiliation ?? ''
+}

--- a/frontend/utils/getORCID.ts
+++ b/frontend/utils/getORCID.ts
@@ -78,7 +78,7 @@ function buildAutocompleteOptions(data: OrcidRecord[]): AutocompleteOption<Searc
         given_names: item['given-names'],
         family_names: item['family-names'],
         email_address: item['email'][0] ?? null,
-        affiliation: item['institution-name'].join('; ') ?? null,
+        institution: item['institution-name'] ?? null,
         orcid: item['orcid-id'],
         display_name,
         source: 'ORCID' as 'ORCID'

--- a/frontend/utils/getProjects.ts
+++ b/frontend/utils/getProjects.ts
@@ -4,7 +4,7 @@ import {MentionForProject} from '../types/Mention'
 import {
   KeywordForProject,
   OrganisationsOfProject, Project,
-  ProjectLink, RawProject, RelatedProject, ResearchDomain
+  ProjectLink, RawProject, RelatedProject, ResearchDomain, TeamMember
 } from '../types/Project'
 import {RelatedTools} from '../types/SoftwareTypes'
 import {getUrlFromLogoId} from './editOrganisation'
@@ -427,7 +427,7 @@ export async function getTeamForProject({project, token, frontend}:
     })
 
     if (resp.status === 200) {
-      const data: Contributor[] = await resp.json()
+      const data: TeamMember[] = await resp.json()
       return data.map(item => ({
         ...item,
         // add avatar url based on uuid


### PR DESCRIPTION
# Edit project team

Closes #252
Closes #164

Changes proposed in this pull request:
* Project maintainer add/edit/delete team members using find/add options
* We search in RSD and ORCID database
* If person extracted from ORCID has more than one affiliation we show them in drop-down. User still can type in completely different affiliation. Same solution is implemented the edit contributors modal.

How to test:
* `docker-compose down --volumes`: remove old
* `docker-compose build`: to build solution
* `docker-compose up`: to start
* data-migration is optional
* login using any of test users, eg. professor1
* create new project
* add team members using search on the right side of the screen, the section should look like in the example below
* when using information from ORCID, which might provide multiple affiliation values, first affiliation from the array is used and the other values can be selected from dropdown. To make clear that multiple options are present, the dropdown will open on focus. The help text is updated to state "Select or type in...". Beside selecting the dropdown options the user can type in any text value.

![image](https://user-images.githubusercontent.com/9204081/167309208-e6bc7b24-e201-453a-a8f6-ffad182a930a.png)

## Affiliation from ORCID example

![image](https://user-images.githubusercontent.com/9204081/167579166-4b7aec57-9ff0-47f7-af10-a50307753af2.png)


PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
