### PR TITLE
fix: mui contained button color should be applied

### DIFF
--- a/frontend/styles/createEmotionCache.ts
+++ b/frontend/styles/createEmotionCache.ts
@@ -14,6 +14,6 @@ export default function createEmotionCache(nonce?:string) {
     key: 'css',
     // https://mui.com/material-ui/guides/content-security-policy/
     nonce,
-    prepend: true
+    prepend: false
   })
 }


### PR DESCRIPTION
# Fix button color on 

Closes #572 

Changes proposed in this pull request:
*  Applies MUI color on the buttons     

How to test:
* `docker-compose build frontend` to build solution
* login as rsd_admin or user and create software/project
* add contributor/team member/organisation
* then try to delete item. The popup will apprear for confirmation. The button background color should be red

![image](https://user-images.githubusercontent.com/9204081/194908338-8a56b789-ae81-42de-b4d0-ffe821b92096.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
