### PR TITLE
fix: show a custom error message when logging in fails

### DIFF
--- a/authentication/README.md
+++ b/authentication/README.md
@@ -1,5 +1,7 @@
 <!--
 SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 dv4all
 
 SPDX-License-Identifier: CC-BY-4.0
@@ -7,24 +9,24 @@ SPDX-License-Identifier: CC-BY-4.0
 
 # Authentication module
 
-This modules handles authentication from third parties using oAuth2 and OpenID.
+This module handles authentication from third parties using oAuth2 and OpenID.
 
 ## Environment variables
+Check `.env.example` to see which environment variables are needed. 
 
-It requires the following variables at run time.
-
-```env
-# connection to backend
-POSTGREST_URL=
-
-# SURFconext
-NEXT_PUBLIC_SURFCONEXT_CLIENT_ID=
-NEXT_PUBLIC_SURFCONEXT_REDIRECT=
-AUTH_SURFCONEXT_CLIENT_SECRET=
-
-# JWT secret for postgREST
-PGRST_JWT_SECRET=
+## Developing locally
+If you want to develop and run the auth module locally, i.e. outside of Docker, you have to make two changes to files tracked by Git.
+1. In `docker-compose.yml`, add the following lines to the `nginx` service:
+```yml
+extra_hosts:
+  - "host.docker.internal:host-gateway"
 ```
+2. In `nginx.conf`, replace `server auth:7000;` with `server host.docker.internal:7000;`
+
+Remember to undo these changes before committing!
+
+It is recommended to use the [envFile plugin](https://plugins.jetbrains.com/plugin/7861-envfile)  of IntelliJ IDEA to load your `.env` file.
+Furthermore, set the value of `POSTGREST_URL` to `http://localhost/api/v1`.
 
 ## Running the tests
 

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestCheckOrcidWhitelistedAccount.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestCheckOrcidWhitelistedAccount.java
@@ -37,7 +37,7 @@ public class PostgrestCheckOrcidWhitelistedAccount implements Account {
 		JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
 		String token = jwtCreator.createAdminJwt();
 		String response = PostgrestAccount.getAsAdmin(queryUri, token);
-		if (!orcidInResponse(orcid, response)) throw new AuthenticationException("Your ORCID (" + orcid + ") is not whitelisted.");
+		if (!orcidInResponse(orcid, response)) throw new RsdAuthenticationException("Your ORCID (" + orcid + ") is not whitelisted.");
 
 		return origin.account(openIdInfo, provider);
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdAuthenticationException.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdAuthenticationException.java
@@ -5,9 +5,9 @@
 
 package nl.esciencecenter.rsd.authentication;
 
-public class AuthenticationException extends RuntimeException {
+public class RsdAuthenticationException extends RuntimeException {
 
-	public AuthenticationException(String message) {
+	public RsdAuthenticationException(String message) {
 		super(message);
 	}
 }

--- a/frontend/auth/locationCookie.ts
+++ b/frontend/auth/locationCookie.ts
@@ -17,6 +17,7 @@ export function saveLocationCookie() {
     case '/login':
     case '/logout':
     case '/login/local':
+    case '/login/failed':
       break
     case '/':
       // root is send to /software

--- a/frontend/pages/login/failed.tsx
+++ b/frontend/pages/login/failed.tsx
@@ -1,13 +1,29 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Link from 'next/link'
 import ContentInTheMiddle from '../../components/layout/ContentInTheMiddle'
+import {useEffect} from 'react'
+import {useState} from 'react'
 
 export default function LoginFailed() {
+  const [errorMessage, setErrorMessage] = useState<string>()
+
+  useEffect(() => {
+    const errorCookie = document.cookie.split(';')
+      .find(cookie => cookie.trim().startsWith('rsd_login_failure_message='))
+
+    if (errorCookie) {
+      setErrorMessage(errorCookie.replace('rsd_login_failure_message=', ''))
+      document.cookie = 'rsd_login_failure_message=; expires=Thu, 01 Jan 1970 00:00:00 UTC; path=/login/failed; SameSite=Lax'
+    }
+  }, [])
+
   return (
     <ContentInTheMiddle>
       <div className="border p-12">
@@ -15,8 +31,11 @@ export default function LoginFailed() {
         <p className="py-8">
           Unfortunately, something went wrong during the login process.
         </p>
+        {errorMessage && <p className="pb-8 text-error">
+          {errorMessage}
+        </p>}
         <Link href="/" passHref>
-          <a>Go home</a>
+          <a>Return to home page</a>
           </Link>
       </div>
     </ContentInTheMiddle>


### PR DESCRIPTION
# Message on failed login

Changes proposed in this pull request:

* When logging in, if this fails, we show a custom error, e.g. that your ORCID is not whitelisted
* This message is passed from the auth module to the frontend using a cookie

How to test:
* `docker-compose build --parallel && docker-compose up`
* Make sure your sandbox ORCID is not on the whitelist, login with this ORCID, this should fail and you should see a custom error message in red
* In your `.env`, set a value for `RSD_AUTH_USER_MAIL_WHITELIST`, restart the containers
* Login with either SURFConext or Helmholtz AAI with an account with a different email address, you should see a custom error message again

Closes #617

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests