### PR TITLE
464 case sensitive doi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 Netherlands eScience Center
@@ -14,9 +15,6 @@ start:
 	docker-compose down --volumes #cleanup phase
 	docker-compose build # build all services
 	docker-compose up  --scale scrapers=0 -d
-	# Sleep 30 seconds to be sure that docker-compose up is running
-	sleep 30
-	cd data-migration && docker-compose build && docker-compose up
 	# open http://localhost to see the application running
 
 install:
@@ -27,7 +25,6 @@ install:
 	cd documentation && yarn -d
 	# Sleep 30 seconds to be sure that docker-compose up is running
 	sleep 30
-	cd data-migration && docker-compose build && docker-compose up
 	docker-compose down
 
 dev:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Copy the file `.env.example` to `.env` file at the root of the project
 and fill the secrets and passwords. Check if the secrets are correct.
 The `Makefile` will take care about creating an appropraite `frontend/.env.local`
 from the `.env` file.
-2. Running once `make local` will install all dependencies, build the docker images and run the **data migration** script.
+2. Running once `make install` will install all dependencies and build the docker images.
 
 **Requirements:**
 
@@ -41,7 +41,7 @@ from the `.env` file.
 ### List of commands
 
 ```shell
-make up     # Run the complete solution locally.
+make start     # Run the complete solution locally.
 make down      # Stop all services with `docker-compose down`
 ```
 
@@ -55,7 +55,7 @@ make down      # Stop all services with `docker-compose down`
 ```shell
 # Developing the frontend
 # One time
-make install   # Build and install all dependencies and will run the **data migration** script.
+make install   # Build and install all dependencies.
 
 # Run the Development version
 make dev       # Run the frontend and the documentation locally on localhost:3000 and localhost:3030 respectively

--- a/data-migration/README.md
+++ b/data-migration/README.md
@@ -1,11 +1,14 @@
 <!--
-SPDX-FileCopyrightText: 2021 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2021 Netherlands eScience Center
+SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2022 dv4all
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
+
+#DEPRECATED
+This script is now deprecated and should not be used anymore.
 
 # Data migration
 

--- a/database/002-create-software-table.sql
+++ b/database/002-create-software-table.sql
@@ -5,6 +5,11 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+-- install citext extension for
+-- case insensitive indexing
+-- https://www.postgresql.org/docs/current/citext.html
+CREATE EXTENSION IF NOT EXISTS citext;
+
 CREATE TYPE description_type AS ENUM (
 	'link',
 	'markdown'
@@ -14,7 +19,7 @@ CREATE TABLE software (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
 	slug VARCHAR(200) UNIQUE NOT NULL CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
 	brand_name VARCHAR(200) NOT NULL,
-	concept_doi VARCHAR(100) CHECK (concept_doi ~ '^10(\.\w+)+/\S+$'),
+	concept_doi CITEXT CHECK (concept_doi ~ '^10(\.\w+)+/\S+$' AND LENGTH(concept_doi) <= 255),
 	description VARCHAR(10000),
 	description_url VARCHAR(200) CHECK (description_url ~ '^https?://'),
 	description_type description_type DEFAULT 'markdown' NOT NULL,

--- a/database/006-create-keyword.sql
+++ b/database/006-create-keyword.sql
@@ -3,11 +3,6 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
--- install citex extension for
--- case insensitive indexing
--- https://www.postgresql.org/docs/current/citext.html
-CREATE EXTENSION IF NOT EXISTS citext;
-
 CREATE TABLE keyword (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
 	value CITEXT UNIQUE

--- a/database/008-create-mention-table.sql
+++ b/database/008-create-mention-table.sql
@@ -27,7 +27,7 @@ CREATE TYPE mention_type AS ENUM (
 
 CREATE TABLE mention (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	doi VARCHAR(255) UNIQUE CHECK (doi ~ '^10(\.\w+)+/\S+$'),
+	doi CITEXT UNIQUE CHECK (doi ~ '^10(\.\w+)+/\S+$' AND LENGTH(doi) <= 255),
 	url VARCHAR(500) CHECK (url ~ '^https?://'),
 	title VARCHAR(500) NOT NULL,
 	authors VARCHAR(15000),

--- a/database/009-create-release-table.sql
+++ b/database/009-create-release-table.sql
@@ -45,7 +45,7 @@ CREATE TRIGGER sanitise_update_release BEFORE UPDATE ON release FOR EACH ROW EXE
 CREATE FUNCTION software_join_release() RETURNS TABLE (
 	software_id UUID,
 	slug VARCHAR,
-	concept_doi VARCHAR,
+	concept_doi CITEXT,
 	release_id UUID,
 	releases_scraped_at TIMESTAMPTZ
 ) LANGUAGE plpgsql STABLE AS
@@ -67,7 +67,7 @@ CREATE TABLE release_content (
 	release_id UUID REFERENCES release (id) NOT NULL,
 	citability citability NOT NULL,
 	date_published DATE NOT NULL,
-	doi VARCHAR NOT NULL UNIQUE,
+	doi CITEXT NOT NULL UNIQUE CHECK (doi ~ '^10(\.\w+)+/\S+$' AND LENGTH(doi) <= 255),
 	tag VARCHAR NOT NULL,
 	url VARCHAR NOT NULL,
 	bibtex VARCHAR,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:1.2.0
+    image: rsd/database:1.3.0
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -116,7 +116,7 @@ services:
 
   scrapers:
     build: ./scrapers
-    image: rsd/scrapers:1.0.1
+    image: rsd/scrapers:1.0.2
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -1,4 +1,5 @@
 <!--
+SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 
@@ -102,22 +103,6 @@ To clear the database, if the database structure has changed or you need to run 
 ```bash
 docker-compose down --volumes
 ```
-
-## Data migration
-
-A data migration script is available to migrate data from the legacy RSD to the new one:
-
-*   run current RSD solution using `docker-compose up` from the root of the project
-*   run the migration script using docker-compose file in the data-migration folder
-
-```bash
-# navigate to data-migration folder
-cd data-migration
-# run data migration docker-compose file
-docker-compose up
-```
-
-More information about [data migration is available here](data-migration/README.md).
 
 ## Tech Stack
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.stream.Collectors;
 
 public class MainMentions {
@@ -30,7 +31,7 @@ public class MainMentions {
 //		we will remove successfully scraped mentions from here,
 //		we use this to set scrapedAt even for failed mentions,
 //		to put them back at the scraping order
-		Map<String, MentionRecord> mentionsFailedToScrape = new HashMap<>();
+		Map<String, MentionRecord> mentionsFailedToScrape = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 		for (MentionRecord mentionRecord : mentionsToScrape) {
 			mentionsFailedToScrape.put(mentionRecord.doi, mentionRecord);
 		}


### PR DESCRIPTION
# Make DOI's case insensitive

Changes proposed in this pull request:

* Columns in the database that store a DOI now use the case insensitive variable type `CITEXT` (see https://www.postgresql.org/docs/14/citext.html)
* Fix the mentions scraper to be case insensitive with respect to DOI's
* This update breaks the data-migration script, so we deprecate it and update the documentation

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up`
* Add a software page, add a mention with doi `10.4230/DagMan.6.1.1`. The mention should be found in Datacite.
* Add another software page, add a mention with doi `10.4230/dagman.6.1.1` (note that it's the same DOI but with different casing). It should find this mention in the RSD instead of Datacite. You should be able to add this mention without an error.
* Use DBeaver or something comparable to change the DOI of mention in the database to `10.4230/DagMan.6.1.1`. Run the scraper (`docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions`). It should finish without an error, and the DOI of the mention will be changed back to small letters (`10.4230/dagman.6.1.1`)


Closes #464
Closes #460

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests