### PR TITLE
Improve visibility of programming language bars

### DIFF
--- a/frontend/components/software/AboutLanguages.tsx
+++ b/frontend/components/software/AboutLanguages.tsx
@@ -73,7 +73,7 @@ export default function AboutLanguages({languages}: {languages: ProgramingLangua
           <li key={key}>
             {key} <span className="ml-2">{stats[key].pct}%</span>
             <div
-              className="bg-base-300"
+              className="bg-primary"
               style={{
                 width: `${stats[key].pct}%`,
                 height: '0.5rem',


### PR DESCRIPTION
# Improve visibility of programming language bars

Changes proposed in this pull request:

* change the color of the programming language bars to a more visible color (primary)

Before:

![image](https://user-images.githubusercontent.com/1287885/184861324-f3caf8b7-8d60-4850-93f3-20753b171263.png)

Now with this change:

![image](https://user-images.githubusercontent.com/1287885/184861139-19a2714f-f8b5-4255-91d2-3cf5ca743d25.png)

How to test:

* have a software entry with scraped programming languages
* the bars for the programming languages should have the primary color

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
