### PR TITLE
442 duplicate ror organization

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:1.4.1
+    image: rsd/frontend:1.4.2
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -88,15 +88,11 @@ export async function fetchRSDOrganisations({searchFor, rorIds, token, frontend}
         }
       })
       return options
-    } else if (resp.status === 404) {
-      logger('findRSDOrganisationByProperty ERROR: 404 Not found', 'error')
-      // query not found
-      return []
     }
-    logger(`findRSDOrganisationByProperty ERROR: ${resp?.status} ${resp?.statusText}`, 'error')
+    logger(`fetchRSDOrganisations ERROR: ${resp?.status} ${resp?.statusText}`, 'error')
     return []
   } catch (e: any) {
-    logger(`findRSDOrganisationByProperty: ${e?.message}`, 'error')
+    logger(`fetchRSDOrganisations: ${e?.message}`, 'error')
     return []
   }
 }

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -34,10 +34,9 @@ export async function searchForOrganisation({searchFor, token, frontend}:
   { searchFor: string, token?: string, frontend?: boolean }) {
   try {
     // make requests to RSD and ROR
-    const [rsdOptions, rorOptions] = await Promise.all([
-      findRSDOrganisation({searchFor, token, frontend}),
-      findInROR({searchFor})
-    ])
+    const rorOptions = await findInROR({searchFor})
+    const rorIdsFound: string[] = rorOptions.map(rorResult => rorResult.key)
+    const rsdOptions = await findRSDOrganisation({searchFor, token, frontend, rorIds: rorIdsFound})
     // create options collection
     const options = [
       ...rsdOptions,
@@ -55,10 +54,16 @@ export async function searchForOrganisation({searchFor, token, frontend}:
   }
 }
 
-export async function findRSDOrganisationByProperty({searchFor, property, token, frontend}:
-  { searchFor: string, property:string, token?: string, frontend?: boolean }) {
+export async function fetchRSDOrganisations({searchFor, rorIds, token, frontend}:
+  { searchFor: string, rorIds: string[], token?: string, frontend?: boolean }) {
   try {
-    const query = `rpc/organisations_overview?${property}=ilike.*${searchFor}*&limit=20`
+    let query
+    if (rorIds.length) {
+      const rorIdsCommaSeparated = rorIds.join(',')
+      query = `rpc/organisations_overview?or=(name.ilike.*${searchFor}*,website.ilike.*${searchFor}*,ror_id.in.(${rorIdsCommaSeparated}))&limit=20`
+    } else {
+      query = `rpc/organisations_overview?or=(name.ilike.*${searchFor}*,website.ilike.*${searchFor}*)&limit=20`
+    }
     let url = `${process.env.POSTGREST_URL}/${query}`
     if (frontend) {
       url = `/api/v1/${query}`
@@ -96,27 +101,12 @@ export async function findRSDOrganisationByProperty({searchFor, property, token,
   }
 }
 
-export async function findRSDOrganisation({searchFor, token, frontend}:
-  { searchFor: string, token?: string, frontend?: boolean }){
+export async function findRSDOrganisation({searchFor, token, frontend, rorIds}:
+  { searchFor: string, token?: string, frontend?: boolean, rorIds: string[] }){
   try {
-    // search for term in name and website
-    // because postgrest or does not return desired results we use 2 calls
-    const [byName, byWebsite] = await Promise.all([
-      findRSDOrganisationByProperty({searchFor, property: 'name', token, frontend}),
-      findRSDOrganisationByProperty({searchFor, property: 'website', token, frontend})
-    ])
-    // remove duplicate website entries
-    const websiteOnly = itemsNotInReferenceList<AutocompleteOption<SearchOrganisation>>({
-      list: byWebsite,
-      referenceList: byName,
-      key: 'key'
-    })
-    // return unique collection of both requests
-    const foundInRSD = [
-      ...byName,
-      ...websiteOnly
-    ]
-    return foundInRSD
+    // search for term in name, website and rorIds
+    const fetchResults = await fetchRSDOrganisations({searchFor, rorIds, token, frontend})
+    return fetchResults
   } catch (e:any) {
     logger(`findRSDOrganisation: ${e?.message}`, 'error')
     return []


### PR DESCRIPTION
# Improve ROR search

Changes proposed in this pull request:

* When searching to add a participating/funding organisation, we first query the ROR database, then we search the RSD database, where we also query for ROR-ids found in the first search
* The search to the RSD db does only one query for name, website and ROR-ids, not multiple queries

How to test:
* `docker-compose build --parallel && docker-compose up --scale scrapers=0`
* Login as an admin
* If necessary, create a software and project page
* On the sw page, add organisation by searching for `Vrije Universiteit`, add the `Vrije Universiteit Amsterdam` one from ROR.
* Go to the Vrije Universiteit Amsterdam page, edit the name to be `Free University` (or something completely random if you want)
* Go to the project page, search for `Vrije Universiteit` both in participating and funding organisations, the `Free University` entry from the RSD db should show up and the result from the ROR db should *not* show up

Closes #442
Closes #531

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests