### PR TITLE
fix:pass search value when enter key is pressed.

### DIFF
--- a/frontend/components/form/Searchbox.tsx
+++ b/frontend/components/form/Searchbox.tsx
@@ -50,9 +50,12 @@ export default function Searchbox({placeholder, onSearch, delay = 400}: { placeh
         })
       }}
       onKeyPress={(event)=>{
-        // pass search value on enter
-        if (event.key.toLowerCase()==='enter'){
-          onSearch(state)
+        if (event.key.toLowerCase() === 'enter') {
+          // pass search value on enter
+          setState({
+            value:state.value,
+            wait:false
+          })
         }
       }}
       startAdornment={


### PR DESCRIPTION
# Fix using enter key on searchbox for software and projects

Fixes #378 

Changes proposed in this pull request:
*   When using enter the search request will be issued with the proper value instead of the object.   

How to test:

* `docker-compose build frontend` to build frontend
* `docker-compose up` to start
*  type value in searchbox and use enter key. It should work. You can validate search term in the url `search=res&page=0&rows=12`

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
