### PR TITLE
327 & 328 organisation maintainer rls

### DIFF
--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -131,8 +131,12 @@ CREATE POLICY admin_all_rights ON invite_maintainer_for_organisation TO rsd_admi
 -- software
 ALTER TABLE software ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY anyone_can_read ON software FOR SELECT TO web_anon, rsd_user
+CREATE POLICY anyone_can_read ON software FOR SELECT TO web_anon
 	USING (is_published);
+
+-- RSD user can read all software incl. not published ones
+CREATE POLICY rsd_user_can_read ON software FOR SELECT TO rsd_user
+	USING (TRUE);
 
 CREATE POLICY maintainer_all_rights ON software TO rsd_user
 	USING (id IN (SELECT * FROM software_of_current_maintainer()))

--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -247,8 +247,11 @@ CREATE POLICY admin_all_rights ON keyword_for_software TO rsd_admin
 -- projects
 ALTER TABLE project ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY anyone_can_read ON project FOR SELECT TO web_anon, rsd_user
+CREATE POLICY anyone_read_published ON project FOR SELECT TO web_anon
 	USING (is_published);
+
+CREATE POLICY rsd_user_read_all ON project FOR SELECT TO rsd_user
+	USING (TRUE);
 
 CREATE POLICY maintainer_all_rights ON project TO rsd_user
 	USING (id IN (SELECT * FROM projects_of_current_maintainer()))

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -241,7 +241,10 @@ BEGIN
 		FROM
 			software_for_organisation
 		WHERE
-			status = 'approved'
+			software_for_organisation.status = 'approved' AND
+			software IN (
+				SELECT id FROM software WHERE is_published=TRUE
+			)
 		GROUP BY software_for_organisation.organisation;
 	ELSE
 		RETURN QUERY
@@ -272,7 +275,10 @@ BEGIN
 		FROM
 			project_for_organisation
 		WHERE
-			status = 'approved'
+			status = 'approved' AND
+			project IN (
+				SELECT id FROM project WHERE is_published=TRUE
+			)
 		GROUP BY project_for_organisation.organisation;
 	ELSE
 		RETURN QUERY
@@ -499,6 +505,7 @@ CREATE FUNCTION related_projects_for_project() RETURNS TABLE (
 	subtitle VARCHAR,
 	date_end DATE,
 	updated_at TIMESTAMPTZ,
+	is_published BOOLEAN,
 	status relation_status,
 	image_id UUID
 ) LANGUAGE plpgsql STABLE AS
@@ -513,6 +520,7 @@ BEGIN
 		project.subtitle,
 		project.date_end,
 		project.updated_at,
+		project.is_published,
 		project_for_project.status,
 		image_for_project.project AS image_id
 	FROM
@@ -535,6 +543,7 @@ CREATE FUNCTION related_projects_for_software() RETURNS TABLE (
 	subtitle VARCHAR,
 	date_end DATE,
 	updated_at TIMESTAMPTZ,
+	is_published BOOLEAN,
 	status relation_status,
 	image_id UUID
 ) LANGUAGE plpgsql STABLE AS
@@ -549,6 +558,7 @@ BEGIN
 		project.subtitle,
 		project.date_end,
 		project.updated_at,
+		project.is_published,
 		software_for_project.status,
 		image_for_project.project AS image_id
 	FROM

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.36
+    image: rsd/database:0.0.37
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -88,7 +88,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.9.9
+    image: rsd/frontend:0.10.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/auth/permissions/addMaintainerToOrganisation.ts
+++ b/frontend/auth/permissions/addMaintainerToOrganisation.ts
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {createJsonHeaders, extractReturnMessage} from '~/utils/fetchHelpers'
+import logger from '~/utils/logger'
+
+export async function addMaintainerToOrganisation({organisation, account, token, frontend = false}:
+  { organisation: string, account: string, token: string, frontend: boolean }) {
+  try {
+    const query ='maintainer_for_organisation'
+    let url = `${process.env.POSTGREST_URL}/${query}`
+    if (frontend === true) {
+      url = `/api/v1/${query}`
+    }
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token),
+        'Prefer': 'resolution=merge-duplicates'
+      },
+      body: JSON.stringify({
+        maintainer: account,
+        organisation,
+      })
+    })
+    // return info
+    const info = await extractReturnMessage(resp)
+    return info
+  } catch (e: any) {
+    logger(`addMaintainerToOrganisation failed: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}

--- a/frontend/auth/permissions/isMaintainerOfOrganisation.ts
+++ b/frontend/auth/permissions/isMaintainerOfOrganisation.ts
@@ -37,8 +37,12 @@ export async function isMaintainerOfOrganisation({organisation, account, token, 
   }
 }
 
-export async function getMaintainerOrganisations({token, frontend = true}: { token: string, frontend?: boolean }) {
+export async function getMaintainerOrganisations({token, frontend = true}:
+  {token: string, frontend?: boolean}) {
   try {
+    // without token api request is not needed
+    if (!token) return []
+    // build url
     const query = 'rpc/organisations_of_current_maintainer'
     let url = `/api/v1/${query}`
     if (frontend===false) {

--- a/frontend/components/layout/IconOverlay.tsx
+++ b/frontend/components/layout/IconOverlay.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -14,7 +15,8 @@ const IconOverlay = styled('div')(({theme})=>({
   display: 'flex',
   justifyContent: 'center',
   // alignItems: 'center',
-  opacity: 0.5
+  opacity: 0.5,
+  pointerEvents: 'none'
 }))
 
 export default IconOverlay

--- a/frontend/components/organisation/project/ProjectCardWithMenu.tsx
+++ b/frontend/components/organisation/project/ProjectCardWithMenu.tsx
@@ -10,29 +10,49 @@ import ProjectCard from '~/components/projects/ProjectCard'
 import IconBtnMenuOnAction from '~/components/menu/IconBtnMenuOnAction'
 import IconOverlay from '~/components/layout/IconOverlay'
 import {ProjectCardWithMenuProps, useProjectCardActions} from './useProjectCardActions'
+import {useState} from 'react'
 
+type StyledNavProps = {
+  is_featured: boolean
+  in_focus: boolean
+}
 
-const StyledNav = styled('nav')(({theme})=>({
-  position: 'absolute',
-  right: 0,
-  top: 0,
-  display: 'flex',
-  alignItems: 'center',
-  justifyContent: 'center',
-  width: '3rem',
-  height: '3rem',
-  backgroundColor: theme.palette.primary.main,
-  color: theme.palette.primary.contrastText,
-  zIndex: 9,
-  opacity: 0.5,
-  '&:hover': {
-    opacity: 1
+const StyledNav = styled('nav', {
+  shouldForwardProp(propName) {
+    // all custom props that should not be passed to html elements
+    // should be added here using &&
+    return propName!=='is_featured' && propName!=='in_focus'
+  },
+})<StyledNavProps>(({theme, is_featured, in_focus}) => {
+  let color
+  if (is_featured) {
+    color = theme.palette.primary.contrastText
+  } else if (in_focus) {
+    color= theme.palette.primary.contrastText
+  } else {
+    color = theme.palette.secondary.main
   }
-}))
+  return {
+    position: 'absolute',
+    right: 0,
+    top: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: '3rem',
+    height: '3rem',
+    color,
+    zIndex: 9,
+    '&:hover': {
+      color: in_focus ? theme.palette.secondary.main : theme.palette.primary.contrastText
+    }
+  }
+})
 
 
 export default function ProjectCardWithMenu({organisation,item,token}: ProjectCardWithMenuProps) {
-  const {project,menuOptions,onAction} = useProjectCardActions({organisation,item,token})
+  const {project, menuOptions, onAction} = useProjectCardActions({organisation, item, token})
+  const [hover,setHover]=useState(false)
 
   function renderStatus() {
     if (project.status === 'approved') return null
@@ -54,12 +74,19 @@ export default function ProjectCardWithMenu({organisation,item,token}: ProjectCa
   }
 
   return (
-    <div className="relative h-full">
+    <div className="relative h-full"
+      onMouseEnter={()=>setHover(true)}
+      onMouseLeave={()=>setHover(false)}
+    >
       <ProjectCard
         key={project.id}
+        menuSpace={true}
         {...project}
       />
-      <StyledNav>
+      <StyledNav
+        is_featured={project.is_featured ?? false}
+        in_focus={hover}
+      >
         <IconBtnMenuOnAction
           options={menuOptions}
           onAction={onAction}

--- a/frontend/components/organisation/project/ProjectCardWithMenu.tsx
+++ b/frontend/components/organisation/project/ProjectCardWithMenu.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2021 - 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import styled from '@mui/system/styled'
+import BlockIcon from '@mui/icons-material/Block'
+
+import ProjectCard from '~/components/projects/ProjectCard'
+import IconBtnMenuOnAction from '~/components/menu/IconBtnMenuOnAction'
+import IconOverlay from '~/components/layout/IconOverlay'
+import {ProjectCardWithMenuProps, useProjectCardActions} from './useProjectCardActions'
+
+
+const StyledNav = styled('nav')(({theme})=>({
+  position: 'absolute',
+  right: 0,
+  top: 0,
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  width: '3rem',
+  height: '3rem',
+  backgroundColor: theme.palette.primary.main,
+  color: theme.palette.primary.contrastText,
+  zIndex: 9,
+  opacity: 0.5,
+  '&:hover': {
+    opacity: 1
+  }
+}))
+
+
+export default function ProjectCardWithMenu({organisation,item,token}: ProjectCardWithMenuProps) {
+  const {project,menuOptions,onAction} = useProjectCardActions({organisation,item,token})
+
+  function renderStatus() {
+    if (project.status === 'approved') return null
+    return (
+      <IconOverlay
+        title={`Affiliation denied for ${project.title}`}
+      >
+        <a href={`/projects/${project.slug}/`} target="_blank" rel="noreferrer">
+        <BlockIcon
+          sx={{
+            width: '100%',
+            height: '100%',
+            color: 'error.main'
+          }}
+          />
+        </a>
+      </IconOverlay>
+    )
+  }
+
+  return (
+    <div className="relative h-full">
+      <ProjectCard
+        key={project.id}
+        {...project}
+      />
+      <StyledNav>
+        <IconBtnMenuOnAction
+          options={menuOptions}
+          onAction={onAction}
+        />
+      </StyledNav>
+      {renderStatus()}
+    </div>
+  )
+}

--- a/frontend/components/organisation/project/index.tsx
+++ b/frontend/components/organisation/project/index.tsx
@@ -5,16 +5,15 @@
 
 import {useEffect, useState} from 'react'
 
-import {OrganisationForOverview} from '../../../types/Organisation'
-import {Session} from '../../../auth'
+import {OrganisationPageProps} from 'pages/organisations/[...slug]'
 import usePaginationWithSearch from '../../../utils/usePaginationWithSearch'
 import useOrganisationProjects from '../../../utils/useOrganisationProjects'
-import ProjectsGrid from '../../projects/ProjectsGrid'
 import NoContent from '~/components/layout/NoContent'
+import FlexibleGridSection from '~/components/layout/FlexibleGridSection'
+import ProjectCardWithMenu from './ProjectCardWithMenu'
+import ProjectCard from '~/components/projects/ProjectCard'
 
-export default function OrganisationProjects({organisation, session}:
-  { organisation: OrganisationForOverview, session: Session }) {
-  const [init,setInit]=useState(true)
+export default function OrganisationProjects({organisation, session, isMaintainer}:OrganisationPageProps) {
   const {searchFor,page,rows,setCount} = usePaginationWithSearch('Search for projects')
   const {loading, projects, count} = useOrganisationProjects({
     organisation: organisation.id,
@@ -23,10 +22,6 @@ export default function OrganisationProjects({organisation, session}:
     rows,
     token: session.token
   })
-
-  useEffect(() => {
-    setInit(false)
-  },[])
 
   useEffect(() => {
     if (count && loading === false) {
@@ -41,14 +36,31 @@ export default function OrganisationProjects({organisation, session}:
     return <NoContent />
   }
 
-
   return (
-    <ProjectsGrid
-      projects={projects}
+    <FlexibleGridSection
       height='17rem'
       minWidth='25rem'
       maxWidth='1fr'
       className="gap-[0.125rem] pt-2 pb-12"
-    />
+    >
+      {projects.map(item => {
+        if (isMaintainer) {
+          return (
+            <ProjectCardWithMenu
+              key={item.slug}
+              organisation={organisation}
+              item={item}
+              token={session.token}
+            />
+          )
+        }
+        return (
+          <ProjectCard
+            key={item.id}
+            {...item}
+          />
+        )
+      })}
+    </FlexibleGridSection>
   )
 }

--- a/frontend/components/organisation/project/index.tsx
+++ b/frontend/components/organisation/project/index.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useEffect, useState} from 'react'
+import {useEffect} from 'react'
 
 import {OrganisationPageProps} from 'pages/organisations/[...slug]'
 import usePaginationWithSearch from '../../../utils/usePaginationWithSearch'

--- a/frontend/components/organisation/project/index.tsx
+++ b/frontend/components/organisation/project/index.tsx
@@ -20,7 +20,8 @@ export default function OrganisationProjects({organisation, session, isMaintaine
     searchFor,
     page,
     rows,
-    token: session.token
+    token: session.token,
+    isMaintainer
   })
 
   useEffect(() => {

--- a/frontend/components/organisation/project/useProjectCardActions.tsx
+++ b/frontend/components/organisation/project/useProjectCardActions.tsx
@@ -1,0 +1,133 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {IconBtnMenuOption} from '~/components/menu/IconBtnMenuOnAction'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {OrganisationForOverview, ProjectOfOrganisation} from '~/types/Organisation'
+import {patchProjectForOrganisation} from '~/utils/editProject'
+import logger from '~/utils/logger'
+
+export type ProjectCardWithMenuProps = {
+  organisation: OrganisationForOverview,
+  item: ProjectOfOrganisation
+  token: string
+}
+
+export type ProjectMenuAction = {
+  type: 'PIN' | 'UNPIN' | 'DENY' | 'APPROVE',
+  payload?: string
+}
+
+export function useProjectCardActions({organisation, item, token}: ProjectCardWithMenuProps) {
+  const {showErrorMessage, showSuccessMessage} = useSnackbar()
+  const [project, setProject] = useState<ProjectOfOrganisation>(item)
+  const [menuOptions, setMenuOptions] = useState<IconBtnMenuOption<ProjectMenuAction>[]>([])
+
+  useEffect(() => {
+    let abort = false
+    if (typeof project !='undefined') {
+      const options: IconBtnMenuOption<ProjectMenuAction>[] = []
+      if (project.status === 'approved') {
+        options.push({
+          type: 'action', key: 'deny', label: 'Deny affiliation', action: {type: 'DENY'}
+        })
+      } else {
+        options.push({
+          type: 'action', key: 'approve', label: 'Approve affiliation', action: {type: 'APPROVE'}
+        })
+      }
+      if (project.is_published) {
+        if (project.is_featured) {
+          options.push({
+            type: 'action', key: 'unpin', label: 'Unpin project', action: {type: 'UNPIN'}
+          })
+        } else {
+          options.push({
+            type: 'action', key: 'pin', label: 'Pin project', action: {type: 'PIN'}
+          })
+        }
+      }
+      if (abort) return
+      setMenuOptions(options)
+    }
+    return ()=>{abort=true}
+  }, [project])
+
+  async function setPinned(is_featured: boolean) {
+    const pin = await patchProjectForOrganisation({
+      project: project?.id ?? '',
+      organisation: organisation.id,
+      token,
+      data: {
+        is_featured
+      }
+    })
+    if (pin.status !== 200) {
+      showErrorMessage(`Failed to update ${project.title}. ${pin.message}`)
+    } else {
+      showSuccessMessage(`${project.title} ${is_featured ? ' pinned.' : ' unpinned.'}`)
+      const updated = {
+        ...project,
+        is_featured
+      }
+      setProject(updated)
+    }
+  }
+
+  async function setStatus(status: 'approved' | 'rejected_by_relation') {
+    const resp = await patchProjectForOrganisation({
+      project: project.id,
+      organisation: organisation.id,
+      token,
+      data: {
+        status
+      }
+    })
+    if (resp.status !== 200) {
+      showErrorMessage(`Failed to update ${project.title}. ${resp.message}`)
+    } else {
+      let message = `${project.title} is `
+      if (status === 'approved') {
+        message += `approved as project of ${organisation.name}`
+      } else {
+        message += `DENIED affiliation with ${organisation.name}`
+      }
+      showSuccessMessage(message)
+      const updated = {
+        ...project,
+        status
+      }
+      setProject(updated)
+    }
+  }
+
+  function onAction(action: ProjectMenuAction) {
+    // console.log('SoftwareCardWithMenu...action...', action)
+    switch (action.type) {
+      case 'PIN':
+        setPinned(true)
+        break
+      case 'UNPIN':
+        setPinned(false)
+        break
+      case 'DENY':
+        setStatus('rejected_by_relation')
+        break
+      case 'APPROVE':
+        setStatus('approved')
+        break
+      default:
+        logger(`Action type ${action.type} NOT SUPORTED. Check your spelling.`, 'warn')
+    }
+  }
+
+  return {
+    project,
+    setProject,
+    menuOptions,
+    onAction
+  }
+}

--- a/frontend/components/organisation/software/index.tsx
+++ b/frontend/components/organisation/software/index.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useEffect, useState} from 'react'
+import {useEffect} from 'react'
 
 import useOrganisationSoftware from '../../../utils/useOrganisationSoftware'
 import usePaginationWithSearch from '../../../utils/usePaginationWithSearch'
@@ -14,19 +14,15 @@ import SoftwareCard from '~/components/software/SoftwareCard'
 import NoContent from '~/components/layout/NoContent'
 
 export default function OrganisationSoftware({organisation, session, isMaintainer}: OrganisationPageProps) {
-  const [init,setInit]=useState(true)
   const {searchFor,page,rows,setCount} = usePaginationWithSearch('Search for software')
   const {loading, software, count} = useOrganisationSoftware({
     organisation: organisation.id,
     searchFor,
     page,
     rows,
+    isMaintainer,
     token: session.token
   })
-
-  useEffect(() => {
-    setInit(false)
-  },[])
 
   useEffect(() => {
     if (count && loading === false) {

--- a/frontend/components/organisation/software/index.tsx
+++ b/frontend/components/organisation/software/index.tsx
@@ -63,12 +63,7 @@ export default function OrganisationSoftware({organisation, session, isMaintaine
           <SoftwareCard
             key={`/software/${item.slug}/`}
             href={`/software/${item.slug}/`}
-            brand_name={item.brand_name}
-            short_statement={item.short_statement ?? ''}
-            is_featured={item?.is_featured ?? false}
-            updated_at={item.updated_at ?? null}
-            mention_cnt={item?.mention_cnt ?? null}
-            contributor_cnt={item?.contributor_cnt ?? null}
+            {...item}
           />
         )
       })}

--- a/frontend/components/organisation/units/index.tsx
+++ b/frontend/components/organisation/units/index.tsx
@@ -22,6 +22,7 @@ import {sortOnStrProp} from '../../../utils/sortFn'
 import logger from '../../../utils/logger'
 import UnitsList from './ResearchUnitList'
 import ResearchUnitModal from './ResearchUnitModal'
+import {addMaintainerToOrganisation} from '~/auth/permissions/addMaintainerToOrganisation'
 
 type EditOrganisationModal = {
   open: boolean,
@@ -59,7 +60,7 @@ export default function ResearchUnits({organisation, session, isMaintainer}:
       const newOrganisation:EditOrganisation = newOrganisationProps({
         name:'',
         position: 1,
-        primary_maintainer: session?.user?.account ?? null,
+        primary_maintainer: null,
         parent: organisation.id
       })
       // show modal
@@ -127,6 +128,19 @@ export default function ResearchUnits({organisation, session, isMaintainer}:
             id: resp.message
           })
           addUnitToCollection(newUnit)
+          if (newUnit.id && session.user?.account) {
+            // add maintainer to org
+            const resp = await addMaintainerToOrganisation({
+              organisation: newUnit.id,
+              account: session.user?.account,
+              token: session.token,
+              frontend: true
+            })
+            debugger
+            if (resp.status !== 200) {
+              showErrorMessage(`Failed to assign you as maintainer. ${resp.message}`)
+            }
+          }
         } else {
           showErrorMessage(resp.message)
         }

--- a/frontend/components/organisation/units/index.tsx
+++ b/frontend/components/organisation/units/index.tsx
@@ -136,7 +136,7 @@ export default function ResearchUnits({organisation, session, isMaintainer}:
               token: session.token,
               frontend: true
             })
-            debugger
+            // debugger
             if (resp.status !== 200) {
               showErrorMessage(`Failed to assign you as maintainer. ${resp.message}`)
             }

--- a/frontend/components/projects/ProjectCard.tsx
+++ b/frontend/components/projects/ProjectCard.tsx
@@ -18,8 +18,8 @@ export type ProjectCardProps = {
   image_id: string | null
   updated_at: string | null
   date_end: string | null
-  is_featured: boolean
-  is_published: boolean
+  is_featured?: boolean
+  is_published?: boolean
 }
 
 export default function ProjectCard({slug,title,subtitle,image_id,updated_at,date_end,is_featured,is_published}:ProjectCardProps) {

--- a/frontend/components/projects/ProjectCard.tsx
+++ b/frontend/components/projects/ProjectCard.tsx
@@ -20,14 +20,20 @@ export type ProjectCardProps = {
   date_end: string | null
   is_featured?: boolean
   is_published?: boolean
+  menuSpace?: boolean
 }
 
-export default function ProjectCard({slug,title,subtitle,image_id,updated_at,date_end,is_featured,is_published}:ProjectCardProps) {
+export default function ProjectCard({slug, title, subtitle, image_id, updated_at, date_end,
+  is_featured, is_published, menuSpace}: ProjectCardProps) {
   // get current date
   const today = new Date()
-  let opacity = ''
+  // featured has primary bg color
+  const colors = is_featured ? 'bg-primary text-white' : 'bg-grey-100 text-gray-800'
   // if not published use opacity 0.50
-  if (typeof is_published !='undefined' && is_published===false) opacity='opacity-50'
+  let opacity = ''
+  if (typeof is_published != 'undefined' && is_published === false) opacity = 'opacity-50'
+  // add margin to title to make space for more button
+  const titleMargin = menuSpace ? 'mr-8':''
 
   function renderStatus() {
     try {
@@ -62,30 +68,12 @@ export default function ProjectCard({slug,title,subtitle,image_id,updated_at,dat
         </span>
       )
     }
-    if (is_featured===true) {
-      return (
-        <span
-          title="Pinned on your organisation page"
-        >
-          <PushPinIcon
-            sx={{
-              width: '1.5rem',
-              height: '1.5rem',
-              margin: '0 0.25rem 0 0',
-              opacity: 0.5,
-              transform: 'rotate(45deg)'
-            }}
-          />
-        </span>
-      )
-    }
-
     return null
   }
 
   return (
     <Link href={projectUrl()} passHref>
-      <a className={`flex flex-col h-full bg-grey-100 text-gray-800 ${opacity} hover:bg-secondary hover:text-white`}>
+      <a className={`flex flex-col h-full ${colors} ${opacity} hover:bg-secondary hover:text-white`}>
         <article className="flex-1 flex px-4 h-full overflow-hidden">
           <section
             title={subtitle ?? title}
@@ -101,7 +89,7 @@ export default function ProjectCard({slug,title,subtitle,image_id,updated_at,dat
           <section className="flex-1 flex flex-col py-4 pl-6">
             <h2
               title={title}
-              className="max-h-[6rem] overflow-clip">
+              className={`max-h-[6rem] overflow-clip ${titleMargin}`}>
               {renderIcon()} {title}
             </h2>
 

--- a/frontend/components/projects/ProjectCard.tsx
+++ b/frontend/components/projects/ProjectCard.tsx
@@ -4,6 +4,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Link from 'next/link'
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
+import PushPinIcon from '@mui/icons-material/PushPin'
+
 import {getTimeAgoSince} from '../../utils/dateFn'
 import ImageAsBackground from '../layout/ImageAsBackground'
 import {getImageUrl} from '../../utils/getProjects'
@@ -15,11 +18,16 @@ export type ProjectCardProps = {
   image_id: string | null
   updated_at: string | null
   date_end: string | null
+  is_featured: boolean
+  is_published: boolean
 }
 
-export default function ProjectCard({slug,title,subtitle,image_id,updated_at,date_end}:ProjectCardProps) {
+export default function ProjectCard({slug,title,subtitle,image_id,updated_at,date_end,is_featured,is_published}:ProjectCardProps) {
   // get current date
   const today = new Date()
+  let opacity = ''
+  // if not published use opacity 0.50
+  if (typeof is_published !='undefined' && is_published===false) opacity='opacity-50'
 
   function renderStatus() {
     try {
@@ -38,9 +46,46 @@ export default function ProjectCard({slug,title,subtitle,image_id,updated_at,dat
     return `/projects/${slug}/`
   }
 
+  function renderIcon() {
+    if (typeof is_published !='undefined' && is_published===false){
+      return (
+        <span
+          title="Not published"
+        >
+          <VisibilityOffIcon
+            sx={{
+              width: '2rem',
+              height: '2rem',
+              margin: '0 0.5rem 0.5rem 0'
+            }}
+          />
+        </span>
+      )
+    }
+    if (is_featured===true) {
+      return (
+        <span
+          title="Pinned on your organisation page"
+        >
+          <PushPinIcon
+            sx={{
+              width: '1.5rem',
+              height: '1.5rem',
+              margin: '0 0.25rem 0 0',
+              opacity: 0.5,
+              transform: 'rotate(45deg)'
+            }}
+          />
+        </span>
+      )
+    }
+
+    return null
+  }
+
   return (
     <Link href={projectUrl()} passHref>
-      <a className={'flex flex-col h-full bg-grey-100 text-gray-800 hover:bg-secondary hover:text-white'}>
+      <a className={`flex flex-col h-full bg-grey-100 text-gray-800 ${opacity} hover:bg-secondary hover:text-white`}>
         <article className="flex-1 flex px-4 h-full overflow-hidden">
           <section
             title={subtitle ?? title}
@@ -57,7 +102,7 @@ export default function ProjectCard({slug,title,subtitle,image_id,updated_at,dat
             <h2
               title={title}
               className="max-h-[6rem] overflow-clip">
-              {title}
+              {renderIcon()} {title}
             </h2>
 
             <p className="flex-1 py-4 overflow-auto">

--- a/frontend/components/software/SoftwareGrid.tsx
+++ b/frontend/components/software/SoftwareGrid.tsx
@@ -41,6 +41,7 @@ export default function SoftwareGrid({software,grid,className='gap-[0.125rem] pt
             brand_name={item.brand_name}
             short_statement={item.short_statement ?? ''}
             is_featured={item?.is_featured ?? false}
+            is_published={item?.is_published}
             updated_at={item.updated_at ?? null}
             mention_cnt={item?.mention_cnt ?? null}
             contributor_cnt={item?.contributor_cnt ?? null}

--- a/frontend/components/software/edit/information/SoftwareLicenses.tsx
+++ b/frontend/components/software/edit/information/SoftwareLicenses.tsx
@@ -110,7 +110,7 @@ export default function SoftwareLicenses(
       }
     })
     const sorted = found.sort((a, b) => sortBySearchFor(a, b, 'label', searchFor))
-    debugger
+    // debugger
     // set options
     setOptions(found)
     // debugger

--- a/frontend/components/user/organisations/index.tsx
+++ b/frontend/components/user/organisations/index.tsx
@@ -7,7 +7,9 @@
 
 import {useEffect} from 'react'
 import {Session} from '~/auth'
-import OrganisationGrid from '~/components/organisation/OrganisationGrid'
+import FlexibleGridSection from '~/components/layout/FlexibleGridSection'
+import NoContent from '~/components/layout/NoContent'
+import OrganisationCard from '~/components/organisation/OrganisationCard'
 import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
 import useUserOrganisations from './useUserOrganisations'
 
@@ -31,18 +33,25 @@ export default function UserOrganisations({session}: { session: Session }) {
     }
   }, [count, loading, setCount])
 
-  // do not use loader for now
-  // because the layout jumps up-and-down
-  // on pagination
-  // if (loading) {
-  //   return (
-  //     <ContentLoader />
-  //   )
-  // }
+  if (organisations.length === 0) {
+    return <NoContent />
+  }
 
   return (
-    <OrganisationGrid
-      organisations={organisations}
-    />
+    <FlexibleGridSection
+      className="gap-[0.125rem] pt-4 pb-12"
+      height='17rem'
+      minWidth='26rem'
+      maxWidth='1fr'
+    >
+      {organisations.map(item=>{
+        return(
+          <OrganisationCard
+            key={item.slug}
+            {...item}
+          />
+        )
+      })}
+    </FlexibleGridSection>
   )
 }

--- a/frontend/components/user/software/index.tsx
+++ b/frontend/components/user/software/index.tsx
@@ -33,7 +33,7 @@ export default function UserSoftware({session}:{session:Session}) {
         minWidth:'25rem',
         maxWidth:'1fr'
       }}
-      className="gap-[0.125rem] pt-2 pb-12"
+      className="gap-[0.125rem] pt-4 pb-12"
     />
   )
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.9.8",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -157,7 +157,7 @@ export default function Home({software,projects,organisations}:HomeProps) {
 
         <div>
           <div className="text-lg">{organisations} Organisations</div>
-          <div className="opacity-40">involved</div>
+          <div className="opacity-40">contributed</div>
         </div>
       </div>
 

--- a/frontend/pages/organisations/[...slug].tsx
+++ b/frontend/pages/organisations/[...slug].tsx
@@ -73,7 +73,7 @@ export default function OrganisationPage({organisation,slug}:OrganisationPagePro
               {...organisation}
             />
           </div>
-          <div className="min-h-[55rem]">
+          <div className="flex flex-col min-h-[55rem]">
             {renderStepComponent()}
           </div>
         </section>

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -89,17 +89,20 @@ export default function ProjectsIndexPage({count,page,rows,projects=[]}:
 
 // fetching data server side
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
-export async function getServerSideProps(context:GetServerSidePropsContext) {
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const {req: {cookies}} = context
   // extract from page-query
   const {search,rows,page} = ssrProjectsParams(context)
-
+  // extract rsd_token
+  const token = cookies['rsd_token']
   // make api call
   const projects = await getProjectList({
     searchFor: search,
     rows,
     page,
     //baseUrl within docker network
-    baseUrl: process.env.POSTGREST_URL
+    baseUrl: process.env.POSTGREST_URL,
+    token
   })
 
   return {

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -90,19 +90,17 @@ export default function ProjectsIndexPage({count,page,rows,projects=[]}:
 // fetching data server side
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const {req: {cookies}} = context
   // extract from page-query
-  const {search,rows,page} = ssrProjectsParams(context)
-  // extract rsd_token
-  const token = cookies['rsd_token']
-  // make api call
+  const {search, rows, page} = ssrProjectsParams(context)
+
+  // make api call, we do not pass the token
+  // when token is passed it will return not published items too
   const projects = await getProjectList({
     searchFor: search,
     rows,
     page,
     //baseUrl within docker network
-    baseUrl: process.env.POSTGREST_URL,
-    token
+    baseUrl: process.env.POSTGREST_URL
   })
 
   return {

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -138,12 +138,8 @@ export default function SoftwareIndexPage({count,page,rows,tags,software=[]}:
 // fetching data server side
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps(context:GetServerSidePropsContext) {
-  const {req: {cookies}} = context
   // extract params from page-query
   const {search,filterStr,rows,page} = ssrSoftwareParams(context)
-  // extract rsd_token
-  const token = cookies['rsd_token']
-
   // construct postgREST api url with query params
   const url = softwareListUrl({
     baseUrl: process.env.POSTGREST_URL || 'http://localhost:3500',
@@ -154,9 +150,9 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     offset: rows * page
   })
 
-  // get software list, we pass token
-  // when token is present it returns not published items too
-  const software = await getSoftwareList({url, token})
+  // get software list, we do not pass the token
+  // when token is passed it will return not published items too
+  const software = await getSoftwareList({url})
 
   // will be passed as props to page
   // see params of SoftwareIndexPage function

--- a/frontend/types/Organisation.ts
+++ b/frontend/types/Organisation.ts
@@ -116,6 +116,7 @@ export type ProjectOfOrganisation = {
   date_end: string
   updated_at: string
   is_published: boolean
+  is_featured: boolean
   image_id: string | null
   organisation: string
   status: Status

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -473,7 +473,7 @@ export async function patchSoftwareForOrganisation({software, organisation, data
     })
     return extractReturnMessage(resp)
   } catch (e: any) {
-    debugger
+    // debugger
     return {
       status: 500,
       message: e?.message

--- a/frontend/utils/editProject.ts
+++ b/frontend/utils/editProject.ts
@@ -481,6 +481,29 @@ export async function addOrganisationToProject({project, organisation, role, ses
   }
 }
 
+export async function patchProjectForOrganisation({project, organisation, data, token}:
+  { project: string, organisation: string, data: any, token: string }) {
+  try {
+    const query = `project=eq.${project}&organisation=eq.${organisation}`
+    const url = `/api/v1/project_for_organisation?${query}`
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        ...createJsonHeaders(token),
+        'Prefer': 'return=headers-only'
+      },
+      body: JSON.stringify(data)
+    })
+    return extractReturnMessage(resp)
+  } catch (e: any) {
+    debugger
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}
+
 export async function deleteOrganisationFromProject({project,organisation,token}:
   { project: string, organisation:string, token:string }) {
   try {

--- a/frontend/utils/editRelatedSoftware.ts
+++ b/frontend/utils/editRelatedSoftware.ts
@@ -10,7 +10,7 @@ import logger from './logger'
 export async function getRelatedSoftwareForSoftware({software, token, frontend}:
   { software: string, token?: string, frontend?: boolean}) {
   try {
-    const query = `rpc/related_software_for_software?software_id=${software}`
+    const query = `rpc/related_software_for_software?software_id=${software}&is_published=eq.true`
     const order ='order=brand_name.asc'
     let url = `${process.env.POSTGREST_URL}/${query}&${order}`
     if (frontend) {

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -218,7 +218,7 @@ export async function getProjectsForOrganisation({organisation, searchFor, page,
   SoftwareForOrganisationProps) {
   try {
     // baseUrl
-    let url = `/api/v1/rpc/projects_by_organisation?organisation=eq.${organisation}&order=title.asc`
+    let url = `/api/v1/rpc/projects_by_organisation?organisation=eq.${organisation}&order=is_featured.desc,is_published.desc,title.asc`
     // search
     if (searchFor) {
       url += `&or=(title.ilike.*${searchFor}*,subtitle.ilike.*${searchFor}*))`

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -171,7 +171,7 @@ export async function getSoftwareForOrganisation({organisation, searchFor, page,
   SoftwareForOrganisationProps) {
   try {
     // baseUrl
-    let url = `/api/v1/rpc/software_by_organisation?organisation=eq.${organisation}&order=is_featured.desc,is_published.desc,mention_cnt.desc.nullslast,brand_name.asc`
+    let url = `/api/v1/rpc/software_by_organisation?organisation=eq.${organisation}&order=is_published.desc,is_featured.desc,mention_cnt.desc.nullslast,brand_name.asc`
     // filter for public on approved only
     if (!token) {
       url+='&status=eq.approved'
@@ -222,7 +222,7 @@ export async function getProjectsForOrganisation({organisation, searchFor, page,
   SoftwareForOrganisationProps) {
   try {
     // baseUrl
-    let url = `/api/v1/rpc/projects_by_organisation?organisation=eq.${organisation}&order=is_featured.desc,is_published.desc,title.asc`
+    let url = `/api/v1/rpc/projects_by_organisation?organisation=eq.${organisation}&order=is_published.desc,is_featured.desc,title.asc`
     // filter for public on approved only
     if (!token) {
       url += '&status=eq.approved'

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -171,7 +171,8 @@ export async function getSoftwareForOrganisation({organisation, searchFor, page,
   SoftwareForOrganisationProps) {
   try {
     // baseUrl
-    let url = `/api/v1/rpc/software_by_organisation?organisation=eq.${organisation}&order=is_published.desc,is_featured.desc,mention_cnt.desc.nullslast,brand_name.asc`
+    const order ='order=is_published.desc,is_featured.desc,mention_cnt.desc.nullslast,brand_name.asc'
+    let url = `/api/v1/rpc/software_by_organisation?organisation=eq.${organisation}&${order}`
     // filter for public on approved only
     if (!token) {
       url+='&status=eq.approved'
@@ -222,7 +223,8 @@ export async function getProjectsForOrganisation({organisation, searchFor, page,
   SoftwareForOrganisationProps) {
   try {
     // baseUrl
-    let url = `/api/v1/rpc/projects_by_organisation?organisation=eq.${organisation}&order=is_published.desc,is_featured.desc,title.asc`
+    const order ='order=is_published.desc,is_featured.desc,title.asc'
+    let url = `/api/v1/rpc/projects_by_organisation?organisation=eq.${organisation}&${order}`
     // filter for public on approved only
     if (!token) {
       url += '&status=eq.approved'

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -172,6 +172,10 @@ export async function getSoftwareForOrganisation({organisation, searchFor, page,
   try {
     // baseUrl
     let url = `/api/v1/rpc/software_by_organisation?organisation=eq.${organisation}&order=is_featured.desc,is_published.desc,mention_cnt.desc.nullslast,brand_name.asc`
+    // filter for public on approved only
+    if (!token) {
+      url+='&status=eq.approved'
+    }
     // search
     if (searchFor) {
       url+=`&or=(brand_name.ilike.*${searchFor}*, short_statement.ilike.*${searchFor}*))`
@@ -219,6 +223,10 @@ export async function getProjectsForOrganisation({organisation, searchFor, page,
   try {
     // baseUrl
     let url = `/api/v1/rpc/projects_by_organisation?organisation=eq.${organisation}&order=is_featured.desc,is_published.desc,title.asc`
+    // filter for public on approved only
+    if (!token) {
+      url += '&status=eq.approved'
+    }
     // search
     if (searchFor) {
       url += `&or=(title.ilike.*${searchFor}*,subtitle.ilike.*${searchFor}*))`

--- a/frontend/utils/getProjects.ts
+++ b/frontend/utils/getProjects.ts
@@ -12,7 +12,7 @@ import {
   ProjectLink, RawProject, RelatedProjectForProject,
   ResearchDomain, SearchProject, TeamMember
 } from '~/types/Project'
-import {RelatedSoftwareOfProject, SoftwareListItem} from '~/types/SoftwareTypes'
+import {RelatedSoftwareOfProject} from '~/types/SoftwareTypes'
 import {getUrlFromLogoId} from './editOrganisation'
 import {extractCountFromHeader} from './extractCountFromHeader'
 import {createJsonHeaders} from './fetchHelpers'
@@ -463,8 +463,8 @@ export async function getRelatedProjectsForProject({project, token, frontend, ap
     // construct api url based on request source
     let query = `rpc/related_projects_for_project?origin=eq.${project}&order=title.asc`
     if (approved) {
-      // select only approved relations
-      query += '&status=eq.approved'
+      // select only approved and published relations
+      query += '&status=eq.approved&is_published=eq.true'
     }
     let url = `${process.env.POSTGREST_URL}/${query}`
     if (frontend) {
@@ -493,8 +493,8 @@ export async function getRelatedSoftwareForProject({project, token, frontend, ap
   try {
     let query = `rpc/related_software_for_project?project_id=${project}&order=brand_name.asc`
     if (approved) {
-      // select only approved relations
-      query += '&status=eq.approved'
+      // select only approved and published relations
+      query += '&status=eq.approved&is_published=eq.true'
     }
     let url = `${process.env.POSTGREST_URL}/${query}`
     if (frontend) {

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -15,14 +15,13 @@ import {RelatedProjectForSoftware} from '~/types/Project'
 /*
  * Software list for the software overview page
  * Note! url should contain all query params. Use softwareUrl helper fn to construct url.
- * is_featured flag is set for all items having mention_cnt > 4
  */
-export async function getSoftwareList(url:string){
+export async function getSoftwareList({url,token}:{url:string,token:string }){
   try{
     const resp = await fetch(url, {
       method: 'GET',
       headers: {
-        ...createJsonHeaders(undefined),
+        ...createJsonHeaders(token),
         'Prefer':'count=exact'
       },
     })

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -16,7 +16,7 @@ import {RelatedProjectForSoftware} from '~/types/Project'
  * Software list for the software overview page
  * Note! url should contain all query params. Use softwareUrl helper fn to construct url.
  */
-export async function getSoftwareList({url,token}:{url:string,token:string }){
+export async function getSoftwareList({url,token}:{url:string,token?:string }){
   try{
     const resp = await fetch(url, {
       method: 'GET',
@@ -314,7 +314,7 @@ export async function getRelatedProjectsForSoftware({software, token, frontend, 
     let query = `rpc/related_projects_for_software?software=eq.${software}&order=title.asc`
     if (approved) {
       // select only approved relations
-      query+='&status=eq.approved'
+      query +='&status=eq.approved&is_published=eq.true'
     }
     let url = `${process.env.POSTGREST_URL}/${query}`
     if (frontend) {

--- a/frontend/utils/postgrestUrl.test.ts
+++ b/frontend/utils/postgrestUrl.test.ts
@@ -8,7 +8,7 @@ import {PostgrestParams, softwareListUrl, ssrSoftwareUrl} from './postgrestUrl'
 describe('softwareListUrl', () => {
   it('returns softwareListUrl when only baseUrl provided', () => {
     const baseUrl='http://test-base-url'
-    const expectUrl = `${baseUrl}/rpc/software_list?is_published=eq.true&limit=12&offset=0`
+    const expectUrl = `${baseUrl}/rpc/software_list?&limit=12&offset=0`
     const url = softwareListUrl({
       baseUrl
     } as PostgrestParams)
@@ -18,7 +18,7 @@ describe('softwareListUrl', () => {
   it('returns softwareUrl with search', () => {
     const baseUrl = 'http://test-base-url'
     // if you change search value then change expectedUrl values too
-    const expectUrl = `${baseUrl}/rpc/software_list?is_published=eq.true&or=(brand_name.ilike.*test-search*, short_statement.ilike.*test-search*))&limit=12&offset=0`
+    const expectUrl = `${baseUrl}/rpc/software_list?&or=(brand_name.ilike.*test-search*, short_statement.ilike.*test-search*))&limit=12&offset=0`
     const url = softwareListUrl({
       baseUrl,
       // if you change search value then change expectedUrl values too

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -16,11 +16,8 @@ export type PostgrestParams={
 }
 
 export function softwareListUrl(props:PostgrestParams){
-  const {baseUrl,search,columns,filters,order,limit,offset} = props
+  const {baseUrl, search, columns, filters, order, limit, offset} = props
   let url = `${baseUrl}/rpc/software_list?`
-
-  // always filter for only published software!
-  url += 'is_published=eq.true'
 
   if (columns){
     url+=`&select=${columns.join(',')}`

--- a/frontend/utils/useOrganisationProjects.tsx
+++ b/frontend/utils/useOrganisationProjects.tsx
@@ -5,23 +5,15 @@
 
 import {useEffect,useState} from 'react'
 import {ProjectOfOrganisation} from '../types/Organisation'
-import {getProjectsForOrganisation} from './getOrganisations'
-
-type UseOrganisationProjectProp = {
-  searchFor?: string
-  page: number,
-  rows: number,
-  organisation: string,
-  token:string
-}
+import {getProjectsForOrganisation, OrganisationApiParams} from './getOrganisations'
 
 type State = {
   count: number,
   data: ProjectOfOrganisation[]
 }
 
-export default function useOrganisationProjects({organisation, searchFor, page, rows,token}:
-  UseOrganisationProjectProp) {
+export default function useOrganisationProjects({organisation, searchFor, page, rows,isMaintainer,token}:
+  OrganisationApiParams) {
   const [state, setState] = useState<State>({
     count: 0,
     data: []
@@ -39,6 +31,7 @@ export default function useOrganisationProjects({organisation, searchFor, page, 
         searchFor,
         page,
         rows,
+        isMaintainer,
         token
       })
       // abort
@@ -54,7 +47,7 @@ export default function useOrganisationProjects({organisation, searchFor, page, 
     }
 
     return ()=>{abort = true}
-  },[searchFor,page,rows,organisation,token,])
+  },[searchFor,page,rows,organisation,token,isMaintainer])
 
   return {
     projects:state.data,

--- a/frontend/utils/useOrganisationSoftware.tsx
+++ b/frontend/utils/useOrganisationSoftware.tsx
@@ -5,23 +5,15 @@
 
 import {useEffect,useState} from 'react'
 import {SoftwareOfOrganisation} from '../types/Organisation'
-import {getSoftwareForOrganisation} from './getOrganisations'
-
-type UseOrganisationSoftwareProp = {
-  searchFor?: string
-  page: number,
-  rows: number,
-  organisation: string,
-  token:string
-}
+import {getSoftwareForOrganisation, OrganisationApiParams} from './getOrganisations'
 
 type State = {
   count: number,
   data: SoftwareOfOrganisation[]
 }
 
-export default function useOrganisationSoftware({organisation, searchFor, page, rows,token}:
-  UseOrganisationSoftwareProp) {
+export default function useOrganisationSoftware({organisation, searchFor, page, rows,isMaintainer,token}:
+  OrganisationApiParams) {
   const [state, setState] = useState<State>({
     count: 0,
     data: []
@@ -39,6 +31,7 @@ export default function useOrganisationSoftware({organisation, searchFor, page, 
         searchFor,
         page,
         rows,
+        isMaintainer,
         token
       })
       // abort
@@ -54,7 +47,7 @@ export default function useOrganisationSoftware({organisation, searchFor, page, 
     }
 
     return ()=>{abort = true}
-  },[searchFor,page,rows,organisation,token])
+  },[searchFor,page,rows,organisation,token,isMaintainer])
 
   return {
     software:state.data,


### PR DESCRIPTION
# Organisation maintainer features for software and projects

Closes #327 
Closes #328
Related to #346
Related to #350 

Changes proposed in this pull request:
* Organisation maintainer is able to see all software affiliated with the organisation incl. not yet published software items
* Organisation maintainer is able to pin/unpin, deny/accept project affiliation with organisation, and see not yet published projects linking to organisation

How to test:
* `docker-compose down --volumes`: to remove old
* `docker-compose build`: to build all services
* `docker-compose up`: to start
* perform data migration
* start app and login as test user
* make yourself (primary) maintainer of an organisation (or all organisations)
* navigate to your organisation
* pin/unpin software, reload page to see impact, you can also logout and view organisation page as "viewer"
* login as different user
* create new software, add organisation of the "previous" maintainer
* navigate to organisation, you should not be able to see new software you just created because it is not published yet
* logout and login as "previous" user
* navigate to your organisation, you should be able to see not published software from the "second" user in the list
* create new project,
* navigate to your organisation page, you should be able to see new project, even if not published yet
* deny/approve affiliation from the organisation page
* pin/unpin project from organisation page

## Example features organisation maintainer on project page
![image](https://user-images.githubusercontent.com/9204081/174828702-04e14643-8d83-4e53-9396-51dba1abfa25.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
