### PR TITLE
329 authenticator role

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,9 @@
 # ---- PUBLIC ENV VARIABLES -------------
 
 # postgresql
-# consumed by services: database
+# consumed by services: database, backend
 POSTGRES_DB=rsd-db
+# consumed by services: database
 POSTGRES_USER=rsd
 
 # backend (postgREST)
@@ -96,6 +97,10 @@ MAX_REQUESTS_DOI=6
 # consumed by services: database
 # generate random/strong password
 POSTGRES_PASSWORD=
+
+# consumed by services: database, backend
+# generate random/strong password
+POSTGRES_AUTHENTICATOR_PASSWORD=
 
 # SURFCONEXT
 # consumed by services: authentication

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,6 @@
 <!--
 SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2022 Jason Maassen (Netherlands eScience Center) <j.maassen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 Netherlands eScience Center
@@ -161,7 +162,7 @@ Now, copy-paste this template into `pre-commit` and configure it as required:
 #
 # Configuration
 # -------------
-# Any of those variables is optional. The email is only used if an author is defined.
+# Any of those variables is optional. The email and organisation is only used if an author is defined.
 # If none of these variables is defined, only the license will be added.
 AUTHOR=""
 EMAIL=""
@@ -182,12 +183,15 @@ if [[ ${merge_check} ]]; then
     exit 0
 fi
 
-check_program_exists reusee
+check_program_exists reuse
 check_program_exists date
 check_program_exists dirname
 
 YEAR=$(date +"%Y")
 AUTHOR_STRING=$AUTHOR
+if [[ "$ORGANISATION" != "" ]]; then
+    AUTHOR_STRING="${AUTHOR_STRING} (${ORGANISATION})"
+fi
 if [[ "$EMAIL" != "" ]]; then
     AUTHOR_STRING="${AUTHOR_STRING} <${EMAIL}>"
 fi

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,7 +162,7 @@ Now, copy-paste this template into `pre-commit` and configure it as required:
 #
 # Configuration
 # -------------
-# Any of those variables is optional. The email and organisation is only used if an author is defined.
+# Any of those variables is optional. The email and organisation_short is only used if an author is defined.
 # If none of these variables is defined, only the license will be added.
 AUTHOR=""
 EMAIL=""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -167,6 +167,10 @@ Now, copy-paste this template into `pre-commit` and configure it as required:
 AUTHOR=""
 EMAIL=""
 ORGANISATION=""
+# If your organisation's name is very long, put an abbreviation here, otherwise fill in the same value as for ORGANISATION
+# e.g. "Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences" could become "GFZ".
+# This is the value that will be displayed after your name, whereas ORGANISATION will be displayed on a separate line
+ORGANISATION_SHORT=""
 # End of configuration
 
 function check_program_exists () {
@@ -189,8 +193,8 @@ check_program_exists dirname
 
 YEAR=$(date +"%Y")
 AUTHOR_STRING=$AUTHOR
-if [[ "$ORGANISATION" != "" ]]; then
-    AUTHOR_STRING="${AUTHOR_STRING} (${ORGANISATION})"
+if [[ "ORGANISATION_SHORT" != "" ]]; then
+    AUTHOR_STRING="${AUTHOR_STRING} (${ORGANISATION_SHORT})"
 fi
 if [[ "$EMAIL" != "" ]]; then
     AUTHOR_STRING="${AUTHOR_STRING} <${EMAIL}>"

--- a/backend-postgrest/tests/docker-compose.yml
+++ b/backend-postgrest/tests/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   database:
     container_name: database-test
     build: ../../database
-    image: rsd/database-test:0.0.5
+    image: rsd/database-test:0.0.6
     ports:
       # enable connection from outside
       - "5432:5432"

--- a/backend-postgrest/tests/docker-compose.yml
+++ b/backend-postgrest/tests/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - POSTGRES_DB=rsd-db
       - POSTGRES_USER=rsd
       - POSTGRES_PASSWORD=securepassword
+      - POSTGRES_AUTHENTICATOR_PASSWORD=simplepassword
     volumes:
       # persist data in named docker volume
       # to remove use: docker-compose down --volumes

--- a/database/000-fill-authenticator-password.sh
+++ b/database/000-fill-authenticator-password.sh
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+#
+# SPDX-License-Identifier: Apache-2.0
+
+echo $POSTGRES_AUTHENTICATOR_PASSWORD
+sed --in-place "s/POSTGRES_AUTHENTICATOR_PASSWORD/$(echo $POSTGRES_AUTHENTICATOR_PASSWORD)/1" /docker-entrypoint-initdb.d/001-setup-basic-roles.sql

--- a/database/001-setup-basic-roles.sql
+++ b/database/001-setup-basic-roles.sql
@@ -1,9 +1,9 @@
--- SPDX-FileCopyrightText: 2021 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2021 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-CREATE ROLE authenticator NOINHERIT LOGIN PASSWORD 'simplepassword';
+CREATE ROLE authenticator NOINHERIT LOGIN PASSWORD 'POSTGRES_AUTHENTICATOR_PASSWORD';
 
 CREATE ROLE web_anon NOLOGIN;
 

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -4,4 +4,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 FROM postgres:14.2
+RUN chmod a+rwx /docker-entrypoint-initdb.d
+COPY --chown=postgres:postgres *.sh /docker-entrypoint-initdb.d/
 COPY --chown=postgres:postgres *.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       - POSTGRES_DB
       - POSTGRES_USER
       - POSTGRES_PASSWORD
+      - POSTGRES_AUTHENTICATOR_PASSWORD
     volumes:
       # persist data in named docker volume
       # to remove use: docker-compose down --volumes
@@ -40,7 +41,7 @@ services:
       - 3500
     environment:
       # it needs to be here to use values from .env file
-      - PGRST_DB_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@database:5432/rsd-db
+      - PGRST_DB_URI=postgres://authenticator:${POSTGRES_AUTHENTICATOR_PASSWORD}@database:5432/${POSTGRES_DB}
       - PGRST_DB_ANON_ROLE
       - PGRST_DB_SCHEMA
       - PGRST_SERVER_PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.34
+    image: rsd/database:0.0.35
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"


### PR DESCRIPTION
# Use authenticator role

Changes proposed in this pull request:

* The PostgREST backend uses the authenticator role instead of the superuser role to connect to the database
* The authenticator password is set in an env variable now instead of being hardcoded 
* Fix `reusee` typo in pre-commit hook
* When the organisation is set in the pre-commit hook, use it in the copyright line of the author

How to test:
* Copy the new `.env.example` to `.env` (or just the lines with `POSTGRES_AUTHENTICATOR_PASSWORD`) and set a value for `POSTGRES_AUTHENTICATOR_PASSWORD`
* Build and test that eveything still works: 
	* `docker-compose down --volumes && docker-compose build database backend && docker-compose up database backend`
	* The backend should successfully connect to the database


Closes #329

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests