### PR TITLE
500 fix edit project link

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:1.3.2
+    image: rsd/frontend:1.3.3
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/projects/edit/information/index.tsx
+++ b/frontend/components/projects/edit/information/index.tsx
@@ -43,8 +43,8 @@ export type ProjectImageInfo = {
 
 export default function EditProjectInformation({slug, session}: { slug: string, session: Session }) {
   const {showErrorMessage,showSuccessMessage} = useSnackbar()
-  const {handleSubmit, reset, register, control, getFieldState, setValue, getValues,formState} = useFormContext<EditProject>()
   const {step, loading, setLoading, setProjectInfo} = useProjectContext()
+  const {handleSubmit, reset, register, control, getFieldState, setValue, getValues, formState} = useFormContext<EditProject>()
   const {loading:apiLoading, project} = useProjectToEdit({
     slug,
     token: session?.token ?? ''
@@ -64,11 +64,14 @@ export default function EditProjectInformation({slug, session}: { slug: string, 
 
   // const researchFields = useResearchFieldOptions()
   // local state for keeping track what is deleted since last save
-  const [projectState,setProjectState]=useState<EditProject>()
+  const [projectState, setProjectState] = useState<EditProject>()
 
   // form data provided by react-hook-form
   // const formData = watch()
   const formValues = getValues()
+  // NOTE! need to "subscribe" to dirty fields state
+  // in order to detect first change using isDirty prop
+  const {dirtyFields} = formState
 
   useEffect(() => {
     // sync loading values
@@ -84,9 +87,7 @@ export default function EditProjectInformation({slug, session}: { slug: string, 
         // set local state
         setProjectState(project)
         // set project values in the form
-        reset({
-          ...project
-        })
+        reset(project)
       }
     }
   }, [
@@ -103,7 +104,7 @@ export default function EditProjectInformation({slug, session}: { slug: string, 
   // console.log('project...', project)
   // console.log('projectState...', projectState)
   // console.log('formValues...', formValues)
-  // console.log('formState...', formState)
+  // console.log('dirtyFields...', dirtyFields)
   // console.groupEnd()
 
   if (loading || apiLoading) {
@@ -213,9 +214,6 @@ export default function EditProjectInformation({slug, session}: { slug: string, 
       <input type="hidden"
         {...register('id',{required:'id is required'})}
       />
-      <input type="hidden"
-        {...register('slug',{required:'slug is required'})}
-      />
       <EditSection className='xl:grid xl:grid-cols-[3fr,1fr] xl:px-0 xl:gap-[3rem]'>
         {/* middle panel */}
         <div className="py-4 xl:pl-[3rem]">
@@ -238,7 +236,10 @@ export default function EditProjectInformation({slug, session}: { slug: string, 
                 rules={config.slug.validation}
               />
             </>
-            :null
+            :
+            <input type="hidden"
+              {...register('slug',{required:'slug is required'})}
+            />
           }
           <div className="py-2"></div>
           <ControlledTextField

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "1.3.2",
+  "version": "1.3.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/types/Project.ts
+++ b/frontend/types/Project.ts
@@ -34,6 +34,15 @@ export type Project = BasicProject & {
   image_id: string | null
 }
 
+export type EditProject = Project & {
+  image_b64: string | null
+  image_mime_type: string | null
+  url_for_project: ProjectLink[]
+  funding_organisations: FundingOrganisation[]
+  research_domains: ResearchDomain[] | null
+  keywords: KeywordForProject[]
+}
+
 export type CurrentState = 'Starting' | 'Running' | 'Finished'
 export type ProjectSearchRpc = {
   id: string
@@ -117,15 +126,6 @@ export type KeywordForProject = {
   action?: 'add' | 'create'
   // passed to save function for updating form value with uuid
   pos?: number
-}
-
-export type EditProject = Project & {
-  image_b64: string | null
-  image_mime_type: string | null
-  url_for_project: ProjectLink[]
-  funding_organisations: FundingOrganisation[]
-  research_domains: ResearchDomain[] | null
-  keywords: KeywordForProject[]
 }
 
 export type ResearchDomain = {


### PR DESCRIPTION
# Fix saving initial change in project link

Closes #500 

Changes proposed in this pull request:
*  User can edit project link values and save

How to test:

* `docker-compose build`: to build solution
* `docker-compose up` to start services
* login and create project
* add link, save and preview page
* edit page, change link title or url BUT JUST 1 charater. The save button will be enabled 
* use save and view the page, the change you made should be shown. 
* Go back to edit page, the url with latest changes is loaded

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
