### PR TITLE
fix: show homepage counts, align count props with api.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:1.4.0
+    image: rsd/frontend:1.4.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/__tests__/Home.test.tsx
+++ b/frontend/__tests__/Home.test.tsx
@@ -17,9 +17,9 @@ describe('pages/index.tsx', () => {
       name: 'rsd'
     },
     counts: {
-      software: 1,
-      projects: 2,
-      organisations: 3
+      software_cnt: 1111,
+      project_cnt: 2222,
+      organisation_cnt: 3333
     }
   }
   it('renders default RSD Home page when host=rsd', () => {
@@ -44,6 +44,19 @@ describe('pages/index.tsx', () => {
     render(WrappedComponentWithProps(Home))
     const page = screen.getByTestId('rsd-home-page')
     expect(page).toBeInTheDocument()
+  })
+
+  it('renders counts on RSD Home page', () => {
+    render(WrappedComponentWithProps(Home,{props}))
+    // software_cnt
+    const software = screen.getByText(`${props.counts.software_cnt} Software`)
+    expect(software).toBeInTheDocument()
+    // project_cnt
+    const project = screen.getByText(`${props.counts.project_cnt} Projects`)
+    expect(project).toBeInTheDocument()
+    // organisation_cnt
+    const organisation = screen.getByText(`${props.counts.organisation_cnt} Organisations`)
+    expect(organisation).toBeInTheDocument()
   })
 
   it('renders Helmholtz Home page when host=helmholtz', () => {

--- a/frontend/components/home/rsd/index.tsx
+++ b/frontend/components/home/rsd/index.tsx
@@ -25,12 +25,12 @@ import styles from './home.module.css'
 import 'aos/dist/aos.css'
 
 export type RsdHomeProps = {
-  software: number,
-  projects: number,
-  organisations: number
+  software_cnt: number,
+  project_cnt: number,
+  organisation_cnt: number
 }
 
-export default function RsdHome({software, projects, organisations}: RsdHomeProps) {
+export default function RsdHome({software_cnt, project_cnt, organisation_cnt}: RsdHomeProps) {
   // Initialize AOS library
   useEffect(() => {
     AOS.init()
@@ -110,17 +110,17 @@ export default function RsdHome({software, projects, organisations}: RsdHomeProp
       {/* stats  */}
       <div className="w-full max-w-screen-xl mx-auto flex flex-wrap gap-10 md:gap-16 p-5 md:p-10 ">
         <div>
-          <div className="text-lg">{software} Software</div>
+          <div className="text-lg">{software_cnt} Software</div>
           <div className="opacity-40">packages</div>
         </div>
 
         <div>
-          <div className="text-lg">{projects} Projects</div>
+          <div className="text-lg">{project_cnt} Projects</div>
           <div className="opacity-40">registered</div>
         </div>
 
         <div>
-          <div className="text-lg">{organisations} Organisations</div>
+          <div className="text-lg">{organisation_cnt} Organisations</div>
           <div className="opacity-40">contributed</div>
         </div>
       </div>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
# Show software, project and organisation counts on the homepage

Changes proposed in this pull request:
*  After introducing dynamic homepage the counts were lost. This fix ensures the counts are shown on RSD home page (incl. additional test).

How to test:
* `docker-compose build frontend` to build frontend
* `docker-compose up` to start solution

## Example
![image](https://user-images.githubusercontent.com/9204081/191711769-59ae76f5-2aba-4d0a-b1d7-5a1a3d3a56c7.png)

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
