### PR TITLE
build: use volume for let's encrypt certificates

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -137,6 +137,7 @@ services:
       - "443:443"
     volumes:
       - ./nginx.conf:/etc/nginx/conf.d/default.conf
+      - lets-encrypt:/etc/letsencrypt
     depends_on:
       - database
       - backend
@@ -155,3 +156,4 @@ networks:
 # volume should have name rsd-as-a-service_pgdb
 volumes:
   pgdb:
+  lets-encrypt:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
     container_name: nginx
     build:
       context: ./nginx
-    image: rsd/nginx:1.0.0
+    image: rsd/nginx:1.0.1
     ports:
       - "80:80"
       - "443:443"
@@ -151,6 +151,8 @@ services:
       - frontend
     networks:
       - net
+    volumes:
+      - lets-encrypt:/etc/letsencrypt
 
 # define name for docker network
 # it should have name: rsd-as-a-service_net
@@ -161,3 +163,4 @@ networks:
 # volume should have name rsd-as-a-service_pgdb
 volumes:
   pgdb:
+  lets-encrypt:


### PR DESCRIPTION
# Use a volume for Let's Encrypt certificates

Fixes #407 

Changes proposed in this pull request:

* Use a named volume to store Let's Encrypt certificates to facilitate easier updates in production

How to test:

* This was tested on the dev vm

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
