### PR TITLE
270 correct platform type migration

### DIFF
--- a/data-migration/docker-compose.yml
+++ b/data-migration/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build:
       context: ../
       dockerfile: ./data-migration/Dockerfile
-    image: rsd/data-migration:0.0.12
+    image: rsd/data-migration:0.0.13
     env_file:
       # use main env file
       - ../.env

--- a/data-migration/src/main/java/nl/esciencecenter/rsd/migration/Main.java
+++ b/data-migration/src/main/java/nl/esciencecenter/rsd/migration/Main.java
@@ -236,7 +236,11 @@ public class Main {
 				JsonObject repoUrlToSave = new JsonObject();
 				repoUrlToSave.addProperty("software", slugToId.get(slug));
 				repoUrlToSave.add("url", jsonUrl);
-				repoUrlToSave.addProperty("code_platform", "github");
+				String url = jsonUrl.getAsString();
+				if (url.startsWith("https://github.com")) repoUrlToSave.addProperty("code_platform", "github");
+				else if (url.contains("gitlab")) repoUrlToSave.addProperty("code_platform", "gitlab");
+				else if (url.contains("bitbucket")) repoUrlToSave.addProperty("code_platform", "bitbucket");
+				else repoUrlToSave.addProperty("code_platform", "other");
 				allRepoUrlsToSave.add(repoUrlToSave);
 			}
 		});


### PR DESCRIPTION
# Detect code platform when migrating

Changes proposed in this pull request:

* The data migration script does a few simple checks to see if the code platform of a repo url is from GitHub, GitLab, Bitbucket or something else

How to test:

* Start with an empty database:
	* `docker-compose down --volumes && docker-compose up --scale scrapers=0`
* Build and run data migration:
	* `cd data-migration && docker-compose build && docker-compose up`
* Run the following query and check that the results are correct (there is only one row to check at the time of writing, which is a GitLab repo):
	`SELECT * FROM repository_url WHERE url NOT ILIKE '%github%';`
* Also check that the rest is indeed GitHub:
	`SELECT * FROM repository_url WHERE url ILIKE '%github%';`

Closes #270

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests