### PR TITLE
minor: auto-create .env.local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 #
@@ -40,5 +42,10 @@ down:
 dev-docs:
 	cd documentation && yarn dev
 
-dev-frontend:
+frontend/.env.local: .env
+	@echo "Creating frontend/.env.local"
+	cp .env frontend/.env.local
+	sed -i 's/POSTGREST_URL=http:\/\/backend:3500/POSTGREST_URL=http:\/\/localhost\/api\/v1/g' frontend/.env.local
+
+dev-frontend: frontend/.env.local
 	cd frontend && yarn dev

--- a/Makefile
+++ b/Makefile
@@ -46,6 +46,7 @@ frontend/.env.local: .env
 	@echo "Creating frontend/.env.local"
 	cp .env frontend/.env.local
 	sed -i 's/POSTGREST_URL=http:\/\/backend:3500/POSTGREST_URL=http:\/\/localhost\/api\/v1/g' frontend/.env.local
+	sed -i 's/RSD_AUTH_URL=http:\/\/auth:7000/RSD_AUTH_URL=http:\/\/localhost\/auth/g' frontend/.env.local
 
 dev-frontend: frontend/.env.local
 	cd frontend && yarn dev

--- a/README.md
+++ b/README.md
@@ -25,33 +25,42 @@ SPDX-License-Identifier: CC-BY-4.0
 
 This repo contains the new RSD-as-a-service implementation
 
+## Running development version locally in 3 steps.
 
-## Running a local version in 2 steps. 
+## Running a local version in 2 steps.
+
 1. Before installing the dependencies be sure you have ruuning Docker locally. You need to set the environment variables in place:
 Copy the file `.env.example` to `.env` file at the root of the project
-and fill the secrets in `./frontend/.env.local`. Check if the secrets are correct.
+and fill the secrets and passwords. Check if the secrets are correct.
+The `Makefile` will take care about creating an appropraite `frontend/.env.local`
+from the `.env` file.
 2. Running once `make local` will install all dependencies, build the docker images and run the **data migration** script.
 
 
-**Requirements:** 
+**Requirements:**
+
 - Docker installed locally
+
 #### List of commands
+
 ```shell
 make up     # Run the complete solution locally.
 make down      # Stop all services with `docker-compose down`
 ```
 
 ### Developing the Frontend
+
 **Requirements:**
+
 - Docker
-- NodeJs ^16 or major 
+- NodeJs ^16 or major
 
 ```shell
 # Developing the frontend
 # One time
-make install   # Build and install all dependencies and will run the **data migration** script. 
+make install   # Build and install all dependencies and will run the **data migration** script.
 
-# Run the Development version 
+# Run the Development version
 make dev       # Run the frontend and the documentation locally on localhost:3000 and localhost:3030 respectively
 make down      # Stop all services with `docker-compose down`
 ```


### PR DESCRIPTION
# Create .env.local with Makefile

Here is a minor suggestion to improve the `Makefile` by @ctwhome:

* Use the `Makefile` to auto-generate the file `frontend/.env.local` from `.env`
* Uses `sed` to replace `POSTGREST_URL`

How to test:

* delete (or make a backup) of your `frontend/.env.local`
* `make dev-frontend`
* Should now tell you that it creates `frontend/.env.local` and then starts `yarn dev`
* shutdown the dev server
* `make dev-frontend`
* starts the server without recreating `.env.local`
* shutdown the dev server again
* edit the `.env`, e.g. `echo "# just a comment" >> .env`
* `make dev-frontend` should detect the change and regenerate `.env.local`
* shutdown the dev server one more time
* edit the `.env.local`, e.g. `echo "# another comment" >> frontend/.env.local`
* `make dev-frontend` should start the dev server without changing `frontend/.env.local`

When starting from scratch `make dev-frontend` will fail and tell that it requires `.env`

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
