### PR TITLE
437 cached images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:1.6.5
+    image: rsd/frontend:1.6.6
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -43,6 +45,9 @@ export default function AutosaveProjectImage() {
         mime_type,
         token
       })
+      await fetch(`/image/rpc/get_project_image?id=${form_id}`, {cache: 'reload'})
+      // @ts-ignore
+      location.reload(true)
     } else {
       // add new image
       resp = await addImage({

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -330,6 +330,9 @@ export async function uploadOrganisationLogo({id, data, mime_type, token}:
         mime_type
       })
     })
+    await fetch(`/image/rpc/get_logo?id=${id}`, {cache: 'reload'})
+    // @ts-ignore
+    location.reload(true)
     return extractReturnMessage(resp)
   } catch (e: any) {
     return {


### PR DESCRIPTION
# Refresh image cache when changing image

Changes proposed in this pull request:

* When an image for a project or organisation is changed, do a `reload` fetch request in the background to store the updated image in the browser cache (needed for Chromium) and then do a hard refresh of the page (needed for Firefox) to refresh the cache for this image in the browser
* This is not done for contributors and team members, as a refresh would bring you to the first edit section

How to test:
* `docker-compose build frontend && docker-compose up`
* Login as an admin
* Change the image for a project, the browser should refresh and you should always see the new image
* Do the same for an organisation image

Closes #437

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests