### PR TITLE
Add Matomo cookie banner

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -3,72 +3,37 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-# Based on Next official example for minimal image size (standalone approach)
-# https://github.com/vercel/next.js/blob/canary/examples/with-docker/Dockerfile
-# it requires output: 'standalone' in next.config.js
-
-# ----------------------------------------
-# 1. Install dependencies only when needed
-# ----------------------------------------
-FROM node:18.5-buster-slim AS deps
-
-WORKDIR /app
-
-# copy
-COPY package.json yarn.lock ./
-# install
-RUN yarn install --frozen-lockfile --silent
-
-# ----------------------------------------
-# 2. Build image
-# ----------------------------------------
-FROM node:18.5-buster-slim AS builder
-
-WORKDIR /app
-
-# copy node_module from deps image
-COPY --from=deps /app/node_modules ./node_modules
-# copy all files from repo (ones not defined in .dockerignore)
-COPY . .
+FROM node:18.5-buster-slim
 
 # Next.js collects completely anonymous telemetry data about general usage.
 # Learn more here: https://nextjs.org/telemetry
 # Uncomment the following line in case you want to disable telemetry.
 ENV NEXT_TELEMETRY_DISABLED 1
 
+WORKDIR /app
+
+# copy
+COPY package.json yarn.lock ./
+
+# install
+RUN yarn install --frozen-lockfile --silent
+
+# copy all files from repo (ones not defined in .dockerignore)
+COPY . .
+
 # test solution
 RUN yarn test
+
+ENV NODE_ENV production
 
 # build the solution
 RUN yarn build
 
-# ----------------------------------------
-# 3. Production image (standalone mode)
-# ----------------------------------------
-FROM node:18.5-buster-slim AS runner
-
-# optional install updates
-# RUN apt-get upgrade -y
-
-WORKDIR /app
-
-ENV NODE_ENV production
-
 RUN addgroup --system --gid 1001 nodejs
 RUN adduser --system --uid 1001 nextjs
-
-# You only need to copy next.config.js if you are NOT using the default configuration
-# COPY --from=builder /app/next.config.js ./
-COPY --from=builder /app/public ./public
-COPY --from=builder /app/package.json ./package.json
-
-# Using standalone output to reduce image size
-# https://nextjs.org/docs/advanced-features/output-file-tracing
-COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
-COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
 
 USER nextjs
 
 EXPOSE 3000
 
-CMD ["node", "server.js"]
+CMD ["yarn", "start"]

--- a/frontend/components/dialogs/MatomoCookieConsentDialog.tsx
+++ b/frontend/components/dialogs/MatomoCookieConsentDialog.tsx
@@ -2,21 +2,29 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Link from 'next/link'
 import CookieConsent from 'react-cookie-consent'
+import useRsdSettings from '~/config/useRsdSettings'
 
 export default function MatomoCookieConsentDialog() {
+  const {setCookiesAccepted} = useRsdSettings()
+
   const onAccept = () => {
     if ('_paq' in window) {
       (window as any)._paq.push(['rememberConsentGiven'])
     }
+    setCookiesAccepted(true)
   }
 
   const onDecline = () => {
     if ('_paq' in window) {
       (window as any)._paq.push(['forgetConsentGiven'])
     }
+    setCookiesAccepted(false)
   }
 
+  // The CookieConsent component will only open if no value for the cookie
+  // 'cookie_consent' is set.
   return (
     <CookieConsent
       location="bottom"
@@ -24,6 +32,7 @@ export default function MatomoCookieConsentDialog() {
       enableDeclineButton
       flipButtons
       disableButtonStyles
+      cookieName="cookie_consent"
       buttonText="Accept"
       declineButtonText="Decline"
       buttonClasses="rounded-full bg-primary text-secondary hover:bg-secondary hover:text-primary py-2 px-6 mt-4 mb-4 ml-5 mr-2"
@@ -37,7 +46,13 @@ export default function MatomoCookieConsentDialog() {
       website so that it can be continuously optimized for you and its
       user-friendliness improved. We also use the Matomo web analysis tool,
       which tracks data anonymously. This enables us to statistically evaluate
-      the use of our website.
+      the use of our website. Your consent to the use of Matomo can be revoked
+      at any time via the <Link
+        className="text-primary hover:text-secondary"
+        href="/cookies"
+      >
+        cookie settings
+      </Link>.
     </CookieConsent>
   )
 }

--- a/frontend/components/dialogs/MatomoCookieConsentDialog.tsx
+++ b/frontend/components/dialogs/MatomoCookieConsentDialog.tsx
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import CookieConsent from 'react-cookie-consent'
+
+export default function MatomoCookieConsentDialog() {
+  const onAccept = () => {
+    if ('_paq' in window) {
+      (window as any)._paq.push(['rememberConsentGiven'])
+    }
+  }
+
+  const onDecline = () => {
+    if ('_paq' in window) {
+      (window as any)._paq.push(['forgetConsentGiven'])
+    }
+  }
+
+  return (
+    <CookieConsent
+      location="bottom"
+      overlay
+      enableDeclineButton
+      flipButtons
+      disableButtonStyles
+      buttonText="Accept"
+      declineButtonText="Decline"
+      buttonClasses="rounded-full bg-primary text-secondary hover:bg-secondary hover:text-primary py-2 px-6 mt-4 mb-4 ml-5 mr-2"
+      declineButtonClasses="rounded-full bg-primary text-secondary hover:bg-secondary hover:text-primary py-2 px-6 mt-4 mb-4 ml-2 mr-5"
+      contentClasses="pb-2"
+      overlayClasses=""
+      onAccept={onAccept}
+      onDecline={onDecline}
+    >
+      We use cookies that are necessary for the basic functionality of our
+      website so that it can be continuously optimized for you and its
+      user-friendliness improved. We also use the Matomo web analysis tool,
+      which tracks data anonymously. This enables us to statistically evaluate
+      the use of our website.
+    </CookieConsent>
+  )
+}

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -18,16 +18,18 @@ export type RsdTheme = {
   host: string
 }
 
-export enum RsdActionType{
+export enum RsdActionType {
   SET_LINKS = 'SET_LINKS',
   SET_THEME = 'SET_THEME',
-  SET_EMBED = 'SET_EMBED'
+  SET_EMBED = 'SET_EMBED',
+  SET_COOKIES_ACCEPTED = 'SET_COOKIES_ACCEPTED',
 }
 
 export type RsdSettingsState = {
-  embed: boolean
+  embed: boolean,
   theme: RsdTheme,
-  links: RsdLink[]
+  links: RsdLink[],
+  cookiesAccepted: boolean,
 }
 
 export type RsdSettingsAction = {
@@ -41,9 +43,10 @@ export const defaultRsdSettings = {
   embed: false,
   theme: {
     mode: 'default',
-    host: 'default'
+    host: 'default',
   },
-  links:[]
+  links: [],
+  cookiesAccepted: false,
 }
 
 export function rsdSettingsReducer(state: RsdSettingsState, action: RsdSettingsAction) {
@@ -65,7 +68,12 @@ export function rsdSettingsReducer(state: RsdSettingsState, action: RsdSettingsA
     case RsdActionType.SET_EMBED:
       return {
         ...state,
-        theme: action.payload
+        embed: action.payload
+      }
+    case RsdActionType.SET_COOKIES_ACCEPTED:
+      return {
+        ...state,
+        cookiesAccepted: action.payload
       }
     default:
       logger(`rsdSettingsReducer UNKNOWN ACTION TYPE ${action.type}`, 'warn')

--- a/frontend/config/useRsdSettings.tsx
+++ b/frontend/config/useRsdSettings.tsx
@@ -31,12 +31,21 @@ export default function useRsdSettings() {
     })
   }
 
+  function setCookiesAccepted(accepted: boolean=false) {
+    dispatch({
+      type: RsdActionType.SET_COOKIES_ACCEPTED,
+      payload: accepted
+    })
+  }
+
   return {
     links: state.links,
     theme: state.theme,
     embedMode: state.embed,
+    cookiesAccepted: state.cookiesAccepted,
     setRsdLinks,
     setRsdTheme,
-    setEmbedMode
+    setEmbedMode,
+    setCookiesAccepted,
   }
 }

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -50,4 +50,9 @@ module.exports = {
     })
     return config
   },
+
+  env: {
+    MATOMO_URL: process.env.MATOMO_URL,
+    MATOMO_ID: process.env.MATOMO_ID,
+  },
 }

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -30,7 +30,7 @@ const rewritesConfig = isDevelopment
 module.exports = {
   // create standalone output to use in docker image
   // and achieve minimal image size (see Dockerfile)
-  output: 'standalone',
+  //output: 'standalone',
   // disable strict mode for react-beautiful-dnd in development
   // see for more info https://nextjs.org/docs/api-reference/next.config.js/react-strict-mode
   reactStrictMode: true,
@@ -51,7 +51,7 @@ module.exports = {
     return config
   },
 
-  env: {
+  publicRuntimeConfig: {
     MATOMO_URL: process.env.MATOMO_URL,
     MATOMO_ID: process.env.MATOMO_ID,
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -29,6 +29,7 @@
     "nprogress": "0.2.0",
     "react": "18.2.0",
     "react-beautiful-dnd": "13.1.0",
+    "react-cookie-consent": "^8.0.1",
     "react-dom": "18.2.0",
     "react-hook-form": "7.33.1",
     "react-markdown": "8.0.3",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "react-dom": "18.2.0",
     "react-hook-form": "7.33.1",
     "react-markdown": "8.0.3",
+    "react-use-cookie": "^1.4.0",
     "remark-breaks": "^3.0.2",
     "remark-gfm": "3.0.1"
   },

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -23,6 +23,8 @@ import {saveLocationCookie} from '../auth/locationCookie'
 import PageSnackbar from '../components/snackbar/PageSnackbar'
 import PageSnackbarContext, {snackbarDefaults} from '../components/snackbar/PageSnackbarContext'
 
+import MatomoCookieConsentDialog from '~/components/dialogs/MatomoCookieConsentDialog'
+
 // global CSS and tailwind
 import '../styles/global.css'
 // nprogress styles
@@ -54,6 +56,9 @@ function RsdApp(props: MuiAppProps) {
   //currently we support only default (light) and dark RSD theme for MUI
   const muiTheme = loadMuiTheme(settings.theme.mode as RsdThemes)
   const router = useRouter()
+
+  const matomoUrl = process.env.MATOMO_URL
+  const matomoId = process.env.MATOMO_ID
 
   useEffect(()=>{
     router.events.on('routeChangeStart', ()=>{
@@ -93,10 +98,18 @@ function RsdApp(props: MuiAppProps) {
         {/* <CssBaseline /> */}
         <AuthProvider session={session}>
           <RsdSettingsProvider settings={settings}>
-          <PageSnackbarContext.Provider value={{options, setSnackbar}}>
-            <Component {...pageProps} />
-          </PageSnackbarContext.Provider>
-          <PageSnackbar options={options} setOptions={setSnackbar} />
+            <PageSnackbarContext.Provider value={{options, setSnackbar}}>
+              <Component {...pageProps} />
+            </PageSnackbarContext.Provider>
+
+            <PageSnackbar options={options} setOptions={setSnackbar} />
+
+            {/* Cookie consents */}
+            {
+              matomoUrl !== undefined && matomoUrl.length !== 0 &&
+              matomoId !== undefined && matomoId.length !== 0 &&
+              <MatomoCookieConsentDialog />
+            }
           </RsdSettingsProvider>
         </AuthProvider>
       </ThemeProvider>

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useEffect, useState} from 'react'
+import getConfig from 'next/config'
 import {useRouter} from 'next/router'
 import App, {AppContext, AppProps} from 'next/app'
 import Head from 'next/head'
@@ -56,9 +57,10 @@ function RsdApp(props: MuiAppProps) {
   //currently we support only default (light) and dark RSD theme for MUI
   const muiTheme = loadMuiTheme(settings.theme.mode as RsdThemes)
   const router = useRouter()
+  const {publicRuntimeConfig: config} = getConfig()
 
-  const matomoUrl = process.env.MATOMO_URL
-  const matomoId = process.env.MATOMO_ID
+  const matomoUrl = config.MATOMO_URL
+  const matomoId = config.MATOMO_ID
 
   useEffect(()=>{
     router.events.on('routeChangeStart', ()=>{
@@ -106,8 +108,10 @@ function RsdApp(props: MuiAppProps) {
 
             {/* Cookie consents */}
             {
-              matomoUrl !== undefined && matomoUrl.length !== 0 &&
-              matomoId !== undefined && matomoId.length !== 0 &&
+              (
+                matomoUrl !== undefined && matomoUrl.length !== 0 &&
+                matomoId !== undefined && matomoId.length !== 0
+              ) &&
               <MatomoCookieConsentDialog />
             }
           </RsdSettingsProvider>

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -63,6 +63,7 @@ export default class MyDocument extends Document {
               dangerouslySetInnerHTML={{__html: `
                 var _paq = window._paq = window._paq || [];
                 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
+                _paq.push(['requireConsent']);
                 _paq.push(['trackPageView']);
                 _paq.push(['enableLinkTracking']);
                 (function() {

--- a/frontend/pages/cookies.tsx
+++ b/frontend/pages/cookies.tsx
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect} from 'react'
+import {getCookie, setCookie} from 'react-use-cookie'
+import DefaultLayout from '~/components/layout/DefaultLayout'
+import useRsdSettings from '~/config/useRsdSettings'
+
+export default function Cookies() {
+  const matomoUrl = process.env.MATOMO_URL
+  const matomoId = process.env.MATOMO_ID
+  const matomoEnabled = matomoUrl !== undefined && matomoUrl.length !== 0
+    && matomoId !== undefined && matomoId.length !== 0
+  const {cookiesAccepted, setCookiesAccepted} = useRsdSettings()
+
+  useEffect(
+    () => {
+      setCookiesAccepted(getCookie('cookie_consent') === 'true')
+    },
+    // call setCookiesAccepted only once, use an empty array
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  )
+
+  const onDeclineMatomo = () => {
+    if ('_paq' in window) {
+      (window as any)._paq.push(['forgetConsentGiven'])
+    }
+    setCookie('cookie_consent', 'false')
+    setCookiesAccepted(false)
+  }
+
+  const onAcceptMatomo = () => {
+    if ('_paq' in window) {
+      (window as any)._paq.push(['rememberConsentGiven'])
+    }
+    setCookie('cookie_consent', 'true')
+    setCookiesAccepted(true)
+  }
+
+  const buttonClasses = 'rounded-full text-secondary bg-primary hover:bg-secondary hover:text-primary py-2 px-6'
+
+  return (
+    <DefaultLayout>
+      <div className="p-12">
+        <h1 className="mb-5">Cookies</h1>
+        <p className="mb-5">
+          Cookies are stored on the user&apos;s computer, from where they are
+          sent to our website. This means that users have full control over the
+          use of cookies. Users can deactivate or restrict the transmission of
+          cookies by changing their web browser settings. Any cookies already
+          stored can be deleted at any time. This can also be effected
+          automatically. If cookies are deactivated for this website, it may
+          no longer be possible to use all the website&apos;s functions in
+          full.
+        </p>
+
+        { /* Matomo specific section */ }
+        {
+          matomoEnabled &&
+          <h2 className="mb-5">Matomo Tracking</h2>
+        }
+        {
+          matomoEnabled &&
+          <p className="mb-5">
+            Detailed information about Matomo&apos;s privacy settings is
+            available at <a
+              className="text-primary hover:text-secondary"
+              target="_blank"
+              href="https://matomo.org/docs/privacy"
+              rel="noreferrer"
+            >https://matomo.org/docs/privacy</a>.
+          </p>
+        }
+
+        {
+          matomoEnabled &&
+          cookiesAccepted &&
+          <p>
+            <button onClick={onDeclineMatomo} className={buttonClasses}>
+              Revoke tracking consent
+            </button>
+          </p>
+        }
+
+        {
+          matomoEnabled &&
+          !cookiesAccepted &&
+          <p>
+            <button onClick={onAcceptMatomo} className={buttonClasses}>
+              Accept tracking
+            </button>
+          </p>
+        }
+      </div>
+    </DefaultLayout>
+  )
+}

--- a/frontend/pages/cookies.tsx
+++ b/frontend/pages/cookies.tsx
@@ -3,22 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useEffect} from 'react'
+import getConfig from 'next/config'
 import {getCookie, setCookie} from 'react-use-cookie'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import useRsdSettings from '~/config/useRsdSettings'
 
 export default function Cookies() {
-  const matomoUrl = process.env.MATOMO_URL
-  const matomoId = process.env.MATOMO_ID
-  const matomoEnabled = matomoUrl !== undefined && matomoUrl.length !== 0
-    && matomoId !== undefined && matomoId.length !== 0
   const {cookiesAccepted, setCookiesAccepted} = useRsdSettings()
+  const {publicRuntimeConfig: config} = getConfig()
+  const matomoUrl = config.MATOMO_URL
+  const matomoId = config.MATOMO_ID
 
   useEffect(
     () => {
       setCookiesAccepted(getCookie('cookie_consent') === 'true')
     },
-    // call setCookiesAccepted only once, use an empty array
+    // use an empty array to call setCookiesAccepted only once
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   )
@@ -58,11 +58,17 @@ export default function Cookies() {
 
         { /* Matomo specific section */ }
         {
-          matomoEnabled &&
+          (
+            matomoUrl !== undefined && matomoUrl.length !== 0 &&
+            matomoId !== undefined && matomoId.length !== 0
+          ) &&
           <h2 className="mb-5">Matomo Tracking</h2>
         }
         {
-          matomoEnabled &&
+          (
+            matomoUrl !== undefined && matomoUrl.length !== 0 &&
+            matomoId !== undefined && matomoId.length !== 0
+          ) &&
           <p className="mb-5">
             Detailed information about Matomo&apos;s privacy settings is
             available at <a
@@ -75,8 +81,11 @@ export default function Cookies() {
         }
 
         {
-          matomoEnabled &&
-          cookiesAccepted &&
+          (
+            matomoUrl !== undefined && matomoUrl.length !== 0 &&
+            matomoId !== undefined && matomoId.length !== 0 &&
+            cookiesAccepted
+          ) &&
           <p>
             <button onClick={onDeclineMatomo} className={buttonClasses}>
               Revoke tracking consent
@@ -85,8 +94,11 @@ export default function Cookies() {
         }
 
         {
-          matomoEnabled &&
-          !cookiesAccepted &&
+          (
+            matomoUrl !== undefined && matomoUrl.length !== 0 &&
+            matomoId !== undefined && matomoId.length !== 0 &&
+            !cookiesAccepted
+          ) &&
           <p>
             <button onClick={onAcceptMatomo} className={buttonClasses}>
               Accept tracking

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -4799,6 +4799,11 @@ jest@28.1.2:
     import-local "^3.0.2"
     jest-cli "^28.1.2"
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6059,6 +6064,13 @@ react-beautiful-dnd@13.1.0:
     react-redux "^7.2.0"
     redux "^4.0.4"
     use-memo-one "^1.1.1"
+
+react-cookie-consent@^8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/react-cookie-consent/-/react-cookie-consent-8.0.1.tgz#83526a39c19be82872e9374c6fef98d05e12e5ba"
+  integrity sha512-4A2jzPQDFfBhtxIz4hYX+vJ0QnOknGdOXpEoetXzgwUrMtxVJVow8YgBsGerNt5rJI7WhKkHwr8LmxekxgVejg==
+  dependencies:
+    js-cookie "^2.2.1"
 
 react-dom@18.2.0:
   version "18.2.0"

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -6143,6 +6143,11 @@ react-transition-group@^4.4.2:
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
 
+react-use-cookie@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/react-use-cookie/-/react-use-cookie-1.4.0.tgz#8f9fffeea9ad48d97dfbb6818aa0c63771946e3a"
+  integrity sha512-e21YFkimh8OX6Ctqq89YeeiwsIL1jr2GyCeBdkBKDWY5X5o2yonbQuqfFODK4opteJS3F7ya0OuYg06lOeqvJQ==
+
 react@18.2.0:
   version "18.2.0"
   resolved "https://registry.yarnpkg.com/react/-/react-18.2.0.tgz#555bd98592883255fa00de14f1151a917b5d77d5"


### PR DESCRIPTION
# Add cookie banner for Matomo tracking

Fixes https://github.com/hifis-net/RSD-as-a-service/issues/37
See also #392

See [Matomo tracking-consent documentation](https://developer.matomo.org/guides/tracking-consent) for technical details.

Changes proposed in this pull request:

* add a banner on all pages to ask the user for consent on being tracked (+cookies) from Matomo
* for this we use the library [react-cookie-consent](https://www.npmjs.com/package/react-cookie-consent) which offers a solution for a customizable cookie banner
* on a separate page the user is able to revoke or accept the tracking consent again

How to test:

* use a private browser tab or remove all your cookies for localhost
* opening any page of the RSD will show an overlay asking the user to consent/decline to the tracking+cookies of Matomo
* no requests on first page load are send out to Matomo
* accepting the tracking lead to requests being send out to the Matomo server
* by clicking on "decline" no requests are send to the Matomo ever and until this cookie is valid
* at the page `/cookies` the user gets some information about cookies in general and is able to revoke the matomo tracking consent again, each of them having the effect of stopping or starting the tracking of Matomo

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
