### PR TITLE
612: fix cropped cookie banner on mobile

### DIFF
--- a/frontend/components/cookies/CookieConsentMatomo.tsx
+++ b/frontend/components/cookies/CookieConsentMatomo.tsx
@@ -52,8 +52,8 @@ export default function CookieConsentMatomo({matomo, route}: CookieConsentMatomo
       className="fixed bottom-0 right-0 animated animatedFadeInUp fadeInUp"
       data-testid="cookie-consent-matomo"
     >
-      <div className="container mx-auto px-20 ">
-          <div className="border border-b-base-content border-t-4 border-x-4 border-b-0 w-96 bg-white shadow-lg p-6 rounded-tr-3xl">
+      <div className="container mx-auto sm:px-20">
+          <div className="border border-b-base-content border-t-4 border-x-4 border-b-0 bg-white shadow-lg p-6 rounded-tr-3xl sm:w-96">
             <div className="w-16 mx-auto relative  mb-3">
               <CookieTwoToneIcon className="scale-[2]  mb-3" color="primary" fontSize="large"/>
             </div>


### PR DESCRIPTION
# Fix cropped cookie banner on mobile

Closes #612

Changes proposed in this pull request:
*     On mobile the cookie banner takes full width on the bottom of the screen

How to test:
* `make start` to rebuild all (docker-compose down where you done)
*  validate you have matomo env variables active:
```env
MATOMO_URL=https://matomo.research.software/
MATOMO_ID=1
```
* remove matomo cookies and settings from cookies and local storage (F12 -> Application tab)
  * local storage variable: rsd_cookies_consent
  * cookies
![image](https://user-images.githubusercontent.com/9204081/198556944-6e88728c-da5f-45da-86ac-d80d80a4cc92.png)

## Example mobile 
![image](https://user-images.githubusercontent.com/9204081/198557488-13c0e128-a25d-41e7-a718-d35673a184de.png)

## Example tablet (portrait)
![image](https://user-images.githubusercontent.com/9204081/198557653-f57b0705-aeb1-4189-b3d2-7810630f2c14.png)

## Example tablet (landscape)
![image](https://user-images.githubusercontent.com/9204081/198557760-6b4e857b-b60e-4883-a28b-bb1ac9479ea4.png)

## Example desktop
![image](https://user-images.githubusercontent.com/9204081/198557986-def9cc45-5e40-4d32-8b37-c0af6f385bbf.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
