### PR TITLE
316 default approval

### DIFF
--- a/.github/workflows/pr_frontend.yml
+++ b/.github/workflows/pr_frontend.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
 #
@@ -16,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "install node v16 and cash yarn"
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'

--- a/.github/workflows/tests_main.yml
+++ b/.github/workflows/tests_main.yml
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 Netherlands eScience Center
@@ -23,7 +24,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: "install node v16 and cash yarn"
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: 16
           cache: 'yarn'

--- a/backend-postgrest/tests/RSD-SaaS-auth.postman_collection.json
+++ b/backend-postgrest/tests/RSD-SaaS-auth.postman_collection.json
@@ -1102,7 +1102,7 @@
 				"header": [],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"software\" : \"{{software_id_1}}\",\n\t\"organisation\" : \"{{organisation_id_1}}\",\n\t\"status\" : \"requested_by_origin\"\n}",
+					"raw": "{\n\t\"software\" : \"{{software_id_1}}\",\n\t\"organisation\" : \"{{organisation_id_1}}\",\n\t\"status\" : \"rejected_by_origin\"\n}",
 					"options": {
 						"raw": {
 							"language": "json"
@@ -1165,6 +1165,576 @@
 					],
 					"path": [
 						"software_for_organisation"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "patch software organisation relation reject status correct",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"\tpm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"status\" : \"rejected_by_origin\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation?software=eq.{{software_id_1}}&organisation=eq.{{organisation_id_1}}",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					],
+					"query": [
+						{
+							"key": "software",
+							"value": "eq.{{software_id_1}}"
+						},
+						{
+							"key": "organisation",
+							"value": "eq.{{organisation_id_1}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "patch software organisation relation rejected status wrong",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 400\", function () {",
+							"\tpm.response.to.have.status(400);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"status\" : \"rejected_by_relation\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation?software=eq.{{software_id_1}}&organisation=eq.{{organisation_id_1}}",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					],
+					"query": [
+						{
+							"key": "software",
+							"value": "eq.{{software_id_1}}"
+						},
+						{
+							"key": "organisation",
+							"value": "eq.{{organisation_id_1}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "patch software organisation relation approve status correct",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"\tpm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"status\" : \"approved\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation?software=eq.{{software_id_1}}&organisation=eq.{{organisation_id_1}}",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					],
+					"query": [
+						{
+							"key": "software",
+							"value": "eq.{{software_id_1}}"
+						},
+						{
+							"key": "organisation",
+							"value": "eq.{{organisation_id_1}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "patch software organisation relation rejected status correct 2",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"\tpm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"status\" : \"rejected_by_relation\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation?software=eq.{{software_id_1}}&organisation=eq.{{organisation_id_1}}",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					],
+					"query": [
+						{
+							"key": "software",
+							"value": "eq.{{software_id_1}}"
+						},
+						{
+							"key": "organisation",
+							"value": "eq.{{organisation_id_1}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "patch software organisation relation rejected status wrong 2",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 400\", function () {",
+							"\tpm.response.to.have.status(400);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"status\" : \"rejected_by_origin\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation?software=eq.{{software_id_1}}&organisation=eq.{{organisation_id_1}}",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					],
+					"query": [
+						{
+							"key": "software",
+							"value": "eq.{{software_id_1}}"
+						},
+						{
+							"key": "organisation",
+							"value": "eq.{{organisation_id_1}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "post software organisation is_featured wrong",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 403\", function () {",
+							"\tpm.response.to.have.status(403);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user_2}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"software\" : \"{{software_id_2}}\",\n\t\"organisation\" : \"{{organisation_id_1}}\",\n\t\"status\" : \"approved\",\n\t\"is_featured\": true\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "post software organisation is_featured correct",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 201\", function () {",
+							"\tpm.response.to.have.status(201);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user_2}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"software\" : \"{{software_id_2}}\",\n\t\"organisation\" : \"{{organisation_id_1}}\",\n\t\"status\" : \"approved\",\n\t\"is_featured\": false\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "patch software organisation relation is_featured wrong",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 400\", function () {",
+							"\tpm.response.to.have.status(400);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user_2}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"is_featured\" : true\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation?software=eq.{{software_id_2}}&organisation=eq.{{organisation_id_1}}",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					],
+					"query": [
+						{
+							"key": "software",
+							"value": "eq.{{software_id_2}}"
+						},
+						{
+							"key": "organisation",
+							"value": "eq.{{organisation_id_1}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "patch software organisation relation relation rejected wrong",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 400\", function () {",
+							"\tpm.response.to.have.status(400);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user_2}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"status\" : \"rejected_by_relation\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation?software=eq.{{software_id_2}}&organisation=eq.{{organisation_id_1}}",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					],
+					"query": [
+						{
+							"key": "software",
+							"value": "eq.{{software_id_2}}"
+						},
+						{
+							"key": "organisation",
+							"value": "eq.{{organisation_id_1}}"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "patch software organisation relation relation rejected correct 3",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 200\", function () {",
+							"\tpm.response.to.have.status(200);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user_2}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PATCH",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"status\" : \"rejected_by_origin\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/software_for_organisation?software=eq.{{software_id_2}}&organisation=eq.{{organisation_id_1}}",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"software_for_organisation"
+					],
+					"query": [
+						{
+							"key": "software",
+							"value": "eq.{{software_id_2}}"
+						},
+						{
+							"key": "organisation",
+							"value": "eq.{{organisation_id_1}}"
+						}
 					]
 				}
 			},

--- a/backend-postgrest/tests/RSD-SaaS-auth.postman_collection.json
+++ b/backend-postgrest/tests/RSD-SaaS-auth.postman_collection.json
@@ -1024,6 +1024,55 @@
 			"response": []
 		},
 		{
+			"name": "post maintainer of organisation wrong",
+			"event": [
+				{
+					"listen": "test",
+					"script": {
+						"exec": [
+							"pm.test(\"Status code is 403\", function () {",
+							"\tpm.response.to.have.status(403);",
+							"});"
+						],
+						"type": "text/javascript"
+					}
+				}
+			],
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{jwt_user_2}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n\t\"maintainer\" : \"{{account_id_2}}\",\n\t\"organisation\" : \"{{organisation_id_1}}\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "{{backend_url}}/maintainer_for_organisation",
+					"host": [
+						"{{backend_url}}"
+					],
+					"path": [
+						"maintainer_for_organisation"
+					]
+				}
+			},
+			"response": []
+		},
+		{
 			"name": "post software organisation non maintainer wrong",
 			"event": [
 				{

--- a/data-migration/docker-compose.yml
+++ b/data-migration/docker-compose.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -15,7 +16,7 @@ services:
     build:
       context: ../
       dockerfile: ./data-migration/Dockerfile
-    image: rsd/data-migration:0.0.17
+    image: rsd/data-migration:0.0.18
     env_file:
       # use main env file
       - ../.env

--- a/data-migration/src/main/java/nl/esciencecenter/rsd/migration/Main.java
+++ b/data-migration/src/main/java/nl/esciencecenter/rsd/migration/Main.java
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 dv4all
@@ -1002,7 +1003,7 @@ public class Main {
 			if (orgId == null) System.out.println(name);
 			if (existingIds.contains(orgId)) return;
 
-			logoToSave.addProperty("id", orgId);
+			logoToSave.addProperty("organisation", orgId);
 			logoToSave.add("data", logo.get("data"));
 			logoToSave.add("mime_type", logo.get("mimeType"));
 			existingIds.add(orgNameToId.get(name));

--- a/database/011-create-organisation-table.sql
+++ b/database/011-create-organisation-table.sql
@@ -1,3 +1,4 @@
+-- SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 Netherlands eScience Center
@@ -61,7 +62,7 @@ BEGIN
 	NEW.created_at = OLD.created_at;
 	NEW.updated_at = LOCALTIMESTAMP;
 
-	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+	IF CURRENT_USER <> 'rsd_admin' AND NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
 		IF NEW.is_tenant IS DISTINCT FROM OLD.is_tenant OR NEW.primary_maintainer IS DISTINCT FROM OLD.primary_maintainer THEN
 			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to change the tenant status or primary maintainer for organisation ' || OLD.name;
 		END IF;

--- a/database/011-create-organisation-table.sql
+++ b/database/011-create-organisation-table.sql
@@ -60,7 +60,14 @@ BEGIN
 	NEW.slug = OLD.slug;
 	NEW.created_at = OLD.created_at;
 	NEW.updated_at = LOCALTIMESTAMP;
-	return NEW;
+
+	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+		IF NEW.is_tenant IS DISTINCT FROM OLD.is_tenant OR NEW.primary_maintainer IS DISTINCT FROM OLD.primary_maintainer THEN
+			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to change the tenant status or primary maintainer for organisation ' || OLD.name;
+		END IF;
+	END IF;
+
+	RETURN NEW;
 END
 $$;
 

--- a/database/011-create-organisation-table.sql
+++ b/database/011-create-organisation-table.sql
@@ -103,7 +103,7 @@ $$;
 
 
 CREATE TABLE logo_for_organisation (
-	id UUID references organisation(id) PRIMARY KEY,
+	organisation UUID references organisation(id) PRIMARY KEY,
 	data VARCHAR NOT NULL,
 	mime_type VARCHAR(100) NOT NULL,
 	created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
@@ -121,12 +121,12 @@ BEGIN
 		'{"Content-Disposition": "inline; filename=\"%s\""},'
 		'{"Cache-Control": "max-age=259200"}]',
 		logo_for_organisation.mime_type,
-		logo_for_organisation.id)
-	FROM logo_for_organisation WHERE logo_for_organisation.id = get_logo.id INTO headers;
+		logo_for_organisation.organisation)
+	FROM logo_for_organisation WHERE logo_for_organisation.organisation = get_logo.id INTO headers;
 
 	PERFORM set_config('response.headers', headers, TRUE);
 
-	SELECT decode(logo_for_organisation.data, 'base64') FROM logo_for_organisation WHERE logo_for_organisation.id = get_logo.id INTO blob;
+	SELECT decode(logo_for_organisation.data, 'base64') FROM logo_for_organisation WHERE logo_for_organisation.organisation = get_logo.id INTO blob;
 
 	IF FOUND
 		THEN RETURN(blob);

--- a/database/012-inter-relation-tables.sql
+++ b/database/012-inter-relation-tables.sql
@@ -6,8 +6,8 @@
 -- SPDX-License-Identifier: Apache-2.0
 
 CREATE TYPE relation_status AS ENUM (
-	'requested_by_origin',
-	'requested_by_relation',
+	'rejected_by_origin',
+	'rejected_by_relation',
 	'approved'
 );
 
@@ -47,6 +47,18 @@ $$
 BEGIN
 	NEW.software = OLD.software;
 	NEW.project = OLD.project;
+
+	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+		IF NEW.status <> OLD.status AND (
+			(OLD.status = 'rejected_by_origin' AND (NEW.status <> 'approved' OR OLD.software NOT IN (SELECT * FROM software_of_current_maintainer()))) OR
+			(OLD.status = 'rejected_by_relation' AND (NEW.status <> 'approved' OR OLD.project NOT IN (SELECT * FROM projects_of_current_maintainer()))) OR
+			(OLD.status = 'approved' AND NEW.status = 'rejected_by_origin' AND OLD.software NOT IN (SELECT * FROM projects_of_current_maintainer())) OR
+			(OLD.status = 'approved' AND NEW.status = 'rejected_by_relation' AND OLD.project NOT IN (SELECT * FROM software_of_current_maintainer()))
+		) THEN
+			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to make this change to the status value for software ' || OLD.software || ' and project ' || OLD.project;
+		END IF;
+	END IF;
+
 	return NEW;
 END
 $$;
@@ -66,6 +78,18 @@ $$
 BEGIN
 	NEW.origin = OLD.origin;
 	NEW.relation = OLD.relation;
+
+	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+		IF NEW.status <> OLD.status AND (
+			(OLD.status = 'rejected_by_origin' AND (NEW.status <> 'approved' OR OLD.origin NOT IN (SELECT * FROM projects_of_current_maintainer()))) OR
+			(OLD.status = 'rejected_by_relation' AND (NEW.status <> 'approved' OR OLD.relation NOT IN (SELECT * FROM projects_of_current_maintainer()))) OR
+			(OLD.status = 'approved' AND NEW.status = 'rejected_by_origin' AND OLD.origin NOT IN (SELECT * FROM projects_of_current_maintainer())) OR
+			(OLD.status = 'approved' AND NEW.status = 'rejected_by_relation' AND OLD.relation NOT IN (SELECT * FROM projects_of_current_maintainer()))
+		) THEN
+			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to make this change to the status value for origin ' || OLD.origin || ' and relation ' || OLD.relation;
+		END IF;
+	END IF;
+
 	return NEW;
 END
 $$;
@@ -86,6 +110,21 @@ $$
 BEGIN
 	NEW.software = OLD.software;
 	NEW.organisation = OLD.organisation;
+
+	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+		IF NEW.is_featured <> OLD.is_featured AND OLD.organisation NOT IN (SELECT * FROM organisations_of_current_maintainer()) THEN
+			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to change the is_featured value for software ' || OLD.software || 'and organisation ' || OLD.organisation;
+		END IF;
+		IF NEW.status <> OLD.status AND (
+			(OLD.status = 'rejected_by_origin' AND (NEW.status <> 'approved' OR OLD.software NOT IN (SELECT * FROM software_of_current_maintainer()))) OR
+			(OLD.status = 'rejected_by_relation' AND (NEW.status <> 'approved' OR OLD.organisation NOT IN (SELECT * FROM organisations_of_current_maintainer()))) OR
+			(OLD.status = 'approved' AND NEW.status = 'rejected_by_origin' AND OLD.software NOT IN (SELECT * FROM software_of_current_maintainer())) OR
+			(OLD.status = 'approved' AND NEW.status = 'rejected_by_relation' AND OLD.organisation NOT IN (SELECT * FROM organisations_of_current_maintainer()))
+		) THEN
+			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to make this change to the status value for software ' || OLD.software || ' and organisation ' || OLD.organisation;
+		END IF;
+	END IF;
+
 	return NEW;
 END
 $$;
@@ -107,6 +146,21 @@ $$
 BEGIN
 	NEW.project = OLD.project;
 	NEW.organisation = OLD.organisation;
+
+	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+		IF NEW.is_featured <> OLD.is_featured AND OLD.organisation NOT IN (SELECT * FROM organisations_of_current_maintainer()) THEN
+			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to change the is_featured value for project ' || OLD.project || 'and organisation ' || OLD.organisation;
+		END IF;
+		IF NEW.status <> OLD.status AND (
+			(OLD.status = 'rejected_by_origin' AND (NEW.status <> 'approved' OR OLD.project NOT IN (SELECT * FROM projects_of_current_maintainer()))) OR
+			(OLD.status = 'rejected_by_relation' AND (NEW.status <> 'approved' OR OLD.organisation NOT IN (SELECT * FROM organisations_of_current_maintainer()))) OR
+			(OLD.status = 'approved' AND NEW.status = 'rejected_by_origin' AND OLD.project NOT IN (SELECT * FROM projects_of_current_maintainer())) OR
+			(OLD.status = 'approved' AND NEW.status = 'rejected_by_relation' AND OLD.organisation NOT IN (SELECT * FROM organisations_of_current_maintainer()))
+		) THEN
+			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to make this change to the status value for project ' || OLD.project || ' and organisation ' || OLD.organisation;
+		END IF;
+	END IF;
+
 	return NEW;
 END
 $$;

--- a/database/012-inter-relation-tables.sql
+++ b/database/012-inter-relation-tables.sql
@@ -1,3 +1,4 @@
+-- SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 Netherlands eScience Center
@@ -48,7 +49,7 @@ BEGIN
 	NEW.software = OLD.software;
 	NEW.project = OLD.project;
 
-	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+	IF CURRENT_USER <> 'rsd_admin' AND NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
 		IF NEW.status <> OLD.status AND (
 			(OLD.status = 'rejected_by_origin' AND (NEW.status <> 'approved' OR OLD.software NOT IN (SELECT * FROM software_of_current_maintainer()))) OR
 			(OLD.status = 'rejected_by_relation' AND (NEW.status <> 'approved' OR OLD.project NOT IN (SELECT * FROM projects_of_current_maintainer()))) OR
@@ -79,7 +80,7 @@ BEGIN
 	NEW.origin = OLD.origin;
 	NEW.relation = OLD.relation;
 
-	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+	IF CURRENT_USER <> 'rsd_admin' AND NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
 		IF NEW.status <> OLD.status AND (
 			(OLD.status = 'rejected_by_origin' AND (NEW.status <> 'approved' OR OLD.origin NOT IN (SELECT * FROM projects_of_current_maintainer()))) OR
 			(OLD.status = 'rejected_by_relation' AND (NEW.status <> 'approved' OR OLD.relation NOT IN (SELECT * FROM projects_of_current_maintainer()))) OR
@@ -111,7 +112,7 @@ BEGIN
 	NEW.software = OLD.software;
 	NEW.organisation = OLD.organisation;
 
-	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+	IF CURRENT_USER <> 'rsd_admin' AND NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
 		IF NEW.is_featured <> OLD.is_featured AND OLD.organisation NOT IN (SELECT * FROM organisations_of_current_maintainer()) THEN
 			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to change the is_featured value for software ' || OLD.software || 'and organisation ' || OLD.organisation;
 		END IF;
@@ -147,7 +148,7 @@ BEGIN
 	NEW.project = OLD.project;
 	NEW.organisation = OLD.organisation;
 
-	IF CURRENT_USER <> 'rsd_admin' OR NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
+	IF CURRENT_USER <> 'rsd_admin' AND NOT (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) THEN
 		IF NEW.is_featured <> OLD.is_featured AND OLD.organisation NOT IN (SELECT * FROM organisations_of_current_maintainer()) THEN
 			RAISE EXCEPTION USING MESSAGE = 'You are not allowed to change the is_featured value for project ' || OLD.project || 'and organisation ' || OLD.organisation;
 		END IF;

--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -482,12 +482,14 @@ CREATE POLICY admin_all_rights ON organisation TO rsd_admin
 ALTER TABLE logo_for_organisation ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY anyone_can_read ON logo_for_organisation FOR SELECT TO web_anon, rsd_user
-	USING (id IN (SELECT id FROM organisation));
+	USING (organisation IN (SELECT id FROM organisation));
 
+CREATE POLICY maintainer_insert_non_tenant ON logo_for_organisation FOR INSERT TO rsd_user
+	WITH CHECK (NOT (SELECT is_tenant FROM organisation o WHERE o.id = logo_for_organisation.organisation));
 
 CREATE POLICY maintainer_all_rights ON logo_for_organisation TO rsd_user
-	USING (id IN (SELECT * FROM organisations_of_current_maintainer()))
-	WITH CHECK (id IN (SELECT * FROM organisations_of_current_maintainer()));
+	USING (organisation IN (SELECT * FROM organisations_of_current_maintainer()))
+	WITH CHECK (organisation IN (SELECT * FROM organisations_of_current_maintainer()));
 
 CREATE POLICY admin_all_rights ON logo_for_organisation TO rsd_admin
 	USING (TRUE)

--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -198,6 +198,19 @@ CREATE POLICY admin_all_rights ON contributor TO rsd_admin
 	WITH CHECK (TRUE);
 
 
+ALTER TABLE testimonial ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY anyone_can_read ON testimonial FOR SELECT TO web_anon, rsd_user
+	USING (software IN (SELECT id FROM software));
+
+CREATE POLICY maintainer_all_rights ON testimonial TO rsd_user
+	USING (software IN (SELECT * FROM software_of_current_maintainer()))
+	WITH CHECK (software IN (SELECT * FROM software_of_current_maintainer()));
+
+CREATE POLICY admin_all_rights ON testimonial TO rsd_admin
+	USING (TRUE)
+	WITH CHECK (TRUE);
+
 -- keywords
 ALTER TABLE keyword ENABLE ROW LEVEL SECURITY;
 

--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -1,5 +1,6 @@
 -- SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 dv4all
 --

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1,5 +1,6 @@
 -- SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2021 - 2022 dv4all
+-- SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 -- SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 --
@@ -327,6 +328,7 @@ CREATE FUNCTION software_by_organisation() RETURNS TABLE (
 	short_statement VARCHAR,
 	is_published BOOLEAN,
 	is_featured BOOLEAN,
+	status relation_status,
 	contributor_cnt BIGINT,
 	mention_cnt BIGINT,
 	updated_at TIMESTAMP,
@@ -342,6 +344,7 @@ BEGIN
 		software.short_statement,
 		software.is_published,
 		software_for_organisation.is_featured,
+		software_for_organisation.status,
 		count_software_countributors.contributor_cnt,
 		count_software_mentions.mention_cnt,
 		software.updated_at,

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -210,7 +210,7 @@ BEGIN
 		organisation.ror_id,
 		organisation.is_tenant,
 		organisation.website,
-		logo_for_organisation.id AS logo_id,
+		logo_for_organisation.organisation AS logo_id,
 		software_for_organisation.status,
 		software.id AS software
 FROM
@@ -220,7 +220,7 @@ INNER JOIN
 INNER JOIN
 	organisation ON software_for_organisation.organisation = organisation.id
 LEFT JOIN
-	logo_for_organisation ON logo_for_organisation.id = organisation.id;
+	logo_for_organisation ON logo_for_organisation.organisation = organisation.id;
 END
 $$;
 
@@ -300,7 +300,7 @@ BEGIN
 		o.ror_id,
 		o.website,
 		o.is_tenant,
-		logo_for_organisation.id AS logo_id,
+		logo_for_organisation.organisation AS logo_id,
 		software_count_by_organisation.software_cnt,
 		project_count_by_organisation.project_cnt,
 		children_count_by_organisation.children_cnt
@@ -313,7 +313,7 @@ BEGIN
 	LEFT JOIN
 		children_count_by_organisation() ON o.id = children_count_by_organisation.parent
 	LEFT JOIN
-		logo_for_organisation ON o.id = logo_for_organisation.id;
+		logo_for_organisation ON o.id = logo_for_organisation.organisation;
 END
 $$;
 
@@ -429,7 +429,7 @@ BEGIN
 			organisation.ror_id,
 			organisation.is_tenant,
 			organisation.website,
-			logo_for_organisation.id AS logo_id,
+			logo_for_organisation.organisation AS logo_id,
 			project_for_organisation.status,
 			project_for_organisation.role,
 			project.id AS project,
@@ -441,7 +441,7 @@ BEGIN
 	INNER JOIN
 		organisation ON project_for_organisation.organisation = organisation.id
 	LEFT JOIN
-		logo_for_organisation ON logo_for_organisation.id = organisation.id
+		logo_for_organisation ON logo_for_organisation.organisation = organisation.id
 	;
 END
 $$;
@@ -871,14 +871,14 @@ BEGIN
 		o.ror_id,
 		o.website,
 		o.is_tenant,
-		logo_for_organisation.id AS logo_id,
+		logo_for_organisation.organisation AS logo_id,
 		software_count_by_organisation.software_cnt,
 		project_count_by_organisation.project_cnt,
 		children_count_by_organisation.children_cnt
 	FROM
 		organisation AS o
 	LEFT JOIN
-		logo_for_organisation ON o.id = logo_for_organisation.id
+		logo_for_organisation ON o.id = logo_for_organisation.organisation
 	LEFT JOIN
 		software_count_by_organisation() ON software_count_by_organisation.organisation = o.id
 	LEFT JOIN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@
 # SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2021 - 2022 dv4all
 # SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 #
@@ -14,7 +15,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.33
+    image: rsd/database:0.0.34
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -86,7 +87,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.9.5
+    image: rsd/frontend:0.9.6
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/auth/locationCookie.ts
+++ b/frontend/auth/locationCookie.ts
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
@@ -9,12 +10,18 @@ export function saveLocationCookie() {
   // only in browser mode
   if (typeof document == 'undefined') return
   if (typeof location == 'undefined') return
+  // console.log('saveLocationCookie...', location.pathname.toLowerCase())
   // for specific routes
   switch (location.pathname.toLowerCase()) {
     // ingnore these paths
+    case '/auth':
     case '/login':
     case '/logout':
     case '/login/local':
+      break
+    case '/':
+      // root is send to /software
+      document.cookie = `rsd_pathname=${location.href}software;path=/auth;SameSite=None;Secure`
       break
     default:
       // write simple browser cookie

--- a/frontend/auth/permissions/isMaintainerOfOrganisation.ts
+++ b/frontend/auth/permissions/isMaintainerOfOrganisation.ts
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -20,18 +21,15 @@ export async function isMaintainerOfOrganisation({organisation, account, token, 
       // if no account and token provided
       return false
     }
-    const [primary, maintainer] = await Promise.all([
-      isPrimaryMaintainer({
-        organisation, account, token, frontend
-      }),
-      isMaintainer({
-        organisation, account, token, frontend
-      })
-    ])
-    // can be primary or any maintainer
-    if (primary === true) return true
-    if (maintainer === true) return true
-    // otherwise not a maintainer
+    const organisations = await getMaintainerOrganisations({
+      token,
+      frontend
+    })
+    // debugger
+    if (organisations.length > 0) {
+      const isMaintainer = organisations.includes(organisation)
+      return isMaintainer
+    }
     return false
   } catch (e:any) {
     logger(`isMaintainerOfOrganisation: ${e?.message}`, 'error')
@@ -40,7 +38,32 @@ export async function isMaintainerOfOrganisation({organisation, account, token, 
   }
 }
 
-async function isPrimaryMaintainer({organisation, account, token, frontend}: IsMaintainerOfOrganisationProps) {
+export async function getMaintainerOrganisations({token, frontend = true}: { token: string, frontend?: boolean }) {
+  try {
+    const query = 'rpc/organisations_of_current_maintainer'
+    let url = `/api/v1/${query}`
+    if (frontend===false) {
+      url = `${process.env.POSTGREST_URL}/${query}`
+    }
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: createJsonHeaders(token)
+    })
+    if (resp.status === 200) {
+      const json = await resp.json()
+      return json
+    }
+    // ERRORS AS NOT MAINTAINER
+    logger(`getMaintainerOrganisations: ${resp.status}:${resp.statusText}`, 'warn')
+    return []
+  } catch(e:any) {
+    // ERRORS AS NOT MAINTAINER
+    logger(`getMaintainerOrganisations: ${e.message}`, 'error')
+    return []
+  }
+}
+
+export async function isPrimaryMaintainer({organisation, account, token, frontend}: IsMaintainerOfOrganisationProps) {
   try {
     let url = `/api/v1/organisation?select=primary_maintainer&id=eq.${organisation}`
     if (frontend == false) {
@@ -70,7 +93,7 @@ async function isPrimaryMaintainer({organisation, account, token, frontend}: IsM
   }
 }
 
-async function isMaintainer({organisation,account,token,frontend}: IsMaintainerOfOrganisationProps) {
+export async function isMaintainer({organisation,account,token,frontend}: IsMaintainerOfOrganisationProps) {
   try {
     let url = `/api/v1/maintainer_for_organisation?maintainer=eq.${account}&organisation=eq.${organisation}`
     if (frontend == false) {

--- a/frontend/auth/permissions/useOrganisationMaintainer.tsx
+++ b/frontend/auth/permissions/useOrganisationMaintainer.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -5,7 +6,7 @@
 
 import {useEffect,useState} from 'react'
 import {Session} from '..'
-import isMaintainerOfOrganisation from './isMaintainerOfOrganisation'
+import isMaintainerOfOrganisation, {getMaintainerOrganisations} from './isMaintainerOfOrganisation'
 
 type UseOrganisationMaintainerProps = {
   organisation: string
@@ -46,5 +47,33 @@ export default function useOrganisationMaintainer({organisation,session}:UseOrga
   return {
     loading,
     isMaintainer
+  }
+}
+
+// returns a list of organisation ids (uuid) that this token is maintainer of
+export function useMaintainerOfOrganisations({token}: { token: string }) {
+  const [organisations, setOrganisations] = useState<string[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let abort = false
+    async function maintainerOfOrganisations() {
+      const resp = await getMaintainerOrganisations({
+        token,
+        frontend:true
+      })
+      if (abort) return
+      setOrganisations(resp)
+      setLoading(false)
+    }
+    if (token) {
+      maintainerOfOrganisations()
+    }
+    return ()=>{abort=true}
+  }, [token])
+
+  return {
+    loading,
+    organisations
   }
 }

--- a/frontend/components/layout/IconOverlay.tsx
+++ b/frontend/components/layout/IconOverlay.tsx
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import styled from '@emotion/styled'
+
+const IconOverlay = styled('div')(({theme})=>({
+  position: 'absolute',
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  display: 'flex',
+  justifyContent: 'center',
+  // alignItems: 'center',
+  opacity: 0.5
+}))
+
+export default IconOverlay

--- a/frontend/components/layout/ImageAsBackground.tsx
+++ b/frontend/components/layout/ImageAsBackground.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -6,8 +7,17 @@
 /* eslint-disable @next/next/no-img-element */
 import PhotoSizeSelectActualOutlinedIcon from '@mui/icons-material/PhotoSizeSelectActualOutlined'
 
-export default function ImageAsBackground({src, alt, className, bgSize='cover', noImgMsg='no image avaliable'}:
-  {src: string | null | undefined, alt: string, className: string, bgSize?:string, noImgMsg?:string }) {
+type ImpageAsBackgroundProps = {
+  src: string | null | undefined
+  alt: string,
+  className: string,
+  bgSize?: string,
+  bgPosition?: string
+  noImgMsg?: string
+}
+
+export default function ImageAsBackground({src, alt, className, bgSize = 'cover',
+  bgPosition = 'top center', noImgMsg = 'no image avaliable'}:ImpageAsBackgroundProps) {
 
   if (!src) {
     return (
@@ -31,7 +41,7 @@ export default function ImageAsBackground({src, alt, className, bgSize='cover', 
         flex: 1,
         backgroundImage: `url('${src}')`,
         backgroundSize: bgSize,
-        backgroundPosition: 'top center',
+        backgroundPosition: bgPosition,
         backgroundRepeat: 'no-repeat',
       }}
       aria-label={alt}

--- a/frontend/components/mention/MentionEditList.tsx
+++ b/frontend/components/mention/MentionEditList.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -28,7 +29,7 @@ export default function MentionEditList({title, type, items}: MentionSectionList
         boxShadow: 0,
         borderTop: '1px solid',
         borderColor: 'divider',
-        // backgroundColor: 'primary.light',
+        backgroundColor: 'background.paper',
         // remove line above the accordion
         '&:before': {
           height: '0px'

--- a/frontend/components/menu/IconBtnMenuOnAction.tsx
+++ b/frontend/components/menu/IconBtnMenuOnAction.tsx
@@ -1,0 +1,98 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+import IconButton from '@mui/material/IconButton'
+import MoreVertIcon from '@mui/icons-material/MoreVert'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import Divider from '@mui/material/Divider'
+
+export type IconBtnMenuOption<T> = {
+  type: 'divider' | 'action'
+  key: string,
+  label: string,
+  action: T
+  disabled?: boolean,
+}
+
+export type IconBtnMenuOnActionProps<T> = {
+  options: IconBtnMenuOption<T>[]
+  onAction: (action:T) => void
+  IconComponent?: any
+}
+
+export default function IconBtnMenuOnAction({options, onAction,
+  // default icon is MoreVericalIcon
+  IconComponent = MoreVertIcon}: IconBtnMenuOnActionProps<any>) {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+
+  function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
+    setAnchorEl(event.currentTarget)
+  }
+
+  function handleClose() {
+    setAnchorEl(null)
+  }
+
+  function handleAction(action:any) {
+    if (action) {
+      onAction(action)
+    }
+    setAnchorEl(null)
+  }
+
+  function renderMenuOptions(){
+    if (options){
+      return (
+        options.map(item => {
+          if (item.type === 'divider') {
+            return <Divider />
+          }
+          return (
+            <MenuItem
+              data-testid="icon-menu-option"
+              key={item.label}
+              onClick={()=>handleAction(item.action)}>
+              {item.label}
+            </MenuItem>
+          )
+        })
+      )
+    }
+    return null
+  }
+
+  return (
+    <>
+      <IconButton
+        size="large"
+        data-testid="icon-menu-button"
+        aria-controls="more-menu"
+        aria-haspopup="true"
+        aria-expanded={open ? 'true' : 'false'}
+        onClick={handleClick}
+        sx={{
+          color: 'inherit'
+        }}
+      >
+        <IconComponent/>
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        MenuListProps={{
+          'aria-labelledby': 'menu-button',
+        }}
+        transformOrigin={{horizontal: 'right', vertical: 'top'}}
+        anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
+      >
+        {renderMenuOptions()}
+      </Menu>
+    </>
+  )
+}

--- a/frontend/components/organisation/software/SoftwareCardWithMenu.tsx
+++ b/frontend/components/organisation/software/SoftwareCardWithMenu.tsx
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import styled from '@mui/system/styled'
+import BlockIcon from '@mui/icons-material/Block'
+
+import SoftwareCard from '~/components/software/SoftwareCard'
+import IconBtnMenuOnAction from '~/components/menu/IconBtnMenuOnAction'
+import IconOverlay from '~/components/layout/IconOverlay'
+import {SoftwareCardWithMenuProps, useSoftwareCardActions} from './useSoftwareCardActions'
+
+
+const StyledNav = styled('nav')(({theme})=>({
+  position: 'absolute',
+  right: 0,
+  top: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '4rem',
+  height: '4rem',
+  backgroundColor: theme.palette.background.paper,
+  color: theme.palette.secondary.main,
+  zIndex: 9
+}))
+
+
+export default function SoftwareCardWithMenu({organisation,item,token}: SoftwareCardWithMenuProps) {
+  const {software,menuOptions,onAction} = useSoftwareCardActions({organisation,item,token})
+
+  function renderStatus() {
+    if (software.status === 'approved') return null
+    return (
+      <IconOverlay
+        title={`Affiliation denied for ${software.brand_name}`}
+      >
+        <a href={`/software/${software.slug}/`} target="_blank" rel="noreferrer">
+        <BlockIcon
+          sx={{
+            width: '100%',
+            height: '100%',
+            color: 'error.main'
+          }}
+          />
+        </a>
+      </IconOverlay>
+    )
+  }
+
+  return (
+    <div className="relative h-full">
+      <SoftwareCard
+        key={software.id}
+        href={`/software/${software.slug}/`}
+        brand_name={software.brand_name}
+        short_statement={software.short_statement}
+        is_featured={software.is_featured}
+        updated_at={software.updated_at}
+        mention_cnt={software.mention_cnt}
+        contributor_cnt={software.contributor_cnt}
+        is_published={software.is_published}
+      />
+      <StyledNav>
+        <IconBtnMenuOnAction
+          options={menuOptions}
+          onAction={onAction}
+        />
+      </StyledNav>
+      {renderStatus()}
+    </div>
+  )
+}

--- a/frontend/components/organisation/software/index.tsx
+++ b/frontend/components/organisation/software/index.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -5,15 +6,16 @@
 
 import {useEffect} from 'react'
 
-import {Session} from '../../../auth'
-import {OrganisationForOverview} from '../../../types/Organisation'
 import useOrganisationSoftware from '../../../utils/useOrganisationSoftware'
-import SoftwareGrid from '../../software/SoftwareGrid'
 import GridScrim from '../../layout/GridScrim'
 import usePaginationWithSearch from '../../../utils/usePaginationWithSearch'
+import {OrganisationPageProps} from 'pages/organisations/[...slug]'
+import ContentInTheMiddle from '~/components/layout/ContentInTheMiddle'
+import FlexibleGridSection from '~/components/layout/FlexibleGridSection'
+import SoftwareCardWithMenu from './SoftwareCardWithMenu'
+import SoftwareCard from '~/components/software/SoftwareCard'
 
-export default function OrganisationSoftware({organisation, session}:
-  { organisation: OrganisationForOverview, session: Session }) {
+export default function OrganisationSoftware({organisation, session, isMaintainer}:OrganisationPageProps) {
   const {searchFor,page,rows,setCount} = usePaginationWithSearch('Search for software')
   const {loading, software, count} = useOrganisationSoftware({
     organisation: organisation.id,
@@ -41,15 +43,45 @@ export default function OrganisationSoftware({organisation, session}:
     )
   }
 
+  if (software.length===0){
+    return (
+      <ContentInTheMiddle>
+        <h2>No content</h2>
+      </ContentInTheMiddle>
+    )
+  }
+
   return (
-    <SoftwareGrid
-      software={software}
-      grid={{
-        height:'17rem',
-        minWidth:'25rem',
-        maxWidth:'1fr'
-      }}
+    <FlexibleGridSection
       className="gap-[0.125rem] pt-2 pb-12"
-    />
+      height='17rem'
+      minWidth='25rem'
+      maxWidth='1fr'
+    >
+      {software.map(item => {
+        if (isMaintainer) {
+          return(
+            <SoftwareCardWithMenu
+              key={item.id}
+              organisation={organisation}
+              item={item}
+              token={session.token}
+            />
+          )
+        }
+        return(
+          <SoftwareCard
+            key={`/software/${item.slug}/`}
+            href={`/software/${item.slug}/`}
+            brand_name={item.brand_name}
+            short_statement={item.short_statement ?? ''}
+            is_featured={item?.is_featured ?? false}
+            updated_at={item.updated_at ?? null}
+            mention_cnt={item?.mention_cnt ?? null}
+            contributor_cnt={item?.contributor_cnt ?? null}
+          />
+        )
+      })}
+    </FlexibleGridSection>
   )
 }

--- a/frontend/components/organisation/software/useSoftwareCardActions.tsx
+++ b/frontend/components/organisation/software/useSoftwareCardActions.tsx
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {IconBtnMenuOption} from '~/components/menu/IconBtnMenuOnAction'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {OrganisationForOverview, SoftwareOfOrganisation} from '~/types/Organisation'
+import {patchSoftwareForOrganisation} from '~/utils/editOrganisation'
+import logger from '~/utils/logger'
+
+export type SoftwareCardWithMenuProps = {
+  organisation: OrganisationForOverview,
+  item: SoftwareOfOrganisation
+  token: string
+}
+
+export type SoftwareMenuAction = {
+  type: 'PIN' | 'UNPIN' | 'DENY' | 'APPROVE',
+  payload?: string
+}
+
+export function useSoftwareCardActions({organisation, item, token}: SoftwareCardWithMenuProps) {
+  const {showErrorMessage, showSuccessMessage} = useSnackbar()
+  const [software, setSoftware] = useState<SoftwareOfOrganisation>(item)
+  const [menuOptions, setMenuOptions] = useState<IconBtnMenuOption<SoftwareMenuAction>[]>([])
+
+  useEffect(() => {
+    let abort = false
+    if (typeof software !='undefined') {
+      const options: IconBtnMenuOption<SoftwareMenuAction>[] = []
+      if (software.status === 'approved') {
+        options.push({
+          type: 'action', key: 'deny', label: 'Deny affiliation', action: {type: 'DENY'}
+        })
+      } else {
+        options.push({
+          type: 'action', key: 'approve', label: 'Approve affiliation', action: {type: 'APPROVE'}
+        })
+      }
+      if (software.is_published) {
+        if (software.is_featured) {
+          options.push({
+            type: 'action', key: 'unpin', label: 'Unpin software', action: {type: 'UNPIN'}
+          })
+        } else {
+          options.push({
+            type: 'action', key: 'pin', label: 'Pin software', action: {type: 'PIN'}
+          })
+        }
+      }
+      if (abort) return
+      setMenuOptions(options)
+    }
+    return ()=>{abort=true}
+  }, [software])
+
+  async function setPinned(is_featured: boolean) {
+    const pin = await patchSoftwareForOrganisation({
+      software: software?.id ?? '',
+      organisation: organisation.id,
+      token,
+      data: {
+        is_featured
+      }
+    })
+    if (pin.status !== 200) {
+      showErrorMessage(`Failed to update ${software.brand_name}. ${pin.message}`)
+    } else {
+      showSuccessMessage(`${software.brand_name} ${is_featured ? ' PINNED' : ' UNPINNEND'}`)
+      const updated = {
+        ...software,
+        is_featured
+      }
+      setSoftware(updated)
+    }
+  }
+
+  async function setStatus(status: 'approved' | 'rejected_by_relation') {
+    const resp = await patchSoftwareForOrganisation({
+      software: software.id,
+      organisation: organisation.id,
+      token,
+      data: {
+        status
+      }
+    })
+    if (resp.status !== 200) {
+      showErrorMessage(`Failed to update ${software.brand_name}. ${resp.message}`)
+    } else {
+      let message = `${software.brand_name} is `
+      if (status === 'approved') {
+        message += `approved as software of ${organisation.name}`
+      } else {
+        message += `DENIED affiliation with ${organisation.name}`
+      }
+      showSuccessMessage(message)
+      const updated = {
+        ...software,
+        status
+      }
+      setSoftware(updated)
+    }
+  }
+
+  function onAction(action: SoftwareMenuAction) {
+    // console.log('SoftwareCardWithMenu...action...', action)
+    switch (action.type) {
+      case 'PIN':
+        setPinned(true)
+        break
+      case 'UNPIN':
+        setPinned(false)
+        break
+      case 'DENY':
+        setStatus('rejected_by_relation')
+        break
+      case 'APPROVE':
+        setStatus('approved')
+        break
+      default:
+        logger(`Action type ${action.type} NOT SUPORTED. Check your spelling.`, 'warn')
+    }
+  }
+
+  return {
+    software,
+    setSoftware,
+    menuOptions,
+    onAction
+  }
+}

--- a/frontend/components/projects/edit/organisations/index.tsx
+++ b/frontend/components/projects/edit/organisations/index.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -90,7 +91,8 @@ export default function ProjectOrganisations({session}: { session: Session }) {
     const newOrganisation: EditOrganisation = newOrganisationProps({
       name,
       position: organisations.length + 1,
-      primary_maintainer: session?.user?.account ?? null,
+      // new organisations without primary_maintainer
+      primary_maintainer: null,
     })
     // show modal
     setModal({

--- a/frontend/components/projects/edit/related/RelatedProjectsForProject.tsx
+++ b/frontend/components/projects/edit/related/RelatedProjectsForProject.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -55,14 +56,8 @@ export default function RelatedProjectsForProject() {
     const find = relatedProject.filter(item => item.slug === selected.slug)
     // debugger
     if (find.length === 0) {
-      // determine status of relation between projects 'ownership'
-      const isMaintainer = await isMaintainerOfProject({
-        slug: selected.slug,
-        account: session.user?.account,
-        token: session.token,
-        frontend: true
-      })
-      const status:Status = isMaintainer ? 'approved' : 'requested_by_origin'
+      // default status is set to approved without validation
+      const status:Status = 'approved'
       // append(selected)
       const resp = await addRelatedProject({
         origin: project.id,
@@ -71,7 +66,7 @@ export default function RelatedProjectsForProject() {
         token: session.token
       })
       if (resp.status !== 200) {
-        showErrorMessage(`Failed to add related software. ${resp.message}`)
+        showErrorMessage(`Failed to add related project. ${resp.message}`)
       } else {
         const newList = [
           ...relatedProject,
@@ -99,7 +94,7 @@ export default function RelatedProjectsForProject() {
         token: session.token
       })
       if (resp.status !== 200) {
-        showErrorMessage(`Failed to add related software. ${resp.message}`)
+        showErrorMessage(`Failed to remove related project. ${resp.message}`)
       } else {
         const newList = [
           ...relatedProject.slice(0, pos),

--- a/frontend/components/projects/edit/related/RelatedSoftwareForProject.tsx
+++ b/frontend/components/projects/edit/related/RelatedSoftwareForProject.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -53,14 +54,8 @@ export default function RelatedSoftwareForProject() {
     const find = relatedSoftware.filter(item => item.slug === selected.slug)
     // debugger
     if (find.length === 0) {
-      // determine status of relation between software and project 'ownership'
-      const isMaintainer = await isMaintainerOfSoftware({
-        slug: selected.slug,
-        account: session.user?.account,
-        token: session.token,
-        frontend: true
-      })
-      const status:Status = isMaintainer ? 'approved' : 'requested_by_relation'
+      // default status is set to approved without validation
+      const status:Status = 'approved'
       // add selected item to related software
       const resp = await addRelatedSoftware({
         project: project.id,

--- a/frontend/components/software/ParticipatingOrganisation.tsx
+++ b/frontend/components/software/ParticipatingOrganisation.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -18,6 +19,7 @@ export default function OrganisationItem({slug, name, website, logo_url}: Partic
           src={logo_url}
           alt={name}
           bgSize="contain"
+          bgPosition='center center'
         />
       )
     }

--- a/frontend/components/software/SoftwareCard.tsx
+++ b/frontend/components/software/SoftwareCard.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Link from 'next/link'
-import StarIcon from '@mui/icons-material/Star'
 import {getTimeAgoSince} from '../../utils/dateFn'
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 
 export type SoftwareCardType = {
   href: string
@@ -15,13 +16,17 @@ export type SoftwareCardType = {
   updated_at: string | null
   mention_cnt?: number | null
   contributor_cnt: number | null
+  is_published?: boolean
 }
 
 export default function SoftwareCard({href, brand_name, short_statement, is_featured,
-  updated_at, mention_cnt, contributor_cnt}: SoftwareCardType) {
+  updated_at, mention_cnt, contributor_cnt, is_published}: SoftwareCardType) {
 
-  const colors = is_featured ? 'bg-primary text-white' : 'bg-grey-100 text-gray-800'
+  const colors = is_featured ? 'bg-primary text-white' : 'bg-grey-100 text-grey-800'
+  let opacity = ''
   const today = new Date()
+  // if not published use opacity 0.50
+  if (typeof is_published !='undefined' && is_published===false) opacity='opacity-50'
 
   function getInitals() {
     if (brand_name) {
@@ -68,16 +73,35 @@ export default function SoftwareCard({href, brand_name, short_statement, is_feat
     return null
   }
 
+  function renderPublished() {
+    if (typeof is_published !='undefined' && is_published===false){
+      return (
+        <span
+          title="Not published"
+        >
+          <VisibilityOffIcon
+            sx={{
+              width: '2rem',
+              height: '2rem',
+              margin: '0 0.5rem 0.5rem 0'
+            }}
+          />
+        </span>
+      )
+    }
+    return null
+  }
+
   return (
     <Link href={href} passHref>
       <a className="flex flex-col h-full">
-        <article className={`flex-1 flex flex-col ${colors} hover:bg-secondary hover:text-white`}>
+        <article className={`flex-1 flex flex-col ${colors} ${opacity} hover:bg-secondary hover:text-white`}>
           <div className="flex relative">
             <h2
               title={brand_name}
               className="p-4 flex-1 mr-[4rem] overflow-hidden text-ellipsis whitespace-nowrap"
             >
-              {brand_name}
+              {renderPublished()} {brand_name}
             </h2>
             <div
               className="flex w-[4rem] h-[4rem] justify-center items-center bg-white text-gray-800 text-[1.5rem]"

--- a/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
+++ b/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -189,6 +190,7 @@ export default function EditOrganisationModal({open, onCancel, onSubmit,onDelete
                   defaultValue: formData?.name,
                   helperTextMessage: config.name.help,
                   helperTextCnt: `${formData?.name?.length || 0}/${config.name.validation.maxLength.value}`,
+                  disabled: organisation?.source==='ROR' ? true : false
                 }}
                 rules={config.name.validation}
               />
@@ -203,6 +205,7 @@ export default function EditOrganisationModal({open, onCancel, onSubmit,onDelete
                   defaultValue: formData?.website,
                   helperTextMessage: config.website.help,
                   helperTextCnt: `${formData?.website?.length || 0}/${config.website.validation.maxLength.value}`,
+                  disabled: organisation?.source==='ROR' ? true : false
                 }}
                 rules={config.website.validation}
               />

--- a/frontend/components/software/edit/organisations/FindOrganisation.tsx
+++ b/frontend/components/software/edit/organisations/FindOrganisation.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -55,7 +56,7 @@ export default function FindOrganisation({onAdd, onCreate}:
     option: AutocompleteOption<SearchOrganisation>) {
     // if more than one option we add border at the bottom
     // we assume that first option is Add "new item"
-    if (options.length > 1 && onCreate) {
+    if (options.length > 1) {
       if (props?.className) {
         props.className+=' mb-2 border-b'
       } else {
@@ -74,7 +75,7 @@ export default function FindOrganisation({onAdd, onCreate}:
     option: AutocompleteOption<SearchOrganisation>,
     state: object) {
     // when value is not not found option returns input prop
-    if (option?.input && onCreate) {
+    if (option?.input) {
       // if input is over minLength
       if (option?.input.length > config.findOrganisation.validation.minLength) {
         // we offer an option to create this entry

--- a/frontend/components/software/edit/organisations/OrganisationsItem.tsx
+++ b/frontend/components/software/edit/organisations/OrganisationsItem.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -10,10 +11,11 @@ import Avatar from '@mui/material/Avatar'
 import IconButton from '@mui/material/IconButton'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
-import LockIcon from '@mui/icons-material/Lock'
+import BlockIcon from '@mui/icons-material/Block'
 
 import {EditOrganisation} from '../../../../types/Organisation'
 import {getUrlFromLogoId} from '../../../../utils/editOrganisation'
+import IconOverlay from '~/components/layout/IconOverlay'
 
 type OrganisationsListItemProps = {
   organisation: EditOrganisation
@@ -25,6 +27,22 @@ type OrganisationsListItemProps = {
 export default function OrganisationsItem({organisation, pos, onEdit, onDelete}: OrganisationsListItemProps) {
 
   function getSecondaryActions() {
+    if (organisation.status !== 'approved') {
+      return (
+        <div
+          title={`Affiliation rejected by ${organisation.name}`}
+        >
+          <BlockIcon
+            sx={{
+              width: '4rem',
+              height: '4rem',
+              color: 'error.main',
+              opacity:0.5
+            }}
+          />
+        </div>
+      )
+    }
     if (organisation.canEdit) {
       return (
         <>
@@ -68,18 +86,18 @@ export default function OrganisationsItem({organisation, pos, onEdit, onDelete}:
   function getStatusIcon() {
     if (organisation.status !== 'approved') {
       return (
-        <div
-          title="Waiting on approval"
-          className="absolute flex items-center w-[2rem] h-[6rem] bg-primary"
+        <IconOverlay
+          title="Affiliation denied by organisation"
+          // className="absolute flex items-center w-[2rem] h-[6rem] bg-error"
         >
-          <LockIcon
+          <BlockIcon
             sx={{
-              width: '2rem',
-              height: '2rem',
-              color: 'white'
+              width: '100%',
+              height: '100%',
+              color: 'error.main'
             }}
           />
-        </div>
+        </IconOverlay>
       )
     }
     return null
@@ -89,7 +107,8 @@ export default function OrganisationsItem({organisation, pos, onEdit, onDelete}:
      <ListItem
         key={JSON.stringify(organisation)}
         secondaryAction={getSecondaryActions()}
-        sx={{
+      sx={{
+          // position:'relative',
           // this makes space for buttons
           paddingRight:'7.5rem',
           '&:hover': {
@@ -115,7 +134,7 @@ export default function OrganisationsItem({organisation, pos, onEdit, onDelete}:
           {organisation.name.slice(0,3)}
         </Avatar>
       </ListItemAvatar>
-      {getStatusIcon()}
+      {/* {getStatusIcon()} */}
       <ListItemText
         primary={organisation.name}
         secondary={

--- a/frontend/components/software/edit/organisations/index.tsx
+++ b/frontend/components/software/edit/organisations/index.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -105,7 +106,8 @@ export default function SoftwareOganisations({session}:{session:Session}) {
     const newOrganisation: EditOrganisation = newOrganisationProps({
       name,
       position: organisations.length + 1,
-      primary_maintainer: session?.user?.account ?? null,
+      // new organisation without primary maintainer
+      primary_maintainer: null,
     })
     // show modal
     setModal({

--- a/frontend/components/software/edit/related/RelatedProjectsForSoftware.tsx
+++ b/frontend/components/software/edit/related/RelatedProjectsForSoftware.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -57,14 +58,8 @@ export default function RelatedProjectsForSoftware() {
     const find = relatedProject.filter(item => item.slug === selected.slug)
     // debugger
     if (find.length === 0) {
-      // determine status of relation between software and project 'ownership'
-      const isMaintainer = await isMaintainerOfProject({
-        slug: selected.slug,
-        account: session.user?.account,
-        token: session.token,
-        frontend: true
-      })
-      const status:Status = isMaintainer ? 'approved' : 'requested_by_origin'
+      // default status of relation between software and project is approved
+      const status:Status = 'approved'
       // append(selected)
       const resp = await addRelatedSoftware({
         software: software.id ?? '',

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,8 +1,3 @@
-// SPDX-FileCopyrightText: 2021 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2021 dv4all
-//
-// SPDX-License-Identifier: Apache-2.0
-
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 

--- a/frontend/next-env.d.ts.license
+++ b/frontend/next-env.d.ts.license
@@ -1,0 +1,7 @@
+SPDX-FileCopyrightText: 2022 Dusan Mijatovic
+SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
+SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+SPDX-FileCopyrightText: 2022 dv4all
+
+SPDX-License-Identifier: Apache-2.0
+SPDX-License-Identifier: CC-BY-4.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/package.json.license
+++ b/frontend/package.json.license
@@ -1,6 +1,8 @@
 SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2021 - 2022 dv4all
+SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 
+SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: CC-BY-4.0

--- a/frontend/pages/organisations/[...slug].tsx
+++ b/frontend/pages/organisations/[...slug].tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -21,7 +22,7 @@ import {OrganisationForOverview} from '../../types/Organisation'
 import {SearchProvider} from '../../components/search/SearchContext'
 import {PaginationProvider} from '../../components/pagination/PaginationContext'
 
-type OrganisationPageProps = {
+export type OrganisationPageProps = {
   organisation: OrganisationForOverview,
   slug: string[],
   session: Session,

--- a/frontend/types/Organisation.ts
+++ b/frontend/types/Organisation.ts
@@ -1,10 +1,11 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 // based on ENUMS defined in 012-inter-relation-tables.sql
-export type Status = 'requested_by_origin' | 'requested_by_relation' | 'approved'
+export type Status = 'rejected_by_origin' | 'rejected_by_relation' | 'approved'
 export type OrganisationRole = 'participating' | 'funding' | 'hosting'
 export type OrganisationSource = 'RSD' | 'ROR' | 'MANUAL'
 
@@ -100,6 +101,7 @@ export type SoftwareOfOrganisation = {
   short_statement: string
   is_published: boolean
   is_featured: boolean
+  status: Status
   contributor_cnt: number | null
   mention_cnt: number | null
   updated_at: string

--- a/frontend/utils/editProject.ts
+++ b/frontend/utils/editProject.ts
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -326,7 +327,8 @@ export async function createFundingOrganisationAndAddToProject({project,organisa
       id: null,
       parent: null,
       slug: getSlugFromString(organisation.name),
-      primary_maintainer: organisation.primary_maintainer ?? session.user?.account ?? null,
+      // funding organisation without primary maintainer
+      primary_maintainer: null,
       name: organisation.name,
       ror_id: organisation.ror_id,
       is_tenant: false,
@@ -444,14 +446,8 @@ export async function createOrganisationAndAddToProject({project, item, session,
 export async function addOrganisationToProject({project, organisation, role, session}:
   { project: string, organisation: string, role: OrganisationRole, session:Session }) {
   try {
-    // validate if user is maintainer of organisation
-    const isMaintainer = await isMaintainerOfOrganisation({
-      organisation,
-      account: session.user?.account,
-      token: session.token
-    })
-    // determine status
-    const status = isMaintainer ? 'approved' : 'requested_by_origin'
+    // by default request status is approved
+    const status = 'approved'
     // POST
     const url = '/api/v1/project_for_organisation'
     const resp = await fetch(url, {

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
@@ -167,7 +168,7 @@ export async function getSoftwareForOrganisation({organisation, searchFor, page,
   SoftwareForOrganisationProps) {
   try {
     // baseUrl
-    let url = `/api/v1/rpc/software_by_organisation?organisation=eq.${organisation}&order=is_featured.desc,mention_cnt.desc.nullslast,brand_name`
+    let url = `/api/v1/rpc/software_by_organisation?organisation=eq.${organisation}&order=is_featured.desc,is_published.desc,mention_cnt.desc.nullslast,brand_name.asc`
     // search
     if (searchFor) {
       url+=`&or=(brand_name.ilike.*${searchFor}*, short_statement.ilike.*${searchFor}*))`

--- a/frontend/utils/getROR.ts
+++ b/frontend/utils/getROR.ts
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -40,13 +41,15 @@ function buildAutocompleteOptions(rorItems: RORItem[]): AutocompleteOption<Searc
   if (rorItems.length === 0) return []
 
   const options = rorItems.map(item => {
+    const slug = getSlugFromString(item.name)
     return {
-      key: item.id,
+      // we use slug as primary key and ROR id as alternative
+      key: slug ?? item.id,
       label: item.name,
       data: {
         id: null,
         parent: null,
-        slug: getSlugFromString(item.name),
+        slug,
         name: item.name,
         ror_id: item.id,
         is_tenant: false,


### PR DESCRIPTION
# Adding organisations, related software and project

Closes #316
Closes #324 

Changes proposed in this pull request:
*  User is able to add organisation to software without becoming (primary) maintainer of it (these organisation will be maintained in some other way). The organisations are by default shown on the software page
*  On edit software page, user is able to add related software and related projects without any constraints. These items are shown on the software page
* On edit project page, user is able to add organisations (incl. funding org) without becoming maintainer, also user is able to add related software and projects which by default are set to approved relations 
* Maintainer of an organisation can deny organisation affiliation with specific software from the organisation page
* Maintainer of an organisation can pin/unpin software on the organisation page
* Fix #324, mention list header has background color, the scrolling of long mention list looks better now.

How to test:
## Adding organisations, related software and projects
* `docker-compose down --volumes`: to remove old
* `docker-compose build` to build all services
* `docker-compose up`: to strart rsd
* `cd data-migration && docker-compose build && docker-compose up` to run data migration
*  login to RSD using professor1 for example
* create software:
   *  In organisation section:
        * add organisation from RSD (eScience Center for example)
        * add organisation from ROR, you can only add logo in the modal
        * add completely new organisation, you can specify name, website and upload logo
        * **None of these organisation can be edited after initial adding. You can only delete these from software**
   *  In related items section:
        * you can add related software and it should be shown on software the page
        * you can add any related project and it should be shown on software page
* create new project:
   * in the info section, you are able to add the funding organisation (nwo for example) without becoming maintainer of it
   * in organisation section, same approach is used as on software page, test all 3 points
   * in related items section, same approach is used as on software page, text both section

## Organisation maintainer features
* login as professor1 for example
* make yourself maintainer of all organisations in RSD. For this you will need to run SQL queries in DB
```sql
-- LOGIN FIRST THEN NOTE/COPY ID and use it in the second step
select id from account;

-- BECOME MAINTAINER OF ALL ORGANISATIONS, REPLACE uuid in the script below with id shown in the previous query
INSERT INTO 
   maintainer_for_organisation  
   (SELECT column1 AS maintainer, id AS project FROM (VALUES (uuid('730038c4-ecb7-47a4-852a-2a0135be5045'))) AS m CROSS JOIN organisation)
;

-- REMOVE MAINTAINERS, if you made mistake you can remove maintainer id
DELETE FROM maintainer_for_organisation;
```
* navigate to organisation, VU for example (second in the list), you should have additional options as maintainer (see picture)
* pin software on the organisation page: other uses should see these cards in blue and listed first
* you can unpin pinned software
* deny affiliation, the software will be clearly marked as denied, this software will not be visible on the organisation page and on the software page the organisation will not be shown. On edit software page, organisation section the organisation will be displayed as denied affiliation (the software admin is not able to remove this organisation)

![image](https://user-images.githubusercontent.com/9204081/173350599-28aaefa1-c666-4576-aaa2-a629f37024dd.png)

![image](https://user-images.githubusercontent.com/9204081/173359341-deb517e9-ec50-40b6-b284-ac1812cd7c92.png)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
