### PR TITLE
609: Mention improvements

### DIFF
--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -37,6 +37,7 @@ function generateMentions(amountExtra = 10) {
 		'thesis',
 		'videoRecording',
 		'webpage',
+		'workshop',
 		'other',
 	];
 
@@ -55,6 +56,7 @@ function generateMentions(amountExtra = 10) {
 			image_url: null,
 			mention_type: faker.helpers.arrayElement(mentionTypes),
 			source: 'faker',
+			note: faker.helpers.maybe(() => faker.company.catchPhrase(), 0.3) ?? null
 		});
 	}
 
@@ -70,6 +72,7 @@ function generateMentions(amountExtra = 10) {
 			image_url: null,
 			mention_type: faker.helpers.arrayElement(mentionTypes),
 			source: 'faker',
+			note: faker.helpers.maybe(() => faker.company.catchPhrase(), 0.3) ?? null
 		});
 	}
 

--- a/database/008-create-mention-table.sql
+++ b/database/008-create-mention-table.sql
@@ -22,6 +22,7 @@ CREATE TYPE mention_type AS ENUM (
 	'thesis',
 	'videoRecording',
 	'webpage',
+	'workshop',
 	'other'
 );
 

--- a/database/008-create-mention-table.sql
+++ b/database/008-create-mention-table.sql
@@ -38,6 +38,7 @@ CREATE TABLE mention (
 	image_url VARCHAR(500) CHECK (image_url ~ '^https?://'),
 	mention_type mention_type NOT NULL,
 	source VARCHAR(50) NOT NULL,
+	note VARCHAR(500),
 	scraped_at TIMESTAMPTZ,
 	created_at TIMESTAMPTZ NOT NULL,
 	updated_at TIMESTAMPTZ NOT NULL

--- a/frontend/components/mention/EditMentionModal.tsx
+++ b/frontend/components/mention/EditMentionModal.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -212,6 +214,18 @@ export default function EditMentionModal({open, onCancel, onSubmit, item, pos, t
               helperTextCnt: `${formData?.url?.length || 0}/${config.url.validation.maxLength.value}`,
             }}
             rules={config.url.validation}
+          />
+          <ControlledTextField
+            control={control}
+            options={{
+              name: 'note',
+              label: config.note.label,
+              useNull: true,
+              defaultValue: formData?.note,
+              helperTextMessage: config.note.help,
+              helperTextCnt: `${formData?.note?.length || 0}/${config.note.validation.maxLength.value}`,
+            }}
+            rules={config.note.validation}
           />
           <div className="py-2"></div>
           {formData.mention_type === 'highlight' ?

--- a/frontend/components/mention/EditMentionModal.tsx
+++ b/frontend/components/mention/EditMentionModal.tsx
@@ -215,6 +215,25 @@ export default function EditMentionModal({open, onCancel, onSubmit, item, pos, t
             }}
             rules={config.url.validation}
           />
+          {formData.mention_type === 'highlight' ?
+            <>
+              <div className="py-2"></div>
+              <ControlledTextField
+                control={control}
+                options={{
+                  name: 'image_url',
+                  label: config.image_url.label,
+                  useNull: true,
+                  defaultValue: formData?.image_url,
+                  helperTextMessage: config.image_url.help,
+                  helperTextCnt: `${formData?.image_url?.length || 0}/${config.image_url.validation.maxLength.value}`
+                }}
+                rules={config.image_url.validation}
+              />
+            </>
+            :null
+          }
+          <div className="py-2"></div>
           <ControlledTextField
             control={control}
             options={{
@@ -227,22 +246,6 @@ export default function EditMentionModal({open, onCancel, onSubmit, item, pos, t
             }}
             rules={config.note.validation}
           />
-          <div className="py-2"></div>
-          {formData.mention_type === 'highlight' ?
-            <ControlledTextField
-              control={control}
-              options={{
-                name: 'image_url',
-                label: config.image_url.label,
-                useNull: true,
-                defaultValue: formData?.image_url,
-                helperTextMessage: config.image_url.help,
-                helperTextCnt: `${formData?.image_url?.length || 0}/${config.image_url.validation.maxLength.value}`
-              }}
-              rules={config.image_url.validation}
-            />
-            :null
-          }
           <Alert severity="warning" sx={{marginTop: '1.5rem'}}>
             {/* <AlertTitle sx={{fontWeight: 500}}>Validate entered information</AlertTitle> */}
             Please double check the data because this entry <strong>cannot be edited after it has been created</strong>.

--- a/frontend/components/mention/MentionItemBase.tsx
+++ b/frontend/components/mention/MentionItemBase.tsx
@@ -8,6 +8,7 @@ import {ReactNode} from 'react'
 import {MentionItemProps} from '~/types/Mention'
 import MentionAuthors from './MentionAuthors'
 import MentionDoi from './MentionDoi'
+import MentionNote from './MentionNote'
 import MentionPublisherItem from './MentionPublisherItem'
 
 export type MentionItemRole = 'list'|'find'|'view'
@@ -69,6 +70,7 @@ export default function MentionItemBase({item,pos,nav,type,role='find'}:MentionI
         className="text-sm"
         role={role}
       />
+      <MentionNote note={item.note} />
     </article>
   )
 }

--- a/frontend/components/mention/MentionNote.tsx
+++ b/frontend/components/mention/MentionNote.tsx
@@ -1,0 +1,7 @@
+
+export default function MentionNote({note}: { note: string | null }) {
+  if (note) {
+    return <div className="mt-2 text-sm opacity-60">{note}</div>
+  }
+  return null
+}

--- a/frontend/components/mention/MentionViewItem.tsx
+++ b/frontend/components/mention/MentionViewItem.tsx
@@ -11,6 +11,7 @@ import MentionAuthors from './MentionAuthors'
 import MentionPublisherItem from './MentionPublisherItem'
 import MentionDoi from './MentionDoi'
 import {MentionTitle} from './MentionItemBase'
+import MentionNote from './MentionNote'
 
 export default function MentionViewItem({item, pos}: {item: MentionItemProps, pos:number}) {
 
@@ -39,6 +40,7 @@ export default function MentionViewItem({item, pos}: {item: MentionItemProps, po
             doi={item?.doi}
             className="text-sm"
           />
+          <MentionNote note={item.note} />
         </div>
         <div className="flex justify-center items-center">
           {item?.url ? <LinkIcon /> : null}

--- a/frontend/components/mention/config.ts
+++ b/frontend/components/mention/config.ts
@@ -89,6 +89,17 @@ export const mentionModal = {
       }
     }
   },
+  note: {
+    label: 'Note',
+    help: 'Add a custom note',
+    validation: {
+      required: false,
+      maxLength: {
+        value: 500,
+        message: 'Maximum length is 500'
+      }
+    }
+  },
   image_url: {
     label: 'Image url*',
     help: 'Url to publication image is required for highlighted mention',

--- a/frontend/components/mention/config.ts
+++ b/frontend/components/mention/config.ts
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -190,7 +192,7 @@ export const mentionType = {
   interview: {
     key: 'interview',
     plural: 'Interviews',
-    singular: 'Interviews',
+    singular: 'Interview',
     manual: true
   },
   journalArticle: {
@@ -220,7 +222,7 @@ export const mentionType = {
   report: {
     key: 'report',
     plural: 'Reports',
-    singular: 'Reports',
+    singular: 'Report',
     manual: true
   },
   thesis: {
@@ -239,6 +241,12 @@ export const mentionType = {
     key: 'webpage',
     plural: 'Webpages',
     singular: 'Webpage',
+    manual: true
+  },
+  workshop: {
+    key: 'workshop',
+    plural: 'Workshops',
+    singular: 'Workshop',
     manual: true
   },
   other: {

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -59,14 +59,16 @@ export default class MyDocument extends Document<RsdDocumentInitialProps>{
           {
             /* Matomo Tracking Code
                NOTE! we use nonce to cover security audit
+               we use next Script tag to load script async (non-blocking)
             */
             this.matomoUrl !== undefined && this.matomoUrl.length !== 0 &&
             this.matomoId !== undefined && this.matomoId.length !== 0 &&
             <Script
               id="matomo-script"
-              strategy="afterInteractive"
+              strategy="lazyOnload"
               nonce={nonce}
-              dangerouslySetInnerHTML={{__html: `
+            >
+             {`
                 var _paq = window._paq = window._paq || [];
                 /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
                 _paq.push(['requireConsent']);
@@ -79,9 +81,9 @@ export default class MyDocument extends Document<RsdDocumentInitialProps>{
                   var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
                   g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
                 })();
-                `,
-              }}
-            />
+                console.log('matomo loaded with nonce...')
+              `}
+            </Script>
           }
         </Head>
         <body className="dark">

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -8,6 +8,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as React from 'react'
+import Script from 'next/script'
 import Document, {Html, Head, Main, NextScript, DocumentInitialProps} from 'next/document'
 import createEmotionServer from '@emotion/server/create-instance'
 import createEmotionCache from '../styles/createEmotionCache'
@@ -61,7 +62,9 @@ export default class MyDocument extends Document<RsdDocumentInitialProps>{
             */
             this.matomoUrl !== undefined && this.matomoUrl.length !== 0 &&
             this.matomoId !== undefined && this.matomoId.length !== 0 &&
-            <script
+            <Script
+              id="matomo-script"
+              strategy="afterInteractive"
               nonce={nonce}
               dangerouslySetInnerHTML={{__html: `
                 var _paq = window._paq = window._paq || [];

--- a/frontend/pages/_document.tsx
+++ b/frontend/pages/_document.tsx
@@ -81,7 +81,6 @@ export default class MyDocument extends Document<RsdDocumentInitialProps>{
                   var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
                   g.async=true; g.src=u+'piwik.js'; s.parentNode.insertBefore(g,s);
                 })();
-                console.log('matomo loaded with nonce...')
               `}
             </Script>
           }

--- a/frontend/types/Mention.ts
+++ b/frontend/types/Mention.ts
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -30,6 +32,7 @@ export type MentionItemProps = {
   // is_featured?: boolean
   mention_type: MentionTypeKeys | null
   source: string
+  note: string | null
 }
 
 export type MentionByType = {
@@ -47,4 +50,4 @@ export type MentionForProject = MentionItemProps & {
   impact_for_project?: any[]
 }
 
-export const mentionColumns ='id,doi,url,title,authors,publisher,publication_year,page,image_url,mention_type,source'
+export const mentionColumns ='id,doi,url,title,authors,publisher,publication_year,page,image_url,mention_type,source,note'

--- a/frontend/utils/editMentions.ts
+++ b/frontend/utils/editMentions.ts
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -303,7 +305,8 @@ export function newMentionItem(title?: string) {
     // url to external image
     image_url: null,
     mention_type: null,
-    source: 'manual'
+    source: 'manual',
+    note: null
   }
   return newItem
 }

--- a/frontend/utils/getCrossref.ts
+++ b/frontend/utils/getCrossref.ts
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -57,7 +59,8 @@ export function crossrefItemToMentionItem(item: CrossrefSelectItem) {
     page: item.page ?? null,
     image_url: null,
     mention_type: crossrefToRsdType(item.type),
-    source: 'Crossref'
+    source: 'Crossref',
+    note: null
   }
   // debugger
   return mention

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -282,6 +282,7 @@ function rsdTypeFromResourceType(resourceType: string) {
     case 'newspaper-article':
     case 'newspaper article':
       return 'newspaperArticle'
+    case 'audiovisual':
     case 'poster':
     case 'presentation':
       return 'presentation'

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -138,7 +140,8 @@ export function dataCiteGraphQLItemToMentionItem(item: WorkResponse) {
     page: null,
     image_url: null,
     mention_type: dataciteToRsdType(item),
-    source: 'DataCite'
+    source: 'DataCite',
+    note: null
   }
   return mention
 }

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -253,11 +253,15 @@ function rsdTypeFromResourceType(resourceType: string) {
       return 'book'
     case 'book part':
     case 'book chapter':
+    case 'bookchapter':
     case 'book section':
       return 'bookSection'
     case 'conference paper':
+    case 'conferencepaper':
     case 'proceedings series':
     case 'proceedings article':
+    case 'conference proceeding':
+    case 'conferenceproceeding':
       return 'conferencePaper'
     case 'dissertation':
     case 'thesis':
@@ -270,6 +274,7 @@ function rsdTypeFromResourceType(resourceType: string) {
     case 'journal volume':
     case 'journal issue':
     case 'journal article':
+    case 'journalarticle':
       return 'journalArticle'
     case 'magazine-article':
     case 'magazine article':
@@ -277,6 +282,7 @@ function rsdTypeFromResourceType(resourceType: string) {
     case 'newspaper-article':
     case 'newspaper article':
       return 'newspaperArticle'
+    case 'poster':
     case 'presentation':
       return 'presentation'
     case 'report series':
@@ -284,11 +290,15 @@ function rsdTypeFromResourceType(resourceType: string) {
       return 'report'
     case 'software':
     case 'computer program':
+    case 'computational notebook':
+    case 'computationalnotebook':
       return 'computerProgram'
     case 'video recording':
       return 'videoRecording'
     case 'webpage':
       return 'webpage'
+    case 'event':
+      return 'workshop'
     default:
       return 'other'
   }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -67,7 +67,7 @@ public class DataciteMentionRepository implements MentionRepository {
 		dataciteTypeMap.put("DataPaper", MentionType.other);
 		dataciteTypeMap.put("Dataset", MentionType.dataset);
 		dataciteTypeMap.put("Dissertation", MentionType.thesis);
-		dataciteTypeMap.put("Event", MentionType.other);
+		dataciteTypeMap.put("Event", MentionType.workshop);
 		dataciteTypeMap.put("Image", MentionType.other);
 		dataciteTypeMap.put("InteractiveResource", MentionType.other);
 		dataciteTypeMap.put("Journal", MentionType.other);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -70,7 +70,7 @@ public class DataciteMentionRepository implements MentionRepository {
 		dataciteTypeMap.put("Event", MentionType.workshop);
 		dataciteTypeMap.put("Image", MentionType.other);
 		dataciteTypeMap.put("InteractiveResource", MentionType.other);
-		dataciteTypeMap.put("Journal", MentionType.other);
+		dataciteTypeMap.put("Journal", MentionType.journalArticle);
 		dataciteTypeMap.put("JournalArticle", MentionType.journalArticle);
 		dataciteTypeMap.put("Model", MentionType.other);
 		dataciteTypeMap.put("OutputManagementPlan", MentionType.other);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -55,20 +55,33 @@ public class DataciteMentionRepository implements MentionRepository {
 	private static final Map<String, MentionType> dataciteTextTypeMap;
 
 	static {
-//		https://schema.datacite.org/meta/kernel-4.3/
+//		https://schema.datacite.org/meta/kernel-4.4/
 		dataciteTypeMap = new HashMap<>();
 		dataciteTypeMap.put("Audiovisual", MentionType.presentation);
+		dataciteTypeMap.put("Book", MentionType.book);
+		dataciteTypeMap.put("BookChapter", MentionType.bookSection);
 		dataciteTypeMap.put("Collection", MentionType.other);
+		dataciteTypeMap.put("ComputationalNotebook", MentionType.computerProgram);
+		dataciteTypeMap.put("ConferencePaper", MentionType.conferencePaper);
+		dataciteTypeMap.put("ConferenceProceeding", MentionType.conferencePaper);
 		dataciteTypeMap.put("DataPaper", MentionType.other);
 		dataciteTypeMap.put("Dataset", MentionType.dataset);
+		dataciteTypeMap.put("Dissertation", MentionType.thesis);
 		dataciteTypeMap.put("Event", MentionType.other);
 		dataciteTypeMap.put("Image", MentionType.other);
 		dataciteTypeMap.put("InteractiveResource", MentionType.other);
+		dataciteTypeMap.put("Journal", MentionType.other);
+		dataciteTypeMap.put("JournalArticle", MentionType.journalArticle);
 		dataciteTypeMap.put("Model", MentionType.other);
+		dataciteTypeMap.put("OutputManagementPlan", MentionType.other);
+		dataciteTypeMap.put("PeerReview", MentionType.other);
+		dataciteTypeMap.put("Preprint", MentionType.other);
 		dataciteTypeMap.put("PhysicalObject", MentionType.other);
+		dataciteTypeMap.put("Report", MentionType.report);
 		dataciteTypeMap.put("Service", MentionType.other);
 		dataciteTypeMap.put("Software", MentionType.computerProgram);
 		dataciteTypeMap.put("Sound", MentionType.other);
+		dataciteTypeMap.put("Standard", MentionType.other);
 //		dataciteTypeMap.put("Text", MentionType.other);
 		dataciteTypeMap.put("Workflow", MentionType.other);
 		dataciteTypeMap.put("Other", MentionType.other);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionType.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionType.java
@@ -22,5 +22,6 @@ public enum MentionType {
 	thesis,
 	videoRecording,
 	webpage,
+	workshop,
 	other
 }


### PR DESCRIPTION
# Improve mention type classification

Closes #609 
Closes #559 
Closes #514 
Closes #513 

Changes proposed in this pull request:
* The classification of data cite mention type is updated to new version 4.4 for the scrapers and in initial frontend import      
* Unrelated change: use next Script component to lazy load matomo script

How to test:
* `make start` to rebuild all
* login as rsd_admin 
* edit software, go to mentions and add these 2 DOI's: 
   * https://doi.org/10.4233/uuid:92565bdb-cf5a-4110-abf3-1b4298720466
   * https://doi.org/10.4233/uuid:6d18abba-a418-4870-ab19-c195364b654b
* both mentions should be placed under Thesis mention section. This classification remain after the scrapers made updates of these mentions.
* Create a manual mention with a note. The note should be visible both in the admin section and the public view.
* Create a manual mention with as type `workshop`. This category should then be visible both in the admin section and the public view.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
