### PR TITLE
465 remove related project

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:1.0.3
+    image: rsd/database:1.2.0
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -85,7 +85,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:1.4.0
+    image: rsd/frontend:1.2.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/form/AsyncAutocompleteSC.tsx
+++ b/frontend/components/form/AsyncAutocompleteSC.tsx
@@ -121,7 +121,7 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
    * value to useDebounce, which returns searchFor value after the timeout.
    */
   function onInputChange(e: any, newInputValue: string) {
-    // console.log('onInputChange.AsyncAutocompleteSC')
+    // console.log('onInputChange.AsyncAutocompleteSC...',newInputValue)
     if (e?.key === 'Enter') {
       // ignore enter
     } else {
@@ -258,9 +258,6 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
               if (e.key === 'Enter' && open === false) {
                 // stop propagation
                 e.stopPropagation()
-              }
-              if (e.key === 'Delete') {
-                setInputValue('')
               }
             }}
             InputProps={{

--- a/frontend/components/projects/edit/related/RelatedProjectsForProject.tsx
+++ b/frontend/components/projects/edit/related/RelatedProjectsForProject.tsx
@@ -32,7 +32,9 @@ export default function RelatedProjectsForProject() {
         project: project.id,
         token: session.token,
         frontend: true,
-        approved: false
+        approved: false,
+        // order by title only
+        order:'title.asc'
       })
       // check abort
       if (abort) return null
@@ -94,7 +96,7 @@ export default function RelatedProjectsForProject() {
         const newList = [
           ...relatedProject.slice(0, pos),
           ...relatedProject.slice(pos+1)
-        ].sort((a, b) => sortOnStrProp(a, b, 'brand_name'))
+        ].sort((a, b) => sortOnStrProp(a, b, 'title'))
         setRelatedProject(newList)
       }
     }

--- a/frontend/components/software/edit/organisations/FindOrganisationItem.tsx
+++ b/frontend/components/software/edit/organisations/FindOrganisationItem.tsx
@@ -9,22 +9,18 @@ import {SearchOrganisation} from '../../../../types/Organisation'
 export default function FindOrganisationItem({option}: { option: AutocompleteOption<SearchOrganisation> }) {
 
   function renderSecondRow() {
-    if (option.data?.website && option.data?.ror_id) {
-      return (
-        <div className="grid grid-cols-[4fr,3fr] gap-2">
-          <div className="break-all" >{option.data?.website}</div>
-          <div className="pl-4 text-right">{option.data?.ror_id}</div>
-        </div>
-      )
-    }
-    if (option.data?.ror_id) {
-      return (
-        <div className="flex-1">
-          {option.data?.ror_id}
-        </div>
-      )
-    }
-    return null
+    return (
+      <div className="grid grid-cols-[4fr,3fr] gap-2">
+        <div className="break-all" >{
+          option.data?.website ??
+          <span className="text-base-content-disabled">website url missing</span>
+        }</div>
+        <div className="pl-4 text-right">{
+          option.data?.ror_id ??
+          <span className="text-base-content-disabled">ror_id missing</span>
+        }</div>
+      </div>
+    )
   }
 
   return (

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -33,7 +33,7 @@ module.exports = {
   output: 'standalone',
   // disable strict mode for react-beautiful-dnd in development
   // see for more info https://nextjs.org/docs/api-reference/next.config.js/react-strict-mode
-  reactStrictMode: false,
+  reactStrictMode: true,
   eslint: {
     // Run ESLint in these directories during production builds (next build)
     // by default next runs linter only in pages/, components/, and lib/

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "1.4.0",
+  "version": "1.2.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/utils/getProjects.ts
+++ b/frontend/utils/getProjects.ts
@@ -490,11 +490,17 @@ export async function getTeamForProject({project, token, frontend}:
   }
 }
 
-export async function getRelatedProjectsForProject({project, token, frontend, approved = true}:
-  { project: string, token?: string, frontend?: boolean, approved?: boolean }) {
+export async function getRelatedProjectsForProject({project, token, frontend, approved = true, order}:
+  { project: string, token?: string, frontend?: boolean, approved?: boolean, order?:string }) {
   try {
     // construct api url based on request source
-    let query = `rpc/related_projects_for_project?origin_id=${project}&order=current_state.desc,date_start.desc,title.asc`
+    let query = `rpc/related_projects_for_project?origin_id=${project}`
+    if (order) {
+      query += `&order=${order}`
+    } else {
+      // default project order
+      query += '&order=current_state.desc,date_start.desc,title.asc'
+    }
     if (approved) {
       // select only approved and published relations
       query += '&status=eq.approved&is_published=eq.true'

--- a/frontend/utils/sortFn.ts
+++ b/frontend/utils/sortFn.ts
@@ -3,16 +3,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import logger from './logger'
+
 /**
  * Array sorting functions for array of objects.
 */
 
-export function sortOnStrProp(itemA:any, itemB:any, prop:string, sortDir:'asc'|'desc'='asc'){
-  // ignore case
-  const nameA = itemA[prop].toUpperCase()
-  const nameB = itemB[prop].toUpperCase()
-
-  return sortItems(nameA,nameB,sortDir)
+export function sortOnStrProp(itemA: any, itemB: any, prop: string, sortDir: 'asc' | 'desc' = 'asc') {
+  try {
+    // ignore case
+    const nameA = itemA[prop].toUpperCase()
+    const nameB = itemB[prop].toUpperCase()
+    return sortItems(nameA,nameB,sortDir)
+  } catch (e: any) {
+    // on error we log and return neutral score
+    logger(`sortOnStrProp failed. Error: ${e.message}`)
+    return 0
+  }
 }
 
 export function sortOnDateProp(itemA: any, itemB: any, prop: string, sortDir: 'asc' | 'desc' = 'asc'){


### PR DESCRIPTION
# Enable remove of related project on software and project page

Closes #465 
Closes #458

Changes proposed in this pull request:
*  User is able to remove related project and the item will be removed from UI
* When searching for organisation we show website and ror_id below the name and "missing" message when this info is not provided

How to test:
* `docker-compose build` to build new solution
* `docker-compose up` to start
* confirm you are able to remove related project on software edit page and project edit page
* confirm search for organisation returns following output
![image](https://user-images.githubusercontent.com/9204081/181790451-b680abaa-d5cc-407f-9c4b-a191ee1dd81b.png)

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
