### PR TITLE
398 git scapers robust

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
   scrapers:
     container_name: scrapers
     build: ./scrapers
-    image: rsd/scrapers:1.0.0
+    image: rsd/scrapers:1.0.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainLicenses.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainLicenses.java
@@ -8,7 +8,6 @@ package nl.esciencecenter.rsd.scraper.git;
 import nl.esciencecenter.rsd.scraper.Config;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -29,7 +28,7 @@ public class MainLicenses {
 		for (RepositoryUrlData licenseData : dataToScrape) {
 			try {
 				String repoUrl = licenseData.url();
-				String hostname = new URI(repoUrl).getHost();
+				String hostname = URI.create(repoUrl).getHost();
 				String apiUrl = "https://" + hostname + "/api";
 				String projectPath = repoUrl.replace("https://" + hostname + "/", "");
 				if (projectPath.endsWith("/")) projectPath = projectPath.substring(0, projectPath.length() - 1);
@@ -44,9 +43,12 @@ public class MainLicenses {
 			} catch (RuntimeException e) {
 				System.out.println("Exception when handling data from url " + licenseData.url() + ":");
 				e.printStackTrace();
-			} catch (URISyntaxException e) {
-				System.out.println("Error obtaining hostname of repository with url: " + licenseData.url() + ":");
-				e.printStackTrace();
+				RepositoryUrlData oldDataWithUpdatedAt = new RepositoryUrlData(
+						licenseData.software(), licenseData.url(), CodePlatformProvider.GITLAB,
+						licenseData.license(), scrapedAt,
+						licenseData.commitHistory(), licenseData.commitHistoryScrapedAt(),
+						licenseData.languages(), licenseData.languagesScrapedAt());
+				updatedDataAll.add(oldDataWithUpdatedAt);
 			}
 		}
 		new PostgrestSIR(Config.backendBaseUrl() + "/repository_url", CodePlatformProvider.GITLAB).save(updatedDataAll);
@@ -72,6 +74,12 @@ public class MainLicenses {
 			} catch (RuntimeException e) {
 				System.out.println("Exception when handling data from url " + licenseData.url() + ":");
 				e.printStackTrace();
+				RepositoryUrlData oldDataWithUpdatedAt = new RepositoryUrlData(
+						licenseData.software(), licenseData.url(), CodePlatformProvider.GITHUB,
+						licenseData.license(), scrapedAt,
+						licenseData.commitHistory(), licenseData.commitHistoryScrapedAt(),
+						licenseData.languages(), licenseData.languagesScrapedAt());
+				updatedDataAll.add(oldDataWithUpdatedAt);
 			}
 		}
 		new PostgrestSIR(Config.backendBaseUrl() + "/repository_url", CodePlatformProvider.GITHUB).save(updatedDataAll);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainProgrammingLanguages.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainProgrammingLanguages.java
@@ -8,7 +8,6 @@ package nl.esciencecenter.rsd.scraper.git;
 import nl.esciencecenter.rsd.scraper.Config;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -30,7 +29,7 @@ public class MainProgrammingLanguages {
 		for (RepositoryUrlData programmingLanguageData : dataToScrape) {
 			try {
 				String repoUrl = programmingLanguageData.url();
-				String hostname = new URI(repoUrl).getHost();
+				String hostname = URI.create(repoUrl).getHost();
 				String apiUrl = "https://" + hostname + "/api";
 				String projectPath = repoUrl.replace("https://" + hostname + "/", "");
 				if (projectPath.endsWith("/")) projectPath = projectPath.substring(0, projectPath.length() - 1);
@@ -45,9 +44,12 @@ public class MainProgrammingLanguages {
 			} catch (RuntimeException e) {
 				System.out.println("Exception when handling data from url " + programmingLanguageData.url() + ":");
 				e.printStackTrace();
-			} catch (URISyntaxException e) {
-				System.out.println("Error obtaining hostname of repository with url: " + programmingLanguageData.url() + ":");
-				e.printStackTrace();
+				RepositoryUrlData oldDataWithUpdatedAt = new RepositoryUrlData(
+						programmingLanguageData.software(), programmingLanguageData.url(), CodePlatformProvider.GITLAB,
+						programmingLanguageData.license(), programmingLanguageData.licenseScrapedAt(),
+						programmingLanguageData.commitHistory(), programmingLanguageData.commitHistoryScrapedAt(),
+						programmingLanguageData.languages(), scrapedAt);
+				updatedDataAll.add(oldDataWithUpdatedAt);
 			}
 
 		}
@@ -79,6 +81,12 @@ public class MainProgrammingLanguages {
 			} catch (RuntimeException e) {
 				System.out.println("Exception when handling data from url " + programmingLanguageData.url() + ":");
 				e.printStackTrace();
+				RepositoryUrlData oldDataWithUpdatedAt = new RepositoryUrlData(
+						programmingLanguageData.software(), programmingLanguageData.url(), CodePlatformProvider.GITHUB,
+						programmingLanguageData.license(), programmingLanguageData.licenseScrapedAt(),
+						programmingLanguageData.commitHistory(), programmingLanguageData.commitHistoryScrapedAt(),
+						programmingLanguageData.languages(), scrapedAt);
+				updatedDataAll.add(oldDataWithUpdatedAt);
 			}
 		}
 		new PostgrestSIR(Config.backendBaseUrl() + "/repository_url", CodePlatformProvider.GITHUB).save(updatedDataAll);


### PR DESCRIPTION
# Make git scrapers more robust

Changes proposed in this pull request:

* When scraping from GitHub or GitLab fails, still update the `*_scraped_at` so that it will be pushed back in the scraping order

How to test:
* `docker-compose build scrapers && docker-compose up`
* Add two software packages, both with repository url https://www.example.com, one with GitHub as platform provider and one with GitLab
* Let the scrapers run or do it manually:
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages`
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainLicenses`
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits`
* Check that the `*_scraped_at` fields are updated.


Closes #398

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests