### PR TITLE
fix: image cache reload on organisation page but not on the software page

### DIFF
--- a/frontend/components/organisation/metadata/OrganisationLogo.tsx
+++ b/frontend/components/organisation/metadata/OrganisationLogo.tsx
@@ -12,7 +12,6 @@ import {useSession} from '~/auth'
 import useSnackbar from '../../snackbar/useSnackbar'
 import {deleteOrganisationLogo, getUrlFromLogoId, uploadOrganisationLogo} from '../../../utils/editOrganisation'
 import logger from '../../../utils/logger'
-import Link from 'next/link'
 import LogoAvatar from '~/components/layout/LogoAvatar'
 import IconButton from '@mui/material/IconButton'
 
@@ -30,7 +29,7 @@ type LogoProps = {
   mime_type: string | null
 }
 
-export default function OrganisationLogo({id,name,website,logo_id,isMaintainer}:
+export default function OrganisationLogo({id,name,logo_id,isMaintainer}:
   OrganisationLogoProps) {
   const {token} = useSession()
   const {showWarningMessage,showErrorMessage} = useSnackbar()
@@ -77,6 +76,10 @@ export default function OrganisationLogo({id,name,website,logo_id,isMaintainer}:
         b64,
         mime_type
       })
+      // fetch image to reload the cache
+      await fetch(`/image/rpc/get_logo?id=${id}`, {cache: 'reload'})
+      // @ts-ignore (hard) reload the page, true is for FF
+      location.reload(true)
     }
     if (upload.id && upload.b64 && upload.mime_type && token) {
       uploadLogo({

--- a/frontend/components/organisation/units/index.tsx
+++ b/frontend/components/organisation/units/index.tsx
@@ -107,6 +107,7 @@ export default function ResearchUnits({organisation}: OrganisationComponentsProp
       ...units.slice(pos+1),
       unit
     ].sort((a, b) => sortOnStrProp(a, b, 'name'))
+    // debugger
     setUnits({
       // cast type for now and improve later
       data: newList as OrganisationForOverview[],
@@ -130,7 +131,9 @@ export default function ResearchUnits({organisation}: OrganisationComponentsProp
               data,
               id: data.id
             })
-            updateUnitInList(updatedUnit,pos)
+            updateUnitInList(updatedUnit, pos)
+            // @ts-ignore (hard) reload the page, true is for FF
+            location.reload(true)
           } else {
             updateUnitInList(data,pos)
           }

--- a/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
@@ -46,7 +46,7 @@ export default function AutosaveProjectImage() {
         token
       })
       await fetch(`/image/rpc/get_project_image?id=${form_id}`, {cache: 'reload'})
-      // @ts-ignore
+      // @ts-ignore (hard) reload the page, true is for FF
       location.reload(true)
     } else {
       // add new image

--- a/frontend/components/projects/edit/team/editTeamMembers.ts
+++ b/frontend/components/projects/edit/team/editTeamMembers.ts
@@ -55,6 +55,8 @@ export async function updateTeamMember({data, token}:
     // if we uploaded new image we remove
     // data and construct avatar_url
     const returned = removeBase64Data(data)
+    // reload image to update cache
+    if (returned.avatar_url) await fetch(returned.avatar_url, {cache: 'reload'})
     return {
       status: 200,
       message: returned

--- a/frontend/utils/editContributors.ts
+++ b/frontend/utils/editContributors.ts
@@ -182,7 +182,8 @@ export async function updateContributorInDb({data, token}: { data: Contributor, 
     // if we uploaded new image we remove
     // data and construct avatar_url
     const returned = removeBase64Data(data)
-
+    // reload image to update cache
+    if (returned.avatar_url) await fetch(returned.avatar_url, {cache: 'reload'})
     return {
       status: 200,
       message: returned

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -269,6 +269,8 @@ export async function updateOrganisation({item, token}:
         mime_type: item.logo_mime_type,
         token
       })
+      // fetch image to reload the cache
+      await fetch(`/image/rpc/get_logo?id=${item.id}`, {cache: 'reload'})
       return resp
     }
     return extractReturnMessage(resp)
@@ -330,9 +332,6 @@ export async function uploadOrganisationLogo({id, data, mime_type, token}:
         mime_type
       })
     })
-    await fetch(`/image/rpc/get_logo?id=${id}`, {cache: 'reload'})
-    // @ts-ignore
-    location.reload(true)
     return extractReturnMessage(resp)
   } catch (e: any) {
     return {


### PR DESCRIPTION
# Page reload to replace cached image

Changes proposed in this pull request:
*  The page reload is needed with current setup to invalidate cached image when new image is uploaded
*  This is required on project and organisation page. However same (shared) method is used on software/project page organisation section, which resulted in page reload and   

How to test:
* `make start` to rebuild all
*  login to RSD, as rsd_admin
*  Edit software, add new organisation and upload the logo. This should not result in page reload
*  Edit project, add image. This should result in page reload
*  Add organisation to project with an logo (upload logo). This should not result in page reload
*  Navigate to an organisation as rsd_admin. Change organisation logo. This should result in page reload.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
