### PR TITLE
Swagger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,6 @@
 # automatically name the containers.
 COMPOSE_PROJECT_NAME="rsd"
 
-
 # ---- PUBLIC ENV VARIABLES -------------
 
 # postgresql
@@ -37,10 +36,14 @@ PGRST_DB_ANON_ROLE=web_anon
 PGRST_DB_SCHEMA=public
 PGRST_SERVER_PORT=3500
 
-# postgREST api
+# postgREST API
 # consumed by services: authentication,frontend,auth-tests, scrapers
 # .env.local: http://localhost/api/v1, .env: http://backend:3500
 POSTGREST_URL=http://backend:3500
+
+# postgREST API reachable outside of Docker
+# consumed by services: swagger
+POSTGREST_URL_EXTERNAL=http://localhost/api/v1
 
 # RSD Auth module
 # consumed by services: frontend (api/fe)

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -148,7 +148,8 @@ services:
     expose:
       - "8080"
     environment:
-      API_URL: ${POSTGREST_URL_EXTERNAL}
+      - API_URL=${POSTGREST_URL_EXTERNAL}
+      - SUPPORTED_SUBMIT_METHODS=[]
     networks:
       - net
     restart: unless-stopped

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -143,6 +143,16 @@ services:
       - net
     restart: unless-stopped
 
+  swagger:
+    image: swaggerapi/swagger-ui:v4.15.0
+    expose:
+      - "8080"
+    environment:
+      API_URL: ${POSTGREST_URL_EXTERNAL}
+    networks:
+      - net
+    restart: unless-stopped
+
   nginx:
     container_name: nginx
     image: ghcr.io/research-software-directory/rsd-saas/nginx:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -153,7 +153,8 @@ services:
     expose:
       - "8080"
     environment:
-      API_URL: ${POSTGREST_URL_EXTERNAL}
+      - API_URL=${POSTGREST_URL_EXTERNAL}
+      - SUPPORTED_SUBMIT_METHODS=[]
     networks:
       - net
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,6 +148,15 @@ services:
     networks:
       - net
 
+  swagger:
+    image: swaggerapi/swagger-ui:v4.15.0
+    expose:
+      - "8080"
+    environment:
+      API_URL: ${POSTGREST_URL_EXTERNAL}
+    networks:
+      - net
+
   nginx:
     build:
       context: ./nginx
@@ -160,6 +169,7 @@ services:
       - backend
       - auth
       - frontend
+      - swagger
     networks:
       - net
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
   nginx:
     build:
       context: ./nginx
-    image: rsd/nginx:1.1.1
+    image: rsd/nginx:1.1.2
     ports:
       - "80:80"
       - "443:443"

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -84,4 +84,8 @@ server {
 		proxy_set_header Accept text/xml;
 		proxy_pass http://backend/oaipmh?select=data;
 	}
+
+	location /swagger/ {
+		proxy_pass http://swagger:8080/;
+	}
 }


### PR DESCRIPTION
# Add Swagger UI

Changes proposed in this pull request:

* Add Swagger UI
* Add an env variable that contains the public (i.e. outside of docker) URL of the PostgREST API

How to test:
* Copy the `POSTGREST_URL_EXTERNAL` env variable from `.env.example` to `.env`
* `docker-compose up`
* Visit http://localhost/swagger/

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests