### PR TITLE
Correct typo in 'Login failed' message

### DIFF
--- a/frontend/pages/login/failed.tsx
+++ b/frontend/pages/login/failed.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +13,7 @@ export default function LoginFailed() {
       <div className="border p-12">
         <h1>Login failed</h1>
         <p className="py-8">
-          Unfortunatelly, something went wrong during the login process
+          Unfortunately, something went wrong during the login process.
         </p>
         <Link href="/" passHref>
           <a>Go home</a>


### PR DESCRIPTION
# Correct typo in 'Login failed' message

(No relevant issue number)

Changes proposed in this pull request:

* just fixed a small typo

How to test:

* trigger a failure during login process

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
