### PR TITLE
447 link research domains

### DIFF
--- a/frontend/components/layout/EditSectionTitle.tsx
+++ b/frontend/components/layout/EditSectionTitle.tsx
@@ -1,13 +1,18 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Link from '@mui/material/Link'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
+
 export default function EditSectionTitle(
-  {title, subtitle = '', children, hlevel = 2}:
-  {title: string, subtitle?: string, children?: any, hlevel?: number}
+  {title, subtitle = '', children, hlevel = 2, infoLink}:
+  {title: string, subtitle?: string, children?: any, hlevel?: number, infoLink?: string}
 ) {
 
   const HeadingTag: any = `h${hlevel}`
@@ -26,7 +31,7 @@ export default function EditSectionTitle(
     return (
       <>
         <div className="flex">
-          <HeadingTag className="flex-1">{title}</HeadingTag>
+          <HeadingTag className="flex-1">{title} {infoLink && <Link href={infoLink} target="_blank" rel="noreferrer"><InfoOutlinedIcon fontSize="small"/></Link>}</HeadingTag>
           {children}
         </div>
         {getSubtitle()}
@@ -36,7 +41,7 @@ export default function EditSectionTitle(
 
   return (
     <>
-      <HeadingTag>{title}</HeadingTag>
+      <HeadingTag>{title} {infoLink && <Link href={infoLink} target="_blank" rel="noreferrer"><InfoOutlinedIcon fontSize="small"/></Link>}</HeadingTag>
       {getSubtitle()}
     </>
   )

--- a/frontend/components/projects/ProjectSidebar.tsx
+++ b/frontend/components/projects/ProjectSidebar.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -46,6 +48,7 @@ export default function ProjectSidebar({date_start, date_end, grant_id, links, r
       <ProjectTags
         title="Research domains"
         tags={researchDomains.map(item => ({label: item.key, title: item.description}))}
+        infoLink = "https://erc.europa.eu/news/new-erc-panel-structure-2021-and-2022"
       />
 
       <ProjectTags

--- a/frontend/components/projects/ProjectTags.tsx
+++ b/frontend/components/projects/ProjectTags.tsx
@@ -1,16 +1,20 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Link from '@mui/material/Link'
 import TagListItem from '../layout/TagListItem'
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 
 type TagWithTitle = {
   title: string
   label: string
 }
 
-export default function ProjectTags({title,tags}:{title:string, tags: string[] | TagWithTitle[] }) {
+export default function ProjectTags({title,tags,infoLink}:{title: string, tags: string[] | TagWithTitle[], infoLink?: string }) {
 
   function renderTags() {
     if (tags.length === 0) {
@@ -44,7 +48,7 @@ export default function ProjectTags({title,tags}:{title:string, tags: string[] |
 
   return (
     <div>
-      <h4 className="text-primary py-4">{title}</h4>
+      <h4 className="text-primary py-4">{title} {infoLink && <Link href={infoLink} target="_blank" rel="noreferrer"><InfoOutlinedIcon fontSize="small"/></Link>}</h4>
       {renderTags()}
     </div>
   )

--- a/frontend/components/projects/edit/information/ResearchDomains.tsx
+++ b/frontend/components/projects/edit/information/ResearchDomains.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -131,6 +133,7 @@ export default function ResearchDomains() {
       <EditSectionTitle
         title={config.research_domain.title}
         subtitle={config.research_domain.subtitle}
+        infoLink={config.research_domain.infoLink}
       />
       <div className="flex flex-wrap pb-4">
         {

--- a/frontend/components/projects/edit/information/config.ts
+++ b/frontend/components/projects/edit/information/config.ts
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -70,6 +72,7 @@ export const projectInformation = {
   research_domain: {
     title: 'Research domains',
     subtitle: 'ERC classification',
+    infoLink: 'https://erc.europa.eu/news/new-erc-panel-structure-2021-and-2022',
     label: 'Select main research domain and field'
   },
   keywords: {


### PR DESCRIPTION
# Add link to ECR explanation

Changes proposed in this pull request:

* On both the public project pages and the project admin pages, add an info link (as an info icon) to https://erc.europa.eu/news/new-erc-panel-structure-2021-and-2022 for research domains

How to test:
* `docker-compose build frontend && docker-compose up --scale scrapers=0`
* If there is no project yet, create one
* On the project admin page, on the right sidebar, look of the info icon and verify where it links to
* Go to the view page, the icon is there as well on the right sidebar

Closes #447

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests