### PR TITLE
feat: enable docker-compose project names

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,14 @@
 
 # You also need to obtain/generate missing secrets
 
+# ---- DOCKER PROJECT SETTINGS ----------
+
+# Define this variable, if you are running different versions of the RSD, in
+# order to define the docker project name. If you leave this empty, docker will
+# automatically name the containers.
+COMPOSE_PROJECT_NAME="rsd"
+
+
 # ---- PUBLIC ENV VARIABLES -------------
 
 # postgresql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,6 @@ version: "3.0"
 
 services:
   database:
-    container_name: database
     build: ./database
     image: rsd/database:1.0.1
     ports:
@@ -33,7 +32,6 @@ services:
       - net
 
   backend:
-    container_name: backend
     build: ./backend-postgrest
     image: rsd/backend-postgrest:1.0.0
     expose:
@@ -51,7 +49,6 @@ services:
       - net
 
   auth:
-    container_name: auth
     build: ./authentication
     image: rsd/auth:1.0.0
     expose:
@@ -83,7 +80,6 @@ services:
       - net
 
   frontend:
-    container_name: frontend
     build:
       context: ./frontend
       # dockerfile to use for build
@@ -117,7 +113,6 @@ services:
       - net
 
   scrapers:
-    container_name: scrapers
     build: ./scrapers
     image: rsd/scrapers:1.0.1
     environment:
@@ -137,7 +132,6 @@ services:
       - net
 
   nginx:
-    container_name: nginx
     build:
       context: ./nginx
     image: rsd/nginx:1.0.1
@@ -158,6 +152,7 @@ services:
 # it should have name: rsd-as-a-service_net
 networks:
   net:
+
 
 # named volumes can be managed easier using docker-compose
 # volume should have name rsd-as-a-service_pgdb


### PR DESCRIPTION
# Enable docker-compose project names

Fixes #429 

Allow using project names for docker-compose, so the same containers and volumes will not be used for different versions of the RSD. Example: you have the origin repo in `~/git/RSD-as-a-service`, and a fork in `~/git/fork-project/RSD-as-a-service/`, they will share the same volumes, networks and containers (because `container_name` is defined). In case there are differences in the DB structure or elsewhere, this might cause some troubles.

This approach makes use of the `COMPOSE_PROJECT_NAME` environment variable (see [docs](https://docs.docker.com/compose/reference/envvars/#compose_project_name=)). Since the property `container_name` is specified for each container in the `docker-compose.yml`, this property would override `COMPOSE_PROJECT_NAME`. This is why I removed the `container_name`. The relations between the containers are not affected, their names refer to the id's in the yml.

Changes proposed in this pull request:

* Adds a new environment variable `COMPOSE_PROJECT_NAME="rsd"` to `.env.example`
* removes `container_name` properties in `docker-compose.yml`

How to test:

* `docker-compose --down` to clear networks and volumes (optional)
* leave `COMPOSE_PROJECT_NAME` undefined or `COMPOSE_PROJECT_NAME=""`
  * `docker-compose up`
  * will create containers and networks with default names, in this case with prefix `rsd-as-a-service` (=directory name)
* set `COMPOSE_PROJECT_NAME="rsd"`
  * `docker-compose up`
  * will create containers named `rsd-<container>-<#>`, and volumes/networks with prefix `rsd_<..>`

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation (`.env.example`)
*   [ ] Tests
