### PR TITLE
fix: add functionality to find a mention by its full DOI URL

### DIFF
--- a/frontend/components/projects/edit/impact/FindImpact.tsx
+++ b/frontend/components/projects/edit/impact/FindImpact.tsx
@@ -23,7 +23,9 @@ export default function FindImpact() {
 
   async function findPublication(searchFor: string) {
     // regex validation if DOI string
-    if (searchFor.match(/^10(\.\w+)+\/\S+$/) !== null) {
+    const doiRegexMatch = searchFor.match(/^\s*((https?:\/\/)?(www\.)?(dx\.)?doi\.org\/)?(10(\.\w+)+\/\S+)\s*$/)
+    if (doiRegexMatch !== null && doiRegexMatch[5] !== undefined) {
+      searchFor = doiRegexMatch[5]
       // look first at RSD
       const rsd = await getMentionByDoiFromRsd({
         doi: searchFor,

--- a/frontend/components/projects/edit/output/FindOutput.tsx
+++ b/frontend/components/projects/edit/output/FindOutput.tsx
@@ -23,7 +23,9 @@ export default function FindOutput() {
 
   async function findPublication(searchFor: string) {
     // regex validation if DOI string
-    if (searchFor.match(/^10(\.\w+)+\/\S+$/) !== null) {
+    const doiRegexMatch = searchFor.match(/^\s*((https?:\/\/)?(www\.)?(dx\.)?doi\.org\/)?(10(\.\w+)+\/\S+)\s*$/)
+    if (doiRegexMatch !== null && doiRegexMatch[5] !== undefined) {
+      searchFor = doiRegexMatch[5]
       // look first at RSD
       const rsd = await getMentionByDoiFromRsd({
         doi: searchFor,

--- a/frontend/components/software/edit/mentions/FindSoftwareMention.tsx
+++ b/frontend/components/software/edit/mentions/FindSoftwareMention.tsx
@@ -24,7 +24,9 @@ export default function FindSoftwareMention() {
 
   async function findPublication(searchFor: string) {
     // regex validation if DOI string
-    if (searchFor.match(/^10(\.\w+)+\/\S+$/) !== null) {
+    const doiRegexMatch = searchFor.match(/^\s*((https?:\/\/)?(www\.)?(dx\.)?doi\.org\/)?(10(\.\w+)+\/\S+)\s*$/)
+    if (doiRegexMatch !== null && doiRegexMatch[5] !== undefined) {
+      searchFor = doiRegexMatch[5]
       // look first at RSD
       const rsd = await getMentionByDoiFromRsd({
         doi: searchFor,


### PR DESCRIPTION
# Mention search improvement

Changes proposed in this pull request:

* Mentions can now be searched for with a full URL, and leading and trailing whitespace is allowed as well

How to test:
* `docker-compose build frontend && docker-compose up --scale scrapers=0`
* Create software, search for a mention (but don't add it) with each of the variants below, in the devtools you should see a request to `localhost`, `doi.org` and `api.datacite.org`, but not to Crossref, the result should show up quickly
    * `10.5281/zenodo.7010594`
    * `doi.org/10.5281/zenodo.7010594`
    * `https://doi.org/10.5281/zenodo.7010594`
    * `http://doi.org/10.5281/zenodo.7010594`
    * `https://dx.doi.org/10.5281/zenodo.7010594`
    * `http://dx.doi.org/10.5281/zenodo.7010594`
    * `dx.doi.org/10.5281/zenodo.7010594`
    * `www.doi.org/10.5281/zenodo.7010594`
    * `https://www.doi.org/10.5281/zenodo.7010594`
    * `http://www.doi.org/10.5281/zenodo.7010594`
    * `https://www.dx.doi.org/10.5281/zenodo.7010594`
    * `http://www.dx.doi.org/10.5281/zenodo.7010594`
    * `www.dx.doi.org/10.5281/zenodo.7010594`
* See also https://regex101.com/r/XmCRO8/1
* The same should work when repeating this for impact and output for a project
* It should also work with leading and/or trailing whitespace

Closes #519
Closes on of the comments in [#512](https://github.com/research-software-directory/RSD-as-a-service/issues/512#issuecomment-1241693876)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests