### PR TITLE
305: Organisation maintainers management

### DIFF
--- a/database/015-create-maintainer-tables.sql
+++ b/database/015-create-maintainer-tables.sql
@@ -166,3 +166,95 @@ BEGIN
 	RETURN;
 END
 $$;
+
+-- ORGANISATION
+-- create tables and rpc for maintainer's "magic link" invitations
+CREATE TABLE invite_maintainer_for_organisation (
+	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
+	organisation UUID REFERENCES organisation (id) NOT NULL,
+	created_by UUID REFERENCES account (id),
+	claimed_by UUID REFERENCES account (id),
+	claimed_at TIMESTAMP,
+	created_at TIMESTAMP NOT NULL DEFAULT LOCALTIMESTAMP
+);
+
+CREATE FUNCTION sanitise_insert_invite_maintainer_for_organisation() RETURNS TRIGGER LANGUAGE plpgsql AS
+$$
+BEGIN
+	NEW.id = gen_random_uuid();
+	NEW.created_at = LOCALTIMESTAMP;
+	NEW.claimed_by = NULL;
+	NEW.claimed_at = NULL;
+	return NEW;
+END
+$$;
+
+CREATE TRIGGER sanitise_insert_invite_maintainer_for_organisation BEFORE INSERT ON invite_maintainer_for_organisation FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_invite_maintainer_for_organisation();
+
+
+CREATE FUNCTION sanitise_update_invite_maintainer_for_organisation() RETURNS TRIGGER LANGUAGE plpgsql AS
+$$
+BEGIN
+	NEW.id = OLD.id;
+	NEW.organisation = OLD.organisation;
+	NEW.created_by = OLD.created_by;
+	NEW.created_at = OLD.created_at;
+	return NEW;
+END
+$$;
+
+CREATE TRIGGER sanitise_update_invite_maintainer_for_organisation BEFORE UPDATE ON invite_maintainer_for_organisation FOR EACH ROW EXECUTE PROCEDURE sanitise_update_invite_maintainer_for_organisation();
+
+
+CREATE FUNCTION accept_invitation_organisation(invitation UUID) RETURNS TABLE(
+	name VARCHAR,
+	slug VARCHAR
+) LANGUAGE plpgsql VOLATILE SECURITY DEFINER AS
+$$
+DECLARE invitation_row invite_maintainer_for_organisation%ROWTYPE;
+DECLARE account UUID;
+BEGIN
+	account = uuid(current_setting('request.jwt.claims', FALSE)::json->>'account');
+	IF account IS NULL THEN
+		RAISE EXCEPTION USING MESSAGE = 'Please login first';
+	END IF;
+
+	IF invitation IS NULL THEN
+		RAISE EXCEPTION USING MESSAGE = 'Please provide an invitation id';
+	END IF;
+
+	SELECT * FROM invite_maintainer_for_organisation WHERE id = invitation INTO invitation_row;
+	IF invitation_row.id IS NULL THEN
+		RAISE EXCEPTION USING MESSAGE = 'Invitation with id ' || invitation || ' does not exist';
+	END IF;
+
+	IF invitation_row.claimed_by IS NOT NULL OR invitation_row.claimed_at IS NOT NULL THEN
+		RAISE EXCEPTION USING MESSAGE = 'Invitation with id ' || invitation || ' is expired';
+	END IF;
+
+-- Only use the invitation if not already a maintainer
+	IF NOT EXISTS(
+		SELECT
+			maintainer
+		FROM
+			maintainer_for_organisation
+		WHERE
+			maintainer=account AND maintainer_for_organisation.organisation=invitation_row.organisation
+		UNION
+		SELECT
+			primary_maintainer AS maintainer
+		FROM
+			organisation
+		WHERE
+			primary_maintainer=account AND organisation.id=invitation_row.organisation
+		LIMIT 1
+	) THEN
+		UPDATE invite_maintainer_for_organisation SET claimed_by = account, claimed_at = LOCALTIMESTAMP WHERE id = invitation;
+		INSERT INTO maintainer_for_organisation VALUES (account, invitation_row.organisation);
+	END IF;
+
+	RETURN QUERY
+		SELECT organisation.name, organisation.slug FROM organisation WHERE organisation.id = invitation_row.organisation;
+	RETURN;
+END
+$$;

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -796,3 +796,69 @@ BEGIN
 	SELECT COUNT(DISTINCT organisations_of_current_maintainer) FROM organisations_of_current_maintainer() INTO organisation_cnt;
 END
 $$;
+
+
+-- ORGANISATION maintainers list with basic personal info
+-- used in the organisation maintainers page
+CREATE FUNCTION maintainers_of_organisation(organisation_id UUID) RETURNS TABLE (
+	maintainer UUID,
+	name VARCHAR[],
+	email VARCHAR[],
+	affiliation VARCHAR[],
+	is_primary BOOLEAN
+) LANGUAGE plpgsql STABLE SECURITY DEFINER AS
+$$
+DECLARE account_authenticated UUID;
+BEGIN
+	account_authenticated = uuid(current_setting('request.jwt.claims', FALSE)::json->>'account');
+	IF account_authenticated IS NULL THEN
+		RAISE EXCEPTION USING MESSAGE = 'Please login first';
+	END IF;
+
+	IF organisation_id IS NULL THEN
+		RAISE EXCEPTION USING MESSAGE = 'Please provide a organisation id';
+	END IF;
+
+	IF NOT organisation_id IN (SELECT * FROM organisations_of_current_maintainer()) THEN
+		RAISE EXCEPTION USING MESSAGE = 'You are not a maintainer of this organisation';
+	END IF;
+
+	RETURN QUERY
+	-- primary maintainer of organisation
+	SELECT
+		organisation.primary_maintainer AS maintainer,
+		ARRAY_AGG(login_for_account."name") AS name,
+		ARRAY_AGG(login_for_account.email) AS email,
+		ARRAY_AGG(login_for_account.home_organisation) AS affiliation,
+		TRUE AS is_primary
+	FROM
+		organisation
+	INNER JOIN
+		login_for_account ON organisation.primary_maintainer = login_for_account.account
+	WHERE
+		organisation.id  = organisation_id
+	GROUP BY
+		organisation.id,organisation.primary_maintainer
+	-- append second selection
+	UNION
+	-- other maintainers of organisation
+	SELECT
+		maintainer_for_organisation.maintainer,
+		ARRAY_AGG(login_for_account."name") AS name,
+		ARRAY_AGG(login_for_account.email) AS email,
+		ARRAY_AGG(login_for_account.home_organisation) AS affiliation,
+		FALSE AS is_primary
+	FROM
+		maintainer_for_organisation
+	INNER JOIN
+		login_for_account ON maintainer_for_organisation.maintainer = login_for_account.account
+	WHERE
+		maintainer_for_organisation.organisation = organisation_id
+	GROUP BY
+		maintainer_for_organisation.organisation, maintainer_for_organisation.maintainer
+	-- primary as first record
+	ORDER BY is_primary DESC;
+	RETURN;
+END
+$$;
+

--- a/frontend/auth/api/authHelpers.ts
+++ b/frontend/auth/api/authHelpers.ts
@@ -140,3 +140,47 @@ export async function claimSoftwareMaintainerInvite({id, token, frontend = false
     }
   }
 }
+
+export async function claimOrganisationMaintainerInvite({id, token, frontend = false}:
+  { id: string, token: string, frontend?: boolean }) {
+  try {
+    const query = 'rpc/accept_invitation_organisation'
+    let url = `${process.env.POSTGREST_URL}/${query}`
+    if (frontend) {
+      url = `/api/v1/${query}`
+    }
+    // console.log('url...', url)
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token),
+        'Accept': 'application/vnd.pgrst.object + json',
+      },
+      body: JSON.stringify({
+        'invitation': id
+      })
+    })
+    if (resp.status === 200) {
+      const json = await resp.json()
+      return {
+        organisationInfo: json,
+        error: null
+      }
+    }
+    logger(`claimOrganisationMaintainerInvite failed: ${resp?.status} ${resp.statusText}`, 'error')
+    const error = await extractReturnMessage(resp)
+    return {
+      organisationInfo: null,
+      error
+    }
+  } catch (e: any) {
+    logger(`claimOrganisationMaintainerInvite failed: ${e?.message}`, 'error')
+    return {
+      organisationInfo: null,
+      error: {
+        status: 500,
+        message: e?.message
+      }
+    }
+  }
+}

--- a/frontend/components/organisation/maintainers/OrganisationMaintainerLink.tsx
+++ b/frontend/components/organisation/maintainers/OrganisationMaintainerLink.tsx
@@ -1,0 +1,93 @@
+import {useState} from 'react'
+import Button from '@mui/material/Button'
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
+import EmailIcon from '@mui/icons-material/Email'
+import CopyIcon from '@mui/icons-material/ContentCopy'
+
+import {copyToClipboard,canCopyToClipboard} from '~/utils/copyToClipboard'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {organisationMaintainerLink} from './useOrganisationMaintainer'
+
+export default function OrganisationMaintainerLink({organisation, account, token}:
+  { organisation: string, account: string, token: string }) {
+  const {showErrorMessage,showInfoMessage} = useSnackbar()
+  const [magicLink, setMagicLink] = useState(null)
+  const canCopy = useState(canCopyToClipboard())
+
+  async function createInviteLink() {
+    const resp = await organisationMaintainerLink({
+      organisation,
+      account,
+      token
+    })
+    if (resp.status === 201) {
+      setMagicLink(resp.message)
+    } else {
+      showErrorMessage(`Failed to generate maintainer link. ${resp.message}`)
+    }
+  }
+
+  async function toClipboard() {
+    if (magicLink) {
+      // copy doi to clipboard
+      const copied = await copyToClipboard(magicLink)
+      // notify user about copy action
+      if (copied) {
+        showInfoMessage('Copied to clipboard')
+      } else {
+        showErrorMessage(`Failed to copy link ${magicLink}`)
+      }
+    }
+  }
+
+  function renderLinkOptions() {
+    if (magicLink) {
+      return (
+        <div>
+          <p>{magicLink}</p>
+          <div className="py-4 flex justify-between">
+            <Button
+              disabled={!canCopy}
+              startIcon={<CopyIcon />}
+              onClick={toClipboard}
+              sx={{
+                marginRight:'1rem'
+              }}
+            >
+              Copy to clipboard
+            </Button>
+
+            <Button
+              startIcon={<EmailIcon />}
+            >
+            <a
+              target="_blank"
+              href={`mailto:?subject=Organisation maintainer invite&body=Please use the link to become organisation maintainer. \n ${magicLink}`} rel="noreferrer">
+              Email this invite
+            </a>
+            </Button>
+          </div>
+        </div>
+      )
+    }
+    return null
+  }
+
+  return (
+    <>
+    <Button
+      sx={{
+        marginTop: '2rem',
+        display: 'flex',
+        alignItems: 'center'
+      }}
+      startIcon={<AutoFixHighIcon />}
+      onClick={createInviteLink}
+    >
+      Generate invite link
+    </Button>
+    <div className="py-2"></div>
+    {renderLinkOptions()}
+    </>
+  )
+}

--- a/frontend/components/organisation/maintainers/OrganisationMaintainersList.tsx
+++ b/frontend/components/organisation/maintainers/OrganisationMaintainersList.tsx
@@ -1,0 +1,52 @@
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
+import List from '@mui/material/List'
+import logger from '~/utils/logger'
+
+import ProjectMaintainer from '~/components/projects/edit/maintainers/ProjectMaintainer'
+import {MaintainerOfOrganisation} from './useOrganisationMaintainer'
+
+type ProjectMaintainerListProps = {
+  maintainers: MaintainerOfOrganisation[]
+  onDelete:(pos:number)=>void
+}
+
+export default function OrganisationMaintainersList({maintainers,onDelete}:ProjectMaintainerListProps) {
+
+  if (maintainers.length === 0) {
+    return (
+      <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
+        <AlertTitle sx={{fontWeight:500}}>No maintainers</AlertTitle>
+        Add project mantainer by using <strong>invite link button!</strong>
+      </Alert>
+    )
+  }
+
+  function onEdit(pos:number) {
+    logger('onEdit...NOT SUPPORTED FOR MAINTAINERS','info')
+  }
+
+  function renderList() {
+    return maintainers.map((item, pos) => {
+      return (
+        <ProjectMaintainer
+          key={pos}
+          pos={pos}
+          maintainer={item}
+          onEdit={onEdit}
+          onDelete={onDelete}
+          // disable delete for primary maintainer
+          disableDelete={item?.is_primary ?? false}
+        />
+      )
+    })
+  }
+
+  return (
+    <List sx={{
+      width: '100%',
+    }}>
+      {renderList()}
+    </List>
+  )
+}

--- a/frontend/components/organisation/maintainers/index.tsx
+++ b/frontend/components/organisation/maintainers/index.tsx
@@ -1,8 +1,130 @@
+import {useEffect,useState} from 'react'
 
-export default function OrganisationMaintainers() {
+import {Session} from '~/auth'
+import ContentLoader from '~/components/layout/ContentLoader'
+import EditSection from '~/components/layout/EditSection'
+import EditSectionTitle from '~/components/layout/EditSectionTitle'
+import {maintainers as config} from '~/components/projects/edit/maintainers/config'
+import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import useOrganisationMaintainers, {
+  deleteMaintainerFromOrganisation, MaintainerOfOrganisation
+} from './useOrganisationMaintainer'
+import OrganisationMaintainerLink from './OrganisationMaintainerLink'
+import {OrganisationForOverview} from '~/types/Organisation'
+import OrganisationMaintainersList from './OrganisationMaintainersList'
+
+type DeleteModal = {
+  open: boolean,
+  pos?: number,
+  displayName?:string
+}
+
+
+export default function OrganisationMaintainers({session, organisation}:
+  {session: Session, organisation:OrganisationForOverview }) {
+  const {showErrorMessage} = useSnackbar()
+  const {loading,maintainers} = useOrganisationMaintainers({
+    organisation: organisation.id ?? '',
+    token: session.token
+  })
+  const [organisationMaintainers, setOrganisationMaintaners] = useState<MaintainerOfOrganisation[]>([])
+  const [modal, setModal] = useState<DeleteModal>({
+    open: false
+  })
+
+  useEffect(() => {
+    let abort = false
+    if (loading === false &&
+      abort === false) {
+      setOrganisationMaintaners(maintainers)
+    }
+    return () => { abort = true }
+  },[maintainers,loading])
+
+  if (loading) {
+    return (
+      <ContentLoader />
+    )
+  }
+
+  function closeModal() {
+    setModal({
+      open: false
+    })
+  }
+
+  function onDeleteMaintainer(pos: number) {
+    const maintainer = maintainers[pos]
+    if (maintainer) {
+      setModal({
+        open: true,
+        pos,
+        displayName: maintainer.name
+      })
+    }
+  }
+
+  async function deleteMaintainer(pos: number) {
+    // console.log('delete maintainer...pos...', pos)
+    closeModal()
+    const admin = maintainers[pos]
+    if (admin) {
+      const resp = await deleteMaintainerFromOrganisation({
+        maintainer: admin.account,
+        organisation: organisation.id ?? '',
+        token: session.token,
+        frontend: true
+      })
+      if (resp.status === 200) {
+        const newMaintainersList = [
+          ...maintainers.slice(0, pos),
+          ...maintainers.slice(pos+1)
+        ]
+        setOrganisationMaintaners(newMaintainersList)
+      } else {
+        showErrorMessage(`Failed to remove maintainer. ${resp.message}`)
+      }
+    }
+  }
+
   return (
-    <section>
-      <h2>Under construction</h2>
-    </section>
+    <>
+      <EditSection className='xl:grid xl:grid-cols-[1fr,1fr] xl:px-0 xl:gap-[3rem]'>
+        <div className="py-4 xl:pl-[3rem]">
+          <EditSectionTitle
+            title={config.title}
+          />
+          <OrganisationMaintainersList
+            onDelete={onDeleteMaintainer}
+            maintainers={organisationMaintainers}
+          />
+        </div>
+        <div className="py-4 min-w-[21rem] xl:my-0">
+          <EditSectionTitle
+            title={config.inviteLink.title}
+            subtitle={config.inviteLink.subtitle}
+          />
+          <OrganisationMaintainerLink
+            organisation={organisation.id ?? ''}
+            account={session.user?.account ?? ''}
+            token={session.token}
+          />
+        </div>
+      </EditSection>
+      <ConfirmDeleteModal
+        open={modal.open}
+        title="Remove maintainer"
+        body={
+          <p>Are you sure you want to remove <strong>{modal.displayName ?? 'No name'}</strong>?</p>
+        }
+        onCancel={() => {
+          setModal({
+            open:false
+          })
+        }}
+        onDelete={()=>deleteMaintainer(modal.pos ?? 0)}
+      />
+    </>
   )
 }

--- a/frontend/components/organisation/maintainers/useOrganisationMaintainer.tsx
+++ b/frontend/components/organisation/maintainers/useOrganisationMaintainer.tsx
@@ -1,0 +1,169 @@
+import {useState,useEffect} from 'react'
+import {createJsonHeaders, extractReturnMessage} from '~/utils/fetchHelpers'
+import logger from '~/utils/logger'
+
+export type RawMaintainerOfOrganisation = {
+  // unique maintainer id
+  maintainer: string
+  name: string[]
+  email: string[]
+  affiliation: string[],
+  is_primary?: boolean
+}
+
+export type MaintainerOfOrganisation = {
+  // unique maintainer id
+  account: string
+  name: string
+  email: string
+  affiliation: string,
+  is_primary?: boolean
+}
+
+export async function getMaintainersOfOrganisation({organisation, token, frontend=true}:
+  {organisation: string, token: string,frontend?:boolean}) {
+  try {
+    let query = `rpc/maintainers_of_organisation?organisation_id=${organisation}`
+    let url = `/api/v1/${query}`
+    if (frontend === false) {
+      url = `${process.env.POSTGREST_URL}/${query}`
+    }
+
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: createJsonHeaders(token)
+    })
+
+    if (resp.status === 200) {
+      const json:RawMaintainerOfOrganisation[] = await resp.json()
+      return json
+    }
+    // ERRORS
+    logger(`getMaintainersOfOrganisation: ${resp.status}:${resp.statusText} organisation: ${organisation}`, 'warn')
+    return []
+  } catch (e: any) {
+    logger(`getMaintainersOfOrganisation: ${e?.message}`, 'error')
+    return []
+  }
+}
+
+export default function useOrganisationMaintainers({organisation, token}:
+  {organisation: string, token: string }) {
+  const [maintainers, setMaintainers] = useState<MaintainerOfOrganisation[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let abort = false
+    async function getMaintainers() {
+      setLoading(true)
+      const raw_maintainers = await getMaintainersOfOrganisation({
+        organisation,
+        token,
+        frontend:true
+      })
+      const maintainers = rawMaintainersToMaintainers(raw_maintainers)
+      if (abort) return null
+      // update maintainers state
+      setMaintainers(maintainers)
+      // update loading flag
+      setLoading(false)
+    }
+
+    if (organisation && token) {
+      getMaintainers()
+    }
+
+    ()=>{abort=true}
+  },[organisation,token])
+
+  return {maintainers, loading}
+}
+
+export function rawMaintainersToMaintainers(raw_maintainers: RawMaintainerOfOrganisation[]) {
+  try {
+    const maintainers:MaintainerOfOrganisation[] = []
+    raw_maintainers.forEach(item => {
+      // use name as second loop indicator
+      item.name.forEach((name, pos) => {
+        const maintainer = {
+          account: item.maintainer,
+          name,
+          email: item.email[pos] ? item.email[pos] : '',
+          affiliation: item.affiliation[pos] ? item.affiliation[pos] : '',
+          is_primary: item?.is_primary ?? false
+        }
+        maintainers.push(maintainer)
+      })
+    })
+    return maintainers
+  } catch (e:any) {
+    logger(`rawMaintainersToMaintainers: ${e?.message}`,'error')
+    return []
+  }
+}
+
+
+export async function deleteMaintainerFromOrganisation({maintainer,organisation,token,frontend=true}:
+  {maintainer:string,organisation:string,token:string,frontend?:boolean}) {
+  try {
+    let query = `maintainer_for_organisation?maintainer=eq.${maintainer}&organisation=eq.${organisation}`
+    let url = `/api/v1/${query}`
+    if (frontend === false) {
+      url = `${process.env.POSTGREST_URL}/${query}`
+    }
+
+    const resp = await fetch(url, {
+      method: 'DELETE',
+      headers: createJsonHeaders(token)
+    })
+
+    return extractReturnMessage(resp)
+
+  } catch (e: any) {
+    logger(`deleteMaintainerFromSoftware: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}
+
+export async function organisationMaintainerLink({organisation, account, token}:
+  { organisation: string, account: string, token: string }) {
+  try {
+    // POST
+    const url = '/api/v1/invite_maintainer_for_organisation'
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token),
+        'Prefer': 'return=headers-only'
+      },
+      body: JSON.stringify({
+        organisation,
+        created_by:account
+      })
+    })
+    if (resp.status === 201) {
+      const id = resp.headers.get('location')?.split('.')[1]
+      if (id) {
+        const link = `${location.origin}/invite/organisation/${id}`
+        return {
+          status: 201,
+          message: link
+        }
+      }
+      return {
+        status: 400,
+        message: 'Id is missing'
+      }
+    }
+    return extractReturnMessage(resp, organisation ?? '')
+  } catch (e: any) {
+    logger(`organisationMaintainerLink: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}

--- a/frontend/pages/invite/organisation/[id].tsx
+++ b/frontend/pages/invite/organisation/[id].tsx
@@ -1,0 +1,108 @@
+import {GetServerSidePropsContext} from 'next'
+import Head from 'next/head'
+import Link from 'next/link'
+
+import {claimOrganisationMaintainerInvite} from '~/auth/api/authHelpers'
+import {getAccountFromToken} from '~/auth/jwtUtils'
+import ContentInTheMiddle from '~/components/layout/ContentInTheMiddle'
+import DefaultLayout from '~/components/layout/DefaultLayout'
+import PageErrorMessage from '~/components/layout/PageErrorMessage'
+import PageTitle from '~/components/layout/PageTitle'
+
+type InviteOrganisationMaintainerProps = {
+  organisationInfo: {
+    slug: string,
+    name: string,
+  }|null,
+  error: {
+    status: number,
+    message: string
+  }|null
+}
+
+export default function InviteOrganisationMaintainer({organisationInfo, error}:
+  InviteOrganisationMaintainerProps) {
+  // console.group('InviteOrganisationMaintainer')
+  // console.log('organisationInfo..', organisationInfo)
+  // console.log('error..', error)
+  // console.groupEnd()
+  function renderContent() {
+    if (error!==null) {
+      return (
+        <PageErrorMessage {...error}/>
+      )
+    }
+    return (
+      <ContentInTheMiddle>
+        <h2>
+          You are now a maintainer of {organisationInfo?.name ?? 'missing'}!
+          &nbsp;
+          <Link href={`/organisations/${organisationInfo?.slug ?? 'missing'}`}>
+            <a>
+              Open organisation page
+            </a>
+          </Link>
+        </h2>
+      </ContentInTheMiddle>
+    )
+  }
+
+  return (
+     <DefaultLayout>
+      <Head>
+        <title>Organisation Maintainer Invite | RSD</title>
+      </Head>
+      <PageTitle title="Organisation Maintainer Invite" />
+      {renderContent()}
+    </DefaultLayout>
+  )
+}
+
+// fetching data server side
+// see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  // extract from page-query
+  const {params,req} = context
+  // extract rsd_token
+  const token = req?.cookies['rsd_token']
+  // extract id
+  const id = params?.id
+
+  // extract account id from token
+  const account = getAccountFromToken(token)
+  // console.log('account...', account)
+  if (typeof account == 'undefined') {
+    return {
+      props: {
+        projectInfo: null,
+        error: {
+          status: 401,
+          message: 'You need to sign in to RSD first!'
+        }
+      }
+    }
+  }
+
+  if (id) {
+    // claim the software maintainer invite
+    const resp:InviteOrganisationMaintainerProps = await claimOrganisationMaintainerInvite({
+      id: id.toString(),
+      token,
+      frontend: false
+    })
+    // pass software info to page component as props
+    return {
+      props: resp
+    }
+  } else {
+    return {
+      props: {
+        softwareInfo:null,
+        error: {
+          status: 404,
+          message: 'This invite is invalid. It\'s missing invite id. Please ask the organisation mantainer to provide you a new link.'
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Organisation maintainers invite

Closes #305

Changes proposed in this pull request:
*  Maintainer of an organisation can invite others to become maintainers
*  Maintainer can remove other maintainers EXCEPT primary_maintainer (delete button is disabled on primary maintainer)    

How to test:
* `docker-compose down --volumes`: to remove old db
* `docker-compose build` to build 
* `docker-compose up` to start
*  login as professor1
*  create new software/project
*  add new organisation to RSD, for example `New Zealand eScience Infrastructure` in order to become primary maintainer of that organisation
* View software page, click on the organisation to go to organisation page
* You should see maintainer section
* Click on generate invite link button
* Click on send email invite, provide your second email address where invite should be send
* Logout from RSD
* Open your email and click on link:
    * if you are logged out you should see message "401 - You need to sign in first". Login with another account `professor2` for example. You should then get confirmation. Click on the link and confirm that second account is in the list of maintainers  
    * if you login with original account (professor1) you will also get confirmation that you are maintainer of organisation
    * After you used invite link with the professor2 account, successive attempts should show message "invite is expired"

## Example creating maintainer invite for organisation 
![image](https://user-images.githubusercontent.com/9204081/172054626-fa7cc52b-89c0-4b10-8ca3-80528b50959b.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
