### PR TITLE
Fixes: pre-commit hook alters files in merge-commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -175,6 +175,13 @@ function check_program_exists () {
     fi
 }
 
+# Check whether we are in a merge commit
+merge_check=$(git rev-parse -q --verify MERGE_HEAD)
+if [[ ${merge_check} ]]; then
+    # We are in a merge commit and do not want to alter this
+    exit 0
+fi
+
 check_program_exists reusee
 check_program_exists date
 check_program_exists dirname


### PR DESCRIPTION
# Fix pre-commit hook in merge commits

Fixes #320

Changes proposed in this pull request:

* Added a check that will detect merge commits and abort the pre-commit
hook.

How to test:

* create `.git/hooks/pre-commit` as described in `CONTRIBUTING.md`
* optionally, after line 33 of the pre-commit script, you may add an `echo "Aborting pre-commit hook"` to see the terminal output:
  ```bash
  # Check whether we are in a merge commit
  merge_check=$(git rev-parse -q --verify MERGE_HEAD)
  if [[ ${merge_check} ]]; then
      # We are in a merge commit and do not want to alter this
      echo "Aborting pre-commit hook"
      exit 0
  fi
  ```
* to test we need to create a merge conflict, e.g. 
* From the `320-fix_pre-commit_merges` branch, create a new branch and make some additions
  ```bash
  git checkout -b 320_TEST
  echo "Some string" >> CONTRIBUTING.md
  git add CONTRIBUTING.md
  git commit -n -m "320_TEST additions"
  ```
* Now switch back and add a conflict
  ```bash
  git checkout 320-fix_pre-commit_merges
  echo "Another string that will cause a conflict" >> CONTRIBUTING.md
  git add CONTRIBUTING.md
  git commit -n -m "Actual branch addition"
  ```
* merge the test branch
  ```bash
  git merge 320_TEST
  ```
* Handle the merge conflict, e.g. by accepting both changes, then run
  ```bash
  git add CONTRIBUTING.md
  git merge --continue
  ```
* you should now be asked to enter a commit message. Save and commit.
* when returning to the terminal and if you entered the `echo` to the script, you should see the message in the terminal now
* to reset the branch, run
  ```
  git reset --hard HEAD~2
  ```

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
