### PR TITLE
597 sanitise keywords and improve checks

### DIFF
--- a/database/006-create-keyword.sql
+++ b/database/006-create-keyword.sql
@@ -5,7 +5,7 @@
 
 CREATE TABLE keyword (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	value CITEXT UNIQUE
+	value CITEXT UNIQUE CHECK (value ~ '^\S+( \S+)*$')
 );
 
 CREATE FUNCTION sanitise_insert_keyword() RETURNS TRIGGER LANGUAGE plpgsql AS

--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -241,6 +241,9 @@ CREATE POLICY anyone_can_read ON keyword FOR SELECT TO web_anon, rsd_user
 CREATE POLICY maintainer_can_insert ON keyword FOR INSERT TO rsd_user
 	WITH CHECK (TRUE);
 
+CREATE POLICY maintainer_can_delete ON keyword FOR DELETE TO rsd_user
+	USING (TRUE);
+
 CREATE POLICY admin_all_rights ON keyword TO rsd_admin
 	USING (TRUE)
 	WITH CHECK (TRUE);

--- a/frontend/components/form/AsyncAutocompleteSC.tsx
+++ b/frontend/components/form/AsyncAutocompleteSC.tsx
@@ -82,7 +82,7 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
     ) {
       // debugger
       // issue search request using trimmed value
-      onSearch(searchFor.trim())
+      onSearch(searchFor)
       // set raw value as processing
       setProcessing(searchFor)
     }
@@ -105,7 +105,7 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
     if (value.trim().length >= config.minLength &&
       loading === false && onCreate) {
       // we send trimmed value
-      onCreate(value.trim())
+      onCreate(value)
       if (config?.reset) {
         // reset selected value to nothing
         setSelected(null)
@@ -244,7 +244,7 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
           // console.log('searchFor...', searchFor)
           // console.log('foundFor...', foundFor)
           // check if newInputValue is in the options
-          const inputInOptions = options.some(option => option.label.toLowerCase() === inputValue.toLowerCase())
+          const inputInOptions = options.some(option => option.label.trim().toLowerCase() === inputValue.trim().toLowerCase())
           // console.log('inputInOptions...', inputInOptions)
           // console.groupEnd()
           if (loading === false &&

--- a/frontend/components/form/AsyncAutocompleteSC.tsx
+++ b/frontend/components/form/AsyncAutocompleteSC.tsx
@@ -81,9 +81,9 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
       newInputValue!==''
     ) {
       // debugger
-      // issue search requestion AND
-      // set value as processing
-      onSearch(searchFor)
+      // issue search request using trimmed value
+      onSearch(searchFor.trim())
+      // set raw value as processing
       setProcessing(searchFor)
     }
   }, [searchFor, foundFor, processing, newInputValue, config.minLength, onSearch])
@@ -102,9 +102,10 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
     // if the length is sufficient
     // and we are not loading api responses
     // AND onCreate method is provided
-    if (value.length >= config.minLength &&
+    if (value.trim().length >= config.minLength &&
       loading === false && onCreate) {
-      onCreate(value)
+      // we send trimmed value
+      onCreate(value.trim())
       if (config?.reset) {
         // reset selected value to nothing
         setSelected(null)

--- a/frontend/components/keyword/FindKeyword.tsx
+++ b/frontend/components/keyword/FindKeyword.tsx
@@ -79,7 +79,7 @@ export default function FindKeyword({config, onAdd, searchForKeyword, onCreate}:
     return (
       <li {...props} key={option.key}>
         {/* if new option (has input) show label and count  */}
-        <strong>{`Add "${option.label}"`}</strong>
+        <strong>{`Add "${option.label.trim()}"`}</strong>
       </li>
     )
   }
@@ -91,7 +91,7 @@ export default function FindKeyword({config, onAdd, searchForKeyword, onCreate}:
     // when value is not not found option returns input prop
     if (option?.input && onCreate) {
       // if input is over minLength
-      if (option?.input.length > config.minLength) {
+      if (option?.input.trim().length > config.minLength) {
         // we offer an option to create this entry
         return renderAddOption(props,option)
       } else {

--- a/frontend/components/keyword/FindKeyword.tsx
+++ b/frontend/components/keyword/FindKeyword.tsx
@@ -37,7 +37,10 @@ export default function FindKeyword({config, onAdd, searchForKeyword, onCreate}:
     // set loading status and clear foundFor
     setStatus({loading: true, foundFor: undefined})
     // make search request
-    const resp = await searchForKeyword({searchFor})
+    const resp = await searchForKeyword({
+      // we trim raw search value
+      searchFor: searchFor.trim()
+    })
     // console.log('searchKeyword...resp...', resp)
     // convert keywords to autocomplete options
     const options = resp.map(item => ({

--- a/frontend/components/layout/TagChip.tsx
+++ b/frontend/components/layout/TagChip.tsx
@@ -13,7 +13,8 @@ export default function TagChip({label, title}:
         marginBottom: '1rem',
         marginRight: '0.5rem',
         maxWidth: '21rem',
-        borderRadius: '0.125rem'
+        borderRadius: '0.125rem',
+        textTransform: 'capitalize'
       }}
     />
   )

--- a/frontend/components/projects/edit/information/AutosaveProjectKeywords.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectKeywords.tsx
@@ -11,7 +11,10 @@ import {KeywordForProject} from '~/types/Project'
 import FindKeyword, {Keyword} from '~/components/keyword/FindKeyword'
 import {projectInformation as config} from './config'
 import {searchForProjectKeyword} from './searchForKeyword'
-import {addKeywordsToProject, createKeyword, deleteKeywordFromProject} from '~/utils/editKeywords'
+import {
+  addKeywordsToProject, createOrGetKeyword,
+  deleteKeywordFromProject, silentKeywordDelete
+} from '~/utils/editKeywords'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {sortOnStrProp} from '~/utils/sortFn'
 
@@ -60,7 +63,7 @@ export default function AutosaveProjectKeywords({project_id,items}:ProjectKeywor
     const find = keywords.filter(item => item.keyword.trim().toLowerCase() === selected.trim().toLowerCase())
     if (find.length === 0) {
       // create keyword
-      let resp = await createKeyword({
+      let resp = await createOrGetKeyword({
         keyword: selected,
         token
       })
@@ -95,6 +98,13 @@ export default function AutosaveProjectKeywords({project_id,items}:ProjectKeywor
           ...keywords.slice(pos+1)
         ]
         setKeywords(items)
+        // try to delete this keyword from keyword table
+        // delete will fail if the keyword is referenced
+        // therefore we do not check the status
+        const del = await silentKeywordDelete({
+          keyword: item.keyword,
+          token
+        })
       }else{
         showErrorMessage(`Failed to delete keyword. ${resp.message}`)
       }

--- a/frontend/components/projects/edit/information/AutosaveProjectKeywords.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectKeywords.tsx
@@ -31,7 +31,7 @@ export default function AutosaveProjectKeywords({project_id,items}:ProjectKeywor
 
   async function onAdd(selected: Keyword) {
     // check if already exists
-    const find = keywords.filter(item => item.keyword === selected.keyword)
+    const find = keywords.filter(item => item.keyword.trim().toLowerCase() === selected.keyword.trim().toLowerCase())
     let resp
     if (find.length === 0) {
       resp = await addKeywordsToProject({
@@ -57,7 +57,7 @@ export default function AutosaveProjectKeywords({project_id,items}:ProjectKeywor
 
   async function onCreate(selected: string) {
     // check if already exists
-    const find = keywords.filter(item => item.keyword === selected)
+    const find = keywords.filter(item => item.keyword.trim().toLowerCase() === selected.trim().toLowerCase())
     if (find.length === 0) {
       // create keyword
       let resp = await createKeyword({
@@ -114,6 +114,9 @@ export default function AutosaveProjectKeywords({project_id,items}:ProjectKeywor
               title={field.keyword}
               label={field.keyword}
               onDelete={() => onRemove(pos)}
+              sx={{
+                textTransform:'capitalize'
+              }}
             />
           </div>
         )

--- a/frontend/components/projects/edit/information/AutosaveProjectKeywords.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectKeywords.tsx
@@ -69,8 +69,8 @@ export default function AutosaveProjectKeywords({project_id,items}:ProjectKeywor
       })
       if (resp.status===201){
         const keyword = {
-          id: resp.message as string,
-          keyword: selected,
+          id: resp.message.id,
+          keyword: resp.message.value,
           project: project_id,
           cnt: null
         }

--- a/frontend/components/software/edit/information/AutosaveSoftwareKeywords.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareKeywords.tsx
@@ -36,7 +36,7 @@ export default function AutosaveSoftwareKeywords({software_id, items, concept_do
 
   async function onAdd(selected: Keyword) {
     // check if already added
-    const find = keywords.filter(item => item.keyword === selected.keyword)
+    const find = keywords.filter(item => item.keyword.trim().toLowerCase() === selected.keyword.trim().toLowerCase())
     let resp
     if (find.length === 0) {
       resp = await addKeywordsToSoftware({
@@ -56,13 +56,13 @@ export default function AutosaveSoftwareKeywords({software_id, items, concept_do
         showErrorMessage(`Failed to save keyword. ${resp.message}`)
       }
     }else{
-      showInfoMessage(`${selected.keyword} is already in the list`)
+      showInfoMessage(`${selected.keyword.trim()} is already in the list`)
     }
   }
 
   async function onCreate(selected: string) {
     // check if already exists
-    const find = keywords.filter(item => item.keyword === selected)
+    const find = keywords.filter(item => item.keyword.trim().toLowerCase() === selected.trim().toLowerCase())
     if (find.length === 0) {
       // create keyword
       let resp = await createKeyword({
@@ -82,7 +82,7 @@ export default function AutosaveSoftwareKeywords({software_id, items, concept_do
         showErrorMessage(`Failed to save keyword. ${resp.message}`)
       }
     }else{
-      showInfoMessage(`${selected} is already in the list`)
+      showInfoMessage(`${selected.trim()} is already in the list`)
     }
   }
 
@@ -123,6 +123,9 @@ export default function AutosaveSoftwareKeywords({software_id, items, concept_do
               title={item.keyword}
               label={item.keyword}
               onDelete={() => onRemove(pos)}
+              sx={{
+                textTransform:'capitalize'
+              }}
             />
           </div>
         )

--- a/frontend/components/software/edit/information/AutosaveSoftwareKeywords.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareKeywords.tsx
@@ -74,8 +74,8 @@ export default function AutosaveSoftwareKeywords({software_id, items, concept_do
       })
       if (resp.status === 201) {
         const keyword = {
-          id: resp.message as string,
-          keyword: selected,
+          id: resp.message.id,
+          keyword: resp.message.value,
           software: software_id,
           cnt: null
         }

--- a/frontend/components/software/edit/information/ImportKeywordsFromDoi.tsx
+++ b/frontend/components/software/edit/information/ImportKeywordsFromDoi.tsx
@@ -88,13 +88,13 @@ export default function ImportKeywordsFromDoi({software_id, concept_doi, keyword
         continue
       }
       // is it already added to this software?
-      const find = keywords.filter(item => item.keyword === kw)
+      const find = keywords.filter(item => item.keyword.trim().toLowerCase() === kw.trim().toLowerCase())
       if (find.length > 0) {
         // skip to next item in the loop
         continue
       }
       // is it already in RSD?
-      const findDb = await searchForSoftwareKeywordExact({searchFor: kw})
+      const findDb = await searchForSoftwareKeywordExact({searchFor: kw.trim()})
       if (findDb.length === 1) {
         const {status, keyword} = await addKeyword(findDb[0])
         if (status === 200) {

--- a/frontend/utils/editKeywords.ts
+++ b/frontend/utils/editKeywords.ts
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // import {SoftwareKeyword} from '~/components/software/edit/information/softwareKeywordsChanges'
+import {Keyword} from '~/components/keyword/FindKeyword'
 import {createJsonHeaders, extractReturnMessage} from './fetchHelpers'
 import logger from './logger'
 
@@ -42,6 +43,57 @@ export async function createKeyword({keyword, token}: { keyword: string, token: 
     return extractReturnMessage(resp, keyword ?? '')
   } catch (e: any) {
     logger(`createKeyword: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}
+
+export async function createOrGetKeyword({keyword, token}: {keyword: string, token: string }) {
+  try {
+    // try to find keyword
+    const url = '/api/v1/keyword'
+    const find = `${url}?value=eq.${keyword}`
+    const resp = await fetch(find, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token)
+      }
+    })
+    if (resp.status === 200) {
+      const json:Keyword[] = await resp.json()
+      if (json.length > 0) {
+        return {
+          status: 201,
+          message: json[0].id
+        }
+      }
+    }
+    // if not found create new
+    return createKeyword({keyword,token})
+  } catch (e:any) {
+    logger(`createOrGetKeyword: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}
+
+export async function silentKeywordDelete({keyword, token}: { keyword: string, token: string }) {
+  try {
+    // try to find keyword
+    const url = `/api/v1/keyword?value=eq.${keyword}`
+    const resp = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        ...createJsonHeaders(token)
+      }
+    })
+    return extractReturnMessage(resp, keyword)
+  } catch (e: any) {
+    logger(`silentKeywordDelete: ${e?.message}`, 'warn')
     return {
       status: 500,
       message: e?.message

--- a/frontend/utils/editKeywords.ts
+++ b/frontend/utils/editKeywords.ts
@@ -15,6 +15,11 @@ export type ProjectKeyword = {
   keyword: string
 }
 
+type KeywordItem = {
+  id: string,
+  value: string
+}
+
 export async function createKeyword({keyword, token}: { keyword: string, token: string }) {
   try {
     // POST
@@ -23,20 +28,17 @@ export async function createKeyword({keyword, token}: { keyword: string, token: 
       method: 'POST',
       headers: {
         ...createJsonHeaders(token),
-        // return id in header
-        'Prefer': 'return=headers-only'
+        'Prefer': 'return=representation',
       },
       body: JSON.stringify({
         value: keyword.trim()
       })
     })
     if (resp.status === 201) {
-      // we need to return id of created record
-      // it can be extracted from header.location
-      const id = resp.headers.get('location')?.split('.')[1]
+      const json:KeywordItem[] = await resp.json()
       return {
         status: 201,
-        message: id
+        message: json[0]
       }
     }
     // debugger
@@ -62,11 +64,11 @@ export async function createOrGetKeyword({keyword, token}: {keyword: string, tok
       }
     })
     if (resp.status === 200) {
-      const json:Keyword[] = await resp.json()
+      const json: KeywordItem[] = await resp.json()
       if (json.length > 0) {
         return {
           status: 201,
-          message: json[0].id
+          message: json[0]
         }
       }
     }

--- a/frontend/utils/editKeywords.ts
+++ b/frontend/utils/editKeywords.ts
@@ -26,7 +26,7 @@ export async function createKeyword({keyword, token}: { keyword: string, token: 
         'Prefer': 'return=headers-only'
       },
       body: JSON.stringify({
-        value: keyword.trim().toLocaleLowerCase()
+        value: keyword.trim()
       })
     })
     if (resp.status === 201) {

--- a/frontend/utils/editKeywords.ts
+++ b/frontend/utils/editKeywords.ts
@@ -26,7 +26,7 @@ export async function createKeyword({keyword, token}: { keyword: string, token: 
         'Prefer': 'return=headers-only'
       },
       body: JSON.stringify({
-        value: keyword
+        value: keyword.trim().toLocaleLowerCase()
       })
     })
     if (resp.status === 201) {

--- a/frontend/utils/editKeywords.ts
+++ b/frontend/utils/editKeywords.ts
@@ -56,7 +56,7 @@ export async function createOrGetKeyword({keyword, token}: {keyword: string, tok
   try {
     // try to find keyword
     const url = '/api/v1/keyword'
-    const find = `${url}?value=eq.${keyword}`
+    const find = `${url}?value=eq.${keyword.trim()}`
     const resp = await fetch(find, {
       method: 'GET',
       headers: {


### PR DESCRIPTION
# Additional validations on the keyword entries and deduplication

Closes #596 
Closes #597

Changes proposed in this pull request:
* We do not allow leading & trailing spaces or multiple spaces between the words. The database will reject these entries
* On input side we improved search (without leading/trailing spaces) and deduplication of imported keywords
* The keywords are trimmed before send to api
* On the presentation side we use capitalized value in the "chips", this does not impact accronims, for example GPU is still shown in capitals

How to test:
* `make start` to reset and rebuild
* login as rsd_admin or create new software or project
* navigate to software and try to add Python and python with some spaces before or after the keyword. All the results should produce one python entry which in "chip" will be shown with capital P.

## Example of capitalized keyword presentation on edit page
![image](https://user-images.githubusercontent.com/9204081/197245833-e065085d-af68-4e47-a46d-be78a24a11ab.png)

## Example of capitalized keyword on software page
![image](https://user-images.githubusercontent.com/9204081/197486354-bfa9baf1-b18c-49fd-81b5-5895542c524d.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
