### PR TITLE
fix: more information in invitation email templates

### DIFF
--- a/frontend/components/organisation/maintainers/OrganisationMaintainerLink.tsx
+++ b/frontend/components/organisation/maintainers/OrganisationMaintainerLink.tsx
@@ -18,8 +18,8 @@ import InvitationList from '~/components/layout/InvitationList'
 import {Invitation} from '~/types/Invitation'
 import {getUnusedInvitations} from '~/utils/getUnusedInvitations'
 
-export default function OrganisationMaintainerLink({organisation, account, token}:
-  { organisation: string, account: string, token: string }) {
+export default function OrganisationMaintainerLink({organisation, name, account, token}:
+  {organisation: string, name: string, account: string, token: string}) {
   const {showErrorMessage,showInfoMessage} = useSnackbar()
   const [magicLink, setMagicLink] = useState(null)
   const [unusedInvitations, setUnusedInvitations] = useState<Invitation[]>([])
@@ -81,7 +81,7 @@ export default function OrganisationMaintainerLink({organisation, account, token
             >
             <a
               target="_blank"
-              href={`mailto:?subject=Organisation maintainer invite&body=Please use the link to become organisation maintainer. \n ${magicLink}`} rel="noreferrer">
+              href={`mailto:?subject=Organisation maintainer invite&body=Please use the following link to become a maintainer of the organisation ${name}. \n ${magicLink}`} rel="noreferrer">
               Email this invite
             </a>
             </Button>

--- a/frontend/components/organisation/maintainers/OrganisationMaintainerLink.tsx
+++ b/frontend/components/organisation/maintainers/OrganisationMaintainerLink.tsx
@@ -81,7 +81,7 @@ export default function OrganisationMaintainerLink({organisation, name, account,
             >
             <a
               target="_blank"
-              href={`mailto:?subject=Organisation maintainer invite&body=Please use the following link to become a maintainer of the organisation ${name}. \n ${magicLink}`} rel="noreferrer">
+              href={`mailto:?subject=Maintainer invite for organisation ${encodeURIComponent(name)}&body=Please use the following link to become a maintainer of the organisation ${encodeURIComponent(name)}. ${encodeURIComponent('\n')}${magicLink}`} rel="noreferrer">
               Email this invite
             </a>
             </Button>

--- a/frontend/components/organisation/maintainers/index.tsx
+++ b/frontend/components/organisation/maintainers/index.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -113,6 +115,7 @@ export default function OrganisationMaintainers({organisation, isMaintainer}:
           />
           <OrganisationMaintainerLink
             organisation={organisation.id ?? ''}
+            name={organisation.name}
             account={user?.account ?? ''}
             token={token}
           />

--- a/frontend/components/projects/edit/maintainers/ProjectMaintainerLink.tsx
+++ b/frontend/components/projects/edit/maintainers/ProjectMaintainerLink.tsx
@@ -18,7 +18,7 @@ import InvitationList from '~/components/layout/InvitationList'
 import {Invitation} from '~/types/Invitation'
 import {getUnusedInvitations} from '~/utils/getUnusedInvitations'
 
-export default function ProjectMaintainerLink({project,account,token}: { project: string,account:string,token: string }) {
+export default function ProjectMaintainerLink({project,title,account,token}: {project: string, title: string, account: string, token: string}) {
   const {showErrorMessage,showInfoMessage} = useSnackbar()
   const [magicLink, setMagicLink] = useState(null)
   const [unusedInvitations, setUnusedInvitations] = useState<Invitation[]>([])
@@ -80,7 +80,7 @@ export default function ProjectMaintainerLink({project,account,token}: { project
             >
             <a
               target="_blank"
-              href={`mailto:?subject=Project maintainer invite&body=Please use the link to become project maintainer. \n ${magicLink}`} rel="noreferrer">
+              href={`mailto:?subject=Project maintainer invite&body=Please use the following link to become a maintainer of the project ${title}. \n ${magicLink}`} rel="noreferrer">
               Email this invite
             </a>
             </Button>

--- a/frontend/components/projects/edit/maintainers/ProjectMaintainerLink.tsx
+++ b/frontend/components/projects/edit/maintainers/ProjectMaintainerLink.tsx
@@ -80,7 +80,7 @@ export default function ProjectMaintainerLink({project,title,account,token}: {pr
             >
             <a
               target="_blank"
-              href={`mailto:?subject=Project maintainer invite&body=Please use the following link to become a maintainer of the project ${title}. \n ${magicLink}`} rel="noreferrer">
+              href={`mailto:?subject=Maintainer invite for project ${encodeURIComponent(title)}&body=Please use the following link to become a maintainer of the project ${encodeURIComponent(title)}. ${encodeURIComponent('\n')}${magicLink}`} rel="noreferrer">
               Email this invite
             </a>
             </Button>

--- a/frontend/components/projects/edit/maintainers/index.tsx
+++ b/frontend/components/projects/edit/maintainers/index.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -113,6 +115,7 @@ export default function ProjectMaintainers() {
           />
           <ProjectMaintainerLink
             project={project.id}
+            title={project.title}
             account={user?.account ?? ''}
             token={token}
           />

--- a/frontend/components/software/edit/editSoftwareContext.tsx
+++ b/frontend/components/software/edit/editSoftwareContext.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -13,7 +15,7 @@ import {EditSoftwareAction, editSoftwareReducer} from './editSoftwareReducer'
 export type SoftwareInfo = {
   id: string | null,
   slug: string | null,
-  brand_name: string | null,
+  brand_name: string,
   concept_doi: string | null,
 }
 

--- a/frontend/components/software/edit/maintainers/SoftwareMaintainerLink.tsx
+++ b/frontend/components/software/edit/maintainers/SoftwareMaintainerLink.tsx
@@ -20,7 +20,7 @@ import {Invitation} from '~/types/Invitation'
 import InvitationList from '~/components/layout/InvitationList'
 import {getUnusedInvitations} from '~/utils/getUnusedInvitations'
 
-export default function SoftwareMaintainerLink({software,account,token}: { software: string,account:string,token: string }) {
+export default function SoftwareMaintainerLink({software,brand_name,account,token}: {software: string, brand_name: string, account: string,token: string}) {
   const {showErrorMessage,showInfoMessage} = useSnackbar()
   const [magicLink, setMagicLink] = useState(null)
   const [unusedInvitations, setUnusedInvitations] = useState<Invitation[]>([])
@@ -82,7 +82,7 @@ export default function SoftwareMaintainerLink({software,account,token}: { softw
             >
             <a
               target="_blank"
-              href={`mailto:?subject=Software maintainer invite&body=Please use the link to become software maintainer. \n ${magicLink}`} rel="noreferrer">
+              href={`mailto:?subject=Software maintainer invite&body=Please use the following link to become a maintainer of the software ${brand_name}. \n ${magicLink}`} rel="noreferrer">
               Email this invite
             </a>
             </Button>

--- a/frontend/components/software/edit/maintainers/SoftwareMaintainerLink.tsx
+++ b/frontend/components/software/edit/maintainers/SoftwareMaintainerLink.tsx
@@ -82,7 +82,7 @@ export default function SoftwareMaintainerLink({software,brand_name,account,toke
             >
             <a
               target="_blank"
-              href={`mailto:?subject=Software maintainer invite&body=Please use the following link to become a maintainer of the software ${brand_name}. \n ${magicLink}`} rel="noreferrer">
+              href={`mailto:?subject=Maintainer invite for software ${encodeURIComponent(brand_name)}&body=Please use the following link to become a maintainer of the software ${encodeURIComponent(brand_name)}. ${encodeURIComponent('\n')}${magicLink}`} rel="noreferrer">
               Email this invite
             </a>
             </Button>

--- a/frontend/components/software/edit/maintainers/index.tsx
+++ b/frontend/components/software/edit/maintainers/index.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -110,6 +112,7 @@ export default function SoftwareMaintainers() {
           />
           <SoftwareMaintainerLink
             software={software.id ?? ''}
+            brand_name={software.brand_name}
             account={user?.account ?? ''}
             token={token}
           />

--- a/frontend/config/userMenuItems.tsx
+++ b/frontend/config/userMenuItems.tsx
@@ -9,7 +9,7 @@ import TerminalIcon from '@mui/icons-material/Terminal'
 import ListAltIcon from '@mui/icons-material/ListAlt'
 import BusinessIcon from '@mui/icons-material/Business'
 import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
-import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck';
+import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck'
 import Logout from '@mui/icons-material/Logout'
 
 import {MenuItemType} from './menuItems'


### PR DESCRIPTION
# More information in invite email templates

Changes proposed in this pull request:

* Add the name of the software/project/organisation in the invite email template

How to test:
* `docker-compose build frontend && docker-compose up --scale scrapers=0`
* Login as an admin
* Create invites for software, projects and invitations
* Check that the email templates contain the names of the unit

Closes #451

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests