### PR TITLE
346 improve counts on project, software and organisation pages

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -241,7 +241,10 @@ BEGIN
 		FROM
 			software_for_organisation
 		WHERE
-			status = 'approved'
+			software_for_organisation.status = 'approved' AND
+			software IN (
+				SELECT id FROM software WHERE is_published=TRUE
+			)
 		GROUP BY software_for_organisation.organisation;
 	ELSE
 		RETURN QUERY
@@ -272,7 +275,10 @@ BEGIN
 		FROM
 			project_for_organisation
 		WHERE
-			status = 'approved'
+			status = 'approved' AND
+			project IN (
+				SELECT id FROM project WHERE is_published=TRUE
+			)
 		GROUP BY project_for_organisation.organisation;
 	ELSE
 		RETURN QUERY
@@ -499,6 +505,7 @@ CREATE FUNCTION related_projects_for_project() RETURNS TABLE (
 	subtitle VARCHAR,
 	date_end DATE,
 	updated_at TIMESTAMPTZ,
+	is_published BOOLEAN,
 	status relation_status,
 	image_id UUID
 ) LANGUAGE plpgsql STABLE AS
@@ -513,6 +520,7 @@ BEGIN
 		project.subtitle,
 		project.date_end,
 		project.updated_at,
+		project.is_published,
 		project_for_project.status,
 		image_for_project.project AS image_id
 	FROM
@@ -535,6 +543,7 @@ CREATE FUNCTION related_projects_for_software() RETURNS TABLE (
 	subtitle VARCHAR,
 	date_end DATE,
 	updated_at TIMESTAMPTZ,
+	is_published BOOLEAN,
 	status relation_status,
 	image_id UUID
 ) LANGUAGE plpgsql STABLE AS
@@ -549,6 +558,7 @@ BEGIN
 		project.subtitle,
 		project.date_end,
 		project.updated_at,
+		project.is_published,
 		software_for_project.status,
 		image_for_project.project AS image_id
 	FROM

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
   database:
     container_name: database
     build: ./database
-    image: rsd/database:0.0.36
+    image: rsd/database:0.0.37
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -88,7 +88,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:0.9.9
+    image: rsd/frontend:0.10.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/auth/permissions/isMaintainerOfOrganisation.ts
+++ b/frontend/auth/permissions/isMaintainerOfOrganisation.ts
@@ -37,8 +37,12 @@ export async function isMaintainerOfOrganisation({organisation, account, token, 
   }
 }
 
-export async function getMaintainerOrganisations({token, frontend = true}: { token: string, frontend?: boolean }) {
+export async function getMaintainerOrganisations({token, frontend = true}:
+  {token: string, frontend?: boolean}) {
   try {
+    // without token api request is not needed
+    if (!token) return []
+    // build url
     const query = 'rpc/organisations_of_current_maintainer'
     let url = `/api/v1/${query}`
     if (frontend===false) {

--- a/frontend/components/organisation/project/index.tsx
+++ b/frontend/components/organisation/project/index.tsx
@@ -20,7 +20,8 @@ export default function OrganisationProjects({organisation, session, isMaintaine
     searchFor,
     page,
     rows,
-    token: session.token
+    token: session.token,
+    isMaintainer
   })
 
   useEffect(() => {

--- a/frontend/components/organisation/software/index.tsx
+++ b/frontend/components/organisation/software/index.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useEffect, useState} from 'react'
+import {useEffect} from 'react'
 
 import useOrganisationSoftware from '../../../utils/useOrganisationSoftware'
 import usePaginationWithSearch from '../../../utils/usePaginationWithSearch'
@@ -14,19 +14,15 @@ import SoftwareCard from '~/components/software/SoftwareCard'
 import NoContent from '~/components/layout/NoContent'
 
 export default function OrganisationSoftware({organisation, session, isMaintainer}: OrganisationPageProps) {
-  const [init,setInit]=useState(true)
   const {searchFor,page,rows,setCount} = usePaginationWithSearch('Search for software')
   const {loading, software, count} = useOrganisationSoftware({
     organisation: organisation.id,
     searchFor,
     page,
     rows,
+    isMaintainer,
     token: session.token
   })
-
-  useEffect(() => {
-    setInit(false)
-  },[])
 
   useEffect(() => {
     if (count && loading === false) {

--- a/frontend/components/organisation/units/index.tsx
+++ b/frontend/components/organisation/units/index.tsx
@@ -136,7 +136,7 @@ export default function ResearchUnits({organisation, session, isMaintainer}:
               token: session.token,
               frontend: true
             })
-            debugger
+            // debugger
             if (resp.status !== 200) {
               showErrorMessage(`Failed to assign you as maintainer. ${resp.message}`)
             }

--- a/frontend/components/software/edit/information/SoftwareLicenses.tsx
+++ b/frontend/components/software/edit/information/SoftwareLicenses.tsx
@@ -110,7 +110,7 @@ export default function SoftwareLicenses(
       }
     })
     const sorted = found.sort((a, b) => sortBySearchFor(a, b, 'label', searchFor))
-    debugger
+    // debugger
     // set options
     setOptions(found)
     // debugger

--- a/frontend/components/user/organisations/index.tsx
+++ b/frontend/components/user/organisations/index.tsx
@@ -7,7 +7,9 @@
 
 import {useEffect} from 'react'
 import {Session} from '~/auth'
-import OrganisationGrid from '~/components/organisation/OrganisationGrid'
+import FlexibleGridSection from '~/components/layout/FlexibleGridSection'
+import NoContent from '~/components/layout/NoContent'
+import OrganisationCard from '~/components/organisation/OrganisationCard'
 import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
 import useUserOrganisations from './useUserOrganisations'
 
@@ -31,18 +33,25 @@ export default function UserOrganisations({session}: { session: Session }) {
     }
   }, [count, loading, setCount])
 
-  // do not use loader for now
-  // because the layout jumps up-and-down
-  // on pagination
-  // if (loading) {
-  //   return (
-  //     <ContentLoader />
-  //   )
-  // }
+  if (organisations.length === 0) {
+    return <NoContent />
+  }
 
   return (
-    <OrganisationGrid
-      organisations={organisations}
-    />
+    <FlexibleGridSection
+      className="gap-[0.125rem] pt-4 pb-12"
+      height='17rem'
+      minWidth='26rem'
+      maxWidth='1fr'
+    >
+      {organisations.map(item=>{
+        return(
+          <OrganisationCard
+            key={item.slug}
+            {...item}
+          />
+        )
+      })}
+    </FlexibleGridSection>
   )
 }

--- a/frontend/components/user/software/index.tsx
+++ b/frontend/components/user/software/index.tsx
@@ -33,7 +33,7 @@ export default function UserSoftware({session}:{session:Session}) {
         minWidth:'25rem',
         maxWidth:'1fr'
       }}
-      className="gap-[0.125rem] pt-2 pb-12"
+      className="gap-[0.125rem] pt-4 pb-12"
     />
   )
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "0.9.8",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -90,19 +90,17 @@ export default function ProjectsIndexPage({count,page,rows,projects=[]}:
 // fetching data server side
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps(context: GetServerSidePropsContext) {
-  const {req: {cookies}} = context
   // extract from page-query
-  const {search,rows,page} = ssrProjectsParams(context)
-  // extract rsd_token
-  const token = cookies['rsd_token']
-  // make api call
+  const {search, rows, page} = ssrProjectsParams(context)
+
+  // make api call, we do not pass the token
+  // when token is passed it will return not published items too
   const projects = await getProjectList({
     searchFor: search,
     rows,
     page,
     //baseUrl within docker network
-    baseUrl: process.env.POSTGREST_URL,
-    token
+    baseUrl: process.env.POSTGREST_URL
   })
 
   return {

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -138,12 +138,8 @@ export default function SoftwareIndexPage({count,page,rows,tags,software=[]}:
 // fetching data server side
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps(context:GetServerSidePropsContext) {
-  const {req: {cookies}} = context
   // extract params from page-query
   const {search,filterStr,rows,page} = ssrSoftwareParams(context)
-  // extract rsd_token
-  const token = cookies['rsd_token']
-
   // construct postgREST api url with query params
   const url = softwareListUrl({
     baseUrl: process.env.POSTGREST_URL || 'http://localhost:3500',
@@ -154,9 +150,9 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     offset: rows * page
   })
 
-  // get software list, we pass token
-  // when token is present it returns not published items too
-  const software = await getSoftwareList({url, token})
+  // get software list, we do not pass the token
+  // when token is passed it will return not published items too
+  const software = await getSoftwareList({url})
 
   // will be passed as props to page
   // see params of SoftwareIndexPage function

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -473,7 +473,7 @@ export async function patchSoftwareForOrganisation({software, organisation, data
     })
     return extractReturnMessage(resp)
   } catch (e: any) {
-    debugger
+    // debugger
     return {
       status: 500,
       message: e?.message

--- a/frontend/utils/editRelatedSoftware.ts
+++ b/frontend/utils/editRelatedSoftware.ts
@@ -10,7 +10,7 @@ import logger from './logger'
 export async function getRelatedSoftwareForSoftware({software, token, frontend}:
   { software: string, token?: string, frontend?: boolean}) {
   try {
-    const query = `rpc/related_software_for_software?software_id=${software}`
+    const query = `rpc/related_software_for_software?software_id=${software}&is_published=eq.true`
     const order ='order=brand_name.asc'
     let url = `${process.env.POSTGREST_URL}/${query}&${order}`
     if (frontend) {

--- a/frontend/utils/getProjects.ts
+++ b/frontend/utils/getProjects.ts
@@ -12,7 +12,7 @@ import {
   ProjectLink, RawProject, RelatedProjectForProject,
   ResearchDomain, SearchProject, TeamMember
 } from '~/types/Project'
-import {RelatedSoftwareOfProject, SoftwareListItem} from '~/types/SoftwareTypes'
+import {RelatedSoftwareOfProject} from '~/types/SoftwareTypes'
 import {getUrlFromLogoId} from './editOrganisation'
 import {extractCountFromHeader} from './extractCountFromHeader'
 import {createJsonHeaders} from './fetchHelpers'
@@ -463,8 +463,8 @@ export async function getRelatedProjectsForProject({project, token, frontend, ap
     // construct api url based on request source
     let query = `rpc/related_projects_for_project?origin=eq.${project}&order=title.asc`
     if (approved) {
-      // select only approved relations
-      query += '&status=eq.approved'
+      // select only approved and published relations
+      query += '&status=eq.approved&is_published=eq.true'
     }
     let url = `${process.env.POSTGREST_URL}/${query}`
     if (frontend) {
@@ -493,8 +493,8 @@ export async function getRelatedSoftwareForProject({project, token, frontend, ap
   try {
     let query = `rpc/related_software_for_project?project_id=${project}&order=brand_name.asc`
     if (approved) {
-      // select only approved relations
-      query += '&status=eq.approved'
+      // select only approved and published relations
+      query += '&status=eq.approved&is_published=eq.true'
     }
     let url = `${process.env.POSTGREST_URL}/${query}`
     if (frontend) {

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -16,7 +16,7 @@ import {RelatedProjectForSoftware} from '~/types/Project'
  * Software list for the software overview page
  * Note! url should contain all query params. Use softwareUrl helper fn to construct url.
  */
-export async function getSoftwareList({url,token}:{url:string,token:string }){
+export async function getSoftwareList({url,token}:{url:string,token?:string }){
   try{
     const resp = await fetch(url, {
       method: 'GET',
@@ -314,7 +314,7 @@ export async function getRelatedProjectsForSoftware({software, token, frontend, 
     let query = `rpc/related_projects_for_software?software=eq.${software}&order=title.asc`
     if (approved) {
       // select only approved relations
-      query+='&status=eq.approved'
+      query +='&status=eq.approved&is_published=eq.true'
     }
     let url = `${process.env.POSTGREST_URL}/${query}`
     if (frontend) {

--- a/frontend/utils/useOrganisationProjects.tsx
+++ b/frontend/utils/useOrganisationProjects.tsx
@@ -5,23 +5,15 @@
 
 import {useEffect,useState} from 'react'
 import {ProjectOfOrganisation} from '../types/Organisation'
-import {getProjectsForOrganisation} from './getOrganisations'
-
-type UseOrganisationProjectProp = {
-  searchFor?: string
-  page: number,
-  rows: number,
-  organisation: string,
-  token:string
-}
+import {getProjectsForOrganisation, OrganisationApiParams} from './getOrganisations'
 
 type State = {
   count: number,
   data: ProjectOfOrganisation[]
 }
 
-export default function useOrganisationProjects({organisation, searchFor, page, rows,token}:
-  UseOrganisationProjectProp) {
+export default function useOrganisationProjects({organisation, searchFor, page, rows,isMaintainer,token}:
+  OrganisationApiParams) {
   const [state, setState] = useState<State>({
     count: 0,
     data: []
@@ -39,6 +31,7 @@ export default function useOrganisationProjects({organisation, searchFor, page, 
         searchFor,
         page,
         rows,
+        isMaintainer,
         token
       })
       // abort
@@ -54,7 +47,7 @@ export default function useOrganisationProjects({organisation, searchFor, page, 
     }
 
     return ()=>{abort = true}
-  },[searchFor,page,rows,organisation,token,])
+  },[searchFor,page,rows,organisation,token,isMaintainer])
 
   return {
     projects:state.data,

--- a/frontend/utils/useOrganisationSoftware.tsx
+++ b/frontend/utils/useOrganisationSoftware.tsx
@@ -5,23 +5,15 @@
 
 import {useEffect,useState} from 'react'
 import {SoftwareOfOrganisation} from '../types/Organisation'
-import {getSoftwareForOrganisation} from './getOrganisations'
-
-type UseOrganisationSoftwareProp = {
-  searchFor?: string
-  page: number,
-  rows: number,
-  organisation: string,
-  token:string
-}
+import {getSoftwareForOrganisation, OrganisationApiParams} from './getOrganisations'
 
 type State = {
   count: number,
   data: SoftwareOfOrganisation[]
 }
 
-export default function useOrganisationSoftware({organisation, searchFor, page, rows,token}:
-  UseOrganisationSoftwareProp) {
+export default function useOrganisationSoftware({organisation, searchFor, page, rows,isMaintainer,token}:
+  OrganisationApiParams) {
   const [state, setState] = useState<State>({
     count: 0,
     data: []
@@ -39,6 +31,7 @@ export default function useOrganisationSoftware({organisation, searchFor, page, 
         searchFor,
         page,
         rows,
+        isMaintainer,
         token
       })
       // abort
@@ -54,7 +47,7 @@ export default function useOrganisationSoftware({organisation, searchFor, page, 
     }
 
     return ()=>{abort = true}
-  },[searchFor,page,rows,organisation,token])
+  },[searchFor,page,rows,organisation,token,isMaintainer])
 
   return {
     software:state.data,


### PR DESCRIPTION
Consolidate project and software counts on all pages for different types of users: public, logged in user and maintainer of organisation.

# Improve project and software counts

Fixes #346

Changes proposed in this pull request:
* The software and project counts on home page, software, projects and in the organisation card should be identical. These include only published and approved software and projects.
* When user is maintainer of an organisation, the count in the organisation card remains identical to what other users see (count of published and approved items only). The counts on the organisation page, in the menu on the left and in the pagination component at the top, are different and represent count of all items linked to the organisation (including access denied and not published items).
* On the user specific page, in the organisation section, the organisation card shows the count that all users see (only published and approved items). 

How to test:
### Test concept
To test counts in the various situations I provide you scenario with:
- 3 different users: JRB (professor1), SAW (professor2), SIN (professor3) and public access (not logged in)
- each user creates 3 software and project items and assigns specific companies (C_1, C_2, C_3, nwo, surf)
- each user becomes maintainer of one of the "C" companies: JRB->C_1, SAW->C_2, SIN->C_3
- we assign companies nwo and surf to each software and project (our users are not maintainers of these companies)
- to follow the process easier, I am naming software: S_1...S_9, projects: P_1...P_9, companies: C_1, C_2, C_3.
- each user has one software and project that is not published: JRB: S_3 and P_3, SAW: S_6 and P_6, SIN: S_9 and P_9 
- to assign user as (primary) maintainer of an organisation you will need access to database and to execute sql queries provided below

### Assigning user to be maintainer of an organisation
- You can add organisation using any user on any of the software or project items. You will not become maintainer of the organisation automatically (this feature is removed time ago). 
- When you first login as one of the users: professor1 (JRB), professor2 (SAW), professor3 (SIN) the account id is written in the rsd database. You need to assign this account id to primary_maintainer column of an organisation (to become primary maintainer). The sql commands you can use are
```sql
-- LOGIN FIRST THEN NOTE ID
select id from account;
-- ASSIGN PRIMARY MAINTAINER to C01 organisation
-- REPLACE id value in the query with the value you get from the first SQL statement
UPDATE organisation 
    SET primary_maintainer=uuid('c3982c07-0b36-4cf7-b13a-2c2b9932789b')
    WHERE name='C_1'
;
```
### Setup 
* `docker-compose down --volumes`: to remove old 
* `docker-compose build`: to build
* `docker-compose up`: to start
*  **login as JRB (professor1)**, 
   * create software S_1 to S_3 where S_1 and S_2 are published and S_3 is not published
   * create new organisations C_1, C_2 and C_3 and assign them:
     *  C_1 to S_1, 
     *  C_2 to S_2, 
     *  C_1, C_2 and C_3 to S_3 (which is not published)
     *  in addition add nwo and surf from ROR to all
   * create project P_1 to P_3 and assign organisations in the same manner
   * assign JRB to be maintainer of C_1 using sql script provided
   * visit user profile page and confirm 
       * that JRB has 3 software items, 3 projects and 1 organisation (maintainer of C_1)
       * that S_3 and P_3 are not published
*  **login as SAW (professor2)**, 
   * create software S_4 to S_6 where S_4 and S_5 are published and S_6 is not published
   * assign organisations to software using same patter as with previous user (C_1 to S_4, C_2 to S_5, ...)
   * create project P_4 to P_6 and assign organisations using same pattern
   * assign SAW to be maintainer of C_2 using sql script provided
   * visit user profile page and confirm that SAW 
       * has 3 software items, 3 projects and 1 organisation (maintainer of C_2)
       * S_6 and P_6 are not published
*  **login as SIN (professor3)**, 
   * create software S_7 to S_9 where S_7 and S_8 are published and S_9 is not published
   * assign ONLY C_3, nwo and surf organisations to S_7,S_8 and S_9
   * create project P_7 to P_9 and assign ONLY C_3, nwo and surf organisations to P_7,P_8 and P_9
   * assign SIN to be maintainer of C_3, use sql script provided
   * visit user profile page and confirm that SIN 
       * has 3 software items, 3 projects and 1 organisation (maintainer of C_3)
       * S_9 and P_9 are not published
### Validation 
* Logout and examine counts as public visitor:
   *  **home page** should show: 6 software, 6 projects, 5 organisations (C_1, C_2, C_3, nwo and surf)
   *  **software page**, should confirm 6 software items (only published)
   *  **projects page** should confirm 6 project items (only published)
   *  **organisations page** should conform 5 items, 
   *  the counts in each card would depend on organisations you assigned, if you followed the pattern the counts should be:
      * nwo: 6 software, 6 projects
      * surf: 6 software, 6 projects
      * C_1: 2 software, 2 projects
      * C_2: 2 software, 2 projects
      * C_3: 2 software, 2 projects
* Login as JRB (professor 1)
    * **home page should show same counts**:  6 software, 6 projects, 5 organisations (C_1, C_2, C_3, nwo and surf)
    * **software page should show same counts** as for public user, 6 software items
    * **projects page should show same counts** as for public user, 6 project items
    * **organisation page should show same counts** as for public user, 5 organisations
    * the counts in each card should be the same as for public user
       * nwo: 6 software, 6 projects
       * surf: 6 software, 6 projects
       * C_1: 2 software, 2 projects
       * C_2: 2 software, 2 projects
       * C_3: 2 software, 2 projects
   * **visit C_1 organisation, you are the maintainer of it** and you should see different count:
       *  4 software items: 2 published and 2 not published
       *  4 project items: 2 published and 2 not published
       *  if you deny one item, the count on the card should update, but the counts on C_1 page will remain the same for you as you are the maintainer and can see all items: published, not published and blocked
      
* Login as SAW (professor2)
You should see same counts on home, software, projects and organisations pages as the other users. **You should see different counts from other users when you visit C_2** organisation page, as you are the maintainer of it. As maintainer your counts will include all items: published, not published and "blocked" items. You will also see the items from other users that are not published but are linked to your organisation. 

* Login as SIN (professor3)
You should see same counts on home, software, projects and organisations pages as the other users. **You should see different counts from other users when you visit C_3** organisation page, as you are the maintainer of it. As maintainer your counts will include all items: published, not published and "blocked" items. You will also see the items from other users that are not published but are linked to your organisation. 

 
PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
