### PR TITLE
498 allow organisations multiple roles for projects

### DIFF
--- a/database/012-inter-relation-tables.sql
+++ b/database/012-inter-relation-tables.sql
@@ -18,8 +18,8 @@ CREATE TYPE organisation_role AS ENUM (
 );
 
 CREATE TABLE software_for_software (
-	origin UUID references software (id),
-	relation UUID references software (id),
+	origin UUID REFERENCES software (id),
+	relation UUID REFERENCES software (id),
 	PRIMARY KEY (origin, relation)
 );
 
@@ -36,8 +36,8 @@ CREATE TRIGGER sanitise_update_software_for_software BEFORE UPDATE ON software_f
 
 
 CREATE TABLE software_for_project (
-	software UUID references software (id),
-	project UUID references project (id),
+	software UUID REFERENCES software (id),
+	project UUID REFERENCES project (id),
 	status relation_status NOT NULL DEFAULT 'approved',
 	PRIMARY KEY (software, project)
 );
@@ -67,8 +67,8 @@ CREATE TRIGGER sanitise_update_software_for_project BEFORE UPDATE ON software_fo
 
 
 CREATE TABLE project_for_project (
-	origin UUID references project (id),
-	relation UUID references project (id),
+	origin UUID REFERENCES project (id),
+	relation UUID REFERENCES project (id),
 	status relation_status NOT NULL DEFAULT 'approved',
 	PRIMARY KEY (origin, relation)
 );
@@ -98,8 +98,8 @@ CREATE TRIGGER sanitise_update_project_for_project BEFORE UPDATE ON project_for_
 
 
 CREATE TABLE software_for_organisation (
-	software UUID references software (id),
-	organisation UUID references organisation (id),
+	software UUID REFERENCES software (id),
+	organisation UUID REFERENCES organisation (id),
 	status relation_status NOT NULL DEFAULT 'approved',
 	is_featured BOOLEAN DEFAULT FALSE NOT NULL,
 	PRIMARY KEY (software, organisation)
@@ -133,12 +133,12 @@ CREATE TRIGGER sanitise_update_software_for_organisation BEFORE UPDATE ON softwa
 
 
 CREATE TABLE project_for_organisation (
-	project UUID references project (id),
-	organisation UUID references organisation (id),
+	project UUID REFERENCES project (id),
+	organisation UUID REFERENCES organisation (id),
 	status relation_status NOT NULL DEFAULT 'approved',
 	role organisation_role NOT NULL DEFAULT 'participating',
 	is_featured BOOLEAN DEFAULT FALSE NOT NULL,
-	PRIMARY KEY (project, organisation)
+	PRIMARY KEY (project, organisation, role)
 );
 
 CREATE FUNCTION sanitise_update_project_for_organisation() RETURNS TRIGGER LANGUAGE plpgsql AS

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -334,7 +334,7 @@ BEGIN
 		RETURN QUERY
 		SELECT
 			project_for_organisation.organisation,
-			COUNT(*) AS project_cnt
+			COUNT(DISTINCT project) AS project_cnt
 		FROM
 			project_for_organisation
 		WHERE
@@ -347,7 +347,7 @@ BEGIN
 		RETURN QUERY
 		SELECT
 			project_for_organisation.organisation,
-			COUNT(*) AS project_cnt
+			COUNT(DISTINCT project) AS project_cnt
 		FROM
 			project_for_organisation
 		GROUP BY project_for_organisation.organisation;
@@ -496,7 +496,7 @@ CREATE FUNCTION projects_by_organisation(organisation_id UUID) RETURNS TABLE (
 $$
 BEGIN
 	RETURN QUERY
-	SELECT
+	SELECT DISTINCT ON (project.id)
 		project.id,
 		project.slug,
 		project.title,

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:1.3.0
+    image: rsd/database:1.3.1
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -99,7 +99,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to corespond to frontend/package.json
-    image: rsd/frontend:1.3.4
+    image: rsd/frontend:1.3.5
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/projects/edit/organisations/index.tsx
+++ b/frontend/components/projects/edit/organisations/index.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -143,6 +145,7 @@ export default function ProjectOrganisations({slug}: { slug: string }) {
       const resp = await deleteOrganisationFromProject({
         project: project.id,
         organisation: organisation.id,
+        role: 'participating',
         token: session.token
       })
       if (resp.status === 200) {

--- a/frontend/utils/editProject.ts
+++ b/frontend/utils/editProject.ts
@@ -175,6 +175,7 @@ export async function updateProjectInfo({project, projectLinks, projectImage, fu
       deleteOrganisationFromProject({
         project: item.project,
         organisation: item.organisation,
+        role: 'funding',
         token: session.token
       })
     )
@@ -452,8 +453,6 @@ export async function addOrganisationToProject({project, organisation, role, ses
       method: 'POST',
       headers: {
         ...createJsonHeaders(session.token),
-        // this will add new items and update existing
-        'Prefer': 'resolution=merge-duplicates'
       },
       body: JSON.stringify({
         project,
@@ -503,11 +502,11 @@ export async function patchProjectForOrganisation({project, organisation, data, 
   }
 }
 
-export async function deleteOrganisationFromProject({project,organisation,token}:
-  { project: string, organisation:string, token:string }) {
+export async function deleteOrganisationFromProject({project, organisation, role, token}:
+  { project: string, organisation:string, role: OrganisationRole, token:string }) {
   try {
     // POST
-    const url = `/api/v1/project_for_organisation?project=eq.${project}&organisation=eq.${organisation}`
+    const url = `/api/v1/project_for_organisation?project=eq.${project}&organisation=eq.${organisation}&role=eq.${role}`
     const resp = await fetch(url, {
       method: 'DELETE',
       headers: {


### PR DESCRIPTION
# Multiple roles for organisations of a project

Changes proposed in this pull request:

* Organisations can now be both funding and participating for a project, while before they were mutually exclusive

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale scrapers=0`
* Login and create a project
* Add a funding organisation to that project (in the "Information" tab) and save
* Add the *same* organisation to that project as a participating organisation (in the "Organisations tab")
* The funding organisation should still be there in the admin interface
* View the project and check that the organisation is shown both as funding and as participating
* Delete the organisation as a funding organisation, check it's still a participating organisation
* Add again and now delete it as participating organisation, do the same check
* On the organisations overview, check that the count is correct, i.e., check that the project isn't counted as 2
* Go to the organisation page and check that the project is only shown once
* Are there any other places that I missed where it could show up as a duplicate?

Note: when pinning or denying a project as organisation maintainer, this is done for all its roles. We still have to think if we want to change this later. There is also an edge case when a project is pinned or denied when it had only one role and then is later added with the other role.

Closes #498

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests