### PR TITLE
238 counters homepage

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -982,3 +982,19 @@ BEGIN
 	RETURN;
 END
 $$;
+
+-- TOTAL COUNTS FOR HOMEPAGE
+-- software_cnt, project_cnt, organisation_cnt
+-- this rpc returns json object instead of array
+CREATE FUNCTION homepage_counts(
+	OUT software_cnt BIGINT,
+	OUT project_cnt BIGINT,
+	OUT organisation_cnt BIGINT
+) LANGUAGE plpgsql STABLE AS
+$$
+BEGIN
+	SELECT count(id) FROM software INTO software_cnt;
+	SELECT count(id) FROM project INTO project_cnt;
+	SELECT count(id) FROM organisation WHERE parent IS NULL INTO organisation_cnt;
+END
+$$;

--- a/frontend/components/home/getHomepageCounts.ts
+++ b/frontend/components/home/getHomepageCounts.ts
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {createJsonHeaders} from '~/utils/fetchHelpers'
+import logger from '~/utils/logger'
+
+export async function getHomepageCounts(frontend?:boolean) {
+  try {
+    const query = 'rpc/homepage_counts'
+    let url = `${process.env.POSTGREST_URL}/${query}`
+    if (frontend) {
+      url = `/api/v1/${query}`
+    }
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(),
+      },
+    })
+    debugger
+    if (resp.status === 200) {
+      const data = await resp.json()
+      return data
+    }
+    logger(`getHomepageCounts ${resp.status} ${resp.statusText}`, 'warn')
+    return {
+      software_cnt: null,
+      project_cnt: null,
+      organisation_cnt: null
+    }
+  } catch (e:any) {
+    // otherwise request failed
+    logger(`getHomepageCounts failed: ${e?.message}`, 'error')
+    // we log and return zero
+    return {
+      software_cnt: null,
+      project_cnt: null,
+      organisation_cnt: null
+    }
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -146,18 +146,18 @@ export default function Home({software,projects,organisations}:HomeProps) {
       {/* stats  */}
       <div className="w-full max-w-screen-xl mx-auto flex flex-wrap gap-10 md:gap-16 p-5 md:p-10 ">
         <div>
-          <div className="text-lg"> {software} Software</div>
-          <div className="opacity-40">Packages</div>
+          <div className="text-lg">{software} Software</div>
+          <div className="opacity-40">packages</div>
         </div>
 
         <div>
-          <div className="text-lg">{projects} Research</div>
-          <div className="opacity-40">Projects</div>
+          <div className="text-lg">{projects} Projects</div>
+          <div className="opacity-40">registered</div>
         </div>
 
         <div>
-          <div className="text-lg"> {organisations} Research</div>
-          <div className="opacity-40">Organisations</div>
+          <div className="text-lg">{organisations} Organisations</div>
+          <div className="opacity-40">involved</div>
         </div>
       </div>
 

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -23,9 +23,11 @@ import LogoUMC from '~/assets/logos/LogoUMC.svg'
 import LogoUU from '~/assets/logos/LogoUU.svg'
 import LogoLeiden from '~/assets/logos/LogoLeiden.svg'
 import Arc from '~/components/home/arc.svg'
+import {getHomepageCounts} from '~/components/home/getHomepageCounts'
 
 /*! purgecss start ignore */
 import 'aos/dist/aos.css'
+
 /*! purgecss end ignore */
 
 const whyrsd = [
@@ -41,7 +43,14 @@ const whyrsd = [
   'The Research Software Directory is a content management system that is tailored to software.'
 ]
 
-export default function Home() {
+type HomeProps = {
+  software: number,
+  projects: number,
+  organisations: number
+}
+
+
+export default function Home({software,projects,organisations}:HomeProps) {
   const [isDark, setDark] = useState(true)
 
   // Initialize AOS library
@@ -137,18 +146,18 @@ export default function Home() {
       {/* stats  */}
       <div className="w-full max-w-screen-xl mx-auto flex flex-wrap gap-10 md:gap-16 p-5 md:p-10 ">
         <div>
-          <div className="text-lg"> 30+ thousands</div>
-          <div className="opacity-40">Researchers</div>
-        </div>
-
-        <div>
-          <div className="text-lg">20 Research Centers</div>
-          <div className="opacity-40">Organizations</div>
-        </div>
-
-        <div>
-          <div className="text-lg"> 500+ Software</div>
+          <div className="text-lg"> {software} Software</div>
           <div className="opacity-40">Packages</div>
+        </div>
+
+        <div>
+          <div className="text-lg">{projects} Research</div>
+          <div className="opacity-40">Projects</div>
+        </div>
+
+        <div>
+          <div className="text-lg"> {organisations} Research</div>
+          <div className="opacity-40">Organisations</div>
         </div>
       </div>
 
@@ -276,4 +285,20 @@ export default function Home() {
       </div>
     </div>
   )
+}
+
+// fetching data server side
+// see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
+export async function getServerSideProps() {
+  // extract params from page-query
+  const counts = await getHomepageCounts()
+  // will be passed as props to page
+  // see params of SoftwareIndexPage function
+  return {
+    props: {
+      software: counts.software_cnt ?? null,
+      projects: counts.project_cnt ?? null,
+      organisations: counts.organisation_cnt ?? null
+    },
+  }
 }

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -51,7 +51,7 @@ export async function getOrganisationsList({search, rows, page, token}:
       }
     }
     // otherwise request failed
-    logger(`getSoftwareList failed: ${resp.status} ${resp.statusText}`, 'warn')
+    logger(`getOrganisationsList failed: ${resp.status} ${resp.statusText}`, 'warn')
     // we log and return zero
     return {
       count: 0,


### PR DESCRIPTION
# Get counts for homepage

Closes #238 

Changes proposed in this pull request:
*   The counters on home page load the counts from api using SSR

How to test:
* `docker-compose down --volumes`: to remove
* `docker-compose build`: to build all
* `docker-compose up`: to start
*  perform data migration
*  visit homepage you should have these counts*

## Example homepage counters

![image](https://user-images.githubusercontent.com/9204081/174659804-b44474a0-ac7c-4279-b409-e970a788f2dc.png)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
