### PR TITLE
588 postgrest update

### DIFF
--- a/backend-postgrest/Dockerfile
+++ b/backend-postgrest/Dockerfile
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: 2021 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2021 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgrest/postgrest:v9.0.0
+FROM postgrest/postgrest:v10.0.0

--- a/database/017-create-narcis-table.sql
+++ b/database/017-create-narcis-table.sql
@@ -6,7 +6,7 @@
 CREATE TABLE oaipmh (
 --	trick to only have one row in this table:
 	id BOOLEAN DEFAULT TRUE PRIMARY KEY CHECK (id),
-	data VARCHAR,
+	data XML,
 	created_at TIMESTAMPTZ NOT NULL,
 	updated_at TIMESTAMPTZ NOT NULL
 );

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       - PGRST_DB_SCHEMA
       - PGRST_SERVER_PORT
       - PGRST_JWT_SECRET
-      - PGRST_RAW_MEDIA_TYPES=application/xml
     depends_on:
       - database
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:1.6.3
+    image: rsd/database:1.6.4
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -33,7 +33,7 @@ services:
 
   backend:
     build: ./backend-postgrest
-    image: rsd/backend-postgrest:1.0.0
+    image: rsd/backend-postgrest:1.1.0
     expose:
       - 3500
     environment:
@@ -91,7 +91,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:1.6.4
+    image: rsd/frontend:1.6.5
     environment:
       # it uses values from .env file
       - POSTGREST_URL
@@ -151,7 +151,7 @@ services:
   nginx:
     build:
       context: ./nginx
-    image: rsd/nginx:1.1.0
+    image: rsd/nginx:1.1.1
     ports:
       - "80:80"
       - "443:443"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,7 +43,6 @@ services:
       - PGRST_DB_SCHEMA
       - PGRST_SERVER_PORT
       - PGRST_JWT_SECRET
-      - PGRST_RAW_MEDIA_TYPES=application/xml
     depends_on:
       - database
     networks:

--- a/frontend/types/Project.ts
+++ b/frontend/types/Project.ts
@@ -25,9 +25,9 @@ export type BasicProject = NewProject & {
 }
 
 export type RawProject = BasicProject & {
-  image_for_project?: [
-    { project: string }
-  ]
+  image_for_project?: {
+    project: string
+  } | null
 }
 
 export type Project = BasicProject & {

--- a/frontend/types/SoftwareTypes.ts
+++ b/frontend/types/SoftwareTypes.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -54,7 +56,7 @@ export type SoftwareItem = SoftwareTableItem & {
 }
 
 export type SoftwareItemFromDB = SoftwareTableItem & {
-  repository_url: RepositoryUrl[]
+  repository_url: RepositoryUrl
 }
 
 export type SoftwareListItem = {

--- a/frontend/utils/editSoftware.ts
+++ b/frontend/utils/editSoftware.ts
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -65,9 +67,9 @@ export async function getSoftwareToEdit({slug, token, baseUrl}:
       // fix repositoryUrl
       const software: SoftwareItem = getPropsFromObject(data[0], SoftwarePropsToSave)
       // repository url should at least be http://a.b
-      if (data[0]?.repository_url[0]?.url?.length > 9) {
-        software.repository_url = data[0]?.repository_url[0]?.url
-        software.repository_platform = data[0]?.repository_url[0]?.code_platform
+      if (data[0]?.repository_url?.url?.length > 9) {
+        software.repository_url = data[0]?.repository_url?.url
+        software.repository_platform = data[0]?.repository_url?.code_platform
       } else {
         software.repository_url = null
         software.repository_platform = null

--- a/frontend/utils/getProjects.ts
+++ b/frontend/utils/getProjects.ts
@@ -51,8 +51,8 @@ export async function getProjectList({url, token}: { url: string, token?: string
   }
 }
 export function extractImageInfo(item: RawProject) {
-  if (item.image_for_project && item.image_for_project.length > 0) {
-    return item.image_for_project[0].project
+  if (item?.image_for_project && item?.image_for_project !== null) {
+    return item.image_for_project.project
   } else {
     return null
   }

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -81,7 +81,7 @@ server {
 			return 404;
 		}
 		set $args "";
-		proxy_set_header Accept application/xml;
+		proxy_set_header Accept text/xml;
 		proxy_pass http://backend/oaipmh?select=data;
 	}
 }


### PR DESCRIPTION
# Upgrade to PostgREST 10.0

Changes proposed in this pull request:

* Upgrade from PostgREST 9.0.0 to  10.0.0
* Change the column `data` of the `oaipmh` table from `VARCHAR` to `XML`
* Small fix in the frontend to adapt to [one-to-one embedding](https://postgrest.org/en/stable/releases/v10.0.0.html#resource-embedding)

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=1`
* Check that everything still works, both as a visitor and as an admin
* Check the [oaipmh endpoint](http://localhost/oaipmh?metadataPrefix=datacite4&verb=ListRecords) after having added a real concept DOI and having run the scraper (`docker-compose exec scrapers python3 -u /usr/myjava/oaipmh.py`)
* Check that the API endpoints return JSON again (e.g. [1](http://localhost/api/v1/software) and [2](http://localhost/api/v1/mention?select=title,url,publication_year&order=publication_year))

Is related to #588

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests