### PR TITLE
369: show logo on mobile

### DIFF
--- a/frontend/components/AppFooter/index.tsx
+++ b/frontend/components/AppFooter/index.tsx
@@ -18,7 +18,7 @@ export default function AppFooter () {
 
   return (
     <footer className="flex flex-wrap text-primary-content border-t bg-secondary border-base-300">
-      <div className="grid grid-cols-1 gap-8 px-4 md:grid-cols-[_2fr,1fr] lg:container lg:mx-auto">
+      <div className="grid grid-cols-1 gap-8 px-4 md:grid-cols-[2fr,1fr] lg:container lg:mx-auto">
         <div className="pt-8 md:py-8">
           <p className="text-lg">
             The Research Software Directory aims to promote the impact,

--- a/frontend/components/AppHeader/index.tsx
+++ b/frontend/components/AppHeader/index.tsx
@@ -56,7 +56,7 @@ export default function AppHeader({editButton}: { editButton?: JSX.Element }) {
     >
       {/* keep these styles in sync with main in MainContent.tsx */}
       <div
-        className="flex-1 flex flex-col px-4 xl:flex-row max-w-screen-2xl mx-auto items-start xl:items-center">
+        className="flex-1 flex flex-col px-4 xl:flex-row items-start lg:container lg:mx-auto">
         <div className="w-full flex-1 flex items-center justify-between">
           <Link href="/" passHref>
             <a className="hover:text-inherit">

--- a/frontend/components/keyword/KeywordFilter.tsx
+++ b/frontend/components/keyword/KeywordFilter.tsx
@@ -150,6 +150,8 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
           width: ['100vw', '24rem'],
           height: ['100vh', 'auto']
         }}
+        // disable adding styles to body (overflow:hidden & padding-right)
+        disableScrollLock={true}
       >
         <h3 className="px-4 py-3 text-primary">
           Filter by keyword

--- a/frontend/components/layout/MainContent.tsx
+++ b/frontend/components/layout/MainContent.tsx
@@ -9,7 +9,8 @@ type MaintContainerProps = {
   children:any
 }
 
-export default function MainContent({className,children,...props}:MaintContainerProps) {
+export default function MainContent({className, children, ...props}: MaintContainerProps) {
+  // keep these styles in sync with AppHeader and AppFooter
   return (
     <main
       className={`flex-1 flex flex-col px-4 lg:container lg:mx-auto ${className ?? ''}`}

--- a/frontend/components/organisation/OrganisationCard.tsx
+++ b/frontend/components/organisation/OrganisationCard.tsx
@@ -61,8 +61,8 @@ export default function OrganisationCard(organisation: OrganisationForOverview) 
               />
             }
           </div>
-          <div className="flex-1 flex md:grid md:grid-cols-[3fr,2fr] px-8 pb-4 overflow-hidden">
-            <div className="hidden md:block">
+          <div className="flex-1 grid grid-cols-2 md:grid-cols-[1fr,2fr] px-8 mb-4 overflow-hidden">
+            <div className="min-w-[8rem]">
               <LogoAvatar
                 name={organisation.name ?? ''}
                 src={getUrlFromLogoId(organisation.logo_id) ?? undefined}

--- a/frontend/components/projects/ProjectCard.tsx
+++ b/frontend/components/projects/ProjectCard.tsx
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Link from 'next/link'
-import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 
 import {getTimeAgoSince} from '../../utils/dateFn'
 import ImageAsBackground from '../layout/ImageAsBackground'
@@ -58,10 +57,10 @@ export default function ProjectCard(
   return (
     <Link href={projectUrl()} passHref>
       <a className={`flex flex-col h-full bg-base-200 text-content ${opacity} hover:bg-secondary hover:text-white`}>
-        <article className="flex flex-1 h-full px-4 overflow-hidden">
+        <article className="flex flex-1 h-full px-4 gap-4 overflow-hidden">
           <section
             title={subtitle ?? title}
-            className="py-4 h-full md:w-[13rem]"
+            className="flex-[2] py-4 h-full"
             >
             <ImageAsBackground
               alt={title}
@@ -72,14 +71,14 @@ export default function ProjectCard(
               noImgMsg='no image'
             />
           </section>
-          <section className="flex flex-col flex-1 py-4 md:pl-6">
+          <section className="flex-[3] flex flex-col py-4">
             <h2
               title={title}
               className={`max-h-[6rem] overflow-clip ${titleMargin}`}>
               {renderIcon()} {title}
             </h2>
 
-            <p className="flex-1 py-4 overflow-auto">
+            <p className="flex-1 my-4 overflow-auto">
               {subtitle}
             </p>
             <div className="flex justify-between text-sm">

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -15,6 +15,12 @@
 
 body{
   font-size: 1rem;
+  /*
+    minimal with to have logo,
+    add and edit buttons,
+    mobile menu and profile
+    min-width: 26.125rem;
+  */
 }
 
 #__next {
@@ -47,11 +53,11 @@ RangeError: Maximum call stack size exceeded
     @apply text-xl;
   }
   a {
-    @apply cursor-pointer no-underline transition duration-100 hover:text-primary;
+    @apply no-underline transition duration-100 cursor-pointer hover:text-primary;
   }
 
   body{
-    @apply text-base-content font-normal;
+    @apply font-normal text-base-content;
   }
 }
 


### PR DESCRIPTION
# Show logo on mobile

Closes #369

Changes proposed in this pull request:
* Logo/Avatar is shown on mobile in organisation card      

How to test:
* `make start` to rebuild all
*  navigate to organisation overview page
*  switch to mobile view (chrome: F12, on the right select diferent views - see printscreen)
* confirm that image/logo is visible

## Example mobile
![image](https://user-images.githubusercontent.com/9204081/198114580-da5ca142-1082-4753-b804-170fa240415a.png)

## Example tablet (portait)
![image](https://user-images.githubusercontent.com/9204081/198114751-fb904de4-523e-43f7-9a96-823ff523876e.png)

## Example tablet (landscape)
![image](https://user-images.githubusercontent.com/9204081/198114990-058005bd-49d9-4359-bac7-2fc4613bfd44.png)

## Example laptop
![image](https://user-images.githubusercontent.com/9204081/198115350-d11f1202-ac89-46ca-ad87-a2a112e44aea.png)

## Example HD+
![image](https://user-images.githubusercontent.com/9204081/198116282-10db3ea3-4d4e-4a79-acb3-820bb3c3447d.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
