### PR TITLE
Allow maintainer to see and delete unused invitations

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:1.2.1
+    image: rsd/frontend:1.2.2
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/layout/InvitationList.tsx
+++ b/frontend/components/layout/InvitationList.tsx
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {Invitation} from '~/types/Invitation'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import CopyIcon from '@mui/icons-material/ContentCopy'
+import DeleteIcon from '@mui/icons-material/Delete'
+import IconButton from '@mui/material/IconButton'
+import {createJsonHeaders} from '~/utils/fetchHelpers'
+import copyToClipboard from '~/utils/copyToClipboard'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import ListItemText from '@mui/material/ListItemText'
+import EditSectionTitle from './EditSectionTitle'
+
+export default function InvitationList({invitations, token, onDeleteCallback}: {invitations: Invitation[], token: string, onDeleteCallback: Function}) {
+  const {showErrorMessage, showInfoMessage} = useSnackbar()
+
+  async function deleteMaintainerLink(invitation: Invitation) {
+    const resp = await fetch(`/api/v1/invite_maintainer_for_${invitation.type}?id=eq.${invitation.id}`, {
+      headers: createJsonHeaders(token),
+      method: 'DELETE'
+    })
+    if (resp.status !== 204) showErrorMessage('Failed to delete invitation.')
+    onDeleteCallback()
+  }
+
+  async function toClipboard(message?: string) {
+    if (message) {
+      const copied = await copyToClipboard(message)
+      // notify user about copy action
+      if (copied) {
+        showInfoMessage('Copied to clipboard')
+      } else {
+        showErrorMessage(`Failed to copy link ${message}`)
+      }
+    }
+  }
+
+  if(invitations.length === 0) return null
+
+  return (
+    <>
+      <EditSectionTitle title={'Unused invitations'} subtitle={'These invitations are not used yet'}/>
+      <List>
+        {invitations.map(inv => {
+          const currentLink = `${location.origin}/invite/${inv.type}/${inv.id}`
+          return (
+            <ListItem key={inv.id}>
+              <ListItemText primary={'Created on ' + new Date(inv.created_at).toDateString()} secondary={currentLink}/>
+              <IconButton onClick={() => toClipboard(currentLink)}><CopyIcon/></IconButton>
+              <IconButton onClick={() => deleteMaintainerLink(inv)}><DeleteIcon/></IconButton>
+            </ListItem>
+          )
+        })}
+      </List>
+    </>
+  )
+}

--- a/frontend/components/organisation/maintainers/OrganisationMaintainerLink.tsx
+++ b/frontend/components/organisation/maintainers/OrganisationMaintainerLink.tsx
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useState} from 'react'
+import {useEffect, useState} from 'react'
 import Button from '@mui/material/Button'
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 import EmailIcon from '@mui/icons-material/Email'
@@ -12,12 +14,23 @@ import CopyIcon from '@mui/icons-material/ContentCopy'
 import {copyToClipboard,canCopyToClipboard} from '~/utils/copyToClipboard'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {organisationMaintainerLink} from './useOrganisationMaintainer'
+import InvitationList from '~/components/layout/InvitationList'
+import {Invitation} from '~/types/Invitation'
+import {getUnusedInvitations} from '~/utils/getUnusedInvitations'
 
 export default function OrganisationMaintainerLink({organisation, account, token}:
   { organisation: string, account: string, token: string }) {
   const {showErrorMessage,showInfoMessage} = useSnackbar()
   const [magicLink, setMagicLink] = useState(null)
+  const [unusedInvitations, setUnusedInvitations] = useState<Invitation[]>([])
   const canCopy = useState(canCopyToClipboard())
+
+  async function fetchUnusedInvitations() {
+    setUnusedInvitations(await getUnusedInvitations('organisation', organisation, token))
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {fetchUnusedInvitations()}, [])
 
   async function createInviteLink() {
     const resp = await organisationMaintainerLink({
@@ -27,6 +40,7 @@ export default function OrganisationMaintainerLink({organisation, account, token
     })
     if (resp.status === 201) {
       setMagicLink(resp.message)
+      fetchUnusedInvitations()
     } else {
       showErrorMessage(`Failed to generate maintainer link. ${resp.message}`)
     }
@@ -93,6 +107,7 @@ export default function OrganisationMaintainerLink({organisation, account, token
     </Button>
     <div className="py-2"></div>
     {renderLinkOptions()}
+    <InvitationList invitations={unusedInvitations} token={token} onDeleteCallback={() => fetchUnusedInvitations()}/>
     </>
   )
 }

--- a/frontend/components/software/edit/maintainers/SoftwareMaintainerLink.tsx
+++ b/frontend/components/software/edit/maintainers/SoftwareMaintainerLink.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -12,11 +14,24 @@ import CopyIcon from '@mui/icons-material/ContentCopy'
 import {copyToClipboard,canCopyToClipboard} from '~/utils/copyToClipboard'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {softwareMaintainerLink} from './useSoftwareMaintainer'
+import {useEffect} from 'react'
+
+import {Invitation} from '~/types/Invitation'
+import InvitationList from '~/components/layout/InvitationList'
+import {getUnusedInvitations} from '~/utils/getUnusedInvitations'
 
 export default function SoftwareMaintainerLink({software,account,token}: { software: string,account:string,token: string }) {
   const {showErrorMessage,showInfoMessage} = useSnackbar()
   const [magicLink, setMagicLink] = useState(null)
+  const [unusedInvitations, setUnusedInvitations] = useState<Invitation[]>([])
   const canCopy = useState(canCopyToClipboard())
+
+  async function fetchUnusedInvitations() {
+    setUnusedInvitations(await getUnusedInvitations('software', software, token))
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => {fetchUnusedInvitations()}, [])
 
   async function createInviteLink() {
     const resp = await softwareMaintainerLink({
@@ -26,6 +41,7 @@ export default function SoftwareMaintainerLink({software,account,token}: { softw
     })
     if (resp.status === 201) {
       setMagicLink(resp.message)
+      fetchUnusedInvitations()
     } else {
       showErrorMessage(`Failed to generate maintainer link. ${resp.message}`)
     }
@@ -92,6 +108,7 @@ export default function SoftwareMaintainerLink({software,account,token}: { softw
     </Button>
     <div className="py-2"></div>
     {renderLinkOptions()}
+    <InvitationList invitations={unusedInvitations} token={token} onDeleteCallback={() => fetchUnusedInvitations()}/>
     </>
   )
 }

--- a/frontend/types/Invitation.ts
+++ b/frontend/types/Invitation.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export type Invitation = {
+    id: string,
+    created_at: string,
+    type: 'software' | 'project' | 'organisation'
+}

--- a/frontend/utils/getUnusedInvitations.ts
+++ b/frontend/utils/getUnusedInvitations.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {Invitation} from '~/types/Invitation'
+import {createJsonHeaders} from './fetchHelpers'
+
+export async function getUnusedInvitations(type: 'software' | 'project' | 'organisation', id: string, token?: string) {
+  const resp = await fetch(`/api/v1/invite_maintainer_for_${type}?select=id,created_at&order=created_at&${type}=eq.${id}&claimed_by=is.null&claimed_at=is.null`, {
+    headers: createJsonHeaders(token)
+  })
+  const respJson: Invitation[] = await resp.json()
+  respJson.forEach(invitation => {
+    invitation.type = type
+  })
+  return respJson
+}


### PR DESCRIPTION
# See and delete unused invitations

Changes proposed in this pull request:

* It is now possible for maintainers to see and delete unused invitations

How to test:
* `docker-compose build frontend && docker-compose up`
* Login, add a software page, create some invite links. You should see a list with all unused invitations. You can copy them to the clipboard and delete them.
* Do the same for a project and an organisation.

Closes one of the items in #260

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests