### PR TITLE
Move feedback button to fixed position under the logo

### DIFF
--- a/frontend/components/AppHeader/AddMenu.tsx
+++ b/frontend/components/AppHeader/AddMenu.tsx
@@ -11,8 +11,6 @@ import AddIcon from '@mui/icons-material/Add'
 import TerminalIcon from '@mui/icons-material/Terminal'
 import ListAltIcon from '@mui/icons-material/ListAlt'
 import {IconButton, ListItemIcon} from '@mui/material'
-import CaretIcon from '~/components/icons/caret.svg'
-
 
 export default function AddMenu() {
   const router = useRouter()
@@ -56,9 +54,6 @@ export default function AddMenu() {
       >
         <AddIcon />
       </IconButton>
-
-      <CaretIcon className="-ml-6"/>
-
       <Menu
         anchorEl={anchorEl}
         open={open}
@@ -66,6 +61,8 @@ export default function AddMenu() {
         MenuListProps={{'aria-labelledby': 'menu-button'}}
         transformOrigin={{horizontal: 'right', vertical: 'top'}}
         anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
+        // disable adding styles to body (overflow:hidden & padding-right)
+        disableScrollLock={true}
       >
         <MenuItem data-testid="add-menu-option" onClick={() => handleClose('/software/add')}>
           <ListItemIcon>

--- a/frontend/components/AppHeader/index.tsx
+++ b/frontend/components/AppHeader/index.tsx
@@ -51,22 +51,25 @@ export default function AppHeader({editButton}: { editButton?: JSX.Element }) {
   return (
     <header
       data-testid="app-header"
-      className="z-10 py-4 min-h-[88px] bg-secondary text-primary-content flex items-center flex-wrap"
+      className="z-10 py-4 min-h-[6rem] bg-secondary text-primary-content flex flex-col"
     >
       {/* keep these styles in sync with main in MainContent.tsx */}
       <div
         className="flex-1 flex flex-col items-start px-4 lg:flex-row lg:container lg:mx-auto lg:items-center">
         <div className="w-full flex-1 flex items-center justify-between">
+          {/* Logo */}
           <Link href="/" passHref>
-            <a className="hover:text-inherit">
+            <a title="Homepage"
+              className="hover:text-inherit">
               <LogoApp className="hidden 2xl:block"/>
               <LogoAppSmall className="block 2xl:hidden"/>
             </a>
           </Link>
 
+          {/* Desktop global search*/}
           <GlobalSearchAutocomplete className="hidden lg:block ml-12 mr-6"/>
 
-          {/* Large menu*/}
+          {/* Desktop menu*/}
           <div
             className="justify-center lg:justify-start hidden md:flex text-lg ml-4 gap-5 text-center opacity-90 font-normal flex-1">
             {menuItems.map(item =>
@@ -80,81 +83,68 @@ export default function AppHeader({editButton}: { editButton?: JSX.Element }) {
 
           <div
             className="text-primary-content flex gap-2 justify-end items-center min-w-[8rem] text-right ml-4">
-
             {/* EDIT button */}
             {editButton ? editButton : null}
-
-            {/* FEEDBACK panel */}
-            <div className="hidden md:block">
-              {host.feedback_email
-                ? <FeedbackPanelButton feedback_email={host.feedback_email}/>
-                : null
-              }
-            </div>
 
             {/* ADD menu button */}
             {status === 'authenticated' ? <AddMenu/> : null}
 
+            {/* Mobile menu */}
+            <IconButton
+              size="large"
+              title="Menu"
+              data-testid="menu-button"
+              aria-label="menu button"
+              onClick={handleClick}
+              sx={{
+                display: ['flex', 'flex', 'none'],
+                color: 'primary.contrastText',
+                margin: '0rem 0.5rem',
+                alignSelf: 'center',
+                '&:focus-visible': {
+                  outline: 'auto'
+                }
+              }}
+            >
+              <MenuIcon/>
+            </IconButton>
+            <Menu
+              id="basic-menu"
+              anchorEl={anchorEl}
+              open={open}
+              onClose={handleClose}
+              MenuListProps={{
+                'aria-labelledby': 'menu-button'
+              }}
+              transformOrigin={{horizontal: 'right', vertical: 'top'}}
+              anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
+              // disable adding styles to body (overflow:hidden & padding-right)
+              disableScrollLock={true}
+            >
+              {menuItems.map(item =>
+                <MenuItem onClick={handleClose} key={item.path}>
+                  <Link href={item.path || ''}>
+                    <a className={`${activePath === item.path && 'nav-active'}`}>
+                      {item.label}
+                    </a>
+                  </Link>
+                </MenuItem>
+              )}
+            </Menu>
+
             {/* LOGIN / USER MENU */}
             <LoginButton/>
-
-            {/* Responsive menu */}
-            <div className="block md:hidden">
-
-              <IconButton
-                size="large"
-                title="Menu"
-                data-testid="menu-button"
-                aria-label="menu button"
-                onClick={handleClick}
-                sx={{
-                  display: ['inline-block', 'inline-block', 'inline-block', 'none'],
-                  color: 'primary.contrastText',
-                  margin: '0rem 0.5rem',
-                  alignSelf: 'center',
-                  '&:focus-visible': {
-                    outline: 'auto'
-                  }
-                }}
-              >
-                <MenuIcon/>
-              </IconButton>
-              <Menu
-                id="basic-menu"
-                anchorEl={anchorEl}
-                open={open}
-                onClose={handleClose}
-                MenuListProps={{
-                  'aria-labelledby': 'menu-button',
-                }}
-                transformOrigin={{horizontal: 'right', vertical: 'top'}}
-                anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
-              >
-                {menuItems.map(item =>
-                  <MenuItem onClick={handleClose} key={item.path}>
-                    <Link href={item.path || ''}>
-                      <a className={`${activePath === item.path && 'nav-active'}`}>
-                        {item.label}
-                      </a>
-                    </Link>
-                  </MenuItem>
-                )}
-                <li>
-                  {host.feedback_email
-                    ? <FeedbackPanelButton feedback_email={host.feedback_email}
-                                           closeFeedbackPanel={handleClose}/>
-                    : null
-                  }
-                </li>
-              </Menu>
-            </div>
           </div>
-          <JavascriptSupportWarning/>
+          <JavascriptSupportWarning />
         </div>
-
-
-        <GlobalSearchAutocomplete className="lg:hidden mt-4"/>
+        {/* Mobile global search */}
+        <GlobalSearchAutocomplete className="lg:hidden my-4" />
       </div>
+      {/* FEEDBACK panel */}
+      {host.feedback_email
+        ? <FeedbackPanelButton feedback_email={host.feedback_email}/>
+        : null
+      }
     </header>
   )
 }

--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -124,7 +124,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
       setOpen(false)
     }}>
       <div
-        className={`${props.className} relative z-10 flex w-full lg:w-52 lg:max-w-[320px] focus-within:w-full duration-700`}>
+        className={`${props.className} relative z-10 flex w-full lg:w-52 lg:max-w-[18rem] xl:max-w-[20rem] focus-within:w-full duration-700`}>
         <div className="absolute top-[14px] left-3 pointer-events-none">
           <svg width="16" height="16" viewBox="0 0 14 14" fill="none"
                xmlns="http://www.w3.org/2000/svg">

--- a/frontend/components/feedback/FeedbackPanelButton.test.tsx
+++ b/frontend/components/feedback/FeedbackPanelButton.test.tsx
@@ -4,6 +4,8 @@ import FeedbackPanelButton from './FeedbackPanelButton'
 
 it('it has feedback button', () => {
   render(<FeedbackPanelButton feedback_email='test@email.com' />)
-  const btn = screen.getByRole('button')
+  const btn = screen.getByRole('button', {
+    name: /Feedback/
+  })
   expect(btn).toBeInTheDocument()
 })

--- a/frontend/components/feedback/FeedbackPanelButton.tsx
+++ b/frontend/components/feedback/FeedbackPanelButton.tsx
@@ -1,4 +1,3 @@
-import CaretIcon from '~/components/icons/caret.svg'
 import * as React from 'react'
 import {useState} from 'react'
 import Link from 'next/link'
@@ -7,7 +6,6 @@ import Dialog from '@mui/material/Dialog'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import {useTheme} from '@mui/material/styles'
 import LinkIcon from '@mui/icons-material/Link'
-import Divider from '@mui/material/Divider'
 
 export default function FeedbackPanelButton(
   {feedback_email, closeFeedbackPanel}: { feedback_email: string, closeFeedbackPanel?: () => void }
@@ -46,33 +44,34 @@ export default function FeedbackPanelButton(
   }
 
   return (
-    <div>
-      {/* If desktop size */}
-      <button className="hidden md:flex flex gap-2 items-center no-underline"
-              aria-describedby="feedback panel"
-              onClick={handleClickOpen}
+    <div className="lg:container lg:mx-auto relative">
+      <button
+        title="We value your feedback"
+        aria-describedby="feedback panel"
+        onClick={handleClickOpen}
+        className="bg-error text-error-content"
+        style={{
+          position: 'absolute',
+          left:'1rem',
+          bottom: '-2rem',
+          padding: '0.25rem 0.75rem',
+          borderRadius: '0.5rem 0rem'
+        }}
       >
-        Feedback <CaretIcon/>
+      Your Feedback
       </button>
-      {/*If  mobile size */}
-      <div className="block md:hidden">
-        <Divider/>
-        <button className="flex md:hidden hover:bg-gray-100 hover:text-primary w-full py-2 px-4"
-                onClick={handleClickOpen}>
-          Send feedback
-        </button>
-      </div>
-
       <Dialog
         fullScreen={fullScreen}
         open={open}
         onClose={handleClose}
         aria-labelledby="responsive-dialog-title"
+        // disable adding styles to body (overflow:hidden & padding-right)
+        disableScrollLock={fullScreen}
       >
         <div className="h-full w-full bg-[#232323] p-5 ">
           <div className="mx-auto max-w-[500px]">
             <div className="text-white text-xl mb-4">
-              Send Feedback
+              Your Feedback
             </div>
             <textarea
               autoFocus

--- a/frontend/components/layout/PageTitle.tsx
+++ b/frontend/components/layout/PageTitle.tsx
@@ -26,7 +26,7 @@ export const PageTitleSticky = styled('section')(({theme})=>({
 export default function PageTitle({title,children}:{title:string,children?:ReactNode}) {
   return (
     <PageTitleSticky>
-      <h1 className="flex-1 flex w-full mb-4 md:my-4">{title}</h1>
+      <h1 className="flex-1 flex w-full my-4">{title}</h1>
       {children}
     </PageTitleSticky>
   )

--- a/frontend/components/layout/UserMenu.tsx
+++ b/frontend/components/layout/UserMenu.tsx
@@ -10,6 +10,7 @@ import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import Avatar from '@mui/material/Avatar'
 import {Divider, ListItemIcon} from '@mui/material'
+import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown'
 
 import {useAuth} from '../../auth/index'
 import {MenuItemType} from '../../config/menuItems'
@@ -67,7 +68,7 @@ export default function UserMenu(props: UserMenuType) {
   return (
     <>
       <IconButton
-        title="My RSD"
+        title="Click for menu options"
         data-testid="user-menu-button"
         aria-controls="user-menu"
         aria-haspopup="true"
@@ -90,6 +91,13 @@ export default function UserMenu(props: UserMenuType) {
         >
           {getDisplayInitials(splitName(session?.user?.name ?? ''))}
         </Avatar>
+        {
+        /* Does not fit at 375px in edit software mode
+        <KeyboardArrowDownIcon
+          sx={{
+            color:'secondary.contrastText'
+          }}
+        /> */}
       </IconButton>
       <Menu
         anchorEl={anchorEl}
@@ -100,6 +108,8 @@ export default function UserMenu(props: UserMenuType) {
         }}
         transformOrigin={{horizontal: 'right', vertical: 'top'}}
         anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
+        // disable adding styles to body (overflow:hidden & padding-right)
+        disableScrollLock={true}
       >
         {renderMenuOptions()}
       </Menu>

--- a/frontend/components/login/LoginButton.tsx
+++ b/frontend/components/login/LoginButton.tsx
@@ -20,7 +20,6 @@ import {useAuth} from '~/auth'
 import useLoginProviders from '~/auth/api/useLoginProviders'
 import {getUserMenuItems} from '~/config/userMenuItems'
 import UserMenu from '~/components/layout/UserMenu'
-import CaretIcon from '~/components/icons/caret.svg'
 
 export default function LoginButton() {
   const providers = useLoginProviders()
@@ -42,12 +41,7 @@ export default function LoginButton() {
     // when user is authenticated
     const menuItems = getUserMenuItems(session.user?.role)
     // we show user menu with the avatar and user specific options
-    return (
-      <>
-        <UserMenu menuOptions={menuItems}/>
-        <CaretIcon className="-ml-2"/>
-      </>
-    )
+    return <UserMenu menuOptions={menuItems}/>
   }
 
   // when there are multiple providers

--- a/frontend/config/userMenuItems.tsx
+++ b/frontend/config/userMenuItems.tsx
@@ -9,7 +9,7 @@ import TerminalIcon from '@mui/icons-material/Terminal'
 import ListAltIcon from '@mui/icons-material/ListAlt'
 import BusinessIcon from '@mui/icons-material/Business'
 import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
-import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck';
+import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck'
 import Logout from '@mui/icons-material/Logout'
 
 import {MenuItemType} from './menuItems'

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -120,7 +120,7 @@ function RsdApp(props: MuiAppProps) {
     <CacheProvider value={emotionCache}>
       <Head>
         <title>Research Software Directory</title>
-        <meta name="viewport" content="initial-scale=1, width=device-width" />
+        <meta name="viewport" content="width=device-width" />
       </Head>
       {/* MUI Theme provider */}
       <ThemeProvider theme={muiTheme}>

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -15,8 +15,8 @@
 
 body{
   font-size: 1rem;
-  /* minimal with to have logo, menu and profile */
-  min-width: 375px;
+  /* minimal with to have logo, edit, add, profile and menu */
+  min-width: 27rem;
 }
 
 #__next {


### PR DESCRIPTION
fix: white space when opening mui menu on small screens
fix: scaling on small screens with insufficient space to hold all header items

Feedback button requires more space than an icon button. So far we introduced number of "quick access" buttons that on mobile amounts to max. of 4 icons button (logged in maintainer of software/project). Within the current approach I would prefer feedback button to be placed below logo as shown in the screenshots below.

## Example all options on the mobile
![image](https://user-images.githubusercontent.com/9204081/196150491-3e92cda4-aad8-4e2f-8637-3bd82a95b627.png)

## Example all options large screen
![image](https://user-images.githubusercontent.com/9204081/196150863-2669f4b4-d7df-4d93-9dc5-97b20faa527f.png)

## Example homepage
![image](https://user-images.githubusercontent.com/9204081/196150974-a45ce315-61a4-41b2-979d-28248b8d61b2.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
