### PR TITLE
Fix slow organisation pages

### DIFF
--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -377,7 +377,7 @@ async function generateLogosForOrganisations(ids) {
 	const result = [];
 
 	for (let index = 0; index < ids.length; index++) {
-		if (base64Images === null) continue;
+		if (base64Images[index] === null) continue;
 		result.push({
 			organisation: ids[index],
 			data: base64Images[index],

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -323,8 +323,7 @@ BEGIN
 			COUNT(DISTINCT software_for_organisation.software) AS software_cnt
 		FROM
 			software_for_organisation
-		INNER JOIN list_parent_organisations(software_for_organisation.organisation)
-			ON list_parent_organisations.organisation_id IN (SELECT organisation_ID FROM list_parent_organisations(software_for_organisation.organisation))
+		CROSS JOIN list_parent_organisations(software_for_organisation.organisation)
 		WHERE
 			software_for_organisation.status = 'approved' AND
 			software IN (
@@ -338,8 +337,7 @@ BEGIN
 			COUNT(DISTINCT software_for_organisation.software) AS software_cnt
 		FROM
 			software_for_organisation
-		INNER JOIN list_parent_organisations(software_for_organisation.organisation)
-			ON list_parent_organisations.organisation_id IN (SELECT organisation_ID FROM list_parent_organisations(software_for_organisation.organisation))
+		CROSS JOIN list_parent_organisations(software_for_organisation.organisation)
 		GROUP BY list_parent_organisations.organisation_id;
 	END IF;
 END

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - PGRST_DB_SCHEMA
       - PGRST_SERVER_PORT
       - PGRST_JWT_SECRET
+      - PGRST_RAW_MEDIA_TYPES=application/xml
     depends_on:
       - database
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:1.4.0
+    image: rsd/database:1.4.1
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -161,7 +161,7 @@ services:
   #----------------------------------------------
   data-generation:
     build: ./data-generation
-    image: rsd/generation:1.0.0
+    image: rsd/generation:1.0.1
     environment:
       # it needs to be here to use values from .env file
       - PGRST_JWT_SECRET


### PR DESCRIPTION
# Small production fixes

Changes proposed in this pull request:

* Fix slow database function
* Fix data-generation bug that would cause no organisation images to be saved
* Add missing env variable to the deployment `docker-compose.yml`

How to test:
* If you want more test data, change the values in `data-generation/main.js`
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale scrapers=0 --scale data-generation=1`
* Check that the organisation pages ase faster now (eventually change back the old function via a direct query in the database to compare)

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests