### PR TITLE
418 software keywords filter

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:1.0.1
+    image: rsd/database:1.0.2
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -85,7 +85,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:1.2.2
+    image: rsd/frontend:1.3.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/__tests__/OrganisationsIndex.test.tsx
+++ b/frontend/__tests__/OrganisationsIndex.test.tsx
@@ -26,7 +26,7 @@ describe('pages/organisations/index.tsx', () => {
   })
 
   it('getServerSideProps returns mocked values in the props', async () => {
-    const resp = await getServerSideProps({req:{cookies:{}}})
+    const resp = await getServerSideProps({req: {cookies: {}}, query: {}})
     expect(resp).toEqual({
       props:{
         // count is extracted from response header
@@ -35,7 +35,8 @@ describe('pages/organisations/index.tsx', () => {
         page:0,
         rows:12,
         // mocked data
-        organisations: organisationsOverview
+        organisations: organisationsOverview,
+        search: null
       }
     })
   })

--- a/frontend/__tests__/ProjectsIndex.test.tsx
+++ b/frontend/__tests__/ProjectsIndex.test.tsx
@@ -40,7 +40,8 @@ describe('pages/projects/index.tsx', () => {
         page:0,
         rows:12,
         // mocked data
-        projects
+        projects,
+        search: null
       }
     })
   })

--- a/frontend/components/form/Searchbox.tsx
+++ b/frontend/components/form/Searchbox.tsx
@@ -12,9 +12,16 @@ import SearchIcon from '@mui/icons-material/Search'
 import {useDebounce} from '~/utils/useDebounce'
 import ClearIcon from '@mui/icons-material/Clear'
 
-export default function Searchbox({placeholder, onSearch, delay = 400}: { placeholder:string,onSearch:Function,delay?:number}) {
+type SearchboxProps = {
+  placeholder: string,
+  onSearch: Function,
+  delay?: number,
+  defaultValue?:string
+}
+
+export default function Searchbox({placeholder, onSearch, delay = 400, defaultValue=''}: SearchboxProps) {
   const [state,setState]=useState({
-    value:'',
+    value:defaultValue ?? '',
     wait:true
   })
   const searchFor=useDebounce(state.value,delay)

--- a/frontend/components/keyword/KeywordFilter.tsx
+++ b/frontend/components/keyword/KeywordFilter.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useState, useEffect} from 'react'
+import {useState, useEffect,Fragment} from 'react'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import IconButton from '@mui/material/IconButton'
@@ -26,6 +26,9 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 import TagListItem from '~/components/layout/TagListItem'
 import FindKeyword, {Keyword} from './FindKeyword'
 import {searchForSoftwareKeyword} from '../software/edit/information/searchForSoftwareKeyword'
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
+
 
 type KeywordFilterProps = {
   items?: string[]
@@ -88,19 +91,18 @@ export default function KeywordsFilter({items=[], onApply}:KeywordFilterProps) {
   function renderSelectedItems() {
     if (selectedItems && selectedItems.length > 0) {
       return (
-        <section className="flex flex-wrap items-center px-4 pt-4 gap-2">
+        <section className="flex flex-wrap items-center px-4 pb-4 gap-2">
           {selectedItems.map((item, pos) => {
             if (pos > 0) {
               return (
-                <>
-                  <span key={`plus-${pos}`} className="text-md">+</span>
+                <Fragment key={pos}>
+                  <span className="text-md">+</span>
                   <Chip
-                    key={`chip-${pos}`}
                     label={item}
                     size="small"
                     onDelete={() => handleDelete(pos)}
                   />
-                </>
+                </Fragment>
               )
             }
             return (
@@ -115,7 +117,13 @@ export default function KeywordsFilter({items=[], onApply}:KeywordFilterProps) {
         </section>
       )
     }
-    return null
+    // debugger
+    return (
+      <Alert severity="info" sx={{marginTop: '0.5rem'}}>
+        {/* <AlertTitle sx={{fontWeight: 500}}>No keywords to filter.</AlertTitle> */}
+        Add keyword <strong>by typing</strong> in the Find keyword.
+      </Alert>
+    )
   }
 
   return (
@@ -142,14 +150,12 @@ export default function KeywordsFilter({items=[], onApply}:KeywordFilterProps) {
           Filter by keyword
         </h3>
         <Divider />
-        {renderSelectedItems()}
-        <section className="px-4 py-4 w-[22rem]">
+        <div className="px-4 py-4 w-[22rem]">
           <FindKeyword
             config={{
               freeSolo: false,
               minLength: 1,
-              label: 'Add keyword to filter',
-              // help: 'Search for avilable keywords',
+              label: 'Find keyword',
               help: '',
               reset: true
             }}
@@ -157,14 +163,15 @@ export default function KeywordsFilter({items=[], onApply}:KeywordFilterProps) {
             onAdd={onAdd}
             // onCreate={onCreate}
           />
-        </section>
+        </div>
+        {renderSelectedItems()}
         <Divider />
         <div className="flex items-center justify-between px-4 py-2">
           <Button
             color="secondary"
             startIcon={<CloseIcon />}
             onClick={handleClear}>
-            Clear
+            {selectedItems.length === 0 ? 'Close' : 'Clear'}
           </Button>
           <Button
             onClick={handleApply}

--- a/frontend/components/keyword/KeywordFilter.tsx
+++ b/frontend/components/keyword/KeywordFilter.tsx
@@ -92,14 +92,15 @@ export default function KeywordsFilter({items=[], onApply}:KeywordFilterProps) {
           {selectedItems.map((item, pos) => {
             if (pos > 0) {
               return (
-                <div key={pos}>
-                  <span className="text-md">+</span>
+                <>
+                  <span key={`plus-${pos}`} className="text-md">+</span>
                   <Chip
+                    key={`chip-${pos}`}
                     label={item}
                     size="small"
                     onDelete={() => handleDelete(pos)}
                   />
-                </div>
+                </>
               )
             }
             return (

--- a/frontend/components/keyword/KeywordFilter.tsx
+++ b/frontend/components/keyword/KeywordFilter.tsx
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2021 - 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState, useEffect} from 'react'
+import Menu from '@mui/material/Menu'
+import MenuItem from '@mui/material/MenuItem'
+import IconButton from '@mui/material/IconButton'
+import Tooltip from '@mui/material/Tooltip'
+import ListItemText from '@mui/material/ListItemText'
+import Checkbox from '@mui/material/Checkbox'
+import Badge from '@mui/material/Badge'
+import Divider from '@mui/material/Divider'
+import Button from '@mui/material/Button'
+import FilterAltIcon from '@mui/icons-material/FilterAlt'
+import ClearAllIcon from '@mui/icons-material/ClearAll'
+import CloseIcon from '@mui/icons-material/Close'
+import {TagItem} from '../../utils/getSoftware'
+import Popover from '@mui/material/Popover'
+import Box from '@mui/material/Box'
+import Chip from '@mui/material/Chip'
+import Stack from '@mui/material/Stack'
+import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+
+import TagListItem from '~/components/layout/TagListItem'
+import FindKeyword, {Keyword} from './FindKeyword'
+import {searchForSoftwareKeyword} from '../software/edit/information/searchForSoftwareKeyword'
+
+type KeywordFilterProps = {
+  items?: string[]
+  onApply: (items: string[]) => void
+}
+
+/**
+ * Keywords filter component. It receives array of keywords and returns
+ * array of selected tags to use in filter using onSelect callback function
+ */
+export default function KeywordsFilter({items=[], onApply}:KeywordFilterProps) {
+  const [selectedItems, setSelectedItems] = useState<string[]>(items ?? [])
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+
+  // console.group('KeywordsFilter')
+  // console.log('selectedItems...', selectedItems)
+  // console.log('open...', open)
+  // console.groupEnd()
+
+
+  function handleOpen(event: React.MouseEvent<HTMLElement>){
+    setAnchorEl(event.currentTarget)
+  }
+  function handleClose(){
+    setAnchorEl(null)
+  }
+
+  function handleClear(){
+    setSelectedItems([])
+    onApply([])
+    handleClose()
+  }
+
+  function handleApply(){
+    onApply(selectedItems)
+    handleClose()
+  }
+
+  function handleDelete(pos:number) {
+    const newList = [
+      ...selectedItems.slice(0, pos),
+      ...selectedItems.slice(pos+1)
+    ]
+    setSelectedItems(newList)
+  }
+
+  function onAdd(item: Keyword) {
+    const find = selectedItems.find(keyword => keyword.toLowerCase() === item.keyword.toLowerCase())
+    // new item
+    if (typeof find == 'undefined') {
+      const newList = [
+        ...selectedItems,
+        item.keyword
+      ].sort()
+      setSelectedItems(newList)
+    }
+  }
+
+  function renderSelectedItems() {
+    if (selectedItems && selectedItems.length > 0) {
+      return (
+        <section className="flex flex-wrap items-center px-4 pt-4 gap-2">
+          {selectedItems.map((item, pos) => {
+            if (pos > 0) {
+              return (
+                <div key={pos}>
+                  <span className="text-md">+</span>
+                  <Chip
+                    label={item}
+                    size="small"
+                    onDelete={() => handleDelete(pos)}
+                  />
+                </div>
+              )
+            }
+            return (
+              <Chip
+                key={pos}
+                label={item}
+                size="small"
+                onDelete={() => handleDelete(pos)}
+              />
+            )
+          })}
+        </section>
+      )
+    }
+    return null
+  }
+
+  return (
+    <>
+      <Tooltip title={`Filter: ${selectedItems.join(' + ')}`}>
+        <IconButton onClick={handleOpen}>
+          <Badge badgeContent={selectedItems.length} color="primary">
+            <FilterAltIcon />
+          </Badge>
+        </IconButton>
+      </Tooltip>
+      <Popover
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        // align menu to the right from the menu button
+        transformOrigin={{horizontal: 'right', vertical: 'top'}}
+        anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
+        sx={{
+          maxWidth:'24rem'
+        }}
+      >
+        <h3 className="px-4 py-3 text-primary">
+          Filter by keyword
+        </h3>
+        <Divider />
+        {renderSelectedItems()}
+        <section className="px-4 py-4 w-[22rem]">
+          <FindKeyword
+            config={{
+              freeSolo: false,
+              minLength: 1,
+              label: 'Add keyword to filter',
+              // help: 'Search for avilable keywords',
+              help: '',
+              reset: true
+            }}
+            searchForKeyword={searchForSoftwareKeyword}
+            onAdd={onAdd}
+            // onCreate={onCreate}
+          />
+        </section>
+        <Divider />
+        <div className="flex items-center justify-between px-4 py-2">
+          <Button
+            color="secondary"
+            startIcon={<CloseIcon />}
+            onClick={handleClear}>
+            Clear
+          </Button>
+          <Button
+            onClick={handleApply}
+            startIcon={<PlayArrowIcon />}
+            disabled={selectedItems.length===0}
+          >
+            Apply
+          </Button>
+        </div>
+      </Popover>
+    </>
+  )
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/organisations/index.tsx
+++ b/frontend/pages/organisations/index.tsx
@@ -20,11 +20,19 @@ import {ssrOrganisationParams} from '../../utils/extractQueryParam'
 import {getOrganisationsList} from '../../utils/getOrganisations'
 import OrganisationsGrid from '../../components/organisation/OrganisationGrid'
 
+type OrganisationsIndexPageProps = {
+  count: number,
+  page: number,
+  rows: number,
+  organisations: OrganisationForOverview[]
+  search?:string
+}
+
 const pageTitle = `Organisations | ${app.title}`
 
-export default function OrganisationsIndexPage({count,page,rows,organisations=[]}:
-  {count:number,page:number,rows:number,organisations:OrganisationForOverview[]
-}) {
+export default function OrganisationsIndexPage({
+  organisations = [], count, page, rows, search
+}: OrganisationsIndexPageProps){
   // use next router (hook is only for browser)
   const router = useRouter()
 
@@ -34,7 +42,8 @@ export default function OrganisationsIndexPage({count,page,rows,organisations=[]
     newPage: number,
   ){
     const url = ssrOrganisationUrl({
-      query: router.query,
+      // take existing params from url (query)
+      ...ssrOrganisationParams(router.query),
       page: newPage
     })
     router.push(url)
@@ -45,7 +54,8 @@ export default function OrganisationsIndexPage({count,page,rows,organisations=[]
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ){
     const url = ssrOrganisationUrl({
-      query: router.query,
+      // take existing params from url (query)
+      ...ssrOrganisationParams(router.query),
       // reset to first page
       page: 0,
       rows: parseInt(event.target.value),
@@ -55,7 +65,8 @@ export default function OrganisationsIndexPage({count,page,rows,organisations=[]
 
   function handleSearch(searchFor:string){
     const url = ssrOrganisationUrl({
-      query: router.query,
+      // take existing params from url (query)
+      ...ssrOrganisationParams(router.query),
       search: searchFor,
       // start from first page
       page: 0
@@ -74,6 +85,7 @@ export default function OrganisationsIndexPage({count,page,rows,organisations=[]
             <Searchbox
               placeholder='Search for organisation'
               onSearch={handleSearch}
+              defaultValue={search}
             />
           </div>
           <TablePagination
@@ -102,7 +114,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // extract params from page-query
   // extract rsd_token
   const {req} = context
-  const {search, rows, page} = ssrOrganisationParams(context)
+  const {search, rows, page} = ssrOrganisationParams(context.query)
   const token = req?.cookies['rsd_token']
 
   const {count, data} = await getOrganisationsList({
@@ -116,6 +128,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // see params of SoftwareIndexPage function
   return {
     props: {
+      search,
       count,
       page,
       rows,

--- a/frontend/utils/extractQueryParam.test.ts
+++ b/frontend/utils/extractQueryParam.test.ts
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {ParsedUrlQuery} from 'node:querystring'
+import {extractQueryParam} from './extractQueryParam'
+
+
+it('extracts rows param from url query', () => {
+  const query: ParsedUrlQuery = {
+    rows: '12'
+  }
+  const rows = extractQueryParam({
+    query,
+    param: 'rows',
+    defaultValue: 12,
+    castToType: 'number'
+  })
+  expect(rows).toEqual(12)
+})
+
+it('extracts page param from url query', () => {
+  const query: ParsedUrlQuery = {
+    page: '1'
+  }
+  const page = extractQueryParam({
+    query,
+    param: 'page',
+    defaultValue: 0,
+    castToType: 'number'
+  })
+  expect(page).toEqual(1)
+})
+
+
+it('extracts search param from url query', () => {
+  const expected = 'test search'
+  const query: ParsedUrlQuery = {
+    search: expected
+  }
+  const search = extractQueryParam({
+    query,
+    param: 'search',
+    defaultValue: null,
+    castToType: 'string'
+  })
+  expect(search).toEqual(expected)
+})
+
+it('extracts keywords as array from url query', () => {
+  const expected = ['test keyword 1', 'test, keyword & special chars']
+  const encoded = JSON.stringify(expected)
+  const query: ParsedUrlQuery = {
+    keywords: encoded
+  }
+  const keywords = extractQueryParam({
+    query,
+    param: 'keywords',
+    castToType: 'json-encoded',
+    defaultValue: null
+  })
+  expect(keywords).toEqual(expected)
+})

--- a/frontend/utils/extractQueryParam.ts
+++ b/frontend/utils/extractQueryParam.ts
@@ -4,24 +4,32 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import type {GetServerSidePropsContext} from 'next'
+import {ParsedUrlQuery} from 'querystring'
 import logger from './logger'
 
-export function extractQueryParam({ctx,param,castToType='string',defaultValue}:{
-  ctx: GetServerSidePropsContext, param:string, castToType?:('string'|'number'|'date'),
+export function extractQueryParam({query,param,castToType='string',defaultValue}:{
+  query: ParsedUrlQuery, param: string, castToType?: ('string' | 'number' | 'date' | 'csv-to-array' |'json-encoded'),
   defaultValue:any
 }){
   try{
-    if (ctx?.query && ctx.query.hasOwnProperty(param)){
-      const rawVal = ctx.query[param]
+    if (query && query.hasOwnProperty(param)){
+      const rawVal = query[param]
       if (typeof rawVal == 'undefined') return defaultValue
       switch (castToType){
-      case 'number':
-        return parseInt(rawVal?.toString())
-      case 'date':
-        return new Date(rawVal?.toString())
-      case 'string':
-      default:
-        return rawVal?.toString()
+        case 'number':
+          return parseInt(rawVal?.toString())
+        case 'date':
+          return new Date(rawVal?.toString())
+        case 'string':
+          return rawVal?.toString()
+        case 'csv-to-array':
+          const parsed = rawVal.toString().split(',')
+          return parsed
+        case 'json-encoded':
+          const json = JSON.parse(decodeURI(rawVal.toString()))
+          return json
+        default:
+          return rawVal
       }
     }else{
     // return default value
@@ -33,52 +41,60 @@ export function extractQueryParam({ctx,param,castToType='string',defaultValue}:{
     throw e
   }}
 
-export function ssrSoftwareParams(ctx: GetServerSidePropsContext){
+export function ssrSoftwareParams(query: ParsedUrlQuery) {
+  // console.group('ssrSoftwareParams')
+  // console.log('query...', ctx.query)
+  // console.log('params...', ctx.params)
   const rows = extractQueryParam({
-    ctx,
+    query,
     param: 'rows',
     defaultValue: 12,
     castToType:'number'
   })
   const page = extractQueryParam({
-    ctx,
+    query,
     param: 'page',
     defaultValue: 0,
     castToType:'number'
   })
   const search = extractQueryParam({
-    ctx,
+    query,
     param: 'search',
+    defaultValue: null,
+    castToType:'string'
+  })
+  const keywords = extractQueryParam({
+    query,
+    param: 'keywords',
+    castToType: 'json-encoded',
     defaultValue: null
   })
-  const filterStr = extractQueryParam({
-    ctx,
-    param: 'filter',
-    defaultValue: null
-  })
+  // console.log('keywords...', keywords)
+  // console.log('keywords...', typeof keywords)
+  // console.groupEnd()
   return {
     search,
-    filterStr,
+    keywords,
     rows,
     page,
   }
 }
 
-export function ssrProjectsParams(ctx: GetServerSidePropsContext) {
+export function ssrProjectsParams(query: ParsedUrlQuery) {
   const rows = extractQueryParam({
-    ctx,
+    query,
     param: 'rows',
     defaultValue: 12,
     castToType: 'number'
   })
   const page = extractQueryParam({
-    ctx,
+    query,
     param: 'page',
     defaultValue: 0,
     castToType: 'number'
   })
   const search = extractQueryParam({
-    ctx,
+    query,
     param: 'search',
     defaultValue: null
   })
@@ -89,21 +105,21 @@ export function ssrProjectsParams(ctx: GetServerSidePropsContext) {
   }
 }
 
-export function ssrOrganisationParams(ctx: GetServerSidePropsContext) {
+export function ssrOrganisationParams(query: ParsedUrlQuery) {
   const rows = extractQueryParam({
-    ctx,
+    query,
     param: 'rows',
     defaultValue: 12,
     castToType: 'number'
   })
   const page = extractQueryParam({
-    ctx,
+    query,
     param: 'page',
     defaultValue: 0,
     castToType: 'number'
   })
   const search = extractQueryParam({
-    ctx,
+    query,
     param: 'search',
     defaultValue: null
   })

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -38,7 +38,7 @@ export async function getSoftwareList({url,token}:{url:string,token?:string }){
         }))
       }
     } else{
-      logger(`getSoftwareList failed: ${resp.status} ${resp.statusText}`, 'warn')
+      logger(`getSoftwareList failed: ${resp.status} ${resp.statusText} ${url}`, 'warn')
       return {
         count:0,
         data:[]

--- a/frontend/utils/postgrestUrl.test.ts
+++ b/frontend/utils/postgrestUrl.test.ts
@@ -3,12 +3,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {PostgrestParams, softwareListUrl, ssrSoftwareUrl} from './postgrestUrl'
+import {PostgrestParams, softwareListUrl, softwareUrl} from './postgrestUrl'
 
 describe('softwareListUrl', () => {
   it('returns softwareListUrl when only baseUrl provided', () => {
     const baseUrl='http://test-base-url'
-    const expectUrl = `${baseUrl}/rpc/software_list?&limit=12&offset=0`
+    const expectUrl = `${baseUrl}/rpc/software_search?&limit=12&offset=0`
     const url = softwareListUrl({
       baseUrl
     } as PostgrestParams)
@@ -18,7 +18,7 @@ describe('softwareListUrl', () => {
   it('returns softwareUrl with search', () => {
     const baseUrl = 'http://test-base-url'
     // if you change search value then change expectedUrl values too
-    const expectUrl = `${baseUrl}/rpc/software_list?&or=(brand_name.ilike.*test-search*, short_statement.ilike.*test-search*))&limit=12&offset=0`
+    const expectUrl = `${baseUrl}/rpc/software_search?&or=(brand_name.ilike.*test-search*, short_statement.ilike.*test-search*)&limit=12&offset=0`
     const url = softwareListUrl({
       baseUrl,
       // if you change search value then change expectedUrl values too
@@ -26,37 +26,36 @@ describe('softwareListUrl', () => {
     } as PostgrestParams)
     expect(url).toEqual(expectUrl)
   })
+
+  it('returns softwareUrl with keywords', () => {
+    const baseUrl = 'http://test-base-url'
+    // if you change search value then change expectedUrl values too
+    const expectUrl = `${baseUrl}/rpc/software_search?keywords=cs.%7B\"test-filter\"%7D&limit=12&offset=0`
+    const url = softwareListUrl({
+      baseUrl,
+      keywords: ['test-filter']
+    } as PostgrestParams)
+    expect(url).toEqual(expectUrl)
+  })
 })
 
 
-describe('ssrSoftwareUrl', () => {
-  it('returns ssrSoftwareUrl with query filter', () => {
-    const expectUrl = '/software?&filter=filter-1%2Cfilter-2&page=0&rows=12'
-    const url = ssrSoftwareUrl({
-      query:{filter:['filter-1','filter-2']}
+describe('softwareUrl', () => {
+  it('returns softwareUrl with stringified and encoded keywords filter', () => {
+    const expectUrl = '/software?&keywords=%5B%22filter-1%22%2C%22filter-2%22%5D&page=0&rows=12'
+    const url = softwareUrl({
+      keywords: ['filter-1', 'filter-2']
     })
     expect(url).toEqual(expectUrl)
   })
 
-  it('returns ssrSoftwareUrl with search param and page 10', () => {
+  it('returns softwareUrl with search param and page 10', () => {
     const expectUrl = '/software?search=test-search-item&page=10&rows=12'
-    const url = ssrSoftwareUrl({
-      query: {},
+    const url = softwareUrl({
       search: 'test-search-item',
       page: 10
     })
     expect(url).toEqual(expectUrl)
   })
 
-  it('ignores query when filter prop provided, page 10 and 50 rows', () => {
-    const expectUrl = '/software?search=test-search-item&filter=stringified-filter-prefered&page=10&rows=50'
-    const url = ssrSoftwareUrl({
-      filter: 'stringified-filter-prefered',
-      query:{filter:['filter-1','filter-2']},
-      search: 'test-search-item',
-      page: 10,
-      rows: 50
-    })
-    expect(url).toEqual(expectUrl)
-  })
 })


### PR DESCRIPTION
# Add keywords filter to software page

Closes #418 

Changes proposed in this pull request:
* User can filter on keywords on the software overview page. As the keywords are "free" values user needs fist to search for keywords he wants to add to filter
* Filtering on keywords is using AND "binding" between selected keywords.
* The filters are applied to url and can be saved or used to let other user land on the filtered software page.

How to test:

* `docker-compose down --volumes`: to remove old data structure
* `docker-compose build` to build new solution
* `docker-compose up` to start
* optional: run data migration
* on the software overview page you should see filter icon next to search input
![image](https://user-images.githubusercontent.com/9204081/181043539-0b8d1123-d15e-439d-a320-64a263092714.png)
* to add keyword you first type at least one letter of the keyword, a for example. The list of available keywords will be shown and you can select one to add. After you added few keywords click on apply button and the filter should be applied
* If you hover over the filter after it is active it will show you keywords used
![image](https://user-images.githubusercontent.com/9204081/181044787-84f973bf-328a-4745-872f-3df7e3f687da.png)
* The filter is implemented in the url too, so you can use the url to save filter selection. Copy the url, open the new tab and paste the url in the adressbar. It should open new page with filters applied.
* The CLEAR button in the filter drop-down will remove the filter.

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
