### PR TITLE
225 improve releases scraper

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -104,7 +104,7 @@ services:
   scrapers:
     container_name: scrapers
     build: ./scrapers
-    image: rsd/scrapers:0.1.1
+    image: rsd/scrapers:0.1.2
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/scrapers/src/main/resources/releases.py
+++ b/scrapers/src/main/resources/releases.py
@@ -197,7 +197,10 @@ class ReleaseScraper:
 				elif type(e).__name__ == "ScannerError":
 					continue
 				else:
-					raise e
+					print("Something went wrong while generating a file for a release:")
+					print(e)
+					print("Continuing")
+					continue
 		return self
 
 	def is_concept_doi(self):


### PR DESCRIPTION
# Make releases scraper more robust

Changes proposed in this pull request:

* When the releases scraper found a syntax error in a single CITATION.cff file, it would skip all the releases of that software. Now it will print a message and continue with the next file.

How to test:

* Rebuild the project, it is the easiest to start with an empty database
	* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up`
* Create two software entries with the folling concept DOIs: 10.5281/zenodo.4592360 and 10.5281/zenodo.4818029
* Run the releases scraper: `docker-compose exec scrapers python3 releases.py`
* You should see error messages, but the scraper still reaches the end (it prints 1/2 and 2/2)

Closes #225

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests