### PR TITLE
Add explanations for impact and output sections

### DIFF
--- a/frontend/components/projects/edit/impact/ImpactByType.tsx
+++ b/frontend/components/projects/edit/impact/ImpactByType.tsx
@@ -10,6 +10,7 @@ import ContentLoader from '~/components/layout/ContentLoader'
 import useProjectContext from '../useProjectContext'
 import {cfgImpact as config} from './config'
 import useImpactForProject from './useImpactForProject'
+import Alert from '@mui/material/Alert'
 
 export default function ImpactByType({session}: { session: Session }) {
   const {project} = useProjectContext()
@@ -35,7 +36,14 @@ export default function ImpactByType({session}: { session: Session }) {
       >
         <h2>{impactCnt ?? 0}</h2>
       </EditSectionTitle>
-      <div className="py-4"></div>
+      <div className="py-2" />
+      <Alert severity="info">
+      Here you can add results of the project which had impact on others.
+        This could be papers by others re-using your software or data,
+        articles or videos in the press describing the results, policy
+        documents based on these results, etc.
+      </Alert>
+      <div className="py-2" />
       <MentionEditSection />
     </>
   )

--- a/frontend/components/projects/edit/output/OutputByType.tsx
+++ b/frontend/components/projects/edit/output/OutputByType.tsx
@@ -10,6 +10,7 @@ import MentionEditSection from '~/components/mention/MentionEditSection'
 import useProjectContext from '../useProjectContext'
 import {cfgOutput as config} from './config'
 import useOutputForProject from './useOutputForProject'
+import Alert from '@mui/material/Alert'
 
 export default function OutputByType({session}: { session: Session }) {
   const {project} = useProjectContext()
@@ -35,7 +36,12 @@ export default function OutputByType({session}: { session: Session }) {
       >
         <h2>{outputCnt ?? 0}</h2>
       </EditSectionTitle>
-      <div className="py-4"></div>
+      <div className="py-2" />
+      <Alert severity="info">
+        Here you can add things which were produced by the project itself.
+        These can be papers, books, articles, software, datasets, blogs, etc.
+      </Alert>
+      <div className="py-2" />
       <MentionEditSection />
     </>
   )


### PR DESCRIPTION
# Add explanations for impact and output sections

Fixes #468

I am unsure about the specific texts, maybe you have a more appropriate description for the sections.

Changes proposed in this pull request:

* this adds information boxes to the impact and output section of the project edit pages

How to test:

* add or edit a project, on the impact and output sections there should be an info box with further explanations

![image](https://user-images.githubusercontent.com/1287885/182812632-d3bacda8-cc53-4cf0-b27b-6afda9fbf006.png)

![image](https://user-images.githubusercontent.com/1287885/182812687-f1a07186-39a0-4bb0-9dcf-5d02e81461ae.png)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [X] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
