### PR TITLE
add makefile to ease the install, build process and run services in development mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ install:
 	docker-compose up --scale scrapers=0 -d
 	cd frontend && yarn -d
 	cd documentation && yarn -d
-	# Sleep 15 seconds to be sure that that docker-compose up is running
+	# Sleep 15 seconds to be sure that docker-compose up is running
 	sleep 15
 	cd data-migration && docker-compose build && docker-compose up
 	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# PHONY makes possible to call `make commands` from inside the Makefile
+.PHONY: dev-docs dev-frontend
+
+# Main commands
+# ----------------------------------------------------------------
+install:
+	docker-compose down --volumes #cleanup phase
+	docker-compose build database backend auth scrapers nginx   # exclude frontend and wait for the build to finish
+	docker-compose up --scale scrapers=0 -d
+	cd frontend && yarn -d
+	cd documentation && yarn -d
+	# Sleep 15 seconds to be sure that that docker-compose up is running
+	sleep 15
+	cd data-migration && docker-compose build && docker-compose up
+	docker-compose down
+
+dev:
+	docker-compose up --scale scrapers=0 -d
+	make -j 2 dev-docs dev-frontend # Run concurrently
+
+
+down:
+	docker-compose down
+
+
+# Helper commands
+# -
+dev-docs:
+	cd documentation && yarn dev
+
+dev-frontend:
+	cd frontend && yarn dev

--- a/README.md
+++ b/README.md
@@ -12,75 +12,20 @@
 
 This repo contains the new RSD-as-a-service implementation
 
-## Building
 
-The program can easily be built with `docker-compose`. Each service builds the image using specific version (see docker-compose.yml file). Ensure that the version number is increased in the `docker-compose.yml` file when the source code of that service is changed.
+## Running development version locally in 3 steps. 
+1. Before installing the dependencies you need to set the environment variables in place:
+Copy the file `.env.example` to `.env` file at the root of the project
+and fill the secrets in `./frontend/.end.local`. Check if the secrets are correct. 
+2. Running once `make install` will install all dependencies, build the docker images and run the **data migration** script.
+3. Finally, run `make dev` to start the frontend and documentation servers.
 
-### Environment variables
 
-The environment variables should be stored in .env file, which is automatically loaded by docker-compose. To validate loading of env variables use `docker-compose config`. More info about use of enviroment variables in docker-compose is available at [official documentation](https://docs.docker.com/compose/environment-variables/)
-
-- copy the file `.env.example` to `.env` file at the root of the project
-
-```bash
-# from project root dir
-cp .env.example .env
+List of commands
+```shell
+make install   # it will build and install all dependencies and will run the **data migration** script. 
+make dev       # it will run the frontend and the documentation locally on localhost:3000 and localhost:3030 respectively
+make down      # Stop all services with `docker-compose down`
 ```
 
-- `provide missing values in .env file (secrets)`
-- build local images
-
-```bash
-# from project root dir
-docker-compose build
-```
-
-## Running locally
-
-Run the command `docker-compose up`.
-
-```bash
-# from project root dir
-docker-compose up
-```
-
-The application can be viewed on http://localhost
-
-### Frontend with hot-module-replacement (HMR)
-
-To run frontend in the development mode with the hot-module-replacement (HMR) you should start additional instance of the frontend which will be available at http://localhost:3000
-
-```bash
-# navigate to frontend folder
-cd frontend
-# install dependencies
-yarn install
-# start fe in dev mode
-yarn dev
-```
-
-More information about frontend setup is [available in the frontend readme file](/frontend/README.md).
-
-## Clear/remove data (reset)
-
-To clear the database, if the database structure has changed or you need to run data migration again, run the command:
-
-```bash
-docker-compose down --volumes
-```
-
-## Data migration
-
-A data migration script is available to migrate data from the legacy RSD to the new one:
-
-- run current RSD solution using `docker-compose up` from the root of the project
-- run the migration script using docker-compose file in the data-migration folder
-
-```bash
-# navigate to data-migration folder
-cd data-migration
-# run data migration docker-compose file
-docker-compose up
-```
-
-More information about [data migration is avaliable here](data-migration/README.md).
+More information about building and data migration can be found in [Getting started](https://research-software-directory.github.io/RSD-as-a-service/getting-started.html) documentation.

--- a/documentation/docs/.vuepress/config.js
+++ b/documentation/docs/.vuepress/config.js
@@ -4,14 +4,15 @@ module.exports = {
   title: 'RSD Documentation',
   description: 'RSD As a Service documentation',
   base: '/RSD-as-a-service/',
-  
+  port: '3030',
+
   themeConfig: {
     logo: '/images/circle.webp',
     // logoDark: '/images/heroDark.webp',
     repo: 'research-software-directory/RSD-as-a-service',
     // docsDir: 'docs',
     displayAllHeaders: true, // Default: false
-    
+
     navbar: [
       {
         text: 'Documentation',
@@ -53,5 +54,5 @@ module.exports = {
     ],
   ],
 
-   
+
 }

--- a/frontend/components/layout/AppFooter.tsx
+++ b/frontend/components/layout/AppFooter.tsx
@@ -3,6 +3,8 @@ import LogoEscience from '~/components/svg/LogoEscience'
 import Mail from '@mui/icons-material/Mail'
 
 export default function AppFooter () {
+  const isDev = process.env.NODE_ENV === 'development'
+
   return (
     <footer className="flex flex-wrap text-white border-t bg-secondary border-grey-A400">
       <div className="grid grid-cols-1 gap-8 px-4 md:grid-cols-[_2fr,1fr] lg:container lg:mx-auto">
@@ -42,7 +44,7 @@ export default function AppFooter () {
             <Link href="/projects" passHref>
               <a className="footer-link">Projects</a>
             </Link>
-            <a href="https://research-software-directory.github.io/RSD-as-a-service"
+              <a href={isDev ? 'http://localhost:3030' : 'https://research-software-directory.github.io/RSD-as-a-service'}
               target="_blank"
               className="footer-link"
               rel="noreferrer">


### PR DESCRIPTION
Changes proposed in this pull request:

* Adding a Makefile with basic commands tha install, build and execute data migration in one go: make install
* Run development server with one command: made dev      

How to test:

* delete all docker images and volumes and run `make install` from the route

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
