### PR TITLE
482 about organisation section

### DIFF
--- a/frontend/components/organisation/OrganisationNav.tsx
+++ b/frontend/components/organisation/OrganisationNav.tsx
@@ -20,6 +20,9 @@ type OrganisationNavProps = {
 export default function OrganisationNav({isMaintainer, organisation}:OrganisationNavProps) {
   const router = useRouter()
   const page = router.query['page'] ?? ''
+  // console.group('OrganisationNav')
+  // console.log('description...', organisation.description)
+  // console.groupEnd()
   return (
     <nav>
       <List sx={{
@@ -29,14 +32,17 @@ export default function OrganisationNav({isMaintainer, organisation}:Organisatio
           let selected = false
           if (page && page!=='') {
             selected = page === organisationMenu[pos].id
-          } else if (pos === 0) {
-            // select first item by default
+          } else if (pos === 0 && organisation.description) {
+            // select about if description present by default
+            selected=true
+          } else if (pos === 1 && !organisation.description) {
+            // if no about page then first item is default
             selected=true
           }
           // const selected = router.query['id'] ?? organisationMenu[0].id
           if (item.isVisible({
             isMaintainer,
-            children_cnt: organisation?.children_cnt
+            organisation
           }) === true) {
             return (
               <ListItemButton

--- a/frontend/components/organisation/OrganisationNavItems.tsx
+++ b/frontend/components/organisation/OrganisationNavItems.tsx
@@ -3,12 +3,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import InfoIcon from '@mui/icons-material/Info'
 import TerminalIcon from '@mui/icons-material/Terminal'
 import AccountTreeIcon from '@mui/icons-material/AccountTree'
 import ListAltIcon from '@mui/icons-material/ListAlt'
 import PersonIcon from '@mui/icons-material/Person'
 import SettingsIcon from '@mui/icons-material/Settings'
 
+import AboutOrganisation from './about'
 import OrganisationSoftware from './software'
 import OrganisationProjects from './project'
 import OrganisationUnits from './units'
@@ -31,7 +33,25 @@ export type OrganisationMenuProps = {
   showSearch: boolean
 }
 
-export const organisationMenu:OrganisationMenuProps[] = [
+export const organisationMenu: OrganisationMenuProps[] = [
+  {
+    id:'about',
+    label:()=>'About',
+    icon: <InfoIcon />,
+    component: (props) => <AboutOrganisation {...props} />,
+    status: 'Participating organisation',
+    isVisible: ({organisation, isMaintainer}) => {
+      // we always show about section to maintainer
+      if (isMaintainer === true) return true
+      // we do not show to visitors if there is no content
+      else if (typeof organisation?.description === 'undefined') return false
+      else if (organisation?.description === null) return false
+      else if (organisation?.description.trim()==='') return false
+      // else the description is present and we show about section
+      else return true
+    },
+    showSearch: false
+  },
   {
     id:'software',
     label:({software_cnt})=>`Software (${software_cnt ?? 0})`,
@@ -56,7 +76,7 @@ export const organisationMenu:OrganisationMenuProps[] = [
     icon: <AccountTreeIcon />,
     component: (props) => <OrganisationUnits {...props} />,
     status: 'Departments or institutions',
-    isVisible: ({children_cnt, isMaintainer}) => {
+    isVisible: ({organisation: {children_cnt}, isMaintainer}) => {
       // we do not show this options if no children
       // and not a maintainer
       if (isMaintainer===false && (children_cnt === 0 || children_cnt===null)) return false

--- a/frontend/components/organisation/about/index.tsx
+++ b/frontend/components/organisation/about/index.tsx
@@ -17,8 +17,10 @@ export function AboutPagePlaceholder() {
   return (
     <Alert severity="info" sx={{marginTop:'0.5rem'}}>
       <AlertTitle sx={{fontWeight: 500}}>About section not defined</AlertTitle>
-      <p>About section is not visible to the vistors because it does not have any content.</p>
-      <span>To activate about section add the content to about section <strong>
+      <p>
+        The about section is not visible to vistors because it does not have any content.
+      </p>
+      <span>To activate the about section, add content to the about section <strong>
           <button onClick={goToSettings}>in the settings.</button>
         </strong>
       </span>

--- a/frontend/components/organisation/about/index.tsx
+++ b/frontend/components/organisation/about/index.tsx
@@ -1,0 +1,43 @@
+import {useRouter} from 'next/router'
+import {Alert, AlertTitle} from '@mui/material'
+import ReactMarkdownWithSettings from '~/components/layout/ReactMarkdownWithSettings'
+import {OrganisationComponentsProps} from '../OrganisationNavItems'
+
+export function AboutPagePlaceholder() {
+  const router = useRouter()
+  function goToSettings() {
+    router.push({
+      query: {
+        slug:router.query['slug'],
+        page:'settings'
+      }
+    })
+  }
+  // this message is only shown to organisation maintainers
+  return (
+    <Alert severity="info" sx={{marginTop:'0.5rem'}}>
+      <AlertTitle sx={{fontWeight: 500}}>About section not defined</AlertTitle>
+      <p>About section is not visible to the vistors because it does not have any content.</p>
+      <span>To activate about section add the content to about section <strong>
+          <button onClick={goToSettings}>in the settings.</button>
+        </strong>
+      </span>
+    </Alert>
+  )
+}
+
+
+export default function AboutPage({organisation}: OrganisationComponentsProps) {
+  // if description is present we return markdown page
+  if (organisation.description) {
+    return (
+      <section className="pt-2 pb-12">
+        <ReactMarkdownWithSettings
+            markdown={organisation?.description}
+        />
+      </section>
+    )
+  }
+  // if no description we return placeholder info
+  return <AboutPagePlaceholder />
+}

--- a/frontend/components/organisation/maintainers/index.tsx
+++ b/frontend/components/organisation/maintainers/index.tsx
@@ -98,29 +98,27 @@ export default function OrganisationMaintainers({organisation, isMaintainer}:
     <ProtectedOrganisationPage
       isMaintainer={isMaintainer}
     >
-      <EditSection className='xl:grid xl:grid-cols-[1fr,1fr] xl:px-0 xl:gap-[3rem]'>
-        <div className="py-4">
-          <EditSectionTitle
-            title={config.title}
-          />
-          <OrganisationMaintainersList
-            onDelete={onDeleteMaintainer}
-            maintainers={maintainers}
-          />
-        </div>
-        <div className="py-4 min-w-[21rem] xl:my-0">
-          <EditSectionTitle
-            title={config.inviteLink.title}
-            subtitle={config.inviteLink.subtitle}
-          />
-          <OrganisationMaintainerLink
-            organisation={organisation.id ?? ''}
-            name={organisation.name}
-            account={user?.account ?? ''}
-            token={token}
-          />
-        </div>
-      </EditSection>
+      <div className="py-4">
+        <EditSectionTitle
+          title={config.title}
+        />
+        <OrganisationMaintainersList
+          onDelete={onDeleteMaintainer}
+          maintainers={maintainers}
+        />
+      </div>
+      <div className="py-4 min-w-[21rem] xl:my-0">
+        <EditSectionTitle
+          title={config.inviteLink.title}
+          subtitle={config.inviteLink.subtitle}
+        />
+        <OrganisationMaintainerLink
+          organisation={organisation.id ?? ''}
+          name={organisation.name}
+          account={user?.account ?? ''}
+          token={token}
+        />
+      </div>
       <ConfirmDeleteModal
         open={modal.open}
         title="Remove maintainer"

--- a/frontend/components/organisation/organisationConfig.ts
+++ b/frontend/components/organisation/organisationConfig.ts
@@ -69,5 +69,13 @@ export const organisationInformation = {
   is_tenant: {
     label: 'Official member',
     help: 'Set to active if organisation is participating in RSD.',
+  },
+  description: {
+    title: 'About page',
+    subtitle: 'Provide the content of about page. If content is not provided about page is hidden.',
+    validation: {
+      minLength: {value: 16, message: 'Minimum length is 16'},
+      maxLength: {value: 10000, message: 'Maximum length is 10.000'},
+    }
   }
 }

--- a/frontend/components/organisation/project/ProjectCardWithMenu.tsx
+++ b/frontend/components/organisation/project/ProjectCardWithMenu.tsx
@@ -51,7 +51,7 @@ const StyledNav = styled('nav', {
     width: '3rem',
     height: '3rem',
     color,
-    zIndex: 9,
+    zIndex: 7,
     '&:hover': {
       color: hovercolor
     }

--- a/frontend/components/organisation/settings/AutosaveOrganisationTextField.tsx
+++ b/frontend/components/organisation/settings/AutosaveOrganisationTextField.tsx
@@ -1,0 +1,53 @@
+import {useFormContext} from 'react-hook-form'
+import {useSession} from '~/auth'
+import AutosaveControlledTextField, {OnSaveProps} from '~/components/form/AutosaveControlledTextField'
+import {ControlledTextFieldOptions} from '~/components/form/ControlledTextField'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {patchOrganisationTable} from './updateOrganisationSettings'
+
+export type AutosaveProjectInfoProps = {
+  organisation_id: string
+  options: ControlledTextFieldOptions
+  rules?: any
+}
+
+export default function AutosaveOrganisationTextField({organisation_id,options,rules}:AutosaveProjectInfoProps) {
+  const {token} = useSession()
+  const {showErrorMessage} = useSnackbar()
+  const {control, resetField} = useFormContext()
+
+  async function saveSoftwareInfo({name, value}: OnSaveProps) {
+    // patch project table
+    const resp = await patchOrganisationTable({
+      id: organisation_id,
+      data: {
+        [name]:value
+      },
+      token
+    })
+
+    // console.group('AutosaveSoftwareTextField')
+    // console.log('saved...', options.name)
+    // console.log('value...', value)
+    // console.log('status...', resp?.status)
+    // console.groupEnd()
+
+    if (resp?.status !== 200) {
+      showErrorMessage(`Failed to save ${options.name}. ${resp?.message}`)
+    } else {
+      // debugger
+      resetField(options.name, {
+        defaultValue:value
+      })
+    }
+  }
+
+  return (
+    <AutosaveControlledTextField
+      options={options}
+      control={control}
+      rules={rules}
+      onSaveField={saveSoftwareInfo}
+    />
+  )
+}

--- a/frontend/components/organisation/settings/AutosaveOrgnisationMarkdown.tsx
+++ b/frontend/components/organisation/settings/AutosaveOrgnisationMarkdown.tsx
@@ -7,58 +7,52 @@ import {useController, useFormContext} from 'react-hook-form'
 import {useSession} from '~/auth'
 import MarkdownInputWithPreview from '~/components/form/MarkdownInputWithPreview'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import {projectInformation as config} from './config'
-import {patchProjectTable} from './patchProjectInfo'
+import {organisationInformation as config} from '../organisationConfig'
+import {patchOrganisationTable} from './updateOrganisationSettings'
 
-export default function AutosaveProjectMarkdown({project_id,name}: {project_id:string,name:string}) {
+export default function AutosaveOrganisationMarkdown({organisation_id}: {organisation_id:string}) {
   const {token} = useSession()
   const {showErrorMessage} = useSnackbar()
   const {register, control, resetField} = useFormContext()
   const {field:{value},fieldState:{isDirty,error}} = useController({
     control,
-    name
+    name:'description'
   })
 
-  async function saveProjectInfo() {
+  async function saveOrganisationInfo() {
     let description = null
     // we do not save when error or no change
-    if (isDirty === false || error) return
+    if (isDirty===false || error) return
     // only if not empty string, we use null when empty
     if (value!=='') description = value
-    const resp = await patchProjectTable({
-      id:project_id,
+    const resp = await patchOrganisationTable({
+      id:organisation_id,
       data: {
-        [name]:value
+        description
       },
       token
     })
-
-    // console.group('AutosaveProjectMarkdown')
-    // console.log('saved...', name)
+    // console.group('AutosaveOrganisationMarkdown')
+    // console.log('isDirty...', isDirty)
+    // console.log('error...', error)
     // console.log('status...', resp?.status)
     // console.groupEnd()
-
     if (resp?.status !== 200) {
-      showErrorMessage(`Failed to save ${name}. ${resp?.message}`)
+      showErrorMessage(`Failed to save description. ${resp?.message}`)
     } else {
       // debugger
-      resetField(name, {
+      resetField('description', {
         defaultValue:value
       })
     }
   }
-
-  // console.group('AutosaveProjectMarkdown')
-  // console.log('name...', name)
+  // console.group('AutosaveOrganisationMarkdown')
   // console.log('value...', value)
-  // console.log('isDirty...', isDirty)
-  // console.log('error...', error)
   // console.groupEnd()
-
   return (
     <MarkdownInputWithPreview
       markdown={value ?? ''}
-      register={register(name, {
+      register={register('description', {
         maxLength: config.description.validation.maxLength.value
       })}
       disabled={false}
@@ -66,7 +60,7 @@ export default function AutosaveProjectMarkdown({project_id,name}: {project_id:s
         length: value?.length ?? 0,
         maxLength: config.description.validation.maxLength.value
       }}
-      onBlur={()=>saveProjectInfo()}
+      onBlur={()=>saveOrganisationInfo()}
     />
   )
 }

--- a/frontend/components/organisation/settings/OrganisationSettings.test.tsx
+++ b/frontend/components/organisation/settings/OrganisationSettings.test.tsx
@@ -20,7 +20,8 @@ const dummyProps = {
     'software_cnt': 6,
     'project_cnt': 4,
     'children_cnt': 2,
-    'score': 10
+    'score': 10,
+    'description': null
   },
   isMaintainer: true
 }

--- a/frontend/components/organisation/settings/RsdAdminSection.tsx
+++ b/frontend/components/organisation/settings/RsdAdminSection.tsx
@@ -3,67 +3,93 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import ControlledTextField from '~/components/form/ControlledTextField'
+import {useFormContext} from 'react-hook-form'
+import {useSession} from '~/auth'
 import ControlledSwitch from '~/components/form/ControlledSwitch'
-import {Control, useWatch} from 'react-hook-form'
-import {EditOrganisation, OrganisationForOverview} from '~/types/Organisation'
 import {organisationInformation as config} from '../organisationConfig'
+import AutosaveOrganisationTextField from './AutosaveOrganisationTextField'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {patchOrganisationTable} from './updateOrganisationSettings'
+import EditSectionTitle from '~/components/layout/EditSectionTitle'
+import AutosaveControlledMarkdown from '~/components/form/AutosaveControlledMarkdown'
 
-type AdminSectionProps = {
-  control: Control<OrganisationForOverview,any>
-}
+export default function AdminSection() {
+  const {token} = useSession()
+  const {showErrorMessage} = useSnackbar()
+  const {watch, control, resetField} = useFormContext()
+  const [
+    id, slug, primary_maintainer, is_tenant
+  ] = watch([
+    'id', 'slug', 'primary_maintainer', 'is_tenant'
+  ])
 
-export default function AdminSection({control}:AdminSectionProps) {
-  const slug = useWatch({
-    control,
-    name:'slug'
-  })
-  const primary_maintainer = useWatch({
-    control,
-    name:'primary_maintainer'
-  })
-  const is_tenant = useWatch({
-    control,
-    name:'is_tenant'
-  })
+  async function saveIsTenant(value:boolean) {
+    const resp = await patchOrganisationTable({
+      id,
+      data: {
+        is_tenant:value
+      },
+      token
+    })
+
+    if (resp?.status === 200) {
+      // debugger
+      resetField('is_tenant', {
+        defaultValue:value
+      })
+    } else {
+      showErrorMessage(`Failed to save official member. ${resp?.message}`)
+    }
+  }
 
   return (
     <>
-    <section className="grid grid-cols-[1fr,1fr] gap-8 pt-8">
-      <ControlledTextField
+      <section className="grid grid-cols-[1fr,1fr] gap-8 pt-4">
+        <AutosaveOrganisationTextField
+          organisation_id={id}
+          options={{
+            name: 'slug',
+            label: config.slug.label,
+            useNull: true,
+            defaultValue: slug,
+            helperTextMessage: config.slug.help,
+            helperTextCnt: `${slug?.length || 0}/${config.slug.validation.maxLength.value}`
+          }}
+          rules={config.slug.validation}
+        />
+        <AutosaveOrganisationTextField
+          organisation_id={id}
+          options={{
+            name: 'primary_maintainer',
+            label: config.primary_maintainer.label,
+            useNull: true,
+            defaultValue: primary_maintainer,
+            helperTextMessage: config.primary_maintainer.help,
+            helperTextCnt: `${primary_maintainer?.length || 0}/${config.primary_maintainer.validation.maxLength.value}`,
+          }}
+          rules={config.primary_maintainer.validation}
+        />
+      </section>
+      <div className="py-2"></div>
+      <ControlledSwitch
+        name='is_tenant'
+        label={config.is_tenant.label}
         control={control}
-        options={{
-          name: 'slug',
-          // variant: 'outlined',
-          label: config.slug.label,
-          useNull: true,
-          defaultValue: slug,
-          helperTextMessage: config.slug.help,
-          helperTextCnt: `${slug?.length || 0}/${config.slug.validation.maxLength.value}`
-        }}
-        rules={config.slug.validation}
+        defaultValue={is_tenant}
+        onSave={saveIsTenant}
       />
-      <ControlledTextField
-        control={control}
-        options={{
-          name: 'primary_maintainer',
-          // variant: 'outlined',
-          label: config.primary_maintainer.label,
-          useNull: true,
-          defaultValue: primary_maintainer,
-          helperTextMessage: config.primary_maintainer.help,
-          helperTextCnt: `${primary_maintainer?.length || 0}/${config.primary_maintainer.validation.maxLength.value}`,
-        }}
-        rules={config.primary_maintainer.validation}
+      <div className="py-2"></div>
+      <EditSectionTitle
+        title={config.description.title}
+        subtitle={config.description.subtitle}
       />
-    </section>
-    <div className="py-2"></div>
-    <ControlledSwitch
-      name='is_tenant'
-      label={config.is_tenant.label}
-      control={control}
-      defaultValue={is_tenant}
+      <AutosaveControlledMarkdown
+        id={id}
+        name="description"
+        maxLength={config.description.validation.maxLength.value}
+        patchFn={patchOrganisationTable}
       />
+      <div className="py-8"></div>
     </>
   )
 }

--- a/frontend/components/organisation/settings/index.tsx
+++ b/frontend/components/organisation/settings/index.tsx
@@ -5,79 +5,47 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useEffect} from 'react'
-import {useForm} from 'react-hook-form'
+import {FormProvider, useForm} from 'react-hook-form'
 
 import {useSession} from '../../../auth'
-import useSnackbar from '../../snackbar/useSnackbar'
-import ControlledTextField from '../../form/ControlledTextField'
 import {OrganisationForOverview} from '../../../types/Organisation'
 import {organisationInformation as config} from '../organisationConfig'
-import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
 import RorIdWithUpdate from './RorIdWithUpdate'
-import updateOrganisationSettings from './updateOrganisationSettings'
 import RsdAdminSection from './RsdAdminSection'
 import ProtectedOrganisationPage from '../ProtectedOrganisationPage'
+import AutosaveOrganisationTextField from './AutosaveOrganisationTextField'
 
 const formId='organisation-settings-form'
 
 export default function OrganisationSettings({organisation, isMaintainer}:
   { organisation: OrganisationForOverview, isMaintainer: boolean }) {
-  const {token,user} = useSession()
-  const {showErrorMessage, showSuccessMessage} = useSnackbar()
-  const {
-    handleSubmit, watch, formState, reset, control, register, setValue
-  } = useForm<OrganisationForOverview>({
+  const {user} = useSession()
+  const methods = useForm<OrganisationForOverview>({
     mode: 'onChange',
     defaultValues: organisation
   })
-  // extract
-  const {isValid, isDirty} = formState
-  const formData = watch()
+  // extract used methods
+  const {
+    watch, register, formState
+  } = methods
+  // const {isValid, isDirty} = formState
+  const [name,website]=watch(['name','website'])
 
   // console.group('OrganisationSettings')
   // console.log('isDirty...', isDirty)
   // console.log('isValid...', isValid)
-  // console.log('organisation...', organisation)
   // console.groupEnd()
-
-  function isSaveDisabled() {
-    // if pos is undefined we are creating
-    // new entry, but we might already have required
-    // information (first name - last name). In this
-    // case we only check if form is valid
-    if (isValid === false) return true
-    if (isDirty === false) return true
-    return false
-  }
-
-  async function onSubmit(data: OrganisationForOverview) {
-    // console.log('submit...', data)
-    if (data && data.id) {
-      const resp = await updateOrganisationSettings({
-        item: data,
-        token
-      })
-      // debugger
-      if (resp.status === 200) {
-        showSuccessMessage(`Saved ${data.name} settings.`)
-        reset(data)
-      } else {
-        showErrorMessage(`Failed to save. ${resp.message}`)
-      }
-    } else {
-      showErrorMessage('Failed to save. Organisation UUID is missing.')
-    }
-  }
 
   return (
     <ProtectedOrganisationPage
       isMaintainer={isMaintainer}
     >
+    <FormProvider {...methods}>
     <form
       id={formId}
-      onSubmit={handleSubmit(onSubmit)}
+      // onSubmit={handleSubmit(onSubmit)}
       autoComplete="off"
+      className="py-4"
     >
       {/* hidden inputs */}
       <input type="hidden"
@@ -88,54 +56,44 @@ export default function OrganisationSettings({organisation, isMaintainer}:
       />
       <section className="flex justify-between align-center">
         <h2>Settings</h2>
-        <SubmitButtonWithListener
-          formId={formId}
-          disabled={isSaveDisabled()}
-        />
       </section>
       <div className="flex pt-8"></div>
-      <section className="grid grid-cols-[1fr,1fr] gap-8">
-        <ControlledTextField
-          control={control}
-          options={{
-            name: 'name',
-            // variant: 'outlined',
-            label: config.name.label,
-            useNull: true,
-            defaultValue: formData?.name,
-            helperTextMessage: config.name.help,
-            helperTextCnt: `${formData?.name?.length || 0}/${config.name.validation.maxLength.value}`,
-          }}
-          rules={config.name.validation}
-        />
-        <div>
-          <RorIdWithUpdate
-            control={control}
-            setValue={setValue}
+        <section className="grid grid-cols-[1fr,1fr] gap-8">
+          <AutosaveOrganisationTextField
+            organisation_id={organisation.id}
+            options={{
+              name: 'name',
+              label: config.name.label,
+              useNull: true,
+              defaultValue: name,
+              helperTextMessage: config.name.help,
+              helperTextCnt: `${name?.length || 0}/${config.name.validation.maxLength.value}`,
+            }}
+            rules={config.name.validation}
           />
-        </div>
-      </section>
-      <div className="py-4"></div>
-      <ControlledTextField
-        control={control}
-        options={{
-          name: 'website',
-          // variant: 'outlined',
-          label: config.website.label,
-          useNull: true,
-          defaultValue: formData?.website,
-          helperTextMessage: config.website.help,
-          helperTextCnt: `${formData?.website?.length || 0}/${config.website.validation.maxLength.value}`,
-        }}
-        rules={config.website.validation}
-      />
+          <RorIdWithUpdate />
+        </section>
+        <div className="py-4"></div>
+        <AutosaveOrganisationTextField
+          organisation_id={organisation.id}
+          options={{
+            name: 'website',
+            label: config.website.label,
+            useNull: true,
+            defaultValue: website,
+            helperTextMessage: config.website.help,
+            helperTextCnt: `${website?.length || 0}/${config.website.validation.maxLength.value}`,
+          }}
+          rules={config.website.validation}
+        />
       <div className="py-4"></div>
       {/* RSD admin section */}
       {user?.role === 'rsd_admin' ?
-        <RsdAdminSection control={control} />
+        <RsdAdminSection />
         : null
       }
-      </form>
+    </form>
+    </FormProvider>
     </ProtectedOrganisationPage>
   )
 }

--- a/frontend/components/organisation/settings/updateOrganisationSettings.tsx
+++ b/frontend/components/organisation/settings/updateOrganisationSettings.tsx
@@ -30,3 +30,24 @@ export default async function updateOrganisationSettings({item, token}:
     }
   }
 }
+
+export async function patchOrganisationTable({id, data, token}:
+  {id:string, data: any, token: string }) {
+  try {
+    // extract only required items
+     const url = `/api/v1/organisation?id=eq.${id}`
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        ...createJsonHeaders(token)
+      },
+      body: JSON.stringify(data)
+    })
+    return extractReturnMessage(resp)
+  } catch (e: any) {
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}

--- a/frontend/components/organisation/software/SoftwareCardWithMenu.tsx
+++ b/frontend/components/organisation/software/SoftwareCardWithMenu.tsx
@@ -23,7 +23,7 @@ const StyledNav = styled('nav')(({theme})=>({
   height: '4rem',
   backgroundColor: theme.palette.background.paper,
   color: theme.palette.secondary.main,
-  zIndex: 9
+  zIndex: 7
 }))
 
 

--- a/frontend/components/projects/edit/information/AutosaveFundingOrganisations.tsx
+++ b/frontend/components/projects/edit/information/AutosaveFundingOrganisations.tsx
@@ -33,7 +33,8 @@ function createNewOrganisation(organisation:SearchOrganisation){
     logo_mime_type: null,
     position: null,
     // funding organisation come from ROR
-    source: organisation.source
+    source: organisation.source,
+    description: null
   }
   return newOrganisation
 }

--- a/frontend/components/projects/edit/information/index.tsx
+++ b/frontend/components/projects/edit/information/index.tsx
@@ -23,6 +23,8 @@ import AutosaveFundingOrganisations from './AutosaveFundingOrganisations'
 import AutosaveProjectKeywords from './AutosaveProjectKeywords'
 import AutosaveResearchDomains from './AutosaveResearchDomains'
 import AutosaveProjectLinks from './AutosaveProjectLinks'
+import AutosaveControlledMarkdown from '~/components/form/AutosaveControlledMarkdown'
+import {patchProjectTable} from './patchProjectInfo'
 
 export default function EditProjectInformation({slug}: {slug: string}) {
   const {token,user} = useSession()
@@ -139,9 +141,11 @@ export default function EditProjectInformation({slug}: {slug: string}) {
             subtitle={config.description.subtitle}
           />
           <AutosaveProjectImage />
-          <AutosaveProjectMarkdown
-            project_id={formValues.id}
+          <AutosaveControlledMarkdown
+            id={formValues.id}
             name="description"
+            maxLength={config.description.validation.maxLength.value}
+            patchFn={patchProjectTable}
           />
           <div className="xl:py-4"></div>
         </div>

--- a/frontend/components/projects/edit/information/useProjectToEdit.tsx
+++ b/frontend/components/projects/edit/information/useProjectToEdit.tsx
@@ -29,7 +29,8 @@ function prepareFundingOrganisations(organisations:OrganisationsOfProject[]) {
     return {
       ...item,
       pos,
-      source:'RSD'
+      source: 'RSD',
+      description: null
     }
   })
   return data

--- a/frontend/components/projects/edit/organisations/useParticipatingOrganisations.ts
+++ b/frontend/components/projects/edit/organisations/useParticipatingOrganisations.ts
@@ -52,7 +52,8 @@ export function useParticipatingOrganisations({project, token, account}: UsePart
           source: 'RSD' as 'RSD',
           status: item.status,
           // false by default
-          canEdit: false
+          canEdit: false,
+          description: null
         }
         return organisation
       })

--- a/frontend/components/software/edit/information/AutosaveRepositoryUrl.tsx
+++ b/frontend/components/software/edit/information/AutosaveRepositoryUrl.tsx
@@ -34,14 +34,14 @@ export default function AutosaveRepositoryUrl() {
     control,
     name:'repository_url'
   })
-  const [id] = watch(['id'])
+  const [id,repository_platform] = watch(['id','repository_platform'])
   const [platform, setPlatform] = useState<{
     id: CodePlatform | null
     disabled: boolean
     helperText: string
   }>({
-    id: null,
-    disabled: true,
+    id: repository_platform,
+    disabled: repository_platform===null,
     helperText: 'Suggestion'
   })
 
@@ -58,20 +58,23 @@ export default function AutosaveRepositoryUrl() {
   useEffect(() => {
     if (typeof urlError == 'undefined' && repository_url) {
       // debugger
-      const suggestedPlatform = suggestPlatform(repository_url)
-      setPlatform({
-        id: suggestedPlatform,
-        disabled: false,
-        helperText: 'Suggestion'
-      })
+      if (platform.id === null) {
+        const suggestedPlatform = suggestPlatform(repository_url)
+        setPlatform({
+          id: suggestedPlatform,
+          disabled: false,
+          helperText: 'Suggestion'
+        })
+      }
     } else if (urlError) {
+      debugger
       setPlatform({
         id: null,
         disabled: true,
         helperText: ''
       })
     }
-  },[urlError,repository_url])
+  },[urlError,repository_url,platform.id])
 
   async function saveRepositoryInfo({name, value}: OnSaveProps) {
     // complete record for upsert
@@ -90,13 +93,21 @@ export default function AutosaveRepositoryUrl() {
     if (name === 'repository_url') {
       data.url = value
     } else if (name === 'repository_platform') {
+      // compare to suggested platform
+      const suggestedPlatform = suggestPlatform(repository_url)
+      let helperText = 'Selected'
+      if (suggestedPlatform === value) {
+        helperText = 'Suggested'
+      } else {
+        helperText = 'Are you sure?'
+      }
       // update value
       data.code_platform = value as CodePlatform
       // manualy overwriting advice
       setPlatform({
         id: value as CodePlatform,
         disabled: false,
-        helperText: 'Are you sure?'
+        helperText
       })
     }
     let resp

--- a/frontend/components/software/edit/information/patchSoftwareTable.ts
+++ b/frontend/components/software/edit/information/patchSoftwareTable.ts
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {createJsonHeaders, extractReturnMessage} from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
 

--- a/frontend/components/software/edit/organisations/useParticipatingOrganisations.ts
+++ b/frontend/components/software/edit/organisations/useParticipatingOrganisations.ts
@@ -41,7 +41,8 @@ async function getParticipatingOrganisationsForSoftware({software, token, accoun
       source: 'RSD' as 'RSD',
       status: item.status,
       // false by default
-      canEdit: false
+      canEdit: false,
+      description: null
     }
     return organisation
   })

--- a/frontend/pages/organisations/[...slug].tsx
+++ b/frontend/pages/organisations/[...slug].tsx
@@ -41,10 +41,16 @@ export default function OrganisationPage({organisation,slug,page}:OrganisationPa
         setPageState(nextStep)
       }
     } else {
-      // default is the first item
-      setPageState(organisationMenu[0])
+      // if there is description
+      if (organisation.description) {
+        // we show about page
+        setPageState(organisationMenu[0])
+      } else {
+        // otherwise software is default
+        setPageState(organisationMenu[1])
+      }
     }
-  },[page])
+  },[page,organisation.description])
 
   // console.group('OrganisationPage')
   // console.log('organisation...', organisation)

--- a/frontend/types/Organisation.ts
+++ b/frontend/types/Organisation.ts
@@ -20,6 +20,8 @@ export type CoreOrganisationProps = {
   ror_id: string | null
   is_tenant: boolean
   website: string | null
+  // about page content created by maintainer
+  description: string | null
 }
 
 // object for organisation

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -12,7 +12,7 @@ import {
   EditOrganisation, Organisation,
   OrganisationRole,
   OrganisationsForSoftware,
-  SearchOrganisation, SoftwareForOrganisation
+  SearchOrganisation
 } from '../types/Organisation'
 import {createJsonHeaders, extractReturnMessage} from './fetchHelpers'
 import {getPropsFromObject} from './getPropsFromObject'
@@ -466,7 +466,8 @@ export function newOrganisationProps(props: NewOrganisation) {
     source: 'MANUAL' as 'MANUAL',
     primary_maintainer: props.primary_maintainer,
     role: props?.role ?? 'participating',
-    canEdit: false
+    canEdit: false,
+    description: null
   }
   return initOrg
 }

--- a/frontend/utils/getROR.ts
+++ b/frontend/utils/getROR.ts
@@ -57,6 +57,7 @@ function buildAutocompleteOptions(rorItems: RORItem[]): AutocompleteOption<Searc
         website: item.links[0] ?? '',
         logo_id: null,
         source: 'ROR' as 'ROR',
+        description: null
       }
     }
   })


### PR DESCRIPTION
# Add organisation about page

Closes #482
Closes #582

Changes proposed in this pull request:
*  I implemented autosave feature and removed Save button similar to edit software and projects page
*  The markdown section is added to the settings. Organisation admin can add the about text in markdown format to enable additional menu option (about section)
*  About section is allowed at all levels, the top organisation and the research units (children)

How to test:
* `make start` to completely reset and rebuild your local rsd (to stop use `docker-compose down` when you are done)
* login as rsd_admin or maintainer of an organisation
* you will always see about section as maintainer. If there is no content, the info will be shown. You can click on bold text to open settings section
* add markdown in the settings (About page section)
* visit about section and confirm that content is shown
* logout from rsd, visit organisation and confirm that about page is shown

## Example organisation about section (public view)
![image](https://user-images.githubusercontent.com/9204081/196142069-61f1c90c-c0e0-4521-ad6f-803fe3485ec9.png)

## Example organisation (admin view - without about content)
![image](https://user-images.githubusercontent.com/9204081/196245752-c10100c2-db44-409a-b404-cc11510261d9.png)

## Example organisation settings with markdown (admin view)
![image](https://user-images.githubusercontent.com/9204081/196141756-3c727574-e387-423a-b5c0-937ef139aa27.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
