### PR TITLE
475 fix markdown pages

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:1.3.1
+    image: rsd/frontend:1.3.2
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/auth/index.tsx
+++ b/frontend/auth/index.tsx
@@ -63,7 +63,7 @@ export function AuthProvider(props: any) {
       const {user} = session
       const expiresInMs = getExpInMs(user.exp)
       const waitInMs = getWaitInMs(expiresInMs)
-      console.log('waitInMs...', waitInMs)
+      // console.log('waitInMs...', waitInMs)
       if (schedule) clearTimeout(schedule)
       if (expiresInMs <= 0) {
         // token expired
@@ -75,7 +75,7 @@ export function AuthProvider(props: any) {
           // refresh token by sending current valid cookie
           refreshSession()
             .then(newSession => {
-              console.log('newSession.token...', newSession?.token)
+              // console.log('newSession.token...', newSession?.token)
               // update only if "valid" session
               if (newSession?.status === 'authenticated') {
                 setSession(newSession)

--- a/frontend/auth/index.tsx
+++ b/frontend/auth/index.tsx
@@ -11,7 +11,9 @@ import logger from '../utils/logger'
 import {refreshSession} from './refreshSession'
 
 // refresh schedule margin 5min. before expiration time
-export const REFRESH_MARGIN = 5 * 60 * 1000
+// REFRESH_MARGIN_MSEC env variable is used for test purposes ONLY
+const testMargin = process.env.NEXT_PUBLIC_REFRESH_MARGIN_MSEC ? parseInt(process.env.NEXT_PUBLIC_REFRESH_MARGIN_MSEC) : undefined
+export const REFRESH_MARGIN = testMargin || 5 * 60 * 1000
 export type RsdRole = 'rsd_admin' | 'rsd_user'
 export type RsdUser = {
   iss: 'rsd_auth'
@@ -43,7 +45,7 @@ export const defaultSession:Session={
 
 export const initSession: AuthSession = {
   session: defaultSession,
-  setSession: ()=>defaultSession
+  setSession: () => defaultSession
 }
 
 const AuthContext = createContext(initSession)
@@ -61,7 +63,7 @@ export function AuthProvider(props: any) {
       const {user} = session
       const expiresInMs = getExpInMs(user.exp)
       const waitInMs = getWaitInMs(expiresInMs)
-      // console.log('waitInMs...', waitInMs)
+      console.log('waitInMs...', waitInMs)
       if (schedule) clearTimeout(schedule)
       if (expiresInMs <= 0) {
         // token expired
@@ -73,7 +75,7 @@ export function AuthProvider(props: any) {
           // refresh token by sending current valid cookie
           refreshSession()
             .then(newSession => {
-              // console.log('newSession...', newSession)
+              console.log('newSession.token...', newSession?.token)
               // update only if "valid" session
               if (newSession?.status === 'authenticated') {
                 setSession(newSession)

--- a/frontend/components/page/edit/EditMarkdownPage.tsx
+++ b/frontend/components/page/edit/EditMarkdownPage.tsx
@@ -71,12 +71,11 @@ export default function EditMarkdownPage({slug,onDelete,onSubmit}:EditMarkdownPa
     // FIX: this logic is required to prevent reloading
     // of the form/data when token is refreshed
     if (slug && token &&
-      isDirty === false &&
       slug!==loadedSlug
     ) {
       getMarkdown()
     }
-  }, [slug, loadedSlug, token, isDirty,getMarkdown])
+  }, [slug, loadedSlug, token, getMarkdown])
 
   // useEffect(() => {
   //   // fetch markdown from database

--- a/frontend/components/page/edit/EditMarkdownPage.tsx
+++ b/frontend/components/page/edit/EditMarkdownPage.tsx
@@ -3,19 +3,21 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useForm} from 'react-hook-form'
+import {useCallback, useEffect, useState} from 'react'
+import {useFormContext} from 'react-hook-form'
 import Button from '@mui/material/Button'
 import DeleteIcon from '@mui/icons-material/Delete'
 
+import {useAuth} from '~/auth'
 import ControlledSwitch from '~/components/form/ControlledSwitch'
 import ControlledTextField from '~/components/form/ControlledTextField'
 import MarkdownInputWithPreview from '~/components/form/MarkdownInputWithPreview'
-import config from './config'
-import {MarkdownPage} from '../useMarkdownPages'
-
-import {saveMarkdownPage} from '../saveMarkdownPage'
 import ControlledSlugTextField from '~/components/form/ControlledSlugTextField'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
+import ContentLoader from '~/components/layout/ContentLoader'
+import config from './config'
+import {getMarkdownPage, MarkdownPage} from '../useMarkdownPages'
+import {saveMarkdownPage} from '../saveMarkdownPage'
 
 export type SubmitProps = {
   status: number
@@ -28,33 +30,67 @@ export type SubmitProps = {
   }
 }
 
-type EditMarkdownPageProps = {
-  token: string,
-  page?: MarkdownPage
+export type EditMarkdownPageProps = {
+  slug: string
   onDelete: (page: MarkdownPage) => void
   onSubmit: ({status,message,data}:SubmitProps) => void
 }
 
-export default function EditMarkdownPage({token,page,onDelete,onSubmit}:EditMarkdownPageProps) {
-  // const {showErrorMessage,showSuccessMessage} = useSnackbar()
+export default function EditMarkdownPage({slug,onDelete,onSubmit}:EditMarkdownPageProps) {
+  const {session: {token}} = useAuth()
+  const [fetch, setFetch] = useState(false)
+  const [loading, setLoading] = useState(true)
+  const [loadedSlug, setLoadedSlug]=useState<string>()
   const {
     register, handleSubmit, watch, formState, reset, control
-  } = useForm<MarkdownPage>({
-    mode: 'onChange',
-    defaultValues: {
-      ...page
-    }
-  })
+  } = useFormContext()
   // destructure formState
   const {isDirty, isValid} = formState
   // form data provided by react-hook-form
   const formData = watch()
 
+  const getMarkdown = useCallback(()=>{
+    setLoading(true)
+    getMarkdownPage({slug, token, is_published: false})
+      .then(resp => {
+        if (resp.page) {
+          reset(resp.page)
+          setLoadedSlug(slug)
+        }
+      })
+      .finally(() =>
+        setLoading(false)
+      )
+    setFetch(false)
+  },[slug,token,reset])
+
+  useEffect(() => {
+    // request fetching data from database
+    // only if form is not dirty, info present
+    // and not already loaded
+    // FIX: this logic is required to prevent reloading
+    // of the form/data when token is refreshed
+    if (slug && token &&
+      isDirty === false &&
+      slug!==loadedSlug
+    ) {
+      getMarkdown()
+    }
+  }, [slug, loadedSlug, token, isDirty,getMarkdown])
+
+  // useEffect(() => {
+  //   // fetch markdown from database
+  //   // on explicit demand ONLY (token refresh fix)
+  //   if (fetch === true && slug !== currentPage) {
+  //     getMarkdown()
+  //   }
+  // },[fetch,currentPage,getMarkdown])
+
   // console.group('EditMarkdownPage')
   // console.log('isDirty...', isDirty)
   // console.log('isValid...', isValid)
-  // console.log('formData.slug...', formData?.slug)
-  // console.log('page.slug...', page?.slug)
+  // console.log('formData...', formData)
+  // console.log('token...', token)
   // console.groupEnd()
 
   async function savePage(data: MarkdownPage) {
@@ -92,11 +128,12 @@ export default function EditMarkdownPage({token,page,onDelete,onSubmit}:EditMark
     }
   }
 
-  if (!page) return null
+  // loading
+  if (loading) return <ContentLoader />
 
   return (
     <form
-      id={page.slug}
+      id={'edit-markdown'}
       onSubmit={handleSubmit(savePage)}
       className='flex-1 py-4'>
       {/* hidden inputs */}
@@ -113,7 +150,7 @@ export default function EditMarkdownPage({token,page,onDelete,onSubmit}:EditMark
               name: 'title',
               label: config.title.label,
               useNull: true,
-              defaultValue: page?.title,
+              // defaultValue: page?.title,
               helperTextMessage: config.title.help,
               helperTextCnt: `${formData?.title?.length || 0}/${config.title.validation.maxLength.value}`,
             }}
@@ -130,14 +167,14 @@ export default function EditMarkdownPage({token,page,onDelete,onSubmit}:EditMark
         <div className="flex justify-end items-center pb-8 lg:pb-0">
           <SubmitButtonWithListener
             disabled={!isValid || !isDirty}
-            formId={page.slug ?? ''}
+            formId={'edit-markdown'}
           />
           <Button
             id="delete-button"
             variant="text"
             color="error"
             endIcon={<DeleteIcon />}
-            onClick={() => onDelete(page)}
+            onClick={() => onDelete(formData)}
             sx={{
               marginLeft:'1rem'
             }}
@@ -152,7 +189,7 @@ export default function EditMarkdownPage({token,page,onDelete,onSubmit}:EditMark
           name:'slug',
           label: config.slug.label,
           baseUrl: config.slug.baseUrl(),
-          defaultValue: formData.slug,
+          defaultValue: formData.slug ?? '',
           helperTextMessage: config.slug.help,
         }}
         control={control}

--- a/frontend/components/page/edit/PageEditorBody.tsx
+++ b/frontend/components/page/edit/PageEditorBody.tsx
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+
+import {useForm, FormProvider} from 'react-hook-form'
+
+import {RsdLink} from '~/config/rsdSettingsReducer'
+import {MarkdownPage} from '../useMarkdownPages'
+import EditMarkdownPage, {SubmitProps} from './EditMarkdownPage'
+import NoPageItems from './NoPageItems'
+import SortableNav from './SortableNav'
+
+type CustomMarkdownPagesProps = {
+  links: RsdLink[]
+  selected: string
+  onSelect:(item: RsdLink) => void
+  onSorted:(items:RsdLink[])=>void
+  onDelete: (page: MarkdownPage) => void
+  onSubmit: ({status,message,data}:SubmitProps) => void
+}
+
+
+export default function PageEditorBody({links,selected,onSelect,onSorted,onDelete,onSubmit}: CustomMarkdownPagesProps) {
+  const methods = useForm<MarkdownPage>({
+    mode: 'onChange'
+  })
+  return (
+    <section className="flex-1 grid md:grid-cols-[1fr,2fr] xl:grid-cols-[1fr,4fr] gap-[3rem]">
+      {/* use form provider to pull isDirty state into sortablenav component */}
+      <FormProvider {...methods} >
+      <div>
+        <SortableNav
+          onSelect={onSelect}
+          selected={selected}
+          links={links}
+          onSorted={onSorted}
+        />
+      </div>
+      <div>
+        {
+          links.length > 0 ?
+          <EditMarkdownPage
+            slug={selected}
+            onDelete={onDelete}
+            onSubmit={onSubmit}
+          />
+          : <NoPageItems />
+        }
+      </div>
+      </FormProvider>
+    </section>
+  )
+}

--- a/frontend/components/page/edit/SortableNav.tsx
+++ b/frontend/components/page/edit/SortableNav.tsx
@@ -6,8 +6,9 @@
 import {RsdLink} from '~/config/rsdSettingsReducer'
 import SortableList from '~/components/layout/SortableList'
 import PageNavItem from './SortableNavItem'
+import {useFormContext} from 'react-hook-form'
 
-type PagesNavProps = {
+export type PagesNavProps = {
   links: RsdLink[]
   selected: string,
   onSelect: (item: RsdLink) => void
@@ -15,6 +16,15 @@ type PagesNavProps = {
 }
 
 export default function SortableNav({selected, links, onSelect, onSorted}: PagesNavProps) {
+  const {formState: {isDirty}} = useFormContext()
+
+  function onNavigation(item: RsdLink) {
+    if (isDirty === false) {
+      onSelect(item)
+    } else {
+      alert('Please save your changes first.')
+    }
+  }
 
   /**
    * This method is called by SortableList component to enable
@@ -30,15 +40,16 @@ export default function SortableNav({selected, links, onSelect, onSorted}: Pages
         item={item}
         index={index ?? 1}
         selected={selected}
-        onSelect={onSelect}
+        onSelect={onNavigation}
       />
     )
   }
 
-  // console.group('PagesNav')
-  // console.log('selected...', selected)
+  console.group('SortableNav')
+  console.log('selected...', selected)
   // console.log('links...', links)
-  // console.groupEnd()
+  console.log('isDirty...', isDirty)
+  console.groupEnd()
 
   return (
     <SortableList

--- a/frontend/components/page/edit/SortableNav.tsx
+++ b/frontend/components/page/edit/SortableNav.tsx
@@ -4,9 +4,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {RsdLink} from '~/config/rsdSettingsReducer'
+import {useFormContext} from 'react-hook-form'
+
+import {app} from '~/config/app'
 import SortableList from '~/components/layout/SortableList'
 import PageNavItem from './SortableNavItem'
-import {useFormContext} from 'react-hook-form'
+import useOnUnsaveChange from '~/utils/useOnUnsavedChange'
 
 export type PagesNavProps = {
   links: RsdLink[]
@@ -16,13 +19,23 @@ export type PagesNavProps = {
 }
 
 export default function SortableNav({selected, links, onSelect, onSorted}: PagesNavProps) {
-  const {formState: {isDirty}} = useFormContext()
+  const {formState: {isDirty,isValid}} = useFormContext()
+
+  // watch for unsaved changes
+  useOnUnsaveChange({
+    isDirty,
+    isValid,
+    warning: app.unsavedChangesMessage
+  })
 
   function onNavigation(item: RsdLink) {
     if (isDirty === false) {
       onSelect(item)
     } else {
-      alert('Please save your changes first.')
+      const leavePage = confirm(app.unsavedChangesMessage)
+      if (leavePage === true) {
+        onSelect(item)
+      }
     }
   }
 

--- a/frontend/components/page/edit/SortableNav.tsx
+++ b/frontend/components/page/edit/SortableNav.tsx
@@ -45,11 +45,11 @@ export default function SortableNav({selected, links, onSelect, onSorted}: Pages
     )
   }
 
-  console.group('SortableNav')
-  console.log('selected...', selected)
+  // console.group('SortableNav')
+  // console.log('selected...', selected)
   // console.log('links...', links)
-  console.log('isDirty...', isDirty)
-  console.groupEnd()
+  // console.log('isDirty...', isDirty)
+  // console.groupEnd()
 
   return (
     <SortableList

--- a/frontend/components/page/edit/index.tsx
+++ b/frontend/components/page/edit/index.tsx
@@ -9,18 +9,16 @@ import Button from '@mui/material/Button'
 import AddIcon from '@mui/icons-material/Add'
 
 import {useAuth} from '~/auth'
+import logger from '~/utils/logger'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import ContentLoader from '~/components/layout/ContentLoader'
 import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
 import {PageTitleSticky} from '~/components/layout/PageTitle'
 import {RsdLink} from '~/config/rsdSettingsReducer'
 import AddPageModal from '../add/AddPageModal'
-import {MarkdownPage, useMarkdownPage} from '../useMarkdownPages'
-import EditMarkdownPage, {SubmitProps} from './EditMarkdownPage'
-import SortableNav from './SortableNav'
+import {MarkdownPage} from '../useMarkdownPages'
+import {SubmitProps} from './EditMarkdownPage'
 import {deleteMarkdownPage, updatePagePositions} from '../saveMarkdownPage'
-import NoPageItems from './NoPageItems'
-import logger from '~/utils/logger'
+import PageEditorBody from './PageEditorBody'
 
 export default function EditMarkdownPages({links}:{links:RsdLink[]}) {
   const {session} = useAuth()
@@ -29,17 +27,10 @@ export default function EditMarkdownPages({links}:{links:RsdLink[]}) {
   const [selected, setSelected] = useState<string>(links.length>0 ? links[0].slug : '')
   const [open, setOpen] = useState(false)
   const [delModal, setDelModal] = useState({open:false,slug:'',title:''})
-  const {loading, page} = useMarkdownPage({
-    slug: selected,
-    token: session.token,
-    is_published: false
-  })
 
   // console.group('EditMarkdownPages')
   // console.log('navItems...', navItems)
   // console.log('selected...', selected)
-  // console.log('loading...', loading)
-  // console.log('page...', page)
   // console.groupEnd()
 
   function showAddModal() {
@@ -137,21 +128,7 @@ export default function EditMarkdownPages({links}:{links:RsdLink[]}) {
     })
   }
 
-  function renderEditMarkdown() {
-    // loading
-    if (loading) return <ContentLoader />
-    if (navItems.length === 0) return <NoPageItems />
-    return (
-      <EditMarkdownPage
-        page={page}
-        token={session.token}
-        onDelete={onDeletePage}
-        onSubmit={onSavePage}
-      />
-    )
-  }
-
-  function onSorted(items: RsdLink[]) {
+  function onChangePagePostion(items: RsdLink[]) {
     patchPositions(items)
   }
 
@@ -191,20 +168,14 @@ export default function EditMarkdownPages({links}:{links:RsdLink[]}) {
           </Button>
         </div>
       </PageTitleSticky>
-
-      <section className="flex-1 grid md:grid-cols-[1fr,2fr] xl:grid-cols-[1fr,4fr] gap-[3rem]">
-        <div>
-          <SortableNav
-            onSelect={(item)=>setSelected(item.slug)}
-            selected={selected}
-            links={navItems}
-            onSorted={onSorted}
-          />
-        </div>
-        <div>
-          {renderEditMarkdown()}
-        </div>
-      </section>
+      <PageEditorBody
+        links={navItems}
+        selected={selected}
+        onSelect={(item) => setSelected(item.slug)}
+        onSorted={onChangePagePostion}
+        onDelete={onDeletePage}
+        onSubmit={onSavePage}
+      />
       <AddPageModal
         pos={navItems.length + 1}
         open={open}

--- a/frontend/components/software/add/AddSoftwareCard.tsx
+++ b/frontend/components/software/add/AddSoftwareCard.tsx
@@ -60,6 +60,12 @@ export default function AddSoftwareCard() {
   // construct slug from title
   const bouncedSlug = useDebounceValid(slugValue, errors['slug'])
 
+  console.group('AddSoftwareCard')
+  console.log('session...', session)
+  console.log('state...', state)
+  console.log('data...', data)
+  console.groupEnd()
+
   useEffect(() => {
     if (typeof location != 'undefined') {
       setBaseUrl(`${location.origin}/software/`)

--- a/frontend/components/software/add/AddSoftwareCard.tsx
+++ b/frontend/components/software/add/AddSoftwareCard.tsx
@@ -60,11 +60,11 @@ export default function AddSoftwareCard() {
   // construct slug from title
   const bouncedSlug = useDebounceValid(slugValue, errors['slug'])
 
-  console.group('AddSoftwareCard')
-  console.log('session...', session)
-  console.log('state...', state)
-  console.log('data...', data)
-  console.groupEnd()
+  // console.group('AddSoftwareCard')
+  // console.log('session...', session)
+  // console.log('state...', state)
+  // console.log('data...', data)
+  // console.groupEnd()
 
   useEffect(() => {
     if (typeof location != 'undefined') {

--- a/frontend/components/software/edit/testimonials/SortableTestimonialList.tsx
+++ b/frontend/components/software/edit/testimonials/SortableTestimonialList.tsx
@@ -10,6 +10,8 @@ import EditIcon from '@mui/icons-material/Edit'
 import {Testimonial} from '~/types/Testimonial'
 import SortableList from '~/components/layout/SortableList'
 import SortableTestimonialListItem from './SortableTestimonialListItem'
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
 
 type SortableTestimonialProps={
   items: Testimonial[],
@@ -18,7 +20,15 @@ type SortableTestimonialProps={
   onSorted:(items: Testimonial[])=>void
 }
 
-export default function SortableTestimonialList({items, onEdit, onDelete, onSorted}:SortableTestimonialProps){
+export default function SortableTestimonialList({items, onEdit, onDelete, onSorted}: SortableTestimonialProps) {
+  if (items.length === 0) {
+    return (
+      <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
+        <AlertTitle sx={{fontWeight:500}}>No testimonials</AlertTitle>
+        Add one using <strong>ADD button!</strong>
+      </Alert>
+    )
+  }
   /**
    * This method is called by SortableList component to enable
    * rendering of custom sortable items

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# Custom markdown pages: preserve unsaved input during token refresh process

Closes #475 

Changes proposed in this pull request:
*  When editing markdown pages, when input is changed by not saved after for max 60min the refresh token process will run and the page will rerender which leads to lost of changed but not saved input.    

How to test:
* if you do not have latest version of database
  *  `docker-compose down --volumes`: to remove old data
  * `docker-compose build` to build complete solution
* if you have latest db changes
  * `docker-compose build frontend` to build frontend only
* `docker-compose up` to start
* login as rsd_admin
   *  in .env file add this definition: `RSD_ADMIN_EMAIL_LIST=isaacnewton@university-example.org`
   *  then login as professor3, which with this settings will get rsd_admin role
* open adminstration section from the user menu
* create one page, add entries and save
* edit markdown or any of other properties and leave it for max of 60 minutes. When you come back the input values you entered (and not saved) should still be present and you will be able to save changes 

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
