### PR TITLE
fix: enable row level security for oaipmh

### DIFF
--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -636,3 +636,14 @@ CREATE POLICY anyone_can_read ON meta_pages FOR SELECT TO web_anon, rsd_user
 CREATE POLICY admin_all_rights ON meta_pages TO rsd_admin
 	USING (TRUE)
 	WITH CHECK (TRUE);
+
+
+-- oaipmh
+ALTER TABLE oaipmh ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY anyone_can_read ON oaipmh FOR SELECT TO web_anon, rsd_user
+	USING (TRUE);
+
+CREATE POLICY admin_all_rights ON oaipmh TO rsd_admin
+	USING (TRUE)
+	WITH CHECK (TRUE);


### PR DESCRIPTION
# Enable row level security for oaipmh

Changes proposed in this pull request:

* Enable row level security for oaipmh

How to test:
* Execute the same steps as in #529
* The data should still be visible, regardless if you're logged in or not
* If you're not an admin, any change requests to the table should return status code 401

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests