### PR TITLE
fix: remove static rsd title from the footer

### DIFF
--- a/frontend/components/AppFooter/index.tsx
+++ b/frontend/components/AppFooter/index.tsx
@@ -29,12 +29,9 @@ export default function AppFooter () {
           <div className="py-4"></div>
           <OrganisationLogo host={host} />
         </div>
-        <div className="pb-8 md:py-8">
-          <div className="text-lg">Research Software Directory</div>
-          <div className="py-4 flex flex-col">
-            <MarkdownPages pages={pages ?? []} />
-            <CustomLinks links={links ?? []} />
-         </div>
+        <div className="pb-8 md:py-8 flex flex-col gap-2">
+          <MarkdownPages pages={pages ?? []} />
+          <CustomLinks links={links ?? []} />
         </div>
       </div>
     </footer>


### PR DESCRIPTION
# RSD title on right side of the footer

Closes #552 

Changes proposed in this pull request:
*    The static footer title 'Research Software Directory" on the right side of the footer is removed (requested by Maaike).

How to test:
* `docker-compose build frontend` to build frontend
* `docker-compose up` to start
* navigate to home page, or any other page, the right section of the footer should contain only links

## Example implementation

![image](https://user-images.githubusercontent.com/9204081/193244371-87736ee9-d6a5-4bdc-adf4-cca8152ae331.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
