### PR TITLE
235 upgrade openjdk

### DIFF
--- a/authentication/Dockerfile
+++ b/authentication/Dockerfile
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.8.4-openjdk-17 AS builder
+FROM maven:3.8.5-openjdk-18 AS builder
 WORKDIR /usr/mymaven
 RUN mkdir src
 COPY pom.xml .
@@ -15,7 +15,7 @@ RUN mvn dependency:go-offline
 COPY ./src ./src
 RUN mvn package --offline
 
-FROM openjdk:17.0.2-jdk-slim-bullseye
+FROM openjdk:18.0.1.1-jdk-slim-bullseye
 WORKDIR /usr/myjava
 COPY --from=builder /usr/mymaven/target/*-jar-with-dependencies.jar auth.jar
 CMD java -cp auth.jar nl.esciencecenter.rsd.authentication.Main

--- a/data-migration/Dockerfile
+++ b/data-migration/Dockerfile
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.8.4-openjdk-17
+FROM maven:3.8.5-openjdk-18
 WORKDIR /usr/mymaven
 RUN mkdir --parents ./src/main
 COPY data-migration/pom.xml .

--- a/data-migration/docker-compose.yml
+++ b/data-migration/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     build:
       context: ../
       dockerfile: ./data-migration/Dockerfile
-    image: rsd/data-migration:0.0.17
+    image: rsd/data-migration:0.0.18
     env_file:
       # use main env file
       - ../.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
   auth:
     container_name: auth
     build: ./authentication
-    image: rsd/auth:0.0.10
+    image: rsd/auth:0.0.11
     expose:
       - 7000
     environment:
@@ -116,7 +116,7 @@ services:
   scrapers:
     container_name: scrapers
     build: ./scrapers
-    image: rsd/scrapers:0.1.4
+    image: rsd/scrapers:0.1.5
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/scrapers/Dockerfile
+++ b/scrapers/Dockerfile
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.8.4-openjdk-17 AS builder
+FROM maven:3.8.5-openjdk-18 AS builder
 WORKDIR /usr/mymaven
 RUN mkdir ./src
 COPY pom.xml .
@@ -13,7 +13,7 @@ RUN mvn dependency:go-offline
 COPY ./src ./src
 RUN mvn package --offline
 
-FROM openjdk:17.0.2-jdk-slim-bullseye
+FROM openjdk:18.0.1.1-jdk-slim-bullseye
 WORKDIR /usr/myjava
 RUN apt-get update && apt-get --yes install cron python pip nano
 COPY --from=builder /usr/mymaven/src/main/resources/requirements.txt requirements.txt

--- a/scrapers/jobs.cron
+++ b/scrapers/jobs.cron
@@ -2,8 +2,8 @@
 #
 # SPDX-License-Identifier: CC-BY-4.0
 #
-*/6 * * * * /usr/local/openjdk-17/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-2-59/6 * * * * /usr/local/openjdk-17/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainLicenses > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-4-59/6 * * * * /usr/local/openjdk-17/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+*/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+2-59/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainLicenses > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+4-59/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
 1-59/6 * * * * /usr/bin/python3 -u /usr/myjava/releases.py > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-3-59/6 * * * * /usr/local/openjdk-17/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+3-59/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/PostgrestMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/PostgrestMentionRepository.java
@@ -29,7 +29,7 @@ public class PostgrestMentionRepository implements MentionRepository {
 	static Collection<MentionRecord> parseJson(String data) {
 		return new GsonBuilder()
 				.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-				.registerTypeAdapter(Instant.class, (JsonDeserializer) (json, typeOfT, context) -> Instant.parse(json.getAsString()))
+				.registerTypeAdapter(Instant.class, (JsonDeserializer) (json, typeOfT, context) -> Instant.parse(json.getAsString() + "Z"))
 				.create()
 				.fromJson(data, new TypeToken<Collection<MentionRecord>>() {
 				}.getType());


### PR DESCRIPTION
# Upgrade OpenJDK

Changes proposed in this pull request:

* Upgrade OpenJDK images to fix the security bug as described in #235
* Small fix to mentions scraper to correctly deserialize timestamps

How to test:
* Build and test that eveything still works, especially the authentication module, the scrapers and the data-migration script, as those are the only modules that use Java
	* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --detach && cd data-migration && docker-compose build && docker-compose up`
* You can speed up the scrapers with the following commands repsectively:
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainProgrammingLanguages`
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainLicenses`
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCommits`
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions`


Closes #235

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests