### PR TITLE
264 simple test login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,10 +33,11 @@ POSTGREST_URL=http://backend:3500
 # .env.local: http://localhost/auth, .env: http://auth:7000
 RSD_AUTH_URL=http://auth:7000
 
-# consumed by services: frontend (api/fe)
+# consumed by services: authentication, frontend (api/fe)
 # provide a list of supported OpenID auth providers
 # the values should be separated by semicolon (;)
 # if env value is not provided default provider is set to be SURFCONEXT
+# if you add the value "LOCAL", then local accounts are enables, USE THIS FOR TESTING PURPOSES ONLY
 RSD_AUTH_PROVIDERS=SURFCONEXT;HELMHOLTZAAI
 
 # SURFCONEXT - TEST ENVIRONMENT

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
@@ -1,5 +1,10 @@
 package nl.esciencecenter.rsd.authentication;
 
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+
 public class Config {
 
 	private static final long TEN_MINUTES_IN_MILLISECONDS = 600_000L; // 10 * 60 * 1000
@@ -10,6 +15,26 @@ public class Config {
 
 	public static long jwtExpirationTime() {
 		return TEN_MINUTES_IN_MILLISECONDS;
+	}
+
+	private static Collection<String> rsdAuthProviders() {
+		return Optional.ofNullable(System.getenv("RSD_AUTH_PROVIDERS"))
+				.map(s -> s.split(";"))
+				.map(strings -> Set.of(strings))
+				.orElse(Collections.EMPTY_SET);
+	}
+
+	public static boolean isLocalEnabled() {
+		return rsdAuthProviders().contains("LOCAL");
+	}
+
+	public static boolean isSurfConextEnabled() {
+		Collection<String> enabledProviders =  rsdAuthProviders();
+		return enabledProviders.isEmpty() || enabledProviders.contains("SURFCONEXT");
+	}
+
+	public static boolean isHelmholtzEnabled() {
+		return rsdAuthProviders().contains("HELMHOLTZAAI");
 	}
 
 	public static String backendBaseUrl() {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLogin.java
@@ -1,18 +1,7 @@
 package nl.esciencecenter.rsd.authentication;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
-import java.util.Objects;
-
-import net.minidev.json.JSONArray;
-
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-
 import com.nimbusds.oauth2.sdk.AccessTokenResponse;
 import com.nimbusds.oauth2.sdk.AuthorizationCode;
 import com.nimbusds.oauth2.sdk.AuthorizationCodeGrant;
@@ -30,6 +19,15 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
 import com.nimbusds.openid.connect.sdk.UserInfoResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
+import net.minidev.json.JSONArray;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.HttpResponse.BodyHandlers;
+import java.util.Objects;
 
 public class HelmholtzAaiLogin implements Login {
 

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -15,81 +15,87 @@ public class Main {
 		Javalin app = Javalin.create().start(7000);
 		app.get("/", ctx -> ctx.json("{\"Module\": \"rsd/auth\", \"Status\": \"live\"}"));
 
-		app.post("/login/local", ctx -> {
-			try {
-				String returnPath = ctx.cookie("rsd_pathname");
-				JsonObject body = JsonParser.parseString(ctx.body()).getAsJsonObject();
-				String sub = Utils.jsonElementToString(body.get("sub"));
-				String name = Utils.jsonElementToString(body.get("name"));
-				String email = Utils.jsonElementToString(body.get("email"));
-				String organisation = Utils.jsonElementToString(body.get("organisation"));
-				OpenIdInfo localInfo = new OpenIdInfo(sub, name, email, organisation);
-				AccountInfo accountInfo = new PostgrestAccount(localInfo, "local").account();
-				JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
-				String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
-				setJwtCookie(ctx, token);
-				// redirect based on returnPath
-				if (returnPath != null && !returnPath.trim().isEmpty()) {
-					returnPath = returnPath.trim();
-					ctx.redirect(returnPath);
-				} else {
-					ctx.redirect("/");
+		if (Config.isLocalEnabled()) {
+			app.post("/login/local", ctx -> {
+				try {
+					String returnPath = ctx.cookie("rsd_pathname");
+					JsonObject body = JsonParser.parseString(ctx.body()).getAsJsonObject();
+					String sub = Utils.jsonElementToString(body.get("sub"));
+					String name = Utils.jsonElementToString(body.get("name"));
+					String email = Utils.jsonElementToString(body.get("email"));
+					String organisation = Utils.jsonElementToString(body.get("organisation"));
+					OpenIdInfo localInfo = new OpenIdInfo(sub, name, email, organisation);
+					AccountInfo accountInfo = new PostgrestAccount(localInfo, "local").account();
+					JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
+					String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
+					setJwtCookie(ctx, token);
+					// redirect based on returnPath
+					if (returnPath != null && !returnPath.trim().isEmpty()) {
+						returnPath = returnPath.trim();
+						ctx.redirect(returnPath);
+					} else {
+						ctx.redirect("/");
+					}
+				} catch (RuntimeException ex) {
+					ex.printStackTrace();
+					ctx.status(400);
+					ctx.redirect("/login/failed");
 				}
-			} catch (RuntimeException ex) {
-				ex.printStackTrace();
-				ctx.status(400);
-				ctx.redirect("/login/failed");
-			}
-		});
+			});
+		}
 
-		app.post("/login/surfconext", ctx -> {
-			try {
-				String returnPath = ctx.cookie("rsd_pathname");
-				String code = ctx.formParam("code");
-				String redirectUrl = Config.surfconextRedirect();
-				OpenIdInfo surfconextInfo = new SurfconextLogin(code, redirectUrl).openidInfo();
-				AccountInfo accountInfo = new PostgrestAccount(surfconextInfo, "surfconext").account();
-				JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
-				String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
-				setJwtCookie(ctx, token);
-				// redirect based on returnPath
-				if (returnPath != null && !returnPath.trim().isEmpty()) {
-					returnPath = returnPath.trim();
-					ctx.redirect(returnPath);
-				} else {
-					ctx.redirect("/");
+		if (Config.isSurfConextEnabled()) {
+			app.post("/login/surfconext", ctx -> {
+				try {
+					String returnPath = ctx.cookie("rsd_pathname");
+					String code = ctx.formParam("code");
+					String redirectUrl = Config.surfconextRedirect();
+					OpenIdInfo surfconextInfo = new SurfconextLogin(code, redirectUrl).openidInfo();
+					AccountInfo accountInfo = new PostgrestAccount(surfconextInfo, "surfconext").account();
+					JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
+					String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
+					setJwtCookie(ctx, token);
+					// redirect based on returnPath
+					if (returnPath != null && !returnPath.trim().isEmpty()) {
+						returnPath = returnPath.trim();
+						ctx.redirect(returnPath);
+					} else {
+						ctx.redirect("/");
+					}
+				} catch (RuntimeException ex) {
+					ex.printStackTrace();
+					ctx.status(400);
+					ctx.redirect("/login/failed");
 				}
-			} catch (RuntimeException ex) {
-				ex.printStackTrace();
-				ctx.status(400);
-				ctx.redirect("/login/failed");
-			}
-		});
+			});
+		}
 
-		app.get("/login/helmholtzaai", ctx -> {
-			try {
-				String returnPath = ctx.cookie("rsd_pathname");
-				String code = ctx.queryParam("code");
-				String redirectUrl = Config.helmholtzAaiRedirect();
-				OpenIdInfo helmholtzInfo = new HelmholtzAaiLogin(code, redirectUrl).openidInfo();
-				AccountInfo accountInfo = new PostgrestAccount(helmholtzInfo, "helmholtz").account();
-				JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
-				String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
-				setJwtCookie(ctx, token);
+		if (Config.isHelmholtzEnabled()) {
+			app.get("/login/helmholtzaai", ctx -> {
+				try {
+					String returnPath = ctx.cookie("rsd_pathname");
+					String code = ctx.queryParam("code");
+					String redirectUrl = Config.helmholtzAaiRedirect();
+					OpenIdInfo helmholtzInfo = new HelmholtzAaiLogin(code, redirectUrl).openidInfo();
+					AccountInfo accountInfo = new PostgrestAccount(helmholtzInfo, "helmholtz").account();
+					JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
+					String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
+					setJwtCookie(ctx, token);
 
-				// redirect based on returnPath
-				if (returnPath != null && !returnPath.trim().isEmpty()) {
-					returnPath = returnPath.trim();
-					ctx.redirect(returnPath);
-				} else {
-					ctx.redirect("/");
+					// redirect based on returnPath
+					if (returnPath != null && !returnPath.trim().isEmpty()) {
+						returnPath = returnPath.trim();
+						ctx.redirect(returnPath);
+					} else {
+						ctx.redirect("/");
+					}
+				} catch (RuntimeException ex) {
+					ex.printStackTrace();
+					ctx.status(400);
+					ctx.redirect("/login/failed");
 				}
-			} catch (RuntimeException ex) {
-				ex.printStackTrace();
-				ctx.status(400);
-				ctx.redirect("/login/failed");
-			}
-		});
+			});
+		}
 
 		app.get("/refresh", ctx -> {
 			try {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -1,6 +1,8 @@
 package nl.esciencecenter.rsd.authentication;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 
@@ -13,13 +15,40 @@ public class Main {
 		Javalin app = Javalin.create().start(7000);
 		app.get("/", ctx -> ctx.json("{\"Module\": \"rsd/auth\", \"Status\": \"live\"}"));
 
+		app.post("/login/local", ctx -> {
+			try {
+				String returnPath = ctx.cookie("rsd_pathname");
+				JsonObject body = JsonParser.parseString(ctx.body()).getAsJsonObject();
+				String sub = Utils.jsonElementToString(body.get("sub"));
+				String name = Utils.jsonElementToString(body.get("name"));
+				String email = Utils.jsonElementToString(body.get("email"));
+				String organisation = Utils.jsonElementToString(body.get("organisation"));
+				OpenIdInfo localInfo = new OpenIdInfo(sub, name, email, organisation);
+				AccountInfo accountInfo = new PostgrestAccount(localInfo, "local").account();
+				JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
+				String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
+				setJwtCookie(ctx, token);
+				// redirect based on returnPath
+				if (returnPath != null && !returnPath.trim().isEmpty()) {
+					returnPath = returnPath.trim();
+					ctx.redirect(returnPath);
+				} else {
+					ctx.redirect("/");
+				}
+			} catch (RuntimeException ex) {
+				ex.printStackTrace();
+				ctx.status(400);
+				ctx.redirect("/login/failed");
+			}
+		});
+
 		app.post("/login/surfconext", ctx -> {
 			try {
 				String returnPath = ctx.cookie("rsd_pathname");
 				String code = ctx.formParam("code");
 				String redirectUrl = Config.surfconextRedirect();
 				OpenIdInfo surfconextInfo = new SurfconextLogin(code, redirectUrl).openidInfo();
-				AccountInfo accountInfo = new PostgrestAccount(surfconextInfo).account();
+				AccountInfo accountInfo = new PostgrestAccount(surfconextInfo, "surfconext").account();
 				JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
 				String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
 				setJwtCookie(ctx, token);
@@ -43,7 +72,7 @@ public class Main {
 				String code = ctx.queryParam("code");
 				String redirectUrl = Config.helmholtzAaiRedirect();
 				OpenIdInfo helmholtzInfo = new HelmholtzAaiLogin(code, redirectUrl).openidInfo();
-				AccountInfo accountInfo = new PostgrestAccount(helmholtzInfo).account();
+				AccountInfo accountInfo = new PostgrestAccount(helmholtzInfo, "helmholtz").account();
 				JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
 				String token = jwtCreator.createUserJwt(accountInfo.account(), accountInfo.name());
 				setJwtCookie(ctx, token);

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -20,9 +20,9 @@ public class Main {
 				try {
 					JsonObject body = JsonParser.parseString(ctx.body()).getAsJsonObject();
 					String sub = Utils.jsonElementToString(body.get("sub"));
-					String name = Utils.jsonElementToString(body.get("name"));
-					String email = Utils.jsonElementToString(body.get("email"));
-					String organisation = Utils.jsonElementToString(body.get("organisation"));
+					String name = sub;
+					String email = sub + "@example.com";
+					String organisation = "Example organisation";
 					OpenIdInfo localInfo = new OpenIdInfo(sub, name, email, organisation);
 
 					AccountInfo accountInfo = new PostgrestAccount(localInfo, "local").account();

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -1,8 +1,6 @@
 package nl.esciencecenter.rsd.authentication;
 
 import com.auth0.jwt.exceptions.JWTVerificationException;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 
@@ -18,8 +16,8 @@ public class Main {
 		if (Config.isLocalEnabled()) {
 			app.post("/login/local", ctx -> {
 				try {
-					JsonObject body = JsonParser.parseString(ctx.body()).getAsJsonObject();
-					String sub = Utils.jsonElementToString(body.get("sub"));
+					String sub = ctx.formParam("sub");
+					if (sub == null || sub.isBlank()) throw new RuntimeException("Please provide a username");
 					String name = sub;
 					String email = sub + "@example.com";
 					String organisation = "Example organisation";

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
@@ -1,0 +1,12 @@
+package nl.esciencecenter.rsd.authentication;
+
+import com.google.gson.JsonElement;
+
+public class Utils {
+
+	public static String jsonElementToString(JsonElement elementToConvert) {
+		if (elementToConvert == null || elementToConvert.isJsonNull()) return null;
+		if (!elementToConvert.isJsonPrimitive()) return null;
+		return elementToConvert.getAsString();
+	}
+}

--- a/database/010-create-account-table.sql
+++ b/database/010-create-account-table.sql
@@ -34,12 +34,14 @@ CREATE TRIGGER sanitise_update_account BEFORE UPDATE ON account FOR EACH ROW EXE
 CREATE TABLE login_for_account (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
 	account UUID REFERENCES account (id) NOT NULL,
+	provider VARCHAR(100) NOT NULL,
 	sub VARCHAR NOT NULL,
 	name VARCHAR,
 	email VARCHAR,
 	home_organisation VARCHAR,
 	created_at TIMESTAMP NOT NULL,
-	updated_at TIMESTAMP NOT NULL
+	updated_at TIMESTAMP NOT NULL,
+	UNIQUE(provider, sub)
 );
 
 CREATE FUNCTION sanitise_insert_login_for_account() RETURNS TRIGGER LANGUAGE plpgsql AS

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.28
+    image: rsd/database:0.0.29
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -42,7 +42,7 @@ services:
   auth:
     container_name: auth
     build: ./authentication
-    image: rsd/auth:0.0.8
+    image: rsd/auth:0.0.9
     expose:
       - 7000
     environment:
@@ -76,7 +76,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.7.7
+    image: rsd/frontend:0.7.8
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
     environment:
       # it uses values from .env file
       - POSTGREST_URL
+      - RSD_AUTH_PROVIDERS
       - NEXT_PUBLIC_SURFCONEXT_CLIENT_ID
       - NEXT_PUBLIC_SURFCONEXT_REDIRECT
       - NEXT_PUBLIC_SURFCONEXT_WELL_KNOWN_URL

--- a/frontend/auth/locationCookie.ts
+++ b/frontend/auth/locationCookie.ts
@@ -8,6 +8,7 @@ export function saveLocationCookie() {
     // ingnore these paths
     case '/login':
     case '/logout':
+    case '/login/local':
       break
     default:
       // write simple browser cookie

--- a/frontend/components/login/LoginButton.tsx
+++ b/frontend/components/login/LoginButton.tsx
@@ -38,7 +38,7 @@ export default function LoginButton() {
     )
   }
   // when there is only 1 provider we
-  // link redirect directly yo Sign in button
+  // link redirect directly to Sign in button
   if (providers && providers.length === 1) {
     return (
       <Link

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -4,15 +4,19 @@
 const isDevelopment = process.env.NODE_ENV !== 'production'
 const rewritesConfig = isDevelopment
   ? [
-      {
-        source: '/image/:path*',
-        destination: 'http://localhost/image/:path*',
+    {
+      source: '/image/:path*',
+      destination: 'http://localhost/image/:path*',
     },
     {
-        source: '/api/v1/:path*',
-        destination: 'http://localhost/api/v1/:path*',
-      },
-    ]
+      source: '/api/v1/:path*',
+      destination: 'http://localhost/api/v1/:path*',
+    },
+    {
+      source: '/auth/login/local',
+      destination: 'http://localhost/auth/login/local',
+    },
+  ]
   : []
 
 module.exports = {
@@ -20,7 +24,7 @@ module.exports = {
   eslint: {
     // Run ESLint in these directories during production builds (next build)
     // by default next runs linter only in pages/, components/, and lib/
-    dirs: ['auth','components','config','pages','styles','types','utils']
+    dirs: ['auth', 'components', 'config', 'pages', 'styles', 'types', 'utils']
   },
   // only in development
   rewrites: async () => rewritesConfig,

--- a/frontend/pages/api/fe/auth/index.ts
+++ b/frontend/pages/api/fe/auth/index.ts
@@ -10,6 +10,7 @@ import type {NextApiRequest, NextApiResponse} from 'next'
 // import providers methods
 import {surfconextInfo} from './surfconext'
 import {helmholtzInfo} from './helmholtzaai'
+import {localInfo} from './local'
 import logger from '~/utils/logger'
 
 export type ApiError = {
@@ -32,6 +33,8 @@ async function getRedirectInfo(provider: string) {
       return surfconextInfo()
     case 'helmholtzaai':
       return helmholtzInfo()
+    case 'local':
+      return localInfo()
     default:
       const message = `${provider} NOT SUPPORTED, check your spelling`
       logger(`api/fe/auth/providers: ${message}`, 'error')

--- a/frontend/pages/api/fe/auth/local.ts
+++ b/frontend/pages/api/fe/auth/local.ts
@@ -1,0 +1,6 @@
+export function localInfo() {
+  return {
+    name: 'Local account',
+    redirectUrl: '/login/local'
+  }
+}

--- a/frontend/pages/login/local.tsx
+++ b/frontend/pages/login/local.tsx
@@ -1,0 +1,26 @@
+import {app} from '~/config/app'
+import Head from 'next/head'
+import DefaultLayout from '~/components/layout/DefaultLayout'
+import PageTitle from '~/components/layout/PageTitle'
+import {Button, TextField} from '@mui/material'
+import ContentInTheMiddle from '~/components/layout/ContentInTheMiddle'
+
+export default function LoginFailed() {
+
+  return (
+    <DefaultLayout>
+      <Head>
+        <title>Login | {app.title}</title>
+      </Head>
+      <PageTitle title="Login">
+      </PageTitle>
+      <ContentInTheMiddle>
+        <form action="/auth/login/local" method="post">
+          <TextField required inputProps={{pattern: '\\w+'}} id="username-field" label="Username" variant="standard" name="sub"/>
+          <Button variant="contained" type='submit'>Login</Button>
+        </form>
+
+      </ContentInTheMiddle>
+    </DefaultLayout>
+  )
+}


### PR DESCRIPTION
# Local login

Changes proposed in this pull request:

* Allow for local account creation when the value `LOCAL` is part of env variable `RSD_AUTH_PROVIDERS`
* These account are *not secure* and should be used for testing purposes only
* On the auth module, the endpoints are now disabled if the corresponding values are not a part of `RSD_AUTH_PROVIDERS`; in the case of a missing `RSD_AUTH_PROVIDERS`, SURFconext is enabled

How to test:
* Add `LOCAL` to the env variable `RSD_AUTH_PROVIDERS` (see also the new `.env.example`)
* Build and run
	* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale scrapers=0`
* Click on Sign in
* Click on Local account
* Fill in a username of your choice
* After some redirects, you should now be logged in

Closes #264

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests