### PR TITLE
Add makefile frontend dependency to .env.local

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ dev:
 down:
 	docker-compose down
 
-frontend:
+frontend: frontend/.env.local
 	docker-compose up --scale frontend-dev=1 --scale scrapers=0 -d
 	docker-compose logs -f frontend-dev
 


### PR DESCRIPTION
# Autogenerate .env.local when running make frontend

Changes proposed in this pull request:

* fixes issue that when running `make frontend`, the file `frontend/.env.local` was not automatically updated

How to test:

* create a change in `.env` (e.g. remove or add a login provider)
* `make frontend`
* the first lines should now be:
  ```
  Creating frontend/.env.local
  cp .env frontend/.env.local
  sed -i 's/POSTGREST_URL=http:\/\/backend:3500/POSTGREST_URL=http:\/\/localhost\/api\/v1/g' frontend/.env.local
  sed -i 's/RSD_AUTH_URL=http:\/\/auth:7000/RSD_AUTH_URL=http:\/\/localhost\/auth/g' frontend/.env.local
  ```

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
