### PR TITLE
271 fix scraping releases

### DIFF
--- a/database/002-create-software-table.sql
+++ b/database/002-create-software-table.sql
@@ -15,7 +15,6 @@ CREATE TABLE software (
 	is_featured BOOLEAN DEFAULT FALSE NOT NULL,
 	is_published BOOLEAN DEFAULT FALSE NOT NULL,
 	short_statement VARCHAR(300),
-	releases_scraped_at TIMESTAMP,
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL
 );

--- a/database/009-create-release-table.sql
+++ b/database/009-create-release-table.sql
@@ -3,6 +3,7 @@ CREATE TABLE release (
 	software UUID REFERENCES software (id) UNIQUE NOT NULL,
 	is_citable BOOLEAN,
 	latest_schema_dot_org VARCHAR,
+	releases_scraped_at TIMESTAMP,
 	created_at TIMESTAMP NOT NULL,
 	updated_at TIMESTAMP NOT NULL
 );
@@ -33,6 +34,20 @@ $$;
 
 CREATE TRIGGER sanitise_update_release BEFORE UPDATE ON release FOR EACH ROW EXECUTE PROCEDURE sanitise_update_release();
 
+
+CREATE FUNCTION software_join_release() RETURNS TABLE (
+	software_id UUID,
+	slug VARCHAR,
+	concept_doi VARCHAR,
+	release_id UUID,
+	releases_scraped_at TIMESTAMP
+) LANGUAGE plpgsql STABLE AS
+$$
+BEGIN
+	RETURN QUERY SELECT software.id AS software_id, software.slug, software.concept_doi, release.id AS release_id, release.releases_scraped_at FROM software LEFT JOIN RELEASE ON software.id = RELEASE.software;
+	RETURN;
+END
+$$;
 
 
 CREATE TYPE citability AS ENUM (

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,7 +106,7 @@ services:
   scrapers:
     container_name: scrapers
     build: ./scrapers
-    image: rsd/scrapers:0.1.2
+    image: rsd/scrapers:0.1.3
     environment:
       # it uses values from .env file
       - POSTGREST_URL


### PR DESCRIPTION
# Fix scraping releases updates the timestamp when the software page was updated

Changes proposed in this pull request:

* Move the column `releases_scraped_at` from `software` to `release`
* Create a function in the database that allows (again) for sorting on `releases_scraped_at`
* The `releases_scraped_at` is updated first, so that even if an error occurs later, the entry is pushed back to the end of the scraping order
* A fix that sets `is_citable` and `latest_schema_dot_org` for the corresponding entry only instead of all entries
* Set `NULL` instead of the empty string for `latest_schema_dot_org` when it is missing

How to test:
* The database structure has changed, clear and build:
	* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up`
* Run data migration
* Scraping releases should work, you can speed it up by running `docker-compose exec scrapers python3 releases.py` a few times
* Check (`SELECT * FROM "release";`) that different releases have different values for `latest_schema_dot_org`


Closes #271

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests