### PR TITLE
419 no commits graph

### DIFF
--- a/frontend/components/charts/d3LineChart/NoDataAvailableChart.tsx
+++ b/frontend/components/charts/d3LineChart/NoDataAvailableChart.tsx
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import * as d3 from 'd3'
+import {useRef, useEffect, useState} from 'react'
+import useResizeObserver from './useResizeObserver'
+import {SizeType} from './useResizeObserver'
+import logger from '../../../utils/logger'
+import {colors} from '../../../styles/themeConfig'
+
+export type Point = {x: number, y: number}
+
+type LineChartConfig = {
+  svgEl: SVGAElement,
+  dim: SizeType,
+  text: string | undefined
+}
+
+const margin = {
+  left: 5, right: 5,
+  top: 0, bottom: 20
+}
+
+const noCommitData: Point[] = [
+  {x: 0, y: 0},
+  {x: 48, y: 0},
+  {x: 50, y: 10},
+  {x: 52, y: -5},
+  {x: 54, y: 0},
+  {x: 60, y:0},
+  {x: 65, y: 40},
+  {x: 70, y: -30},
+  {x: 75, y: 0},
+  {x: 100, y: 0},
+]
+
+function drawLine(props: LineChartConfig) {
+  let {dim: {w, h}, svgEl, text} = props
+  if (text === undefined) {
+    text = 'Whoops, something went wronge here.'
+  }
+  // if no data return null
+  // ignore if no size
+  if (!w || !h) return
+
+  // defined dimensions
+  const width = w - margin.left - margin.right
+  const height = h - margin.top - margin.bottom
+
+  // select svg element
+  const svg = d3.select(svgEl)
+    // important! for resizing the svg dimensions
+    // need to be set to 100% while the actual
+    // dimensions of wrapper div element are used
+    // to calculate
+    .attr('width', '100%')
+    .attr('height', '100%')
+    // .style('background', '#eeee')
+
+  const xScale = d3.scaleLinear()
+    .domain([0, 100])
+    .range([0, width])
+
+  // define y scale as linear
+  const yScale = d3.scaleLinear()
+    .domain([-40, 50])
+    .range([height, margin.top])
+
+  // generate
+  const generateScaledLine = d3.line()
+    .x((d:any,i:number) => {
+      // Plot everything below hundred unscaled
+      if (d.x < 100) {
+        return d.x
+      }
+      return xScale(d.x)
+    })
+    .y((d:any,i) => {
+      // y as number, using yScale to calculate position
+      const val = yScale(d.y)
+      if (val < 0) {
+        logger('drawLineChart.generateScaledLine...unexpected negative y values','warn')
+      }
+      return val
+    })
+
+  // remove old groups
+  svg.selectAll('g').remove()
+
+  // position
+  const group = svg
+    .append('g')
+    .attr('id','d3-line-chart')
+    .attr('transform',`translate(${margin.left},${margin.top})`)
+
+  // bottom axe
+  group
+    .append('g')
+    .attr('class', 'bottom-axe')
+    .attr('transform', `translate(0,${height})`)
+
+  const lineGroup = group
+    .append('g')
+    .attr('id','d3-line-group')
+
+  // replace
+  lineGroup.selectAll('.line')
+    .data([noCommitData])
+    .join('path')
+      .attr('class','line')
+      .attr('d',d=>generateScaledLine(d as any))
+      .attr('fill','none')
+      .attr('stroke', colors.primary)
+      .attr('stroke-width', 2)
+      .attr('stroke-opacity', 0.7)
+
+  group.append('text')
+    .attr('x', 100)
+    .attr('y', yScale(0))
+    .attr('dy', '-0.5rem')
+    .text(text)
+
+  return true
+}
+
+export default function NoDataAvailableChart({text}:{text: string | undefined}) {
+  const svgRef: any = useRef()
+  const divRef: any = useRef()
+  const [element, setElement] = useState()
+  const size = useResizeObserver(element)
+
+  useEffect(() => {
+    let abort = false
+    if (divRef.current && abort===false) {
+      setElement(divRef.current)
+    }
+    return ()=>{abort=true}
+  }, [divRef])
+
+  useEffect(() => {
+    if (size?.w && size?.h) {
+      drawLine({
+        dim: {w:size?.w,h:size?.h},
+        svgEl: svgRef.current,
+        text
+      })
+    }
+  },[size?.w, size.h, text])
+
+  return (
+    <div ref={divRef} className="flex-1 overflow-hidden relative">
+      <svg
+          ref={svgRef}
+          // requires block to remove 4px space from parent element
+          // automatically added to parent
+          // see https://stackoverflow.com/questions/22300062/svg-and-parent-height-of-svg-different
+          style={{
+            display: 'block'
+          }}
+      ></svg>
+    </div>
+  )
+}

--- a/frontend/components/charts/d3LineChart/NoDataAvailableChart.tsx
+++ b/frontend/components/charts/d3LineChart/NoDataAvailableChart.tsx
@@ -59,6 +59,8 @@ function drawLine(props: LineChartConfig) {
     // to calculate
     .attr('width', '100%')
     .attr('height', '100%')
+    .attr('xmlns', 'http://www.w3.org/2000/svg')
+    .attr('xmlns:xhtml', 'http://www.w3.org/1999/xhtml')
     // .style('background', '#eeee')
 
   const xScale = d3.scaleLinear()
@@ -118,7 +120,17 @@ function drawLine(props: LineChartConfig) {
       .attr('stroke-width', 2)
       .attr('stroke-opacity', 0.7)
 
-  group.append('text')
+  const sw = group.append('switch')
+  sw.append('foreignObject')
+    .attr('x', 0)
+    .attr('y', 0)
+    .attr('height', yScale(0))
+    .attr('width', '100%')
+    .append('xhtml:p')
+    .attr('style', 'margin-left:100px; position:absolute; bottom:0')
+    .text(text)
+
+  sw.append('text')
     .attr('x', 100)
     .attr('y', yScale(0))
     .attr('dy', '-0.5rem')

--- a/frontend/components/charts/d3LineChart/NoDataAvailableChart.tsx
+++ b/frontend/components/charts/d3LineChart/NoDataAvailableChart.tsx
@@ -10,14 +10,15 @@ import {useRef, useEffect, useState} from 'react'
 import useResizeObserver from './useResizeObserver'
 import {SizeType} from './useResizeObserver'
 import logger from '../../../utils/logger'
-import {colors} from '../../../styles/themeConfig'
+import {useTheme} from '@mui/material'
 
 export type Point = {x: number, y: number}
 
 type LineChartConfig = {
   svgEl: SVGAElement,
   dim: SizeType,
-  text: string | undefined
+  text: string | undefined,
+  strokeColor: string
 }
 
 const margin = {
@@ -39,7 +40,7 @@ const noCommitData: Point[] = [
 ]
 
 function drawLine(props: LineChartConfig) {
-  let {dim: {w, h}, svgEl, text} = props
+  let {dim: {w, h}, svgEl, text, strokeColor} = props
   if (text === undefined) {
     text = 'Whoops, something went wronge here.'
   }
@@ -116,7 +117,7 @@ function drawLine(props: LineChartConfig) {
       .attr('class','line')
       .attr('d',d=>generateScaledLine(d as any))
       .attr('fill','none')
-      .attr('stroke', colors.primary)
+      .attr('stroke', strokeColor)
       .attr('stroke-width', 2)
       .attr('stroke-opacity', 0.7)
 
@@ -139,7 +140,8 @@ function drawLine(props: LineChartConfig) {
   return true
 }
 
-export default function NoDataAvailableChart({text}:{text: string | undefined}) {
+export default function NoDataAvailableChart({text}: { text: string | undefined }) {
+  const theme = useTheme()
   const svgRef: any = useRef()
   const divRef: any = useRef()
   const [element, setElement] = useState()
@@ -154,25 +156,26 @@ export default function NoDataAvailableChart({text}:{text: string | undefined}) 
   }, [divRef])
 
   useEffect(() => {
-    if (size?.w && size?.h) {
+    if (size?.w && size?.h && text) {
       drawLine({
         dim: {w:size?.w,h:size?.h},
         svgEl: svgRef.current,
+        strokeColor:theme.palette.primary.main,
         text
       })
     }
-  },[size?.w, size.h, text])
+  },[size?.w, size.h, text,theme.palette.primary.main])
 
   return (
     <div ref={divRef} className="flex-1 overflow-hidden relative">
       <svg
-          ref={svgRef}
-          // requires block to remove 4px space from parent element
-          // automatically added to parent
-          // see https://stackoverflow.com/questions/22300062/svg-and-parent-height-of-svg-different
-          style={{
-            display: 'block'
-          }}
+        ref={svgRef}
+        // requires block to remove 4px space from parent element
+        // automatically added to parent
+        // see https://stackoverflow.com/questions/22300062/svg-and-parent-height-of-svg-different
+        style={{
+          display: 'block'
+        }}
       ></svg>
     </div>
   )

--- a/frontend/components/charts/d3LineChart/formatData.ts
+++ b/frontend/components/charts/d3LineChart/formatData.ts
@@ -9,7 +9,13 @@ export type Data = {
   [key:string]:number
 }
 
-export function formatUnixDateData(data:Data) {
+export function formatUnixDateData(data: Data) {
+  if (typeof data === 'undefined' || data === null) {
+    return {
+      lineData: [],
+      lastUpdateInMs: 0
+    }
+  }
   const keys = Object.keys(data)
   const lineData: Point[] = []
   let lastUpdateInMs:number|undefined

--- a/frontend/components/home/getHomepageCounts.ts
+++ b/frontend/components/home/getHomepageCounts.ts
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -19,7 +21,7 @@ export async function getHomepageCounts(frontend?:boolean) {
         ...createJsonHeaders(),
       },
     })
-    debugger
+
     if (resp.status === 200) {
       const data = await resp.json()
       return data

--- a/frontend/components/software/CommitsChart.tsx
+++ b/frontend/components/software/CommitsChart.tsx
@@ -11,27 +11,47 @@ import {prepareDataForSoftwarePage} from '../charts/d3LineChart/formatData'
 import NoDataAvailableChart from '../charts/d3LineChart/NoDataAvailableChart'
 import SingleLineChart from '../charts/d3LineChart/SingleLineChart'
 
+type CommitsChartProps = {
+  repository_url: string | null,
+  commit_history: CommitHistory
+  commit_history_scraped_at: string
+  className: string
+}
 
-export default function CommitsChart({commit_history, className, noCommitMessage}:
-  {commit_history: CommitHistory, className?:string, noCommitMessage?:string}) {
-
-    if (noCommitMessage) return (
-    <div className={`flex-1 w-full ${className ?? ''}`}>
-      <NoDataAvailableChart text={noCommitMessage}/>
-    </div>
-  )
-  // format commits data for chart and calculate other stats
-  const {lineData, lastCommitDate, totalCountY} = prepareDataForSoftwarePage(commit_history)
-
-  // render
-  return (
-    <div className={`flex-1 w-full ${className ?? ''}`}>
-      <SingleLineChart data={lineData} />
-      <div className="software_commitsStat pt-4" id="commitsStat">
-        <b>{totalCountY} commits</b> | Last commit <b>&#x2248; {
-          getTimeAgoSince(new Date(),lastCommitDate?.toISOString()??null)
-        }</b>
+export default function CommitsChart({repository_url, commit_history, commit_history_scraped_at, className}: CommitsChartProps) {
+  // if there is commit_history
+  if (commit_history && Object.keys(commit_history).length > 0) {
+    // format commits data for chart and calculate other stats
+    const {lineData, lastCommitDate, totalCountY} = prepareDataForSoftwarePage(commit_history)
+    // render
+    return (
+      <div className={`flex-1 w-full ${className}`}>
+        <SingleLineChart data={lineData} />
+        <div className="software_commitsStat pt-4" id="commitsStat">
+          <b>{totalCountY} commits</b> | Last commit <b>&#x2248; {
+            getTimeAgoSince(new Date(), lastCommitDate?.toISOString() ?? null)
+          }</b>
+        </div>
       </div>
+    )
+  }
+  // ELSE if no commit history we show graph placeholder with the message
+  let noCommitMessage: string | undefined
+  if (typeof repository_url === 'undefined' || repository_url === null) {
+    noCommitMessage = 'We cannot scrape the commit history because repository url is missing.'
+  } else if (typeof commit_history_scraped_at === 'undefined' || commit_history_scraped_at === null) {
+    // not scraped yet
+    noCommitMessage = 'We did not scrape the commit history of this repository yet.'
+  } else if (commit_history_scraped_at && commit_history && Object.keys(commit_history).length == 0) {
+    // we did scraped repo but no commit history
+    noCommitMessage = 'We cannot display this graph because the repository is empty.'
+  } else if (commit_history_scraped_at && (typeof commit_history === 'undefined' || commit_history === null)) {
+    // we did scraped repo but no commit history exists
+    noCommitMessage = 'We cannot display this graph because we cannot read the commit history.'
+  }
+  return (
+    <div className={`flex-1 w-full ${className}`}>
+      <NoDataAvailableChart text={noCommitMessage} />
     </div>
   )
 }

--- a/frontend/components/software/CommitsChart.tsx
+++ b/frontend/components/software/CommitsChart.tsx
@@ -1,22 +1,27 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {CommitHistory} from '../../types/SoftwareTypes'
 import {getTimeAgoSince} from '../../utils/dateFn'
 import {prepareDataForSoftwarePage} from '../charts/d3LineChart/formatData'
+import NoDataAvailableChart from '../charts/d3LineChart/NoDataAvailableChart'
 import SingleLineChart from '../charts/d3LineChart/SingleLineChart'
 
-export default function CommitsChart({commit_history,className}:
-  {commit_history: CommitHistory,className?:string}) {
-  // ignore if no commit histiry
-  if (!commit_history) return null
+
+export default function CommitsChart({commit_history, className, noCommitMessage}:
+  {commit_history: CommitHistory, className?:string, noCommitMessage?:string}) {
+
+    if (noCommitMessage) return (
+    <div className={`flex-1 w-full ${className ?? ''}`}>
+      <NoDataAvailableChart text={noCommitMessage}/>
+    </div>
+  )
   // format commits data for chart and calculate other stats
   const {lineData, lastCommitDate, totalCountY} = prepareDataForSoftwarePage(commit_history)
-
-  // exit if no commit history
-  if (lineData.length===0) return null
 
   // render
   return (

--- a/frontend/components/software/GetStartedSection.tsx
+++ b/frontend/components/software/GetStartedSection.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,8 +9,8 @@ import LinkIcon from '@mui/icons-material/Link'
 import CommitsChart from './CommitsChart'
 import {CommitHistory} from '../../types/SoftwareTypes'
 
-export default function GetStartedSection({get_started_url, commit_history}:
-  {get_started_url: string | null, commit_history: CommitHistory}) {
+export default function GetStartedSection({get_started_url, commit_history, noCommitMessage}:
+  {get_started_url: string | null, commit_history: CommitHistory, noCommitMessage: string | undefined}) {
 
   function renderGetStartedUrl() {
     if (get_started_url) {
@@ -31,12 +33,14 @@ export default function GetStartedSection({get_started_url, commit_history}:
         <CommitsChart
           className='pl-0 lg:pl-24'
           commit_history={commit_history}
+          noCommitMessage={noCommitMessage}
         />
       )
     }
     return (
       <CommitsChart
         commit_history={commit_history}
+        noCommitMessage={noCommitMessage}
       />
     )
   }

--- a/frontend/components/software/GetStartedSection.tsx
+++ b/frontend/components/software/GetStartedSection.tsx
@@ -9,9 +9,15 @@ import LinkIcon from '@mui/icons-material/Link'
 import CommitsChart from './CommitsChart'
 import {CommitHistory} from '../../types/SoftwareTypes'
 
-export default function GetStartedSection({get_started_url, commit_history, noCommitMessage}:
-  {get_started_url: string | null, commit_history: CommitHistory, noCommitMessage: string | undefined}) {
+type GetStartedSectionProps = {
+  get_started_url: string | null,
+  repository_url: string | null,
+  commit_history: CommitHistory,
+  commit_history_scraped_at: string
+}
 
+export default function GetStartedSection(props:GetStartedSectionProps) {
+  const {repository_url,get_started_url,commit_history,commit_history_scraped_at} = props
   function renderGetStartedUrl() {
     if (get_started_url) {
       return (
@@ -27,20 +33,17 @@ export default function GetStartedSection({get_started_url, commit_history, noCo
   }
 
   function renderCommitChart() {
+    let classes=''
     if (get_started_url) {
       // add margin when get_started_url is present
-      return (
-        <CommitsChart
-          className='pl-0 lg:pl-24'
-          commit_history={commit_history}
-          noCommitMessage={noCommitMessage}
-        />
-      )
+      classes = 'pl-0 lg:pl-24'
     }
     return (
       <CommitsChart
+        className={classes}
+        repository_url={repository_url}
         commit_history={commit_history}
-        noCommitMessage={noCommitMessage}
+        commit_history_scraped_at={commit_history_scraped_at}
       />
     )
   }

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -88,17 +88,6 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
     slug, organisations
   } = props
 
-  let noCommitGraphMessage : string | undefined
-  if (repositoryInfo?.commit_history_scraped_at && repositoryInfo?.commit_history && Object.keys( repositoryInfo?.commit_history ).length == 0 ) {
-    noCommitGraphMessage = 'We cannot display this graph because the repository is empty.'
-  }
-  if (repositoryInfo?.commit_history_scraped_at && repositoryInfo?.commit_history === null) {
-    noCommitGraphMessage = 'We cannot display this graph because we cannot read the commit history.'
-  }
-  if (repositoryInfo?.commit_history_scraped_at === null) {
-    noCommitGraphMessage = 'We did not scrape the commit history of this repository yet.'
-  }
-
   useEffect(() => {
     if (typeof location != 'undefined') {
       setResolvedUrl(location.href)
@@ -115,7 +104,7 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
   if (!software?.brand_name){
     return <NoContent />
   }
-  // console.log('SoftwareIndexPage...organisations...', organisations)
+  // console.log('SoftwareIndexPage...repositoryInfo...', repositoryInfo)
   return (
     <>
       {/* Page Head meta tags */}
@@ -154,8 +143,9 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
 
       <GetStartedSection
         get_started_url={software.get_started_url}
+        repository_url={repositoryInfo?.url}
         commit_history={repositoryInfo?.commit_history}
-        noCommitMessage={noCommitGraphMessage}
+        commit_history_scraped_at={repositoryInfo?.commit_history_scraped_at}
       />
       <CitationSection
         citationInfo={citationInfo}

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -86,6 +88,14 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
     slug, organisations
   } = props
 
+  let noCommitGraphMessage : string | undefined
+  if (repositoryInfo?.commit_history_scraped_at && repositoryInfo?.commit_history === null) {
+    noCommitGraphMessage = 'We cannot display this graph because we cannot read the commit history.'
+  }
+  if (repositoryInfo?.commit_history_scraped_at === null) {
+    noCommitGraphMessage = 'We did not scrape the commit history of this repository yet.'
+  }
+
   useEffect(() => {
     if (typeof location != 'undefined') {
       setResolvedUrl(location.href)
@@ -142,6 +152,7 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
       <GetStartedSection
         get_started_url={software.get_started_url}
         commit_history={repositoryInfo?.commit_history}
+        noCommitMessage={noCommitGraphMessage}
       />
       <CitationSection
         citationInfo={citationInfo}

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -89,6 +89,9 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
   } = props
 
   let noCommitGraphMessage : string | undefined
+  if (repositoryInfo?.commit_history_scraped_at && repositoryInfo?.commit_history && Object.keys( repositoryInfo?.commit_history ).length == 0 ) {
+    noCommitGraphMessage = 'We cannot display this graph because the repository is empty.'
+  }
   if (repositoryInfo?.commit_history_scraped_at && repositoryInfo?.commit_history === null) {
     noCommitGraphMessage = 'We cannot display this graph because we cannot read the commit history.'
   }

--- a/frontend/types/SoftwareTypes.ts
+++ b/frontend/types/SoftwareTypes.ts
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -137,7 +139,8 @@ export type RepositoryInfo = {
   url: string,
   languages: ProgramingLanguages,
   license: string,
-  commit_history: CommitHistory
+  commit_history: CommitHistory,
+  commit_history_scraped_at: string,
   code_platform: CodePlatform
 }
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ResponseException.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ResponseException.java
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper;
+
+public class ResponseException extends RuntimeException {
+	private Integer statusCode;
+
+	public ResponseException(Integer statusCode) {
+		this.statusCode = statusCode;
+	}
+
+	public ResponseException(Integer statusCode, String message) {
+		super(message);
+		this.statusCode = statusCode;
+	}
+
+	public Integer getStatusCode() {
+		return this.statusCode;
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
@@ -63,7 +63,7 @@ public class Utils {
 			throw new RuntimeException(e);
 		}
 		if (response.statusCode() >= 300) {
-			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+			throw new ResponseException(response.statusCode(), "Error fetching data from endpoint " + uri + " with response: " + response.body());
 		}
 		return response.body();
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/AggregateContributionsPerWeekSIDecorator.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/AggregateContributionsPerWeekSIDecorator.java
@@ -74,29 +74,31 @@ public class AggregateContributionsPerWeekSIDecorator implements SoftwareInfo {
 	 * @return A String representing JSON
 	 */
 	static String contributionsGitLab(String data) {
-		JsonArray allCommits = JsonParser.parseString(data).getAsJsonArray();
-		String oldestCommit = allCommits.get(allCommits.size() - 1).getAsJsonObject().get("committed_date").getAsString();
-		ZonedDateTime oldestCommitDate = ZonedDateTime.parse(oldestCommit).withZoneSameInstant(ZoneOffset.UTC);
-		ZonedDateTime firstAggregationWeek = collapseToWeekUTC(oldestCommitDate);
-		ZonedDateTime lastAggregationWeek = collapseToWeekUTC(ZonedDateTime.now(ZoneOffset.UTC));
-		long oneWeekInSeconds = 604800L; // 60*60*24*7
 		// create empty map
 		SortedMap<Long, Long> commitsPerWeek = new TreeMap<>();
-		long currentSeconds = firstAggregationWeek.toEpochSecond();
-		while (currentSeconds < lastAggregationWeek.toEpochSecond() + oneWeekInSeconds) {
-			commitsPerWeek.put(currentSeconds, 0L);
-			currentSeconds += oneWeekInSeconds;
-		}
-		// Fill map
-		for (int i = allCommits.size() - 1; i >= 0; i--) {
-			JsonObject currentCommit = allCommits.get(i).getAsJsonObject();
-			ZonedDateTime commitDateUTC = ZonedDateTime.parse(currentCommit.get("committed_date").getAsString()).withZoneSameInstant(ZoneOffset.UTC);
-			ZonedDateTime commitWeek = collapseToWeekUTC(commitDateUTC);
-			Long commitWeekSeconds = commitWeek.toEpochSecond();
-			Long newCommitsThisWeek;
-			newCommitsThisWeek = commitsPerWeek.get(commitWeekSeconds) + 1L;
-			commitsPerWeek.put(commitWeekSeconds, newCommitsThisWeek);
-		}
+		JsonArray allCommits = JsonParser.parseString(data).getAsJsonArray();
+                if (allCommits.size() > 0) {
+                    String oldestCommit = allCommits.get(allCommits.size() - 1).getAsJsonObject().get("committed_date").getAsString();
+                    ZonedDateTime oldestCommitDate = ZonedDateTime.parse(oldestCommit).withZoneSameInstant(ZoneOffset.UTC);
+                    ZonedDateTime firstAggregationWeek = collapseToWeekUTC(oldestCommitDate);
+                    ZonedDateTime lastAggregationWeek = collapseToWeekUTC(ZonedDateTime.now(ZoneOffset.UTC));
+                    long oneWeekInSeconds = 604800L; // 60*60*24*7
+                    long currentSeconds = firstAggregationWeek.toEpochSecond();
+                    while (currentSeconds < lastAggregationWeek.toEpochSecond() + oneWeekInSeconds) {
+                            commitsPerWeek.put(currentSeconds, 0L);
+                            currentSeconds += oneWeekInSeconds;
+                    }
+                    // Fill map
+                    for (int i = allCommits.size() - 1; i >= 0; i--) {
+                            JsonObject currentCommit = allCommits.get(i).getAsJsonObject();
+                            ZonedDateTime commitDateUTC = ZonedDateTime.parse(currentCommit.get("committed_date").getAsString()).withZoneSameInstant(ZoneOffset.UTC);
+                            ZonedDateTime commitWeek = collapseToWeekUTC(commitDateUTC);
+                            Long commitWeekSeconds = commitWeek.toEpochSecond();
+                            Long newCommitsThisWeek;
+                            newCommitsThisWeek = commitsPerWeek.get(commitWeekSeconds) + 1L;
+                            commitsPerWeek.put(commitWeekSeconds, newCommitsThisWeek);
+                    }
+                }
 		return new Gson().toJson(commitsPerWeek);
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GithubSI.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GithubSI.java
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -8,6 +10,7 @@ package nl.esciencecenter.rsd.scraper.git;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import nl.esciencecenter.rsd.scraper.Config;
+import nl.esciencecenter.rsd.scraper.ResponseException;
 import nl.esciencecenter.rsd.scraper.Utils;
 
 import java.util.Objects;
@@ -67,8 +70,21 @@ public class GithubSI implements SoftwareInfo {
 	 */
 	@Override
 	public String contributions() {
-		return Config.apiCredentialsGithub()
+		String contributions = "";
+		try {
+			contributions = Config.apiCredentialsGithub()
 				.map(apiCredentials -> Utils.get(baseApiUrl + "/repos/" + repo + "/stats/contributors", "Authorization", "Basic " + Utils.base64Encode(apiCredentials)))
 				.orElseGet(() -> Utils.get(baseApiUrl + "/repos/" + repo + "/stats/contributors"));
+                        if ( contributions.equals("") ) {
+                                // Repository exists, but no contributions yet, empty list is more appropriate
+                                contributions = "[]";
+                        }
+		} catch (ResponseException e) {
+			if (e.getStatusCode() == 404) {
+                                // Repository does not exist, emtpy string will be parsed to null
+				contributions = "";
+			}
+		}
+		return contributions;
 	}
 }

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/AggregateContributionsPerWeekSIDecoratorTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/AggregateContributionsPerWeekSIDecoratorTest.java
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -11,6 +13,17 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 public class AggregateContributionsPerWeekSIDecoratorTest {
+	private final String apiUrl = "https://api.github.com";
+	private final String projectPath = "cmeessen/empty";
+
+	@Test
+	void emptyRepository() {
+		// String scrapedCommits = new AggregateContributionsPerWeekSIDecorator(new GithubSI(apiUrl, projectPath), CodePlatformProvider.GITHUB).contributions();
+		String scrapedCommits = new AggregateContributionsPerWeekSIDecorator(
+			new GitLabSI("https://gitlab.hzdr.de/api", "christian.meessen/empty"),
+			CodePlatformProvider.GITHUB
+		).contributions();
+	}
 
 	@Test
 	void givenGithubCommitData_whenAggregating_thenAggregatedDataReturned() {

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubSITest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubSITest.java
@@ -36,21 +36,21 @@ public class GithubSITest {
 		Assertions.assertEquals("Apache-2.0", githubScraper.license());
 	}
 
-	// @Disabled
+	@Disabled
 	@Test
 	void contributions() {
 		final String contributions = githubScraper.contributions();
 		Assertions.assertTrue(contributions.startsWith("[{\"total"));
 	}
 
-	// @Disabled
+	@Disabled
 	@Test
 	void contributionsEmpty() {
 		final String contributionsEmpty = githubScraperEmpty.contributions();
 		Assertions.assertTrue(contributionsEmpty.equals("[]"));
 	}
 
-	// @Disabled
+	@Disabled
 	@Test
 	void contributionsNonEx() {
 		final String contributionsNonEx = githubScraperNonEx.contributions();

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubSITest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubSITest.java
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -12,7 +14,12 @@ import org.junit.jupiter.api.Test;
 public class GithubSITest {
 	private final String apiUrl = "https://api.github.com";
 	private final String repo = "research-software-directory/RSD-as-a-service";
+	private final String repoEmpty = "cmeessen/empty";
+	private final String repoNonEx = "research-software-directory/does-not-exist";
+
 	private final GithubSI githubScraper = new GithubSI(apiUrl, repo);
+	private final GithubSI githubScraperEmpty = new GithubSI(apiUrl, repoEmpty);
+	private final GithubSI githubScraperNonEx = new GithubSI(apiUrl, repoNonEx);
 
 	@Disabled
 	@Test
@@ -21,7 +28,6 @@ public class GithubSITest {
 		Assertions.assertTrue(languages.startsWith("{"));
 		Assertions.assertTrue(languages.endsWith("}"));
 		Assertions.assertTrue(languages.contains("Java"));
-
 	}
 
 	@Disabled
@@ -30,10 +36,24 @@ public class GithubSITest {
 		Assertions.assertEquals("Apache-2.0", githubScraper.license());
 	}
 
-	@Disabled
+	// @Disabled
 	@Test
 	void contributions() {
 		final String contributions = githubScraper.contributions();
 		Assertions.assertTrue(contributions.startsWith("[{\"total"));
+	}
+
+	// @Disabled
+	@Test
+	void contributionsEmpty() {
+		final String contributionsEmpty = githubScraperEmpty.contributions();
+		Assertions.assertTrue(contributionsEmpty.equals("[]"));
+	}
+
+	// @Disabled
+	@Test
+	void contributionsNonEx() {
+		final String contributionsNonEx = githubScraperNonEx.contributions();
+		Assertions.assertTrue(contributionsNonEx.equals(""));
 	}
 }


### PR DESCRIPTION
# Adds a commit graph replacement if no commit data is available

Fixes #419

Changes proposed in this pull request:

* Adds a commit graph replacement if the graph cannot be rendered
* If `commit_history_scraped_at` is `null` display "We did not scrape the commit history of this repository yet."
* If a repository was scraped, and there is no commit history display
  "We cannot display this graph because we cannot read the commit history."

To do

* [x] Distinguish between an empty repository and a 404 (repo not accessible). Currently, in both cases the database property `commit_history_scraped_at` is Null. This requires changes in the scrapers.
* [x] Make the text on the graph responsive

How to test:

* add a new software with a closed source repository (e.g. `https://git.gfz-potsdam.de/moose/lynx`)
* add the same url (or another) to get-started url
* Save it and view the page. It should show this message:
  ![image](https://user-images.githubusercontent.com/14222414/182847189-236d8be3-b54d-416f-aa02-8b80f37780e8.png)
* wait until the scrapers ran, or run
  ```
  docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits
  ```
* software page should now display
  ![image](https://user-images.githubusercontent.com/14222414/182847395-9b46599f-2274-4f86-a6d0-fccbad75a7b6.png)
* create a new software entry
* add an **empty** repository (.e.g `https://github.com/cmeessen/empty`) as repo url and also as get-started-url
* save and publish the page
* start the scraper one more time
* the software page will display
  ![image](https://user-images.githubusercontent.com/14222414/195812266-894664ff-8190-4daf-bb2b-42209cf23cbf.png)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
