### PR TITLE
620 retry commit scraper on 202

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,7 +130,7 @@ services:
 
   scrapers:
     build: ./scrapers
-    image: rsd/scrapers:1.2.0
+    image: rsd/scrapers:1.2.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/RsdResponseException.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/RsdResponseException.java
@@ -7,10 +7,10 @@
 
 package nl.esciencecenter.rsd.scraper;
 
-public class ResponseException extends RuntimeException {
+public class RsdResponseException extends RuntimeException {
 	private final Integer statusCode;
 
-	public ResponseException(Integer statusCode, String message) {
+	public RsdResponseException(Integer statusCode, String message) {
 		super(message);
 		this.statusCode = statusCode;
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainCommits.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainCommits.java
@@ -67,6 +67,8 @@ public class MainCommits {
 				if (repo.endsWith("/")) repo = repo.substring(0, repo.length() - 1);
 
 				String scrapedCommits = new AggregateContributionsPerWeekSIDecorator(new GithubSI("https://api.github.com", repo), CodePlatformProvider.GITHUB).contributions();
+//				this happens on 202 response, keep the old value
+				if (scrapedCommits == null) scrapedCommits = commitData.commitHistory();
 				RepositoryUrlData updatedData = new RepositoryUrlData(
 						commitData.software(), commitData.url(), CodePlatformProvider.GITHUB,
 						commitData.license(), commitData.licenseScrapedAt(),


### PR DESCRIPTION
# Retry commit scraper on HTTP status code 202 from GitHub

Changes proposed in this pull request:

* If we get status 202 from GitHub when scraping commits, wait 3 seconds and try again
* If we then still get 202, we treat it as if we could not scrape it and reuse the old data

How to test:
* This is hard to test, since you need a 202 response from GitHub and we don't print to console when this happens, I manually tested this (also with prints)
* Check that it builds at least
	* `docker-compose build auth && docker-compose up`
* Make sure to have some repos in the database and manually run the commit scraper a few times to see no unexpected errors occur:
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits`

Closes #620

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests