### PR TITLE
More convenient frontend-dev configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ dev:
 down:
 	docker-compose down
 
-dev-frontend-docker: frontend/.env.local
+frontend-docker: frontend/.env.local
 	docker-compose build frontend-dev
 	docker-compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
 

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,20 @@
 # PHONY makes possible to call `make commands` from inside the Makefile
 .PHONY: start install frontend data dev down dev-docs
 
+# Detect user and group IDs for frontend-dev configuration
+USER_OS := $(shell uname -s)
+DUID := $(shell /usr/bin/id -u)
+ifeq ($(USER_OS), Linux)
+	DGID := $(shell /usr/bin/id -g)
+endif
+# For MacOS use a workaround, id -g in MacOS returns a GID with a low number (usually 20)
+# such low GIDs are already used in Linux, so let's create a new one
+ifeq ($(USER_OS), Darwin)
+	DGID := $(shell dscl . -list /Groups PrimaryGroupID | awk 'BEGIN{i=0}{if($$2>i)i=$$2}END{print i+1}')
+endif
+export DUID
+export DGID
+
 # Main commands
 # ----------------------------------------------------------------
 start:
@@ -34,9 +48,9 @@ dev:
 down:
 	docker-compose down
 
-frontend: frontend/.env.local
-	docker-compose up --scale frontend-dev=1 --scale scrapers=0 -d
-	docker-compose logs -f frontend-dev
+dev-frontend-docker: frontend/.env.local
+	docker-compose build frontend-dev
+	docker-compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
 
 data:
 	docker-compose up --scale data-generation=1 --scale scrapers=0

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can run frontend in development mode as docker a service (called frontend-de
 
 ```
 # Run frontend development using docker at http://localhost:3000
-make dev-frontend-docker
+make frontend-docker
 # OR use docker-compose directly
 docker-compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
 ```

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ This repo contains the new RSD-as-a-service implementation
 
 ### Building from source code
 
-1. Before installing the dependencies ensure that you have Docker and docker-compose locally. 
-2. Set the required environment variables:  
+1. Before installing the dependencies ensure that you have Docker and docker-compose locally.
+2. Set the required environment variables:
    Copy the file `.env.example` to `.env` file at the root of the project
    and fill the secrets and passwords. Check if the secrets are correct.
    The `Makefile` will take care about creating an appropriate `frontend/.env.local`
@@ -50,7 +50,7 @@ docker-compose up
 ### Stopping the services
 
 ```
-# Stop all services via the makefile 
+# Stop all services via the makefile
 make down
 # OR directly use docker-compose
 docker-compose down
@@ -62,9 +62,9 @@ You can run frontend in development mode as docker a service (called frontend-de
 
 ```
 # Run frontend development using docker at http://localhost:3000
-make frontend
+make dev-frontend-docker
 # OR use docker-compose directly
-docker-compose up --scale frontend-dev=1 --scale scrapers=0 -d
+docker-compose up --scale frontend=0 --scale nginx=0 --scale scrapers=0 --scale frontend-dev=1 --scale nginx-dev=1
 ```
 
 It is possible to directly run the frontend too (without using a docker container). You must then have NodeJS installed, preferably v18.

--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ docker-compose down
 
 ## Developing the frontend
 
-You can run frontend in development mode as docker a service (called frontend-dev) that enables hot reloading. By default this frontend-dev service will not be started automatically.
+You can run frontend in development mode as docker a service (called frontend-dev) that enables hot reloading. By default this frontend-dev service will not be started automatically. For more detailed instructions see [frontend/README.md](frontend/README.md).
 
 ```
 # Run frontend development using docker at http://localhost:3000
 make dev-frontend-docker
 # OR use docker-compose directly
-docker-compose up --scale frontend=0 --scale nginx=0 --scale scrapers=0 --scale frontend-dev=1 --scale nginx-dev=1
+docker-compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
 ```
 
 It is possible to directly run the frontend too (without using a docker container). You must then have NodeJS installed, preferably v18.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,6 +178,9 @@ services:
       context: ./frontend
       # dockerfile to use for build
       dockerfile: Dockerfile.dev
+      args:
+        - DUID
+        - DGID
     # update version number to correspond to frontend/package.json
     image: rsd/frontend-dev:1.4.0
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -155,6 +155,7 @@ services:
       - net
     volumes:
       - lets-encrypt:/etc/letsencrypt
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf
 
   #----------------------------------------------
   # DEVELOPMENT ONLY SERVICES

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,6 +185,7 @@ services:
     image: rsd/frontend-dev:1.4.0
     ports:
       - "3000:3000"
+      - "9229:9229"
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -5,6 +5,22 @@
 
 FROM node:18.5-buster-slim
 
+#  Change the user and group id of the node user to the specified ids
+ARG DUID=1000
+ARG DGID=1000
+ARG DUNAME=node
+RUN export OUID=$(id -u);\
+    if [ $DUID != $OUID ];\
+    then usermod -u $DUID $DUNAME &&\
+    find / -user 1000 -ignore_readdir_race -exec chown -h $DUNAME {} \; ;\
+    fi
+RUN export OGID=$(id -g);\
+    if [ $DGID != $OGID ];\
+    then groupmod -g $DGID $DUNAME &&\
+    find / -group 1000 -ignore_readdir_race -exec chgrp -h $DUNAME {} \; ;\
+    fi
+USER $DUNAME
+
 WORKDIR /app
 
 VOLUME [ "/app" ]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -31,7 +31,7 @@ Based on the features in the legacy application and the current requirements we 
 You can start the frontend in dev mode inside Docker using the `Makefile`. The command will make sure that the created Docker container uses a user with the same user id and group id as your local account. This ensures that you will be the owner of all files that are written via mounted volumes to your drive (mainly everything in the `frontend/.next` and `frontend/node_modules` folders).
 
 ```bash
-make dev-frontend-docker
+make frontend-docker
 ```
 
 Alternatively you can run

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -17,10 +17,32 @@ Based on the features in the legacy application and the current requirements we 
 
 ## Development
 
+### Locally running frontend in dev mode
+
 - intall dependencies `yarn install`
 - create `.env.local` file. Use `.env.example` from the project root as template.
 - run all app modules `docker-compose up`
 - open another terminal and run `yarn dev` to start frontend in development mode
+
+### Frontend dev mode via Docker
+
+**Use this if you are using a custom theme and mount files from the `/deployment` directory**
+
+You can start the frontend in dev mode inside Docker using the `Makefile`. The command will make sure that the created Docker container uses a user with the same user id and group id as your local account. This ensures that you will be the owner of all files that are written via mounted volumes to your drive (mainly everything in the `frontend/.next` and `frontend/node_modules` folders).
+
+```bash
+make dev-frontend-docker
+```
+
+Alternatively you can run
+
+```bash
+# Export your user and group ids to the variables so Docker will correctly build the frontend-dev container. This is required only if you build the container
+export DUID=$(id -u)
+export DGID=$(id -g)
+docker-compose build frontend-dev
+docker-compose up --scale frontend=0 --scale frontend-dev=1 --scale scrapers=0
+```
 
 ### Environment variables
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "dev:docker": "NODE_ENV=docker next dev",
+    "dev:docker": "NODE_ENV=docker NODE_OPTIONS='--inspect=0.0.0.0:9229' next dev",
     "build": "next build",
     "start": "next start",
     "lint": "next lint",

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -16,6 +16,8 @@ server {
 	listen       80;
 	server_name  localhost;
 
+	set $frontend http://frontend:3000;
+
 	charset utf-8;
 
 	# enable gzip file compression
@@ -49,7 +51,10 @@ server {
 
 	# reverse proxy for next fontend server
 	location / {
-		proxy_pass http://frontend:3000;
+		# Use Docker resolver
+		resolver 127.0.0.11 valid=30s;
+		# Use variable for proxy_pass so nginx doesn't check existence on startup
+		proxy_pass $frontend;
 		proxy_http_version 1.1;
 		proxy_set_header Upgrade $http_upgrade;
 		proxy_set_header Connection 'upgrade';


### PR DESCRIPTION
# Enhance docker frontend-dev configuration

Fixes #549 

Changes proposed in this pull request:

Approach number three: I would like to propose a way to run the frontend in development mode without having to build the whole `frontend` container first to save some time. This PR now adds:

**Update 3**

* substituted the `proxy_pass = http://frontend:3000` in nginx with a variable `$frontend` pointing to the same url. This trick stops nginx from checking the availability of the `frontend` container on startup, meaning it will not exit when it is not found. This way, we do not need a separate nginx image for `frontend-dev`
* use the docker resolver in nginx to discover the frontend container
* mount the nginx conf via docker-compose so the container does not have to be rebuilt every time one changes the configuration
* `frontend-dev` container creates files with same permissions as host user
* opened debugging port in `frontend-dev` to allow debugging in external tools
* update README's with instructions how to build the `frontend-dev` container without `Makefile`

**end of update 3**

This PR also fixes the issue that the `frontend-dev` container creates folder with `root` as owner. Upon building the `frontend-dev` container, the makefile will hand over the UID and GID of the user to the container, which internally creates a new user with the correpsonding IDs. That user is used to run the frontend, and accordingly the directories will have the developer's user as owner.

How to test:

* remove the root owned folders in frontend: `sudo rm -rf frontend/.next frontend/node_modules`
* start the frontend-dev container, but not the frontend container: `make frontend-docker`
* observe that the nginx container stays up running (and does not stop because http://frontend could not be found)
* open http://localhost:3000
* Local login works when `frontend` is down (no nginx error)
* `make down`
* `docker-compose up --scale scrapers=0`
* now, the frontend is available via http://localhost again

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
