### PR TITLE
288 & 337: Nothing to show/no content (animated) message and warning on large file upload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -87,7 +87,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.9.7
+    image: rsd/frontend:0.9.8
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/form/ControlledTextField.tsx
+++ b/frontend/components/form/ControlledTextField.tsx
@@ -66,8 +66,9 @@ export default function ControlledTextField({options, control, rules}: {
             type={options?.type ?? 'text'}
             fullWidth={options?.fullWidth ?? true }
             variant={options?.variant ?? 'standard'}
-            defaultValue={options?.defaultValue}
-            value={value}
+            // controlled mui input requires "" instead of null
+            // but the value in controller of react-hook-form is null (can be null)
+            value={value ?? options?.defaultValue ?? ''}
             FormHelperTextProps={{
               sx:{
                 display: 'flex',

--- a/frontend/components/layout/FlexibleGridSection.tsx
+++ b/frontend/components/layout/FlexibleGridSection.tsx
@@ -20,7 +20,8 @@ export const FlexibleGridSection = styled('section', {
 })
   <FlexGridProps>(({theme, minWidth, maxWidth, minHeight, maxHeight, height}) => {
   // basic definitions
-  const props:any = {
+  const props: any = {
+    flex: 1,
     display: 'grid',
     width: '100%',
     // gridGap: '1rem',

--- a/frontend/components/layout/NoContent.tsx
+++ b/frontend/components/layout/NoContent.tsx
@@ -10,12 +10,20 @@ import {Box, Theme} from '@mui/material'
 import Slide from '@mui/material/Slide'
 
 const NoContentText = styled('h2')(({theme}:{theme?:Theme}) => ({
-  fontSize: '2.5rem',
   fontWeight: 500,
   letterSpacing: '0.25rem',
   textTransform: 'uppercase',
-  padding: '0.5rem 0rem 0rem 1rem',
-  color: theme?.palette.grey[500]
+  padding: '1rem 0rem',
+  // color: theme?.palette.grey[500]
+}))
+
+const NoContentBody = styled('div')(({theme}:{theme?:Theme}) => ({
+  margin:'2rem 0rem 0rem 0rem',
+  display: 'flex',
+  flexDirection: 'column',
+  justifyContent: 'center',
+  alignItems: 'center',
+  opacity: 0.25
 }))
 
 export default function NoContent({message='nothing to show'}:{message?:string}) {
@@ -38,18 +46,19 @@ export default function NoContent({message='nothing to show'}:{message?:string})
         flex:1,
         overflow: 'hidden'
       }}
+      component="section"
     >
       <Slide direction="up" in={show} container={containerRef.current}>
-        <div className="mt-12 flex justify-center">
+        <NoContentBody>
           <DoDisturbIcon
             sx={{
-              width: '3rem',
-              height: '3rem',
-              color: 'grey.500'
+              width: '5rem',
+              height: '5rem',
+              // color: 'grey.500'
             }}
           />
           <NoContentText>{message}</NoContentText>
-        </div>
+        </NoContentBody>
       </Slide>
     </Box>
   )

--- a/frontend/components/layout/NoContent.tsx
+++ b/frontend/components/layout/NoContent.tsx
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useRef, useState} from 'react'
+import styled from '@emotion/styled'
+import DoDisturbIcon from '@mui/icons-material/DoDisturb'
+import {Box, Theme} from '@mui/material'
+import Slide from '@mui/material/Slide'
+
+const NoContentText = styled('h2')(({theme}:{theme?:Theme}) => ({
+  fontSize: '2.5rem',
+  fontWeight: 500,
+  letterSpacing: '0.25rem',
+  textTransform: 'uppercase',
+  padding: '0.5rem 0rem 0rem 1rem',
+  color: theme?.palette.grey[500]
+}))
+
+export default function NoContent({message='nothing to show'}:{message?:string}) {
+  const [show, setShow]=useState(false)
+  const containerRef = useRef()
+
+  useEffect(() => {
+    let abort=false
+    setTimeout(() => {
+      if(abort) return
+      setShow(true)
+    }, 200)
+    return ()=>{abort=true}
+  }, [])
+
+  return (
+    <Box
+      ref={containerRef}
+      sx={{
+        flex:1,
+        overflow: 'hidden'
+      }}
+    >
+      <Slide direction="up" in={show} container={containerRef.current}>
+        <div className="mt-12 flex justify-center">
+          <DoDisturbIcon
+            sx={{
+              width: '3rem',
+              height: '3rem',
+              color: 'grey.500'
+            }}
+          />
+          <NoContentText>{message}</NoContentText>
+        </div>
+      </Slide>
+    </Box>
+  )
+}

--- a/frontend/components/organisation/OrganisationGrid.tsx
+++ b/frontend/components/organisation/OrganisationGrid.tsx
@@ -4,20 +4,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {OrganisationForOverview} from '../../types/Organisation'
-import ContentInTheMiddle from '../layout/ContentInTheMiddle'
 import OrganisationCard from './OrganisationCard'
 import FlexibleGridSection from '../layout/FlexibleGridSection'
+import NoContent from '../layout/NoContent'
 
 // render organisation cards
 export default function OrganisationsGrid({organisations}:
   {organisations: OrganisationForOverview[]}) {
 
   if (organisations.length === 0) {
-    return (
-      <ContentInTheMiddle>
-        <h2>No content</h2>
-      </ContentInTheMiddle>
-    )
+    return <NoContent />
   }
 
   return (

--- a/frontend/components/organisation/project/index.tsx
+++ b/frontend/components/organisation/project/index.tsx
@@ -3,17 +3,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useEffect} from 'react'
+import {useEffect, useState} from 'react'
 
 import {OrganisationForOverview} from '../../../types/Organisation'
 import {Session} from '../../../auth'
 import usePaginationWithSearch from '../../../utils/usePaginationWithSearch'
 import useOrganisationProjects from '../../../utils/useOrganisationProjects'
 import ProjectsGrid from '../../projects/ProjectsGrid'
-import GridScrim from '../../layout/GridScrim'
+import NoContent from '~/components/layout/NoContent'
+import GridScrim from '~/components/layout/GridScrim'
 
 export default function OrganisationProjects({organisation, session}:
   { organisation: OrganisationForOverview, session: Session }) {
+  const [init,setInit]=useState(true)
   const {searchFor,page,rows,setCount} = usePaginationWithSearch('Search for projects')
   const {loading, projects, count} = useOrganisationProjects({
     organisation: organisation.id,
@@ -24,12 +26,18 @@ export default function OrganisationProjects({organisation, session}:
   })
 
   useEffect(() => {
+    setInit(false)
+  },[])
+
+  useEffect(() => {
     if (count && loading === false) {
       setCount(count)
     }
   },[count,loading,setCount])
 
-  if (loading){
+
+  if (init) {
+    // show scrim only on initial load
     return (
       <GridScrim
         rows={rows}
@@ -40,6 +48,14 @@ export default function OrganisationProjects({organisation, session}:
       />
     )
   }
+
+  if (projects.length === 0
+    && loading === false) {
+    // show nothing to show message
+    // if no items and loading is completed
+    return <NoContent />
+  }
+
 
   return (
     <ProjectsGrid

--- a/frontend/components/organisation/settings/OrganisationLogo.tsx
+++ b/frontend/components/organisation/settings/OrganisationLogo.tsx
@@ -31,7 +31,7 @@ type LogoProps = {
 
 export default function OrganisationLogo({id,name,website,logo_id,isMaintainer,token}:
   OrganisationLogoProps) {
-  const {showErrorMessage} = useSnackbar()
+  const {showWarningMessage,showErrorMessage} = useSnackbar()
   // currently shown image
   // after new upload uses b64 prop
   const [logo, setLogo] = useState<LogoProps>({
@@ -93,7 +93,7 @@ export default function OrganisationLogo({id,name,website,logo_id,isMaintainer,t
       // check file size
       if (file.size > 2097152) {
         // file is to large > 2MB
-        showErrorMessage('The file is too large. Please select image < 2MB.')
+        showWarningMessage('The file is too large. Please select image < 2MB.')
         return
       }
       let reader = new FileReader()

--- a/frontend/components/organisation/software/index.tsx
+++ b/frontend/components/organisation/software/index.tsx
@@ -3,18 +3,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useEffect} from 'react'
+import {useEffect, useState} from 'react'
 
 import useOrganisationSoftware from '../../../utils/useOrganisationSoftware'
-import GridScrim from '../../layout/GridScrim'
 import usePaginationWithSearch from '../../../utils/usePaginationWithSearch'
 import {OrganisationPageProps} from 'pages/organisations/[...slug]'
-import ContentInTheMiddle from '~/components/layout/ContentInTheMiddle'
 import FlexibleGridSection from '~/components/layout/FlexibleGridSection'
 import SoftwareCardWithMenu from './SoftwareCardWithMenu'
 import SoftwareCard from '~/components/software/SoftwareCard'
+import NoContent from '~/components/layout/NoContent'
+import GridScrim from '../../layout/GridScrim'
 
-export default function OrganisationSoftware({organisation, session, isMaintainer}:OrganisationPageProps) {
+export default function OrganisationSoftware({organisation, session, isMaintainer}: OrganisationPageProps) {
+  const [init,setInit]=useState(true)
   const {searchFor,page,rows,setCount} = usePaginationWithSearch('Search for software')
   const {loading, software, count} = useOrganisationSoftware({
     organisation: organisation.id,
@@ -25,12 +26,17 @@ export default function OrganisationSoftware({organisation, session, isMaintaine
   })
 
   useEffect(() => {
+    setInit(false)
+  },[])
+
+  useEffect(() => {
     if (count && loading === false) {
       setCount(count)
     }
   },[count,loading,setCount])
 
-  if (loading){
+  if (init) {
+    // show scrim only on initial load
     return (
       <GridScrim
         rows={rows}
@@ -42,12 +48,11 @@ export default function OrganisationSoftware({organisation, session, isMaintaine
     )
   }
 
-  if (software.length===0){
-    return (
-      <ContentInTheMiddle>
-        <h2>No content</h2>
-      </ContentInTheMiddle>
-    )
+  if (software.length === 0
+    && loading === false) {
+    // show nothing to show message
+    // if no items and loading is completed
+    return <NoContent/>
   }
 
   return (

--- a/frontend/components/organisation/units/ResearchUnitModal.tsx
+++ b/frontend/components/organisation/units/ResearchUnitModal.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -40,7 +40,7 @@ const formId='research-unit-modal'
 export default function EditOrganisationModal({
   open, onCancel, onSubmit, onDeleteLogo, organisation, pos, title = 'Organisation'
 }: EditOrganisationModalProps) {
-  const {showErrorMessage} = useSnackbar()
+  const {showWarningMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
   const [baseUrl, setBaseUrl] = useState('')
   const [slugValue, setSlugValue] = useState(organisation?.slug ?? '')
@@ -89,7 +89,7 @@ export default function EditOrganisationModal({
       // check file size
       if (file.size > 2097152) {
         // file is to large > 2MB
-        showErrorMessage('The file is too large. Please select image < 2MB.')
+        showWarningMessage('The file is too large. Please select image < 2MB.')
         return
       }
       let reader = new FileReader()

--- a/frontend/components/projects/ProjectsGrid.tsx
+++ b/frontend/components/projects/ProjectsGrid.tsx
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import ContentInTheMiddle from '../layout/ContentInTheMiddle'
 import FlexibleGridSection, {FlexGridProps} from '../layout/FlexibleGridSection'
+import NoContent from '../layout/NoContent'
 import ProjectCard, {ProjectCardProps} from './ProjectCard'
 
 type ProjectGridProps = FlexGridProps & {
@@ -15,11 +15,7 @@ type ProjectGridProps = FlexGridProps & {
 // render software cards
 export default function ProjectsGrid({projects,className='gap-[0.125rem] py-[2rem]',...props}:ProjectGridProps){
   if (typeof projects == 'undefined' || projects.length===0){
-    return (
-      <ContentInTheMiddle>
-        <h2>No content</h2>
-      </ContentInTheMiddle>
-    )
+    return <NoContent />
   }
 
   return (

--- a/frontend/components/projects/edit/information/ProjectImage.tsx
+++ b/frontend/components/projects/edit/information/ProjectImage.tsx
@@ -16,7 +16,7 @@ import {getImageUrl} from '~/utils/getProjects'
 import logger from '~/utils/logger'
 
 export default function ProjectImage() {
-  const {showErrorMessage} = useSnackbar()
+  const {showWarningMessage} = useSnackbar()
   const {control, watch, setValue} = useFormContext<EditProject>()
 
   const formData = watch()
@@ -28,7 +28,7 @@ export default function ProjectImage() {
       // check file size
       if (file.size > 2097152) {
         // file is to large > 2MB
-        showErrorMessage('The file is too large. Please select image < 2MB.')
+        showWarningMessage('The file is too large. Please select image < 2MB.')
         return
       }
       let reader = new FileReader()

--- a/frontend/components/projects/edit/team/TeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberModal.tsx
@@ -35,7 +35,7 @@ type TeamMemberModalProps = {
 const formId='edit-team-member-modal'
 
 export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}: TeamMemberModalProps) {
-  const {showErrorMessage} = useSnackbar()
+  const {showWarningMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
   const [b64Image, setB64Image]=useState<string>()
   const {handleSubmit, watch, formState, reset, control, register, setValue} = useForm<TeamMember>({
@@ -72,7 +72,7 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
       // check file size
       if (file.size > 2097152) {
         // file is to large > 2MB
-        showErrorMessage('The file is too large. Please select image < 2MB.')
+        showWarningMessage('The file is too large. Please select image < 2MB.')
         return
       }
       let reader = new FileReader()

--- a/frontend/components/software/ContributorsList.tsx
+++ b/frontend/components/software/ContributorsList.tsx
@@ -8,7 +8,7 @@
 import {Contributor} from '../../types/Contributor'
 import ContributorAvatar from './ContributorAvatar'
 import {getDisplayName, getDisplayInitials,combineRoleAndAffiliation} from '../../utils/getDisplayName'
-import LogoOrcid from '~/assets/logos/logo-orcid.svg'
+import PersonalInfo from './PersonalInfo'
 
 export default function ContributorsList({contributors}: { contributors: Contributor[] }) {
   // do not render component if no data
@@ -31,15 +31,7 @@ export default function ContributorsList({contributors}: { contributors: Contrib
                 <div className="text-xl text-primary">
                   {displayName}
                 </div>
-                <div>
-                  {combineRoleAndAffiliation(item)}
-                </div>
-                { item.orcid &&
-                  <a href={'https://orcid.org/' + item.orcid} target="_blank" rel="noreferrer">
-                    <LogoOrcid className="inline max-w-[1.125rem] mr-1" />
-                    <span className="text-sm align-bottom">{item.orcid}</span>
-                  </a>
-                }
+                <PersonalInfo {...item} />
               </div>
             </div>
           )

--- a/frontend/components/software/PersonalInfo.tsx
+++ b/frontend/components/software/PersonalInfo.tsx
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import LogoOrcid from '~/assets/logos/logo-orcid.svg'
+
+type PersonalInfoProps = {
+  role?: string | null
+  affiliation?: string | null
+  orcid?: string | null
+}
+
+export default function PersonalInfo({role, affiliation, orcid}:PersonalInfoProps) {
+  if (role && affiliation && orcid) {
+    return (
+      <div>
+        <div>{role}</div>
+        <div>{affiliation}</div>
+        <div>
+          <a href={'https://orcid.org/' + orcid} target="_blank" rel="noreferrer"
+            style={{whiteSpace:'nowrap'}}
+          >
+            <LogoOrcid className="inline max-w-[1.125rem] mr-1" />
+            <span className="text-sm align-bottom">{orcid}</span>
+          </a>
+        </div>
+      </div>
+    )
+  }
+
+  if (role && affiliation) {
+    return (
+      <div>
+        <div>{role}</div>
+        <div>{affiliation}</div>
+      </div>
+    )
+  }
+
+  if (role) {
+    return (
+      <div>
+        {role}
+      </div>
+    )
+  }
+
+  if (affiliation) {
+    return (
+      <div>
+        {affiliation}
+      </div>
+    )
+  }
+
+  return null
+}

--- a/frontend/components/software/SoftwareGrid.tsx
+++ b/frontend/components/software/SoftwareGrid.tsx
@@ -6,6 +6,7 @@
 import ContentInTheMiddle from '../layout/ContentInTheMiddle'
 import SoftwareCard from './SoftwareCard'
 import FlexibleGridSection, {FlexGridProps} from '../layout/FlexibleGridSection'
+import NoContent from '../layout/NoContent'
 
 export type SoftwareGridType = {
   slug: string
@@ -24,11 +25,7 @@ export default function SoftwareGrid({software,grid,className='gap-[0.125rem] pt
   // console.log("renderItems...software...", software)
 
   if (software.length===0){
-    return (
-      <ContentInTheMiddle>
-        <h2>No content</h2>
-      </ContentInTheMiddle>
-    )
+    return <NoContent />
   }
 
   return (

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -35,7 +35,7 @@ type EditContributorModalProps = {
 const formId='edit-contributor-modal'
 
 export default function EditContributorModal({open, onCancel, onSubmit, contributor, pos}: EditContributorModalProps) {
-  const {showErrorMessage} = useSnackbar()
+  const {showWarningMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
   const [b64Image, setB64Image]=useState<string>()
   const {handleSubmit, watch, formState, reset, control, register, setValue} = useForm<Contributor>({
@@ -72,7 +72,7 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
       // check file size
       if (file.size > 2097152) {
         // file is to large > 2MB
-        showErrorMessage('The file is too large. Please select image < 2MB.')
+        showWarningMessage('The file is too large. Please select image < 2MB.')
         return
       }
       let reader = new FileReader()

--- a/frontend/components/software/edit/information/ValidateConceptDoi.tsx
+++ b/frontend/components/software/edit/information/ValidateConceptDoi.tsx
@@ -24,18 +24,19 @@ export default function ValidateConceptDoi({doi, onUpdate}: ValidateConceptDoiPr
   async function validateDoi() {
     setLoading(true)
     const info = await getSoftwareVersionInfoForDoi(doi)
-    if (info) {
-      if (info.versionOfCount === 0) {
+    if (info?.status === 200) {
+      const {software} = info.data
+      if (software.versionOfCount === 0) {
         showSuccessMessage(`The DOI ${doi} is a valid Concept DOI`)
-      } else if (info.versionOfCount === 1) {
-        const concept = info.versionOf.nodes[0].doi
+      } else if (software.versionOfCount === 1) {
+        const concept = software.versionOf.nodes[0].doi
         if (concept) {
           onUpdate(concept)
         }
         showWarningMessage(`This is a version DOI. The Concept DOI is ${concept}`)
       }
     } else {
-      showErrorMessage(`Failed to retrieve info for DOI: ${doi}. It looks like this is not a Concept DOI.`)
+      showErrorMessage(`Failed to retrieve info for DOI: ${doi}. ${info?.message ?? ''}`)
     }
     setLoading(false)
   }

--- a/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
+++ b/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
@@ -36,7 +36,7 @@ type EditOrganisationModalProps = {
 const formId='edit-organisation-modal'
 
 export default function EditOrganisationModal({open, onCancel, onSubmit,onDeleteLogo,organisation, pos}: EditOrganisationModalProps) {
-  const {showErrorMessage} = useSnackbar()
+  const {showWarningMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
   const {handleSubmit, watch, formState, reset, control, register, setValue} = useForm<EditOrganisation>({
     mode: 'onChange',
@@ -67,7 +67,7 @@ export default function EditOrganisationModal({open, onCancel, onSubmit,onDelete
       // check file size
       if (file.size > 2097152) {
         // file is to large > 2MB
-        showErrorMessage('The file is too large. Please select image < 2MB.')
+        showWarningMessage('The file is too large. Please select image < 2MB.')
         return
       }
       let reader = new FileReader()

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/projects/[slug]/index.tsx
+++ b/frontend/pages/projects/[slug]/index.tsx
@@ -40,6 +40,7 @@ import ProjectMentions from '~/components/projects/ProjectMentions'
 import ContributorsSection from '~/components/software/ContributorsSection'
 import RelatedProjectsSection from '~/components/projects/RelatedProjectsSection'
 import RelatedSoftwareSection from '~/components/software/RelatedSoftwareSection'
+import NoContent from '~/components/layout/NoContent'
 
 export interface ProjectPageProps extends ScriptProps{
   slug: string
@@ -70,11 +71,7 @@ export default function ProjectPage(props: ProjectPageProps) {
   }, [])
 
   if (!project?.title){
-    return (
-      <ContentInTheMiddle>
-        <h2>No content</h2>
-      </ContentInTheMiddle>
-    )
+    return <NoContent />
   }
   // console.log('ProjectItemPage...output...', output)
   return (

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -17,7 +17,6 @@ import CanoncialUrl from '~/components/seo/CanonicalUrl'
 import AppHeader from '~/components/layout/AppHeader'
 import AppFooter from '~/components/layout/AppFooter'
 import PageContainer from '~/components/layout/PageContainer'
-import ContentInTheMiddle from '~/components/layout/ContentInTheMiddle'
 import SoftwareIntroSection from '~/components/software/SoftwareIntroSection'
 import GetStartedSection from '~/components/software/GetStartedSection'
 import CitationSection from '~/components/software/CitationSection'
@@ -57,6 +56,7 @@ import {Testimonial} from '~/types/Testimonial'
 import {MentionItemProps} from '~/types/Mention'
 import {ParticipatingOrganisationProps} from '~/types/Organisation'
 import {RelatedProject} from '~/types/Project'
+import NoContent from '~/components/layout/NoContent'
 
 interface SoftwareIndexData extends ScriptProps{
   slug: string
@@ -101,11 +101,7 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
   },[contributors])
 
   if (!software?.brand_name){
-    return (
-      <ContentInTheMiddle>
-        <h2>No content</h2>
-      </ContentInTheMiddle>
-    )
+    return <NoContent />
   }
   // console.log('SoftwareIndexPage...mentions...', mentions)
   return (

--- a/frontend/utils/fetchHelpers.ts
+++ b/frontend/utils/fetchHelpers.ts
@@ -83,3 +83,23 @@ export function extractErrorMessages(responses: { status: number, message: strin
   })
   return errors
 }
+
+
+type GrapQLResponse = {
+  data?: any,
+  errors?:any
+}
+
+export async function extractRespFromGraphQL(resp: Response) {
+  const json: GrapQLResponse = await resp.json()
+  if (json?.errors && json.errors.length > 0) {
+    return {
+      status: 500,
+      message: json.errors[0]?.message ?? 'Unknown error'
+    }
+  }
+  return {
+    status: 200,
+    data: json?.data ?? undefined
+  }
+}

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -3,9 +3,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {DataCiteConceptDoiQlResp, DataciteWorkGraphQLResponse, DataciteWorksGraphQLResponse, WorkResponse} from '~/types/Datacite'
+import {DataciteWorkGraphQLResponse, DataciteWorksGraphQLResponse, WorkResponse} from '~/types/Datacite'
 import {MentionItemProps} from '~/types/Mention'
-import {createJsonHeaders, extractReturnMessage} from './fetchHelpers'
+import {createJsonHeaders, extractRespFromGraphQL, extractReturnMessage} from './fetchHelpers'
 import {apiMentionTypeToRSDTypeKey} from './editMentions'
 import logger from './logger'
 import {makeDoiRedirectUrl} from './getDOI'
@@ -210,13 +210,9 @@ export async function getSoftwareVersionInfoForDoi(doi: string) {
         query
       })
     })
-    if (resp.status === 200) {
-      const json: DataCiteConceptDoiQlResp = await resp.json()
-      if (json.data.software) return json.data.software
-      return undefined
-    }
-    logger(`getConceptDoiByDoi: ${resp.status}: ${resp?.statusText}`, 'warn')
-    return undefined
+
+    const json = await extractRespFromGraphQL(resp)
+    return json
   } catch (e: any) {
     logger(`getConceptDoiByDoi: ${e?.message}`, 'error')
     return undefined


### PR DESCRIPTION
# Improved no content / nothing to show message

Closes #288
Closes #337 

Changes proposed in this pull request:
* When there are no results/items to be returned we show "no content" message
* Developer can use this component and pass custom message, the default message is "nothing to show"
* Uploading image on project page, has in message < 2MB notification
* If user tries to upload large image the warning is shown that will disappear after 5 sec. or so 

How to test:
* `docker-compose build`: to build frontend
* `docker-compose up` to start
* navigate to software or project page. If there is content (items to show), use search to modify term until no results is shown (see example image)

## Example message

![image](https://user-images.githubusercontent.com/9204081/174082063-5be49a20-4fad-4ed6-9f16-7d25921b8cd0.png)

* create new project, try to upload image larger than 2MB, the warning will be shown

## Example file upload message

![image](https://user-images.githubusercontent.com/9204081/174078181-1b105076-b244-4873-837a-9377bab8e1cf.png)

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
