### PR TITLE
fix: 404 error after adding primary maintainer

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -373,7 +373,7 @@ BEGIN
 			COUNT(DISTINCT project_for_organisation.project) AS project_cnt
 		FROM
 			project_for_organisation
-		CROSS JOIN list_parent_organisations(software_for_organisation.organisation)
+		CROSS JOIN list_parent_organisations(project_for_organisation.organisation)
 		GROUP BY list_parent_organisations.organisation_id;
 	END IF;
 END


### PR DESCRIPTION
# Fix 404 error

Closes #569 

Changes proposed in this pull request:
*  Fix query typo    

How to test:
* `make start` to reset and start again
*  login as rsd_admin
* navigate to you profile and copy user uuid,
* navigate to organisation and add yourself as primary maintainer
* revisit the organisation page
* The process should work without errors

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
