### PR TITLE
588 java updates

### DIFF
--- a/authentication/Dockerfile
+++ b/authentication/Dockerfile
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.8.5-openjdk-18 AS builder
+FROM maven:3.8.6-openjdk-18 AS builder
 WORKDIR /usr/mymaven
 RUN mkdir src
 COPY pom.xml .

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -70,28 +70,28 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>io.javalin</groupId>
 			<artifactId>javalin</artifactId>
-			<version>4.4.0</version>
+			<version>5.1.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>1.7.36</version>
+			<version>2.0.3</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
-			<version>3.19.1</version>
+			<version>4.2.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.9.0</version>
+			<version>2.9.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk -->

--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -126,7 +126,6 @@ function generateRepositoryUrls(ids) {
 	];
 
 	const gitlabUrls = [
-		'https://gitlab.com/inkscape/inkscape',
 		'https://gitlab.com/dwt1/dotfiles',
 		'https://gitlab.com/famedly/fluffychat',
 		'https://gitlab.com/gitlab-org/gitlab-shell',

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
   auth:
     build: ./authentication
-    image: rsd/auth:1.1.0
+    image: rsd/auth:1.2.0
     expose:
       - 7000
     environment:
@@ -130,7 +130,7 @@ services:
 
   scrapers:
     build: ./scrapers
-    image: rsd/scrapers:1.1.0
+    image: rsd/scrapers:1.2.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL
@@ -171,7 +171,7 @@ services:
   #----------------------------------------------
   data-generation:
     build: ./data-generation
-    image: rsd/generation:1.0.1
+    image: rsd/generation:1.0.2
     environment:
       # it needs to be here to use values from .env file
       - PGRST_JWT_SECRET

--- a/scrapers/Dockerfile
+++ b/scrapers/Dockerfile
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.8.5-openjdk-18 AS builder
+FROM maven:3.8.6-openjdk-18 AS builder
 WORKDIR /usr/mymaven
 RUN mkdir ./src
 COPY pom.xml .

--- a/scrapers/pom.xml
+++ b/scrapers/pom.xml
@@ -81,14 +81,14 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
-			<version>3.19.0</version>
+			<version>4.2.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.9.0</version>
+			<version>2.9.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
@@ -80,15 +80,17 @@ public class CrossrefMention implements Mention {
 
 		Collection<String> authors = new ArrayList<>();
 		Iterable<JsonObject> authorsJson = (Iterable) workJson.getAsJsonArray("author");
-		for (JsonObject authorJson : authorsJson) {
-			String givenName = Utils.stringOrNull(authorJson.get("given"));
-			String familyName = Utils.stringOrNull(authorJson.get("family"));
-			if (givenName == null && familyName == null) continue;
-			if (givenName == null) authors.add(familyName);
-			else if (familyName == null) authors.add(givenName);
-			else authors.add(givenName + " " + familyName);
+		if (authorsJson != null) {
+			for (JsonObject authorJson : authorsJson) {
+				String givenName = Utils.stringOrNull(authorJson.get("given"));
+				String familyName = Utils.stringOrNull(authorJson.get("family"));
+				if (givenName == null && familyName == null) continue;
+				if (givenName == null) authors.add(familyName);
+				else if (familyName == null) authors.add(givenName);
+				else authors.add(givenName + " " + familyName);
+			}
+			result.authors = String.join(", ", authors);
 		}
-		result.authors = String.join(", ", authors);
 
 		result.publisher = Utils.stringOrNull(workJson.get("publisher"));
 		try {


### PR DESCRIPTION
# Upgrade Java dependencies

Changes proposed in this pull request:

* Upgrade the libraries that we use on the backend to new major versions (Javalin 5 and Java JWT 4)
* Some small upgrades as well
* Remove Inkscape as an example repo for GitLab in the data-generation script, because it takes too long to scrape its commits

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=1`
* Login with every provider, this should work
* Wait until the Java scrapers have run (programming languages, licenses, commits and mentions), this should work

Is related to #588

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests