### PR TITLE
381 missing orcid

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,7 +89,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:1.1.1
+    image: rsd/frontend:1.1.2
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/software/PersonalInfo.tsx
+++ b/frontend/components/software/PersonalInfo.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -12,47 +14,20 @@ type PersonalInfoProps = {
 }
 
 export default function PersonalInfo({role, affiliation, orcid}:PersonalInfoProps) {
-  if (role && affiliation && orcid) {
-    return (
-      <div>
-        <div>{role}</div>
-        <div>{affiliation}</div>
-        <div>
-          <a href={'https://orcid.org/' + orcid} target="_blank" rel="noreferrer"
-            style={{whiteSpace:'nowrap'}}
-          >
-            <LogoOrcid className="inline max-w-[1.125rem] mr-1" />
-            <span className="text-sm align-bottom">{orcid}</span>
-          </a>
-        </div>
-      </div>
-    )
-  }
+  if(!(role || affiliation || orcid)) return null
 
-  if (role && affiliation) {
-    return (
-      <div>
-        <div>{role}</div>
-        <div>{affiliation}</div>
-      </div>
-    )
-  }
-
-  if (role) {
-    return (
-      <div>
-        {role}
-      </div>
-    )
-  }
-
-  if (affiliation) {
-    return (
-      <div>
-        {affiliation}
-      </div>
-    )
-  }
-
-  return null
+  return (
+    <div>
+      {role && <div>{role}</div>}
+      {affiliation && <div>{affiliation}</div>}
+      {orcid && <div>
+        <a href={'https://orcid.org/' + orcid} target="_blank" rel="noreferrer"
+          style={{whiteSpace:'nowrap'}}
+        >
+          <LogoOrcid className="inline max-w-[1.125rem] mr-1" />
+          <span className="text-sm align-bottom">{orcid}</span>
+        </a>
+      </div>}
+    </div>
+  )
 }


### PR DESCRIPTION
# Always show ORCID if present

Changes proposed in this pull request:

* Show ORCID of present, even if role or affiliation is missing

How to test:
* Build and add software and a contributor with any combination of role, affiliation and ORCID. Any of those three fields present should be shown.


Closes #381

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests