### PR TITLE
feat: additional info about published status for software and projects

### DIFF
--- a/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
@@ -18,7 +18,7 @@ import {getImageUrl} from '~/utils/getProjects'
 import logger from '~/utils/logger'
 import {addImage, deleteImage, updateImage} from '~/utils/editProject'
 import AutosaveProjectTextField from './AutosaveProjectTextField'
-import AutosaveControlledSwitch from './AutosaveControlledSwitch'
+import AutosaveProjectSwitch from './AutosaveProjectSwitch'
 import {projectInformation as config} from './config'
 import {patchProjectTable} from './patchProjectInfo'
 
@@ -179,7 +179,7 @@ export default function AutosaveProjectImage() {
       </div>
 
       <div className="flex pb-3">
-        <AutosaveControlledSwitch
+        <AutosaveProjectSwitch
           project_id={form_id}
           name='image_contain'
           label={config.image_contain.label}

--- a/frontend/components/projects/edit/information/AutosaveProjectSwitch.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectSwitch.tsx
@@ -4,19 +4,20 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useFormContext} from 'react-hook-form'
+
 import {useSession} from '~/auth'
 import ControlledSwitch from '~/components/form/ControlledSwitch'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {patchProjectTable} from './patchProjectInfo'
 
-export type AutosaveControlledSwitchProps = {
+export type AutosaveProjectSwitchProps = {
   project_id: string
   name: string,
   label: string,
   defaultValue: boolean
 }
 
-export default function AutosaveControlledSwitch({project_id,name,label,defaultValue}:AutosaveControlledSwitchProps) {
+export default function AutosaveProjectSwitch({project_id,name,label,defaultValue}:AutosaveProjectSwitchProps) {
   const {token} = useSession()
   const {showErrorMessage} = useSnackbar()
   const {control,resetField} = useFormContext()
@@ -30,7 +31,7 @@ export default function AutosaveControlledSwitch({project_id,name,label,defaultV
       token
     })
 
-    // console.group('AutosaveControlledSwitch')
+    // console.group('AutosaveProjectSwitch')
     // console.log('saved...', name)
     // console.log('value...', value)
     // console.log('status...', resp?.status)

--- a/frontend/components/projects/edit/information/PublishingProjectInfo.tsx
+++ b/frontend/components/projects/edit/information/PublishingProjectInfo.tsx
@@ -1,0 +1,20 @@
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
+import Link from 'next/link'
+
+export default function PublishingProjectInfo() {
+  return (
+    <Alert
+        severity="info"
+        sx={{
+          marginTop:'1rem'
+        }}
+      >
+        <AlertTitle>Publishing project page</AlertTitle>
+        Setting the page status to published will expose the project page to public.
+        Not published project can be found under <strong>
+          <Link href="/user/projects"><a>your profile</a></Link>
+        </strong> page.
+      </Alert>
+  )
+}

--- a/frontend/components/projects/edit/information/config.ts
+++ b/frontend/components/projects/edit/information/config.ts
@@ -47,6 +47,10 @@ export const projectInformation = {
       maxLength: {value: 10000},
     }
   },
+  pageStatus: {
+    title: 'Status',
+    subtitle: 'Published project is visible to others.'
+  },
   is_published: {
     label: 'Published',
   },
@@ -74,7 +78,7 @@ export const projectInformation = {
   },
   research_domain: {
     title: 'Research domains',
-    subtitle: 'ERC classification',
+    subtitle: 'ERC classification.',
     infoLink: 'https://erc.europa.eu/news/new-erc-panel-structure-2021-and-2022',
     label: 'Select main research domain and field'
   },
@@ -90,7 +94,7 @@ export const projectInformation = {
   },
   url_for_project: {
     sectionTitle: 'Project links',
-    sectionSubtitle: 'Useful external links',
+    sectionSubtitle: 'Useful external links.',
     title: {
       label: 'Link text',
       placeholder: 'Title',

--- a/frontend/components/projects/edit/information/index.tsx
+++ b/frontend/components/projects/edit/information/index.tsx
@@ -16,8 +16,7 @@ import useProjectToEdit from './useProjectToEdit'
 import {projectInformation as config} from './config'
 import AutosaveProjectTextField from './AutosaveProjectTextField'
 import AutosaveProjectImage from './AutosaveProjectImage'
-import AutosaveProjectMarkdown from './AutosaveProjectMarkdown'
-import AutosaveControlledSwitch from './AutosaveControlledSwitch'
+import AutosaveProjectSwitch from './AutosaveProjectSwitch'
 import AutosaveProjectPeriod from './AutosaveProjectPeriod'
 import AutosaveFundingOrganisations from './AutosaveFundingOrganisations'
 import AutosaveProjectKeywords from './AutosaveProjectKeywords'
@@ -25,6 +24,7 @@ import AutosaveResearchDomains from './AutosaveResearchDomains'
 import AutosaveProjectLinks from './AutosaveProjectLinks'
 import AutosaveControlledMarkdown from '~/components/form/AutosaveControlledMarkdown'
 import {patchProjectTable} from './patchProjectInfo'
+import PublishingProjectInfo from './PublishingProjectInfo'
 
 export default function EditProjectInformation({slug}: {slug: string}) {
   const {token,user} = useSession()
@@ -152,15 +152,16 @@ export default function EditProjectInformation({slug}: {slug: string}) {
         {/* right panel */}
         <div className="py-4 min-w-[21rem] xl:my-0">
           <EditSectionTitle
-            title="Status"
+            title={config.pageStatus.title}
+            subtitle={config.pageStatus.subtitle}
           />
-          <div className="py-2"></div>
-          <AutosaveControlledSwitch
+          <AutosaveProjectSwitch
             project_id={formValues.id}
             name='is_published'
             label={config.is_published.label}
             defaultValue={formValues.is_published}
           />
+          <PublishingProjectInfo />
           <div className="py-4"></div>
           <AutosaveProjectPeriod
             date_start={project?.date_start ?? null}

--- a/frontend/components/software/add/AddSoftwareCard.tsx
+++ b/frontend/components/software/add/AddSoftwareCard.tsx
@@ -119,7 +119,6 @@ export default function AddSoftwareCard() {
         const message = `${slug} is already taken. Use letters, numbers and dash "-" to modify slug value.`
         setError('slug',{type:'validate',message})
       }
-      debugger
       lastValidatedSlug = slug
       setValidating(false)
     }

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -113,8 +113,8 @@ export const softwareInformation = {
     label:'Validate DOI'
   },
   pageStatus: {
-    title: 'Page status',
-    subtitle: 'Only published software is visible to others'
+    title: 'Status',
+    subtitle: 'Published software is visible to others.'
   },
   is_published: {
     label: 'Published',

--- a/frontend/components/software/edit/information/AutosaveSoftwarePageStatus.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwarePageStatus.tsx
@@ -2,6 +2,9 @@
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
+import Link from 'next/link'
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
 
 import EditSectionTitle from '../../../layout/EditSectionTitle'
 import AutosaveControlledSwitch from './AutosaveControlledSwitch'
@@ -31,6 +34,18 @@ export default function AutosaveSoftwarePageStatus() {
           defaultValue={is_published}
         />
       </div>
+      <Alert
+        severity="info"
+        sx={{
+          marginTop:'1rem'
+        }}
+      >
+        <AlertTitle>Publishing software page</AlertTitle>
+        Setting the page status to published will expose the software page to public.
+        Not published software can be found under <strong>
+          <Link href="/user/software"><a>your profile</a></Link>
+        </strong> page.
+      </Alert>
     </>
   )
 }


### PR DESCRIPTION
# Additional information about unpublished software/project and direct link 

Closes #455

Changes proposed in this pull request:
*  Adding info block under Page status explaining the meaning of Published switch and providing direct link to profile page for software/projects     

How to test:
* `make start` to rebuild everything
* login to RSD
* create new project or edit existing one
* Verify that text is clear and the link to profile page is working on both software and project page
* All text suggestions are welcome! Try to keep it compact and clear :-)

## Example edit software page info
![image](https://user-images.githubusercontent.com/9204081/197805551-c90a9754-de1f-4b1c-a7c6-305e81f7cb8c.png)

## Example edit project page info
![image](https://user-images.githubusercontent.com/9204081/197809162-92e5658a-ad50-4940-b1dc-e2d051341b80.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
