### PR TITLE
619: additional explanation login options

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,7 +91,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:1.6.6
+    image: rsd/frontend:1.9.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL
@@ -203,7 +203,7 @@ services:
         - DUID
         - DGID
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend-dev:1.6.4
+    image: rsd/frontend-dev:1.9.1
     ports:
       - "3000:3000"
       - "9229:9229"

--- a/frontend/components/feedback/FeedbackPanelButton.tsx
+++ b/frontend/components/feedback/FeedbackPanelButton.tsx
@@ -11,7 +11,7 @@ import Divider from '@mui/material/Divider'
 import getBrowser from '~/utils/getBrowser'
 
 export default function FeedbackPanelButton(
-  {feedback_email, issues_page_url, closeFeedbackPanel}: { feedback_email: string, issues_page_url:string, closeFeedbackPanel?: () => void }
+  {feedback_email, issues_page_url, closeFeedbackPanel}: {feedback_email: string, issues_page_url:string, closeFeedbackPanel?: () => void }
 ) {
 
   const [text, setText] = useState('')

--- a/frontend/components/login/LoginButton.tsx
+++ b/frontend/components/login/LoginButton.tsx
@@ -10,17 +10,13 @@
 
 import {useState} from 'react'
 import Link from 'next/link'
-import Dialog from '@mui/material/Dialog'
-import DialogContent from '@mui/material/DialogContent'
-import DialogTitle from '@mui/material/DialogTitle'
-import useMediaQuery from '@mui/material/useMediaQuery'
 import {useTheme} from '@mui/material/styles'
 
 import {useAuth} from '~/auth'
 import useLoginProviders from '~/auth/api/useLoginProviders'
 import {getUserMenuItems} from '~/config/userMenuItems'
 import UserMenu from '~/components/layout/UserMenu'
-import CaretIcon from '~/components/icons/caret.svg'
+import LoginDialog from './LoginDialog'
 
 export default function LoginButton() {
   const providers = useLoginProviders()
@@ -28,9 +24,8 @@ export default function LoginButton() {
   const status = session?.status || 'loading'
   const [open, setOpen] = useState(false)
   const theme = useTheme()
-  const fullScreen = useMediaQuery(theme.breakpoints.down('md'))
 
-  /* Sign in dialog */
+  /* LoginDialog */
   const handleClickOpen = () => { setOpen(true) }
   const handleClose = () => { setOpen(false) }
 
@@ -57,37 +52,11 @@ export default function LoginButton() {
         <button onClick={handleClickOpen} tabIndex={0}>
           Sign in
         </button>
-        <Dialog
-          fullScreen={fullScreen}
+        <LoginDialog
+          providers={providers}
           open={open}
           onClose={handleClose}
-          aria-labelledby="responsive-dialog-title"
-        >
-          <DialogTitle id="responsive-dialog-title">
-            Sign in with
-          </DialogTitle>
-
-          <DialogContent>
-            <span className="italic text-gray-600">
-              Somewhere, something incredible is waiting to be known.
-            </span> <br/> Carl Sagan
-            <div className="flex flex-col gap-3 my-8">
-            {providers.map(provider => {
-              return (
-                <Link
-                  key={provider.redirectUrl}
-                  href={provider.redirectUrl}
-                  passHref
-                >
-                  <a className=" w-full hover:bg-black hover:text-primary-content transition font-bold py-2 px-4 rounded-full border outline-1">
-                    {provider.name}
-                  </a>
-                </Link>
-              )
-            })}
-            </div>
-          </DialogContent>
-        </Dialog>
+        />
       </div>
     )
   }

--- a/frontend/components/login/LoginDialog.tsx
+++ b/frontend/components/login/LoginDialog.tsx
@@ -1,0 +1,99 @@
+import Link from 'next/link'
+
+import Dialog from '@mui/material/Dialog'
+import DialogContent from '@mui/material/DialogContent'
+import DialogTitle from '@mui/material/DialogTitle'
+import useMediaQuery from '@mui/material/useMediaQuery'
+import {useTheme} from '@mui/material/styles'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import ListItemText from '@mui/material/ListItemText'
+import CloseIcon from '@mui/icons-material/Close'
+import IconButton from '@mui/material/IconButton'
+
+import {Provider} from 'pages/api/fe/auth'
+
+type LoginDialogProps = {
+  providers: Provider[]
+  open:boolean,
+  onClose:()=>void
+}
+
+export default function LoginDialog({providers,open, onClose}: LoginDialogProps) {
+  const theme = useTheme()
+  const fullScreen = useMediaQuery(theme.breakpoints.down('md'))
+
+  return (
+    <Dialog
+      fullScreen={fullScreen}
+      open={open}
+      onClose={onClose}
+    >
+      <DialogTitle
+        id="responsive-dialog-title"
+        aria-labelledby="responsive-dialog-title"
+        sx={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent:'space-between',
+          fontSize: '1.75rem'
+        }}
+      >
+        Sign in with
+        <IconButton onClick={onClose}>
+          <CloseIcon />
+        </IconButton>
+      </DialogTitle>
+      <DialogContent>
+        <>
+          <List>
+            {providers.map(provider => {
+              return (
+                <Link
+                  key={provider.redirectUrl}
+                  href={provider.redirectUrl}
+                  passHref
+                >
+                <a>
+                  <ListItem
+                    alignItems="flex-start"
+                    className="rounded-[0.25rem] border outline-1 my-2"
+                    sx={{
+                      opacity: 0.75,
+                      '&:hover': {
+                        opacity: 1,
+                        backgroundColor:'background.default'
+                      }
+                    }}
+                  >
+                    <ListItemText
+                      primary={provider.name}
+                      secondary={provider?.html ?
+                        <span
+                          dangerouslySetInnerHTML={{__html: provider.html}}
+                        />
+                        : null
+                      }
+                      sx={{
+                        '.MuiListItemText-primary': {
+                          color:'primary.main',
+                          fontSize: '1.5rem',
+                          fontWeight: 700,
+                          letterSpacing: '0.125rem'
+                        }
+                      }}
+                    />
+                  </ListItem>
+                </a>
+                </Link>
+              )
+            })}
+          </List>
+          <span className="italic text-gray-600">
+          <q>Somewhere, something incredible is waiting to be known.</q>
+          </span> - Carl Sagan
+        </>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/frontend/components/login/LoginDialog.tsx
+++ b/frontend/components/login/LoginDialog.tsx
@@ -12,6 +12,7 @@ import CloseIcon from '@mui/icons-material/Close'
 import IconButton from '@mui/material/IconButton'
 
 import {Provider} from 'pages/api/fe/auth'
+import useRsdSettings from '~/config/useRsdSettings'
 
 type LoginDialogProps = {
   providers: Provider[]
@@ -20,6 +21,7 @@ type LoginDialogProps = {
 }
 
 export default function LoginDialog({providers,open, onClose}: LoginDialogProps) {
+  const {host} = useRsdSettings()
   const theme = useTheme()
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'))
 
@@ -89,9 +91,11 @@ export default function LoginDialog({providers,open, onClose}: LoginDialogProps)
               )
             })}
           </List>
-          <span className="italic text-gray-600">
-          <q>Somewhere, something incredible is waiting to be known.</q>
-          </span> - Carl Sagan
+          {host.login_info_url &&
+            <p className="text-base-content-disabled text-sm">
+              You can find more information on signing in to the RSD in our <a href={host.login_info_url} target="_blank" rel="noreferrer"><strong>documentation</strong></a>.
+            </p>
+          }
         </>
       </DialogContent>
     </Dialog>

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -25,6 +25,7 @@ export type RsdHost = {
     url: string,
     issues_page_url: string
   },
+  login_info_url?:string
 }
 
 export type CustomLink = {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "1.6.4",
+  "version": "1.9.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/api/fe/auth/helmholtzaai.ts
+++ b/frontend/pages/api/fe/auth/helmholtzaai.ts
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
@@ -57,7 +58,10 @@ export async function helmholtzInfo() {
     // provide redirectUrl and name/label
     return {
       name: 'Helmholtz AAI',
-      redirectUrl
+      redirectUrl,
+      html: `
+        Sign in with Helmholtz AAI is enabled for all members of the <strong>Helmholtz Research Foundation</strong>.
+      `
     }
   }
   return null

--- a/frontend/pages/api/fe/auth/index.ts
+++ b/frontend/pages/api/fe/auth/index.ts
@@ -28,7 +28,8 @@ export type ApiError = {
 
 export type Provider = {
   name: string,
-  redirectUrl:string
+  redirectUrl: string,
+  html?: string
 }
 
 type Data = Provider[] | ApiError

--- a/frontend/pages/api/fe/auth/local.ts
+++ b/frontend/pages/api/fe/auth/local.ts
@@ -8,7 +8,7 @@ export function localInfo() {
     name: 'Local account',
     redirectUrl: '/login/local',
     html: `
-      <p>Signing in with local account is <strong>for testing purposes only</strong>.
+      <p>Sign in with local account is <strong>for testing purposes only</strong>.
       This option should not be enabled in the production version.</p>
     `
   }

--- a/frontend/pages/api/fe/auth/local.ts
+++ b/frontend/pages/api/fe/auth/local.ts
@@ -6,6 +6,10 @@
 export function localInfo() {
   return {
     name: 'Local account',
-    redirectUrl: '/login/local'
+    redirectUrl: '/login/local',
+    html: `
+      <p>Signing in with local account is <strong>for testing purposes only</strong>.
+      This option should not be enabled in the production version.</p>
+    `
   }
 }

--- a/frontend/pages/api/fe/auth/orcid.ts
+++ b/frontend/pages/api/fe/auth/orcid.ts
@@ -57,11 +57,11 @@ export async function orcidInfo() {
     const redirectUrl = getRedirectUrl(redirectProps)
     // provide redirectUrl and name/label
     return {
-      name: 'ORCID *',
+      name: 'ORCID',
       redirectUrl,
       html: `
-        Signing in with ORCID is supported <strong>only for persons invited by RSD administrators</strong>.
-        <strong><a href="maito=rsd@escience.nl">Contact us</a></strong> if you wish to login with your ORCID.
+        Sign in with ORCID is supported <strong>only for persons invited by the RSD administrators</strong>.
+        <strong><a href="mailto:rsd@esciencecenter.nl?subject=${encodeURIComponent('Login with ORCID')}" target="_blank">Contact us</a></strong> if you wish to login with your ORCID.
       `
     }
   }

--- a/frontend/pages/api/fe/auth/orcid.ts
+++ b/frontend/pages/api/fe/auth/orcid.ts
@@ -57,8 +57,12 @@ export async function orcidInfo() {
     const redirectUrl = getRedirectUrl(redirectProps)
     // provide redirectUrl and name/label
     return {
-      name: 'ORCID',
-      redirectUrl
+      name: 'ORCID *',
+      redirectUrl,
+      html: `
+        Signing in with ORCID is supported <strong>only for persons invited by RSD administrators</strong>.
+        <strong><a href="maito=rsd@escience.nl">Contact us</a></strong> if you wish to login with your ORCID.
+      `
     }
   }
   return null

--- a/frontend/pages/api/fe/auth/surfconext.ts
+++ b/frontend/pages/api/fe/auth/surfconext.ts
@@ -57,9 +57,9 @@ export async function surfconextInfo() {
     const redirectUrl = getRedirectUrl(redirectProps)
     // provide redirectUrl and name/label
     return {
-      name: 'SURFconext *',
+      name: 'SURFconext',
       redirectUrl,
-      html: `<p>Signing in with SURFconext is for <strong>Dutch Institutions who enabled
+      html: `<p>Sign in with SURFconext is for <strong>Dutch Institutions who enabled the 
       RSD service</strong> in the <a href="https://dashboard.surfconext.nl/apps/9514/oidc10_rp/about" target = "_new">
       SURFconext IdP dashboard</a>.
       </p>`

--- a/frontend/pages/api/fe/auth/surfconext.ts
+++ b/frontend/pages/api/fe/auth/surfconext.ts
@@ -57,8 +57,12 @@ export async function surfconextInfo() {
     const redirectUrl = getRedirectUrl(redirectProps)
     // provide redirectUrl and name/label
     return {
-      name: 'SURFconext',
-      redirectUrl
+      name: 'SURFconext *',
+      redirectUrl,
+      html: `<p>Signing in with SURFconext is for <strong>Dutch Institutions who enabled
+      RSD service</strong> in the <a href="https://dashboard.surfconext.nl/apps/9514/oidc10_rp/about" target = "_new">
+      SURFconext IdP dashboard</a>.
+      </p>`
     }
   }
   return null

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -8,7 +8,8 @@
       "enabled": true,
       "url": "rsd@esciencecenter.nl",
       "issues_page_url": "https://github.com/research-software-directory/RSD-as-a-service/issues"
-    }
+    },
+    "login_info_url":"https://research-software-directory.github.io/documentation/getting-started.html#signing-in"
   },
   "links": [
     {

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -16,7 +16,7 @@
 body{
   font-size: 1rem;
   /* minimal with to have logo, menu and profile */
-  min-width: 29rem;
+  /* min-width: 29rem; */
 }
 
 #__next {


### PR DESCRIPTION
# Additional info per login provider

Closes #619 

Changes proposed in this pull request:
*  Additional property is added to provider object in order to show additional information about the provider and who can make use of this provider. To accommodate additional text the layout of the button is changed. Additional info text is added into service provider api (not in env file). 
* The quote is moved at the bottom of the modal
* In SURFconext text link to IdP listing of RSD service is added
* In ORCID text mailto link is added to contact rsd team
* At the bottom of the login modal a link to sign in page of RSD documentation is added. The link is added into settings as `host.login_info_url`

How to test:
* Ensure you have proper env definitions for login providers (contact me for values of env file)
* Ensure you enabled the providers in .env file variable (it specifies the list order too)
`RSD_AUTH_PROVIDERS=SURFCONEXT;ORCID;HELMHOLTZAAI;LOCAL`
* `make start` to restart all (when you done use docker-compose down)
* click on login button and you should see a list where SURFconext and ORCID have additional info as in the example below
* Pay attention to SURFconext and ORCID info text and links. I am in doubt about the links because these are in the button. So main click on the button will forward you to provider while click on text link should open new page. 
* All improvement ideas are welcome! Pay attention to provided texts in particular.
* Note! If you are changing .env values you need to restart docker-compose to reload .env values (`docker-compose down && docker-compose up` - probably there are other ways to achieve same result ;-)

## Desktop/tablet layout
![image](https://user-images.githubusercontent.com/9204081/199229884-d5f4577c-20e2-493a-94ec-9b444b441ac7.png)

## Mobile layout
![image](https://user-images.githubusercontent.com/9204081/199231083-2dbcde3e-2cb1-46dc-99b4-5f2960d10449.png)

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
