### PR TITLE
496 keyword filter inital list

### DIFF
--- a/frontend/components/form/AsyncAutocompleteSC.tsx
+++ b/frontend/components/form/AsyncAutocompleteSC.tsx
@@ -144,7 +144,14 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
       // because search text is usually not identical to selected item
       // we ignore onInputChange event when reason==='reset'
       setInputValue(newInputValue)
-
+      // if user removes all input and onClear is provided
+      // we trigger on clear event. In addition, in freeSolo
+      // the icon is present that activates reason===clear
+      if (reason === 'input' && newInputValue === '' && onClear) {
+        // console.log('Call on clear event')
+        // issue clear attempt
+        onClear()
+      }
       // we start new search if processing
       // is not empty we should reset it??
       if (processing !== '') {

--- a/frontend/components/keyword/FindKeyword.test.tsx
+++ b/frontend/components/keyword/FindKeyword.test.tsx
@@ -31,6 +31,10 @@ const props = {
   onCreate:mockCreate
 }
 
+afterEach(() => {
+  jest.runOnlyPendingTimers()
+  // jest.useRealTimers()
+})
 
 // this test needs to be first to return mocked non-resolving promise
 it('calls seach Fn and renders the loader', async () => {

--- a/frontend/components/keyword/FindKeyword.test.tsx
+++ b/frontend/components/keyword/FindKeyword.test.tsx
@@ -54,9 +54,9 @@ it('calls seach Fn and renders the loader', async () => {
   })
 
   await waitFor(() => {
-    // validate that searchFn is called once
-    expect(mockSearch).toHaveBeenCalledTimes(1)
-    // is called with seachFor term
+    // validate that searchFn is called twice (first on load then on search)
+    expect(mockSearch).toHaveBeenCalledTimes(2)
+    // last called with seachFor term
     expect(mockSearch).toHaveBeenCalledWith({searchFor})
     // check if loader is present
     const loader = screen.getByTestId('circular-loader')
@@ -80,8 +80,10 @@ it('renders component with label, help and input with role comobox', () => {
 it('offer Add option when search has no results', async() => {
   // prepare
   jest.useFakeTimers()
-  // resolve with no options
-  mockSearch.mockResolvedValueOnce([])
+  // resolve with no options twice (on load and on search)
+  mockSearch
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([])
   // render component
   render(<FindKeyword {...props} />)
 
@@ -113,11 +115,15 @@ it('DOES NOT offer Add option when search return result that match', async () =>
   const searchFor = 'test'
   const searchCnt = 123
   // resolve with no options
-  mockSearch.mockResolvedValueOnce([{
-    id: '123123',
-    keyword: searchFor,
-    cnt: searchCnt
-  }])
+  mockSearch
+    // intial call on load
+    .mockResolvedValueOnce([])
+    // search call
+    .mockResolvedValueOnce([{
+      id: '123123',
+      keyword: searchFor,
+      cnt: searchCnt
+    }])
 
   // render component
   render(<FindKeyword {...props} />)
@@ -152,7 +158,10 @@ it('calls onCreate method with string value to add new option', async() => {
   // prepare
   jest.useFakeTimers()
   // resolve with no options
-  mockSearch.mockResolvedValueOnce([])
+  mockSearch
+    // intial call on load
+    .mockResolvedValueOnce([])
+    .mockResolvedValueOnce([])
   // render component
   render(<FindKeyword {...props} />)
 
@@ -192,7 +201,11 @@ it('calls onAdd method to add option to selection', async() => {
     cnt: searchCnt
   }
   // resolve with no options
-  mockSearch.mockResolvedValueOnce([mockOption])
+  mockSearch
+    // intial call on load
+    .mockResolvedValueOnce([])
+    // search call
+    .mockResolvedValueOnce([mockOption])
   // render component
   render(<FindKeyword {...props} />)
 

--- a/frontend/components/keyword/FindKeyword.tsx
+++ b/frontend/components/keyword/FindKeyword.tsx
@@ -5,7 +5,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {HTMLAttributes, useState} from 'react'
+import {HTMLAttributes, useEffect, useState} from 'react'
 
 import AsyncAutocompleteSC, {AsyncAutocompleteConfig, AutocompleteOption} from '~/components/form/AsyncAutocompleteSC'
 
@@ -31,6 +31,27 @@ export default function FindKeyword({config, onAdd, searchForKeyword, onCreate}:
     loading: false,
     foundFor: undefined
   })
+
+  useEffect(() => {
+    async function getInitalList() {
+      const resp = await searchForKeyword({
+        // we trim raw search value
+        searchFor: ''
+      })
+      // convert keywords to autocomplete options
+      const options = resp.map(item => ({
+        key: item.keyword,
+        label: item.keyword,
+        data: item
+      }))
+      // debugger
+      // set options
+      setOptions(options)
+    }
+    getInitalList()
+  // ignore linter for searchForKeyword fn
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[])
 
   async function searchKeyword(searchFor: string) {
     // console.log('searchKeyword...searchFor...', searchFor)

--- a/frontend/components/keyword/FindKeyword.tsx
+++ b/frontend/components/keyword/FindKeyword.tsx
@@ -23,12 +23,15 @@ type FindKeywordProps = {
 }
 
 export default function FindKeyword({config, onAdd, searchForKeyword, onCreate}: FindKeywordProps) {
+  const [initalList, setInitalList] = useState<AutocompleteOption<Keyword>[]>([])
   const [options, setOptions] = useState<AutocompleteOption<Keyword>[]>([])
   const [status, setStatus] = useState<{
     loading: boolean,
+    searchFor: string | undefined
     foundFor: string | undefined
   }>({
     loading: false,
+    searchFor: undefined,
     foundFor: undefined
   })
 
@@ -47,16 +50,17 @@ export default function FindKeyword({config, onAdd, searchForKeyword, onCreate}:
       // debugger
       // set options
       setOptions(options)
+      setInitalList(options)
     }
     getInitalList()
   // ignore linter for searchForKeyword fn
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  },[])
+  }, [])
 
   async function searchKeyword(searchFor: string) {
     // console.log('searchKeyword...searchFor...', searchFor)
     // set loading status and clear foundFor
-    setStatus({loading: true, foundFor: undefined})
+    setStatus({loading: true, searchFor, foundFor: undefined})
     // make search request
     const resp = await searchForKeyword({
       // we trim raw search value
@@ -75,6 +79,7 @@ export default function FindKeyword({config, onAdd, searchForKeyword, onCreate}:
     // stop loading
     setStatus({
       loading: false,
+      searchFor,
       foundFor: searchFor
     })
   }
@@ -82,6 +87,11 @@ export default function FindKeyword({config, onAdd, searchForKeyword, onCreate}:
   function onAddKeyword(selected:AutocompleteOption<Keyword>) {
     if (selected && selected.data) {
       onAdd(selected.data)
+      // if we use reset of selected input
+      // we also load inital list of keywords
+      if (config.reset === true) {
+        setOptions(initalList)
+      }
     }
   }
 
@@ -139,6 +149,7 @@ export default function FindKeyword({config, onAdd, searchForKeyword, onCreate}:
         onAdd={onAddKeyword}
         onCreate={createKeyword}
         onRenderOption={renderOption}
+        onClear={()=>setOptions(initalList)}
         config={{
           ...config,
           // freeSolo allows create option

--- a/frontend/components/keyword/KeywordFilter.tsx
+++ b/frontend/components/keyword/KeywordFilter.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useState, Fragment} from 'react'
+import {useState, Fragment, useEffect} from 'react'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import Badge from '@mui/material/Badge'
@@ -17,6 +17,7 @@ import PlayArrowIcon from '@mui/icons-material/PlayArrow'
 
 import FindKeyword, {Keyword} from '~/components/keyword/FindKeyword'
 import Alert from '@mui/material/Alert'
+import {height} from '@mui/system'
 
 type SeachApiProps = {
   searchFor: string
@@ -41,7 +42,9 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
   // console.log('selectedItems...', selectedItems)
   // console.log('open...', open)
   // console.groupEnd()
+  useEffect(() => {
 
+  },[])
 
   function handleOpen(event: React.MouseEvent<HTMLElement>){
     setAnchorEl(event.currentTarget)
@@ -92,8 +95,10 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
                   <span className="text-md">+</span>
                   <Chip
                     label={item}
-                    size="small"
                     onDelete={() => handleDelete(pos)}
+                    sx={{
+                      borderRadius:'0.25rem'
+                    }}
                   />
                 </Fragment>
               )
@@ -102,8 +107,10 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
               <Chip
                 key={pos}
                 label={item}
-                size="small"
                 onDelete={() => handleDelete(pos)}
+                sx={{
+                  borderRadius:'0.25rem'
+                }}
               />
             )
           })}
@@ -129,6 +136,8 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
         </IconButton>
       </Tooltip>
       <Popover
+        // anchorReference="anchorPosition"
+        // anchorPosition={{top: 0, left: 0}}
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
@@ -136,7 +145,10 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
         transformOrigin={{horizontal: 'right', vertical: 'top'}}
         anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
         sx={{
-          maxWidth:'24rem'
+          display: 'flex',
+          flexDirection: 'column',
+          width: ['100vw', '24rem'],
+          height: ['100vh', 'auto']
         }}
       >
         <h3 className="px-4 py-3 text-primary">

--- a/frontend/components/keyword/KeywordFilter.tsx
+++ b/frontend/components/keyword/KeywordFilter.tsx
@@ -114,10 +114,11 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
       )
     }
     // debugger
+    // return null
     return (
       <Alert severity="info" sx={{margin: '1rem'}}>
         <AlertTitle sx={{fontWeight: 500}}>Filter is not active</AlertTitle>
-        Select the keyword from the list of most often used terms or <strong>start typing to search for the specific term</strong>.
+        Select a keyword from the list or <strong>start typing</strong>.
       </Alert>
     )
   }
@@ -159,7 +160,7 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
             config={{
               freeSolo: false,
               minLength: 0,
-              label: 'Find keyword',
+              label: 'Select or type a keyword',
               help: '',
               reset: true
             }}

--- a/frontend/components/keyword/KeywordFilter.tsx
+++ b/frontend/components/keyword/KeywordFilter.tsx
@@ -162,7 +162,7 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
           <FindKeyword
             config={{
               freeSolo: false,
-              minLength: 1,
+              minLength: 0,
               label: 'Find keyword',
               help: '',
               reset: true

--- a/frontend/components/keyword/KeywordFilter.tsx
+++ b/frontend/components/keyword/KeywordFilter.tsx
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useState, Fragment, useEffect} from 'react'
+import {useState, Fragment} from 'react'
 import IconButton from '@mui/material/IconButton'
 import Tooltip from '@mui/material/Tooltip'
 import Badge from '@mui/material/Badge'
@@ -11,7 +11,7 @@ import Divider from '@mui/material/Divider'
 import Button from '@mui/material/Button'
 import FilterAltIcon from '@mui/icons-material/FilterAlt'
 import CloseIcon from '@mui/icons-material/Close'
-import CheckIcon from '@mui/icons-material/Check'
+import DeleteIcon from '@mui/icons-material/Delete'
 import Popover from '@mui/material/Popover'
 import Chip from '@mui/material/Chip'
 import Alert from '@mui/material/Alert'
@@ -42,9 +42,6 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
   // console.log('selectedItems...', selectedItems)
   // console.log('open...', open)
   // console.groupEnd()
-  useEffect(() => {
-
-  },[])
 
   function handleOpen(event: React.MouseEvent<HTMLElement>){
     setAnchorEl(event.currentTarget)
@@ -59,17 +56,14 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
     handleClose()
   }
 
-  function handleApply(){
-    onApply(selectedItems)
-    handleClose()
-  }
-
   function handleDelete(pos:number) {
     const newList = [
       ...selectedItems.slice(0, pos),
       ...selectedItems.slice(pos+1)
     ]
     setSelectedItems(newList)
+    // apply directly
+    onApply(newList)
   }
 
   function onAdd(item: Keyword) {
@@ -81,6 +75,8 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
         item.keyword
       ].sort()
       setSelectedItems(newList)
+      // apply directly
+      onApply(newList)
     }
   }
 
@@ -177,16 +173,19 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
         <div className="flex items-center justify-between px-4 py-2">
           <Button
             color="secondary"
-            startIcon={<CloseIcon />}
-            onClick={handleClear}>
-            {selectedItems.length === 0 ? 'Close' : 'Clear'}
-          </Button>
-          <Button
-            onClick={handleApply}
-            startIcon={<CheckIcon />}
+            startIcon={<DeleteIcon />}
+            onClick={handleClear}
             disabled={selectedItems.length===0}
           >
-            Apply
+
+            {/* {selectedItems.length === 0 ? 'Close' : 'Clear'} */}
+            Clear
+          </Button>
+          <Button
+            onClick={handleClose}
+            startIcon={<CloseIcon />}
+          >
+            Close
           </Button>
         </div>
       </Popover>

--- a/frontend/components/keyword/KeywordFilter.tsx
+++ b/frontend/components/keyword/KeywordFilter.tsx
@@ -11,13 +11,13 @@ import Divider from '@mui/material/Divider'
 import Button from '@mui/material/Button'
 import FilterAltIcon from '@mui/icons-material/FilterAlt'
 import CloseIcon from '@mui/icons-material/Close'
+import CheckIcon from '@mui/icons-material/Check'
 import Popover from '@mui/material/Popover'
 import Chip from '@mui/material/Chip'
-import PlayArrowIcon from '@mui/icons-material/PlayArrow'
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
 
 import FindKeyword, {Keyword} from '~/components/keyword/FindKeyword'
-import Alert from '@mui/material/Alert'
-import {height} from '@mui/system'
 
 type SeachApiProps = {
   searchFor: string
@@ -119,9 +119,9 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
     }
     // debugger
     return (
-      <Alert severity="info" sx={{marginTop: '0.5rem'}}>
-        {/* <AlertTitle sx={{fontWeight: 500}}>No keywords to filter.</AlertTitle> */}
-        Add keyword <strong>by typing</strong> in the Find keyword.
+      <Alert severity="info" sx={{margin: '1rem'}}>
+        <AlertTitle sx={{fontWeight: 500}}>Filter is not active</AlertTitle>
+        Select the keyword from the list of most often used terms or <strong>start typing to search for the specific term</strong>.
       </Alert>
     )
   }
@@ -129,7 +129,10 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
   return (
     <>
       <Tooltip title={`Filter: ${selectedItems.length>0 ? selectedItems.join(' + ') : 'None'}`}>
-        <IconButton onClick={handleOpen}>
+        <IconButton
+          onClick={handleOpen}
+          sx={{marginRight:'0.5rem'}}
+        >
           <Badge badgeContent={selectedItems.length} color="primary">
             <FilterAltIcon />
           </Badge>
@@ -142,8 +145,8 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
         open={open}
         onClose={handleClose}
         // align menu to the right from the menu button
-        transformOrigin={{horizontal: 'right', vertical: 'top'}}
-        anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
+        transformOrigin={{horizontal: 'center', vertical: 'top'}}
+        anchorOrigin={{horizontal: 'center', vertical: 'bottom'}}
         sx={{
           display: 'flex',
           flexDirection: 'column',
@@ -180,7 +183,7 @@ export default function KeywordsFilter({items=[], searchApi, onApply}:KeywordFil
           </Button>
           <Button
             onClick={handleApply}
-            startIcon={<PlayArrowIcon />}
+            startIcon={<CheckIcon />}
             disabled={selectedItems.length===0}
           >
             Apply

--- a/frontend/components/mention/FindMention.test.tsx
+++ b/frontend/components/mention/FindMention.test.tsx
@@ -39,6 +39,11 @@ let props:FindMentionProps = {
 
 jest.useFakeTimers()
 
+afterEach(() => {
+  jest.runOnlyPendingTimers()
+  // jest.useRealTimers()
+})
+
 it('has working cancel button when freeSolo', async () => {
   props.config.freeSolo=true
   const searchFor = 'test string'
@@ -230,3 +235,4 @@ it('removes input after selection when reset=true', async () => {
   // exper input to be reset
   expect(searchInput).toHaveValue('')
 })
+

--- a/frontend/components/organisation/project/index.tsx
+++ b/frontend/components/organisation/project/index.tsx
@@ -17,7 +17,7 @@ import {OrganisationComponentsProps} from '../OrganisationNavItems'
 
 export default function OrganisationProjects({organisation, isMaintainer}:OrganisationComponentsProps) {
   const {token} = useSession()
-  const {searchFor,page,rows,setCount} = usePaginationWithSearch('Filter projects')
+  const {searchFor,page,rows,setCount} = usePaginationWithSearch(`Find project in ${organisation.name}`)
   const {loading, projects, count} = useOrganisationProjects({
     organisation: organisation.id,
     searchFor,

--- a/frontend/components/organisation/software/index.tsx
+++ b/frontend/components/organisation/software/index.tsx
@@ -17,7 +17,7 @@ import SoftwareCardWithMenu from './SoftwareCardWithMenu'
 
 export default function OrganisationSoftware({organisation, isMaintainer}: OrganisationComponentsProps) {
   const {token} = useSession()
-  const {searchFor,page,rows,setCount} = usePaginationWithSearch('Filter software')
+  const {searchFor,page,rows,setCount} = usePaginationWithSearch(`Find software in ${organisation.name}`)
   const {loading, software, count} = useOrganisationSoftware({
     organisation: organisation.id,
     searchFor,

--- a/frontend/components/projects/edit/information/config.ts
+++ b/frontend/components/projects/edit/information/config.ts
@@ -86,7 +86,7 @@ export const projectInformation = {
     title: 'Keywords',
     subtitle: 'How to find this project?',
     label: 'Find or add keyword',
-    help: 'Start typing for the suggestions',
+    help: 'Select from top 30 list or start typing for the suggestions',
     validation: {
       //custom validation rule, not in used by react-hook-form
       minLength: 1,

--- a/frontend/components/projects/edit/information/searchForKeyword.ts
+++ b/frontend/components/projects/edit/information/searchForKeyword.ts
@@ -20,8 +20,8 @@ export type NewKeyword = {
 export async function searchForProjectKeyword({searchFor}:
   { searchFor: string }) {
   try {
-    // GET top 50 matches
-    const url = `/api/v1/rpc/keyword_count_for_projects?keyword=ilike.*${searchFor}*&order=keyword.asc&limit=50`
+    // GET top 30 matches
+    const url = `/api/v1/rpc/keyword_count_for_projects?keyword=ilike.*${searchFor}*&order=cnt.desc.nullslast,keyword.asc&limit=30`
     const resp = await fetch(url, {
       method: 'GET'
     })

--- a/frontend/components/software/SoftwareKeywordFilter.tsx
+++ b/frontend/components/software/SoftwareKeywordFilter.tsx
@@ -15,7 +15,7 @@ type KeywordFilterProps = {
  * Keywords filter component. It receives array of keywords and returns
  * array of selected tags to use in filter using onSelect callback function
  */
-export default function SoftwareKeywordsFilter({items=[], onApply}:KeywordFilterProps) {
+export default function SoftwareKeywordsFilter({items = [], onApply}: KeywordFilterProps) {
   return (
     <KeywordFilter
       items={items}

--- a/frontend/components/software/SoftwareKeywords.tsx
+++ b/frontend/components/software/SoftwareKeywords.tsx
@@ -6,7 +6,7 @@
 import LocalOfferIcon from '@mui/icons-material/LocalOffer'
 import {KeywordForSoftware} from '../../types/SoftwareTypes'
 import TagChipFilter from '../layout/TagChipFilter'
-import {softwareUrl} from '~/utils/postgrestUrl'
+import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
 
 export default function SoftwareKeywords({keywords = []}: { keywords: KeywordForSoftware[] }) {
 
@@ -19,7 +19,7 @@ export default function SoftwareKeywords({keywords = []}: { keywords: KeywordFor
     return (
       <div className="flex flex-wrap gap-2 py-1">
         {keywords.map((item, pos) => {
-          const url = softwareUrl({keywords: [item.keyword]})
+          const url = ssrSoftwareUrl({keywords: [item.keyword]})
           return <TagChipFilter url={url} key={pos} label={item.keyword} />
         })}
       </div>

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -123,7 +123,7 @@ export const softwareInformation = {
     title: 'Keywords',
     subtitle: 'Find, add or import using concept DOI.',
     label: 'Find or add keyword',
-    help: 'Start typing for the suggestions',
+    help: 'Select from top 30 list or start typing for the suggestions',
     validation: {
       //custom validation rule, not in used by react-hook-form
       minLength: 1,

--- a/frontend/components/software/edit/information/searchForSoftwareKeyword.ts
+++ b/frontend/components/software/edit/information/searchForSoftwareKeyword.ts
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {Keyword} from '~/components/keyword/FindKeyword'
+import {getBaseUrl} from '~/utils/fetchHelpers'
 import logger from '../../../../utils/logger'
 
 
@@ -15,9 +16,9 @@ export async function searchForSoftwareKeyword(
 ) {
   try {
     const searchForEncoded = encodeURIComponent(searchFor)
-
-    // GET top 20 matches
-    const url = `/api/v1/rpc/keyword_count_for_software?keyword=ilike.*${searchForEncoded}*&order=keyword.asc&limit=20`
+    const baseUrl = getBaseUrl()
+    // GET top 30 matches
+    const url = `${baseUrl}/rpc/keyword_count_for_software?keyword=ilike.*${searchForEncoded}*&order=cnt.desc.nullslast,keyword.asc&limit=30`
     const resp = await fetch(url, {
       method: 'GET'
     })

--- a/frontend/pages/organisations/index.tsx
+++ b/frontend/pages/organisations/index.tsx
@@ -92,7 +92,7 @@ export default function OrganisationsIndexPage({
         <div className="md:flex flex-wrap justify-end">
           <div className="flex items-center lg:ml-4">
             <Searchbox
-              placeholder='Filter organisations'
+              placeholder='Find organisation'
               onSearch={handleSearch}
               defaultValue={search}
             />

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -109,14 +109,14 @@ export default function ProjectsIndexPage(
       <PageTitle title="Projects">
         <div className="md:flex flex-wrap justify-end">
           <div className="flex items-center lg:ml-4">
-            <Searchbox
-              placeholder="Filter projects"
-              onSearch={handleSearch}
-              defaultValue={search}
-            />
             <ProjectKeywordFilter
               items={keywords ?? []}
               onApply={handleFilters}
+            />
+            <Searchbox
+              placeholder={keywords?.length ? 'Find within selection' : 'Find project'}
+              onSearch={handleSearch}
+              defaultValue={search}
             />
           </div>
           <TablePagination
@@ -171,6 +171,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     offset: rows * page,
   })
 
+  // console.log('projects...url...', url)
   // get project list, we do not pass the token
   // when token is passed it will return not published items too
   const projects = await getProjectList({url})

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -22,6 +22,7 @@ import {getSoftwareList} from '../../utils/getSoftware'
 import {ssrSoftwareParams} from '../../utils/extractQueryParam'
 import {softwareListUrl,softwareUrl} from '../../utils/postgrestUrl'
 import SoftwareKeywordFilter from '~/components/software/SoftwareKeywordFilter'
+import {searchForSoftwareKeyword} from '~/components/software/edit/information/searchForSoftwareKeyword'
 
 type SoftwareIndexPageProps = {
   count: number,

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -20,7 +20,7 @@ import {SoftwareListItem} from '../../types/SoftwareTypes'
 import {rowsPerPageOptions} from '../../config/pagination'
 import {getSoftwareList} from '../../utils/getSoftware'
 import {ssrSoftwareParams} from '../../utils/extractQueryParam'
-import {softwareListUrl,softwareUrl} from '../../utils/postgrestUrl'
+import {softwareListUrl,ssrSoftwareUrl} from '../../utils/postgrestUrl'
 import SoftwareKeywordFilter from '~/components/software/SoftwareKeywordFilter'
 import {searchForSoftwareKeyword} from '~/components/software/edit/information/searchForSoftwareKeyword'
 
@@ -50,7 +50,7 @@ export default function SoftwareIndexPage(
     event: MouseEvent<HTMLButtonElement> | null,
     newPage: number,
   ) {
-    const url = softwareUrl({
+    const url = ssrSoftwareUrl({
       // take existing params from url (query)
       ...ssrSoftwareParams(router.query),
       page: newPage,
@@ -70,7 +70,7 @@ export default function SoftwareIndexPage(
   function handleItemsPerPage(
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ){
-    const url = softwareUrl({
+    const url = ssrSoftwareUrl({
       // take existing params from url (query)
       ...ssrSoftwareParams(router.query),
       // reset to first page
@@ -82,7 +82,7 @@ export default function SoftwareIndexPage(
 
   function handleSearch(searchFor: string) {
     // debugger
-    const url = softwareUrl({
+    const url = ssrSoftwareUrl({
       // take existing params from url (query)
       ...ssrSoftwareParams(router.query),
       search: searchFor,
@@ -93,7 +93,7 @@ export default function SoftwareIndexPage(
   }
 
   function handleFilters(keywords: string[]){
-    const url = softwareUrl({
+    const url = ssrSoftwareUrl({
       // take existing params from url (query)
       ...ssrSoftwareParams(router.query),
       keywords,
@@ -116,14 +116,14 @@ export default function SoftwareIndexPage(
       <PageTitle title="Software">
         <div className="md:flex flex-wrap justify-end">
           <div className="flex items-center">
-            <Searchbox
-              placeholder="Filter software"
-              onSearch={handleSearch}
-              defaultValue={search}
-            />
             <SoftwareKeywordFilter
               items={keywords ?? []}
               onApply={handleFilters}
+            />
+            <Searchbox
+              placeholder={keywords?.length ? 'Find within selection' : 'Find software'}
+              onSearch={handleSearch}
+              defaultValue={search}
             />
           </div>
           <TablePagination
@@ -176,6 +176,8 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     limit: rows,
     offset: rows * page,
   })
+
+  // console.log('software...url...', url)
 
   // get software list, we do not pass the token
   // when token is passed it will return not published items too

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -22,7 +22,6 @@ import {getSoftwareList} from '../../utils/getSoftware'
 import {ssrSoftwareParams} from '../../utils/extractQueryParam'
 import {softwareListUrl,ssrSoftwareUrl} from '../../utils/postgrestUrl'
 import SoftwareKeywordFilter from '~/components/software/SoftwareKeywordFilter'
-import {searchForSoftwareKeyword} from '~/components/software/edit/information/searchForSoftwareKeyword'
 
 type SoftwareIndexPageProps = {
   count: number,

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -15,8 +15,6 @@
 
 body{
   font-size: 1rem;
-  /* minimal with to have logo, menu and profile */
-  /* min-width: 29rem; */
 }
 
 #__next {

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -13,7 +13,7 @@ import logger from './logger'
 import {paginationUrlParams} from './postgrestUrl'
 
 
-export function organisationUrl({search, rows = 12, page = 0}:
+export function organisationListUrl({search, rows = 12, page = 0}:
   { search: string | undefined, rows: number, page: number }) {
   // by default order is on software count and name
   let url = `${process.env.POSTGREST_URL}/rpc/organisations_overview?parent=is.null&order=score.desc.nullslast,name.asc`
@@ -32,7 +32,7 @@ export function organisationUrl({search, rows = 12, page = 0}:
 export async function getOrganisationsList({search, rows, page, token}:
   { search: string | undefined, rows: number, page: number, token: string | undefined }) {
   try {
-    const url = organisationUrl({search, rows, page})
+    const url = organisationListUrl({search, rows, page})
 
     const resp = await fetch(url, {
       method: 'GET',

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -25,7 +25,7 @@ type QueryParams={
   rows?:number
 }
 
-export function softwareUrl(params:QueryParams){
+export function ssrSoftwareUrl(params:QueryParams){
   const view = 'software'
   const url = ssrUrl(params, view)
   return url
@@ -139,9 +139,16 @@ export function softwareListUrl(props: PostgrestParams) {
   let query = baseQueryString(props)
 
   if (search) {
-    // search for term in brand_name and short_statement
-    // we use ilike (case INsensitive) and * to indicate partial string match
-    query += `&or=(brand_name.ilike.*${search}*, short_statement.ilike.*${search}*)`
+    // console.log('softwareListUrl...keywords...', props.keywords)
+    const encodedSearch = encodeURIComponent(search)
+    // if keyword filter is not used we search in keywords too!
+    if (typeof props.keywords === 'undefined' || props.keywords===null) {
+      query += `&or=(brand_name.ilike.*${encodedSearch}*,short_statement.ilike.*${encodedSearch}*,keywords.cs.%7B${encodedSearch}%7D)`
+    } else {
+      // search for term in brand_name and short_statement
+      // we use ilike (case INsensitive) and * to indicate partial string match
+      query += `&or=(brand_name.ilike.*${encodedSearch}*,short_statement.ilike.*${encodedSearch}*)`
+    }
   }
 
   const url = `${baseUrl}/rpc/software_search?${query}`
@@ -155,9 +162,15 @@ export function projectListUrl(props: PostgrestParams) {
   let query = baseQueryString(props)
 
   if (search) {
-    // search for term in brand_name and short_statement
-    // we use ilike (case INsensitive) and * to indicate partial string match
-    query += `&or=(title.ilike.*${search}*,subtitle.ilike.*${search}*)`
+    const encodedSearch = encodeURIComponent(search)
+    // if keyword filter is not used we search in keywords too!
+    if (typeof props.keywords === 'undefined' || props.keywords === null) {
+      query += `&or=(title.ilike.*${search}*,subtitle.ilike.*${search}*,keywords.cs.%7B${encodedSearch}%7D)`
+    } else {
+      // search for term in brand_name and short_statement
+      // we use ilike (case INsensitive) and * to indicate partial string match
+      query += `&or=(title.ilike.*${search}*,subtitle.ilike.*${search}*)`
+    }
   }
 
   const url = `${baseUrl}/rpc/project_search?${query}`


### PR DESCRIPTION
# Load initial keyword list and improve search exprience

Closes #496

Changes proposed in this pull request:
* Filter icon moved infront the "Find" input to indicate that filtering is used in combination with find term. When filter is active the find input is limited to filtered content (see screenshot 1)
* The info text in the filter dropdown is extended. **Please check and deliver improvement suggestions**
* The input placeholder is changed to "Find software", when filter is activated message is changed to "Find within selection"
* When filter is not applied the input search by title (partial value), short_description (partial value) and in the keywords (complete value). Note that keyword match is not the wildcard match (it requires complete keyword value)
* Search keywords component is pre-loaded with top 30 items to assist the user during keyword search. **The feature is implemented in the shared component and shows same behavior in the keyword filter on software/project page as well in add keyword section on edit software and project page (see screenshot 2&3). Note, the list is (pre)loaded on the initial search attempt (first focus). After user starts searching/typing the component behaves as before. We are in the process of redefining filtering experience and therefore further enhancement of this component behavior are less desired. New filtering approach will high likely use different component which will not be shared with edit keyword.
* The placeholder of the search input for the software/project within the organisation is dynamic and mentions the organisation name. See screenshot 5

How to test:
* `make start` to rebuild everything, when done with testing use `docker-compose down`
* login as rsd_admin in order to edit software/project
* navigate to software overview page, use filter icon, focus on input field and you should get the list of max. 30 items, ordered by count (see printescreen 2). Similar filter behavior should be on the project overview page.
* apply filter, the placeholder of input will change to "Find within selection". Confirm you can narrow selection by input.
* edit existing software or create new software. Keyword input should show top 30 used keywords
* navigate to organisation software, confirm search input adapts by organisation name

## 1. Filter icon moved infront input
![image](https://user-images.githubusercontent.com/9204081/199588206-17156aa1-acf2-4557-bc92-80cefb62410e.png)

## 2. Placeholder text adapts when filtering is applied
![image](https://user-images.githubusercontent.com/9204081/199588651-db0458d4-fa54-44ef-86ba-328c0b5c4034.png)

## 3. Preload keywords in the filter (top 30) of software overview page
![image](https://user-images.githubusercontent.com/9204081/199595720-f01b37ce-f443-48b5-8398-056e15c43a2b.png)

## 4. Preload software keywords (top 30) in edit software/project
![image](https://user-images.githubusercontent.com/9204081/199596035-7348e121-9d0b-41cb-ae33-267f7a270c13.png)

## 5. Dynamic placeholder text on search input of the organisation
![image](https://user-images.githubusercontent.com/9204081/199592646-368354b5-ad42-4e14-9abd-bacd7f4b3f51.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
