### PR TITLE
Search by doi using encoded url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 **/target
 **.iml
 
+**/nbactions.xml
+**/nb-configuration.xml
+
 # .vscode
 **/launch.json
 

--- a/frontend/components/projects/edit/impact/EditImpactProvider.tsx
+++ b/frontend/components/projects/edit/impact/EditImpactProvider.tsx
@@ -12,7 +12,7 @@ import {
 } from '~/components/mention/editMentionReducer'
 import EditMentionContext from '~/components/mention/editMentionContext'
 import NoImpactItems from './NoImpactItems'
-import {addImpactItem, addImpactToProject, removeImpactForProject} from './impactForProjectApi'
+import {addToImpactForProject, addNewImpactToProject, removeImpactForProject} from './impactForProjectApi'
 import {MentionItemProps} from '~/types/Mention'
 import {getMentionType} from '~/components/mention/config'
 import {updateDoiItem, updateMentionItem} from '~/utils/editMentions'
@@ -63,7 +63,11 @@ export default function EditImpactProvider(props: any) {
       item.id = null
       item.source = 'manual'
       // new item to be added
-      const resp = await addImpactItem({item, project, token})
+      const resp = await addNewImpactToProject({
+        item,
+        project,
+        token
+      })
       // debugger
       if (resp.status === 200) {
         dispatch({
@@ -105,9 +109,9 @@ export default function EditImpactProvider(props: any) {
         return true
       }
     }
-    if (item.id && item.source === 'RSD') {
+    if (item.id) {
       // existing RSD mention item to be added to project
-      const resp = await addImpactToProject({
+      const resp = await addToImpactForProject({
         project,
         mention: item.id,
         token
@@ -124,9 +128,12 @@ export default function EditImpactProvider(props: any) {
         showSuccessMessage(createSuccessMessage(item))
       }
     } else {
-      // new item from crossref or datacite (source)
-      const resp = await addImpactItem({item, project, token})
-      // debugger
+      // probably new item from crossref or datacite
+      const resp = await addNewImpactToProject({
+        item,
+        project,
+        token
+      })
       if (resp.status === 200) {
         dispatch({
           type: EditMentionActionType.ADD_ITEM,

--- a/frontend/components/projects/edit/impact/impactForProjectApi.ts
+++ b/frontend/components/projects/edit/impact/impactForProjectApi.ts
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import logger from '~/utils/logger'
-import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
+import {createJsonHeaders, extractReturnMessage} from '~/utils/fetchHelpers'
 import {MentionItemProps} from '~/types/Mention'
 import {addOrGetMentionItem} from '~/utils/editMentions'
 
@@ -30,55 +30,44 @@ export async function findPublicationByTitle({project, searchFor, token}:
   }
 }
 
-export async function addImpactItem({item, project, token}: { item: MentionItemProps, project: string, token: string }) {
-  let mention: MentionItemProps
-  // new item not in rsd
-  if (item.id === null) {
-    // add mention item to RSD
-    const resp = await addOrGetMentionItem({
-      mention: item,
-      token
-    })
-    if (resp.status !== 200) {
-      // exit
-      return {
-        status: resp.status,
-        message: `Failed to add ${item.title}. ${resp.message}`
-      }
-    }
-    // assign created mention item
-    mention = resp.message
-  } else {
-    // use existing RSD item
-    mention = item
-  }
-  // add mention item to impact table
-  if (mention && mention.id) {
-    const resp = await addImpactToProject({
-      project,
-      mention: mention.id,
-      token
-    })
-    if (resp.status !== 200) {
-      return {
-        status: resp.status,
-        message: `Failed to add ${item.title}. ${resp.message}`
+export async function addNewImpactToProject({item, project, token}:
+  { item: MentionItemProps, project: string, token: string }) {
+  // add new item or get existing by DOI
+  let resp = await addOrGetMentionItem({
+    mention: item,
+    token
+  })
+  // debugger
+  if (resp.status === 200) {
+    // mention item returned in message
+    const mention: MentionItemProps = resp.message
+    if (mention.id) {
+      resp = await addToImpactForProject({
+        project,
+        mention: mention.id,
+        token
+      })
+      if (resp.status === 200) {
+        // we return mention item in message
+        return {
+          status: 200,
+          message: mention
+        }
+      } else {
+        return resp
       }
     } else {
-      // return mention in message
       return {
-        status: 200,
-        message: mention
+        status: 500,
+        message: 'Mention id missing.'
       }
     }
-  }
-  return {
-    status: 500,
-    message: 'Failed to save item'
+  } else {
+    return resp
   }
 }
 
-export async function addImpactToProject({mention, project, token}: { mention: string, project: string, token: string }) {
+export async function addToImpactForProject({mention, project, token}: { mention: string, project: string, token: string }) {
   const url = '/api/v1/impact_for_project'
   try {
     const resp = await fetch(url, {

--- a/frontend/components/projects/edit/output/EditOutputProvider.tsx
+++ b/frontend/components/projects/edit/output/EditOutputProvider.tsx
@@ -14,7 +14,7 @@ import {MentionItemProps} from '~/types/Mention'
 import {updateDoiItem, updateMentionItem} from '~/utils/editMentions'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {getMentionType} from '~/components/mention/config'
-import {addOutputItem, addOutputToProject, removeOutputForProject} from './outputForProjectApi'
+import {addNewOutputToProject, addToOutputForProject, removeOutputForProject} from './outputForProjectApi'
 import NoOutputItems from './NoOutputItems'
 
 export const initialState: EditMentionState = {
@@ -63,8 +63,11 @@ export default function EditOutputProvider(props: any) {
     if (item.id === null || item.id === '') {
       item.id = null
       item.source = 'manual'
-      // new item to be added
-      const resp = await addOutputItem({item, project, token})
+      const resp = await addNewOutputToProject({
+        item,
+        project,
+        token
+      })
       // debugger
       if (resp.status === 200) {
         dispatch({
@@ -106,9 +109,9 @@ export default function EditOutputProvider(props: any) {
         return true
       }
     }
-    if (item.id && item.source === 'RSD') {
+    if (item.id) {
       // existing RSD mention item to be added to project
-      const resp = await addOutputToProject({
+      const resp = await addToOutputForProject({
         project,
         mention: item.id,
         token
@@ -125,8 +128,12 @@ export default function EditOutputProvider(props: any) {
         showSuccessMessage(createSuccessMessage(item))
       }
     } else {
-      // new item from crossref or datacite (source)
-      const resp = await addOutputItem({item, project, token})
+      // probably new item from crossref or datacite
+      const resp = await addNewOutputToProject({
+        item,
+        project,
+        token
+      })
       // debugger
       if (resp.status === 200) {
         dispatch({

--- a/frontend/components/software/edit/mentions/EditMentionsProvider.tsx
+++ b/frontend/components/software/edit/mentions/EditMentionsProvider.tsx
@@ -11,7 +11,7 @@ import {
   editMentionReducer, EditMentionState
 } from '~/components/mention/editMentionReducer'
 import EditMentionContext from '~/components/mention/editMentionContext'
-import {addMention2Item, addMentionToSoftware, removeMentionForSoftware} from './mentionForSoftwareApi'
+import {addNewMentionToSoftware, addToMentionForSoftware, removeMentionForSoftware} from './mentionForSoftwareApi'
 import {MentionItemProps} from '~/types/Mention'
 import {getMentionType} from '~/components/mention/config'
 import {updateDoiItem, updateMentionItem} from '~/utils/editMentions'
@@ -62,7 +62,11 @@ export default function EditMentionsProvider(props: any) {
       item.id = null
       item.source = 'manual'
       // new item to be added
-      const resp = await addMention2Item({item, software, token})
+      const resp = await addNewMentionToSoftware({
+        item,
+        software,
+        token
+      })
       // debugger
       if (resp.status === 200) {
         dispatch({
@@ -103,9 +107,9 @@ export default function EditMentionsProvider(props: any) {
         return true
       }
     }
-    if (item.id && item.source === 'RSD') {
+    if (item.id) {
       // existing RSD mention item to be added to project
-      const resp = await addMentionToSoftware({
+      const resp = await addToMentionForSoftware({
         software,
         mention: item.id,
         token
@@ -122,8 +126,8 @@ export default function EditMentionsProvider(props: any) {
         showSuccessMessage(createSuccessMessage(item))
       }
     } else {
-      // new item from crossref or datacite (source)
-      const resp = await addMention2Item({item, software, token})
+      // probably new item from crossref or datacite
+      const resp = await addNewMentionToSoftware({item, software, token})
       // debugger
       if (resp.status === 200) {
         dispatch({

--- a/frontend/utils/editMentions.ts
+++ b/frontend/utils/editMentions.ts
@@ -52,7 +52,8 @@ export async function getMentionsForSoftware({software,token,frontend}:{software
 
 export async function getMentionByDoiFromRsd({doi,token}:{doi: string, token: string}) {
   try {
-    const url = `/api/v1/mention?select=${mentionColumns}&doi=eq.${doi}`
+    // we need to encode DOI because it supports "exotic" values
+    const url = `/api/v1/mention?select=${mentionColumns}&doi=eq.${encodeURIComponent(doi)}`
     const resp = await fetch(url, {
       method: 'GET',
       headers: {
@@ -115,12 +116,17 @@ export async function addOrGetMentionItem({mention, token}:
   const url = '/api/v1/mention'
   try {
     // check if publication is already
-    // imported to RSD by ID
+    // imported to RSD by DOI
     if (mention.doi) {
+      // console.group('addOrGetMentionItem')
+      // console.log('doi...', mention.doi)
+      // addOrGetMentionItem
       const found = await getMentionByDoiFromRsd({
         doi: mention.doi,
         token
       })
+      // console.log('found...', found)
+      // console.groupEnd()
       // if publication found in RSD
       if (found.status === 200 &&
         found.message.length === 1) {

--- a/frontend/utils/getCrossref.ts
+++ b/frontend/utils/getCrossref.ts
@@ -72,13 +72,16 @@ export async function getCrossrefItemByDoi(doi: string) {
 
     if (resp.status === 200) {
       const json: CrossrefResponse = await resp.json()
-      // find doi item
-      const doiItem = json.message.items.filter(item => item.DOI.toLowerCase() === doi.toLocaleLowerCase())
-      // if found return it
-      if (doiItem.length === 1) {
+      // if found return item
+      if (json.message.items.length > 0) {
         return {
           status: 200,
-          message: doiItem[0]
+          message: json.message.items[0]
+        }
+      } else {
+        return {
+          status: 404,
+          message: 'DOI not found'
         }
       }
     }

--- a/frontend/utils/getDOI.ts
+++ b/frontend/utils/getDOI.ts
@@ -31,7 +31,7 @@ export async function getDoiRA(doi: string) {
 
 export async function getUrlFromDoiOrg(doi: string) {
   try {
-    const url = ` https://doi.org/api/handles/${doi}?type=URL`
+    const url = ` https://doi.org/api/handles/${encodeURIComponent(doi)}?type=URL`
     const resp = await fetch(url)
     // debugger
     if (resp.status === 200) {
@@ -105,7 +105,9 @@ export async function getMentionByDoi(doi: string) {
 
 // This url will always redirect to the current url
 export function makeDoiRedirectUrl(doi: string) {
-  return `https://doi.org/${doi}`
+  // we need to encode doi because it allows lot of
+  // "exotic" values like 10.1175/1520-0469(2003)60%3C1201:ALESIS%3E2.0.CO;2
+  return `https://doi.org/${encodeURIComponent(doi)}`
 }
 
 const exampleUrlResponse = {

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -168,7 +168,7 @@ export async function getDataciteItemsByDoiGraphQL(doi: string) {
     const error = await extractReturnMessage(resp)
     return error
   } catch (e: any) {
-    logger(`getMentionByDoi: ${e?.message}`, 'error')
+    logger(`getDataciteItemsByDoiGraphQL: ${e?.message}`, 'error')
     return {
       status: 500,
       message: e?.message

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
@@ -13,8 +13,6 @@ import nl.esciencecenter.rsd.scraper.Config;
 import nl.esciencecenter.rsd.scraper.Utils;
 
 import java.net.URI;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -69,7 +67,7 @@ public class CrossrefMention implements Mention {
 
 	@Override
 	public MentionRecord mentionData() {
-		StringBuilder url = new StringBuilder("https://api.crossref.org/works/" + URLDecoder.decode(doi, StandardCharsets.UTF_8));
+		StringBuilder url = new StringBuilder("https://api.crossref.org/works/" + Utils.urlEncode(doi));
 		Config.crossrefContactEmail().ifPresent(email -> url.append("?mailto=" + email));
 		String responseJson = Utils.get(url.toString());
 		JsonObject jsonTree = JsonParser.parseString(responseJson).getAsJsonObject();
@@ -77,7 +75,7 @@ public class CrossrefMention implements Mention {
 		JsonObject workJson = jsonTree.getAsJsonObject("message");
 
 		result.doi = doi;
-		result.url = URI.create("https://doi.org/" + result.doi);
+		result.url = URI.create("https://doi.org/" + Utils.urlEncode(result.doi));
 		result.title = workJson.getAsJsonArray("title").get(0).getAsString();
 
 		Collection<String> authors = new ArrayList<>();

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -17,7 +17,9 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 public class DataciteMentionRepository implements MentionRepository {
@@ -86,13 +88,20 @@ public class DataciteMentionRepository implements MentionRepository {
 				.collect(Collectors.joining("\",\"", "\"", "\""));
 	}
 
-	static Collection<MentionRecord> jsonStringToMention(String json) {
+	static Collection<MentionRecord> jsonStringToUniqueMentions(String json) {
 		JsonObject root = JsonParser.parseString(json).getAsJsonObject();
 		JsonArray worksJson = root.getAsJsonObject("data").getAsJsonObject("works").getAsJsonArray("nodes");
 		Collection<MentionRecord> mentions = new ArrayList<>();
+		Set<String> usedDois = new HashSet<>();
 		for (JsonElement work : worksJson) {
 			try {
-				mentions.add(parseWork(work.getAsJsonObject()));
+//				Sometimes, DataCite gives back two of the same results for one DOI, e.g. for 10.4122/1.1000000817,
+//				so we need to only add it once, otherwise we cannot POST it to the backend
+				MentionRecord parsedMention = parseWork(work.getAsJsonObject());
+				if (usedDois.contains(parsedMention.doi)) continue;
+
+				usedDois.add(parsedMention.doi);
+				mentions.add(parsedMention);
 			} catch (RuntimeException e) {
 				System.out.println("Failed to scrape a DataCite mention with data " + work);
 				e.printStackTrace();
@@ -154,7 +163,7 @@ public class DataciteMentionRepository implements MentionRepository {
 		JsonObject body = new JsonObject();
 		body.addProperty("query", QUERY_UNFORMATTED.formatted(joinCollection(dois)));
 		String responseJson = Utils.post("https://api.datacite.org/graphql", body.toString(), "Content-Type", "application/json");
-		return jsonStringToMention(responseJson);
+		return jsonStringToUniqueMentions(responseJson);
 	}
 
 	@Override

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -15,6 +15,7 @@ import java.net.URI;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -103,7 +104,7 @@ public class DataciteMentionRepository implements MentionRepository {
 	static MentionRecord parseWork(JsonObject work) {
 		MentionRecord result = new MentionRecord();
 		result.doi = work.get("doi").getAsString();
-		result.url = URI.create("https://doi.org/" + result.doi);
+		result.url = URI.create("https://doi.org/" + Utils.urlEncode(result.doi));
 		result.title = work.getAsJsonArray("titles").get(0).getAsJsonObject().get("title").getAsString();
 
 		Collection<String> authors = new ArrayList<>();
@@ -148,6 +149,8 @@ public class DataciteMentionRepository implements MentionRepository {
 
 	@Override
 	public Collection<MentionRecord> mentionData(Collection<String> dois) {
+		if (dois.isEmpty()) return Collections.EMPTY_LIST;
+
 		JsonObject body = new JsonObject();
 		body.addProperty("query", QUERY_UNFORMATTED.formatted(joinCollection(dois)));
 		String responseJson = Utils.post("https://api.datacite.org/graphql", body.toString(), "Content-Type", "application/json");

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
@@ -12,8 +12,6 @@ import com.google.gson.JsonParser;
 import nl.esciencecenter.rsd.scraper.Config;
 import nl.esciencecenter.rsd.scraper.Utils;
 
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -38,7 +36,7 @@ public class MainMentions {
 
 		String doisJoined = mentionsToScrape.stream()
 				.map(mention -> mention.doi)
-				.map(doi -> URLEncoder.encode(doi, StandardCharsets.UTF_8))
+				.map(doi -> Utils.urlEncode(doi))
 				.collect(Collectors.joining(","));
 		String jsonSources = Utils.get("https://doi.org/doiRA/" + doisJoined);
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/PostgrestMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/PostgrestMentionRepository.java
@@ -14,6 +14,7 @@ import com.google.gson.reflect.TypeToken;
 import nl.esciencecenter.rsd.scraper.Config;
 import nl.esciencecenter.rsd.scraper.Utils;
 
+import java.net.URI;
 import java.time.Instant;
 import java.util.Collection;
 import java.util.Objects;
@@ -30,6 +31,14 @@ public class PostgrestMentionRepository implements MentionRepository {
 		return new GsonBuilder()
 				.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
 				.registerTypeAdapter(Instant.class, (JsonDeserializer) (json, typeOfT, context) -> Instant.parse(json.getAsString()))
+				.registerTypeAdapter(URI.class, (JsonDeserializer) (json, typeOfT, context) -> {
+					try {
+						return URI.create(json.getAsString());
+					} catch (IllegalArgumentException e) {
+						System.out.println("Warning: couldn't create a URI of the following: " + json.getAsString());
+						return null;
+					}
+				})
 				.create()
 				.fromJson(data, new TypeToken<Collection<MentionRecord>>() {
 				}.getType());


### PR DESCRIPTION
# Support use of encoded url's as DOI value in search box

Closes #578 

Changes proposed in this pull request:
*  Support search using encoded doi url. Additional check in crossref request is removed because it does not match encoded and doi value from api when search uses encoded values and api returns "decoded" value    

How to test:
* `docker-compose build frontend scrapers` to build solution
* `docker-compose up` to start solution
* login as rsd_admin or any other user and go to edit project - impact (or output)
* search for publication using encoded url like thisone `https://doi.org/10.1175/1520-0469(2003)60%3C1201:ALESIS%3E2.0.CO;2`
* Search should return one value.
* Use not valid value like `10.1147/2996913.2997004`, you should see "Nothing found..." message
* Now we test the scrapers
* `docker-compose down --volumes && docker-compose up --scale data-generation=0`
* Run
```SQL
INSERT INTO mention (title, mention_type, "source", doi, url) VALUES
('DOI with weird characters', 'journalArticle', 'crossref','10.1175/1520-0469(2003)60<1201:alesis>2.0.co;2', 'https://doi.org/10.1175/1520-0469(2003)60<1201:alesis>2.0.co;2'),
('DOI with weird characters 2', 'journalArticle', 'crossref','10.1644/1545-1410(2005)771[0001:aj]2.0.co;2', 'https://doi.org/10.1644/1545-1410(2005)771[0001:aj]2.0.co;2');
```
* Run the mention scraper: `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions`
* You should see two warnings about not being able to create a URI, but no other warnings or errors
* Check in the database that the mentions were scraped successfully (`SELECT * FROM MENTION;`)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
