### PR TITLE
fix: add security headers based on advice from securityheaders.com

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,10 +158,6 @@ ZENODO_ACCESS_TOKEN=
 CROSSREF_CONTACT_EMAIL=
 
 # consumed by: frontend
-# ID for Hotjar Tracking Code (needs to be a number)
-HOTJAR_ID=
-
-# consumed by: frontend
 # URL (should end with a trailing slash) and ID for Matomo Tracking Code
 MATOMO_URL=
 MATOMO_ID=

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -8,45 +8,8 @@
 
 /** @type {import('next').NextConfig} */
 
-// proxy to nginx service when running as frontend-dev docker service
-// proxy to localhost when in standalone development mode (yarn dev)
-let rewritesConfig = []
-if (process.env.NODE_ENV === 'docker') {
-  // proxies for frontend-dev service
-  // developing using node docker container
-  rewritesConfig=[
-    {
-      source: '/image/:path*',
-      destination: 'http://nginx/image/:path*',
-    },
-    {
-      source: '/api/v1/:path*',
-      destination: 'http://nginx/api/v1/:path*',
-    },
-    {
-      source: '/auth/login/local',
-      destination: 'http://nginx/auth/login/local',
-    }
-  ]
-} else if (process.env.NODE_ENV === 'development'){
-  rewritesConfig = [
-    {
-      source: '/image/:path*',
-      destination: 'http://localhost/image/:path*',
-    },
-    {
-      source: '/api/v1/:path*',
-      destination: 'http://localhost/api/v1/:path*',
-    },
-    {
-      source: '/auth/login/local',
-      destination: 'http://localhost/auth/login/local',
-    }
-  ]
-}
-
-// console.log('process.env.NODE_ENV',process.env.NODE_ENV)
-// console.log('process.env.PWD', process.env.PWD)
+const rewritesConfig = require('./next.rewrites')
+const securityHeaders = require('./next.headers')
 
 module.exports = {
   // create standalone output to use in docker image
@@ -62,6 +25,16 @@ module.exports = {
   },
   // only in development
   rewrites: async () => rewritesConfig,
+
+  async headers() {
+    return [
+      {
+        // Apply these headers to all routes in your application.
+        source: '/:path*',
+        headers: securityHeaders,
+      },
+    ]
+  },
 
   webpack(config) {
     config.module.rules.push({

--- a/frontend/next.headers.js
+++ b/frontend/next.headers.js
@@ -1,0 +1,60 @@
+/**
+ * Security headers based on the feedback from AMC
+ * using https://securityheaders.com/
+ * and the next.js documentation
+ * https://nextjs.org/docs/advanced-features/security-headers
+ *
+ * Important!
+ * These are static security headers applied to all responses
+ * This information is generated at build time (not runtime).
+ * The security headers which need to be build dynamically, like
+ * Content-Security-Policy are handled by utils/contentSecurityPolicy
+ * script.
+ */
+
+
+// Static headers on each request
+const staticHeaders = [
+  // required by https://securityheaders.com/
+  // info at https://scotthelme.co.uk/hsts-the-missing-link-in-tls/
+  {
+    key: 'Strict-Transport-Security',
+    value: 'max-age=63072000; includeSubDomains; preload'
+  },
+  // we decided to allow embeding
+  // required by https://securityheaders.com/
+  // https://scotthelme.co.uk/hardening-your-http-response-headers/#x-frame-options
+  // {
+  //   key: 'X-Frame-Options',
+  //   value: 'SAMEORIGIN'
+  // },
+  // required by https://securityheaders.com/
+  // https://scotthelme.co.uk/hardening-your-http-response-headers/#x-frame-options
+  {
+    key: 'X-Content-Type-Options',
+    value: 'nosniff'
+  },
+  // required by https://securityheaders.com/
+  // https://scotthelme.co.uk/a-new-security-header-referrer-policy/
+  {
+    key: 'Referrer-Policy',
+    value: 'strict-origin-when-cross-origin'
+  },
+  // required by https://securityheaders.com/
+  // https://scotthelme.co.uk/a-new-security-header-referrer-policy/
+  // used only geolocation, for other values see
+  // https://nextjs.org/docs/advanced-features/security-headers#permissions-policy
+  {
+    key: 'Permissions-Policy',
+    value: 'geolocation=(self)'
+  },
+  // used values from next documentation
+  // https://nextjs.org/docs/advanced-features/security-headers#x-dns-prefetch-control
+  {
+    key: 'X-DNS-Prefetch-Control',
+    value: 'on'
+  }
+]
+
+module.exports = staticHeaders
+

--- a/frontend/next.rewrites.js
+++ b/frontend/next.rewrites.js
@@ -1,0 +1,45 @@
+
+// proxy to nginx service when running as frontend-dev docker service
+// proxy to localhost when in standalone development mode (yarn dev)
+
+// console.log('process.env.NODE_ENV',process.env.NODE_ENV)
+// console.log('process.env.PWD', process.env.PWD)
+
+let rewritesConfig = []
+if (process.env.NODE_ENV === 'docker') {
+  // proxies for frontend-dev service
+  // developing using node docker container
+  rewritesConfig=[
+    {
+      source: '/image/:path*',
+      destination: 'http://nginx/image/:path*',
+    },
+    {
+      source: '/api/v1/:path*',
+      destination: 'http://nginx/api/v1/:path*',
+    },
+    {
+      source: '/auth/login/local',
+      destination: 'http://nginx/auth/login/local',
+    }
+  ]
+} else if (process.env.NODE_ENV === 'development'){
+  rewritesConfig = [
+    {
+      source: '/image/:path*',
+      destination: 'http://localhost/image/:path*',
+    },
+    {
+      source: '/api/v1/:path*',
+      destination: 'http://localhost/api/v1/:path*',
+    },
+    {
+      source: '/auth/login/local',
+      destination: 'http://localhost/auth/login/local',
+    }
+  ]
+}
+
+// console.log('rewritesConfig...', rewritesConfig)
+
+module.exports = rewritesConfig

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -31,6 +31,7 @@ import {RsdSettingsState} from '~/config/rsdSettingsReducer'
 import {getMatomoConsent,Matomo} from '~/components/cookies/nodeCookies'
 import {initMatomoCustomUrl} from '~/components/cookies/setMatomoPage'
 import {getSettingsServerSide} from '~/config/getSettingsServerSide'
+import {setContentSecurityPolicyHeader} from '~/utils/contentSecurityPolicy'
 
 // extend Next app props interface with emotion cache
 export interface MuiAppProps extends AppProps {
@@ -182,6 +183,8 @@ RsdApp.getInitialProps = async(appContext:AppContext) => {
     if (matomo.id) {
       matomo.consent = getMatomoConsent(req).matomoConsent
     }
+    // set content security header
+    setContentSecurityPolicyHeader(res)
   }
   // extract rsd settings
   const settings = await getSettingsServerSide(req, appContext.router.query)

--- a/frontend/styles/createEmotionCache.ts
+++ b/frontend/styles/createEmotionCache.ts
@@ -9,6 +9,11 @@
  */
 import createCache from '@emotion/cache'
 
-export default function createEmotionCache() {
-  return createCache({key: 'css'})
+export default function createEmotionCache(nonce?:string) {
+  return createCache({
+    key: 'css',
+    // https://mui.com/material-ui/guides/content-security-policy/
+    nonce,
+    prepend: true
+  })
 }

--- a/frontend/utils/contentSecurityPolicy.ts
+++ b/frontend/utils/contentSecurityPolicy.ts
@@ -1,0 +1,128 @@
+
+/**
+ * Security headers based on the feedback from AMC
+ * using https://securityheaders.com/
+ * and the next.js documentation
+ * https://nextjs.org/docs/advanced-features/security-headers
+ *
+ * Content-Security-Policy need to be build dynamically
+ * This meta info is added in _document.tsx and _app.tsx
+ *
+ * Important!
+ * We use 'nonce' for the script tags running in _document.tsx
+ * We allow direct connection to scripts for matomo based on MATOMO_URL environment variable
+ * We use 'unsafe-inline' for style-src to enable css script injections but this can be improved
+ * For using nonce with MUI see https://mui.com/material-ui/guides/content-security-policy/
+ * Next: https://stackoverflow.com/questions/65551212/using-csp-in-nextjs-nginx-and-material-uissr
+ * For other libs injecting css into app further investigation is needed.
+ */
+
+import crypto from 'crypto'
+import {IncomingMessage, ServerResponse} from 'http'
+
+// default policies
+let sharedPolicy = `
+  default-src 'self';
+  style-src 'self' 'unsafe-inline';
+  connect-src 'self' https://*;
+  font-src 'self' https://fonts.gstatic.com;
+  img-src 'self' data: https://*;
+`
+// default script def
+let sharedScript = 'script-src \'self\''
+
+function defaultNonce() {
+  if (crypto) return crypto.randomUUID()
+  return '5ef14870-46fd-11ed-b878-0242ac120002'
+}
+
+function monitoringScripts() {
+  if (process.env.MATOMO_URL) {
+    return process.env.MATOMO_URL
+  }
+  return ''
+}
+
+function devScript() {
+  if (process.env.NODE_ENV !== 'production') {
+    // enable script eval in development
+    return '\'unsafe-eval\''
+  }
+  return ''
+}
+
+export function nonceContentSecurity() {
+  const nonce = crypto.randomUUID()
+  // append default, monitoring scripts and dev script
+  let scriptSrc = `${sharedScript} ${monitoringScripts()} ${devScript()} 'nonce-${nonce}'`
+  // combine shared policies with script policy
+  const policy = `${sharedPolicy.replace(/\s{2,}/g, ' ').trim()} ${scriptSrc}`
+  // console.log('shaContentSecurity...', policy)
+  return {
+    policy,
+    nonce
+  }
+}
+
+// RUNS only on server side as it needs server response object to append response header
+export function setContentSecurityPolicyHeader(res?: ServerResponse<IncomingMessage>) {
+  // if server response object is not present returns default nonce value
+  if (!res) return defaultNonce()
+  // get policy to use and nonce to return
+  const {policy, nonce} = nonceContentSecurity()
+  // append to response header
+  if (process.env.NODE_ENV === 'production') {
+    res.setHeader('Content-Security-Policy', policy)
+  } else {
+    // report only in development
+    res.setHeader('Content-Security-Policy-Report-Only', policy)
+  }
+  // return nonce
+  return nonce
+}
+
+/*
+ * SHA content security approach IS NOT USED. It seems that nonce approach is
+ * supported by MUI and can also be applied to injected scripts in _document.tsx.
+ * I decided to use nonce approach only because it is sufficient and simpler.
+ * 2022-10-08 Dusan
+ */
+type ShaContentSecurityProps = {
+  // source code as string
+  source: string,
+  // create nonce and provide the value for the refference
+  withNonce?: boolean
+}
+export function shaContentSecurity({source, withNonce = true}: ShaContentSecurityProps) {
+  // create hash
+  const hash = hashSourceCode(source)
+  let nonce
+  // append default, monitoring scripts and dev script
+  let scriptSrc = `${sharedScript} ${monitoringScripts()} ${devScript()} ${hash}`
+  // add nonce
+  if (withNonce) {
+    nonce = crypto.randomUUID()
+    scriptSrc += ` 'nonce-${nonce}'`
+  }
+  // combine shared policies with dynamic script policy
+  const policy = `${sharedPolicy.replace(/\s{2,}/g, ' ').trim()} ${scriptSrc}`
+  // console.log('shaContentSecurity...', policy)
+  return {
+    policy,
+    nonce
+  }
+}
+
+// Create sha256 hash from the source code
+function hashSourceCode(src: string) {
+  if (src) {
+    const hash = crypto
+      .createHash('sha256')
+      .update(src)
+      .digest('base64')
+
+    return `'sha256-${hash}'`
+  }
+  return ''
+}
+


### PR DESCRIPTION
# Add security headers

Closes #563 

Changes proposed in this pull request:
*  We add security headers required to pass audit by AMC for enabling SURFconnect authorization. We have A grade with one warning and one red point (we allow embeding RSD pages) that cannot be addressed at the moment.
* Load tests showed no significant impact on the website performance after implementing security headers and using matomo instead of hotjar.

How to test:
*  Cannot be tested locally. The headers are applied to dev. Hotjar does not work properly ;-(
*  We allow EMBED of website and have one warning. But A grade should be sufficient!
*  The results can be viewed [here](https://securityheaders.com/?q=https%3A%2F%2Fresearch-software.dev%2F&followRedirects=on)

## Test results 
![image](https://user-images.githubusercontent.com/9204081/194387530-2d137d4a-68a1-4f1b-9ffc-a34136273364.png)

## Performance
**There is no significant change in the website performance after implementation of security headers and matomo**
![image](https://user-images.githubusercontent.com/9204081/194702969-36614a6e-b9b7-4ed2-9cdf-8aa1c0748ebd.png)

PR Checklist:
*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
