### PR TITLE
Minor bug fixes

### DIFF
--- a/frontend/components/mention/MentionEditFeatured.tsx
+++ b/frontend/components/mention/MentionEditFeatured.tsx
@@ -6,7 +6,8 @@
 import {IconButton} from '@mui/material'
 import EditIcon from '@mui/icons-material/Edit'
 import DeleteIcon from '@mui/icons-material/Delete'
-import UpdateIcon from '@mui/icons-material/Update'
+// import UpdateIcon from '@mui/icons-material/Update'
+import {useSession} from '~/auth'
 import {MentionTitle} from './MentionItemBase'
 import {MentionItemProps} from '~/types/Mention'
 import useEditMentionReducer from './useEditMentionReducer'
@@ -19,6 +20,7 @@ type MentionListItem = {
 }
 
 export default function MentionEditFeatured({item}: MentionListItem) {
+  const {user} = useSession()
   // use context methods to pass btn action
   // const {onUpdate, confirmDelete, setEditModal} = useContext(EditMentionContext)
   const {setEditModal,onUpdate,confirmDelete} = useEditMentionReducer()
@@ -30,18 +32,18 @@ export default function MentionEditFeatured({item}: MentionListItem) {
   function renderButtons() {
     const html = []
 
-    if (item.source.toLowerCase() === 'manual' &&
-      item.doi) {
-      // we only update items with DOI
-      html.push(
-        <IconButton
-          key="update-button"
-          title={`Update from DOI: ${item.doi}`}
-          onClick={() => onUpdate(item)}>
-            <UpdateIcon />
-        </IconButton>
-      )
-    } else if (item.source.toLowerCase() === 'manual') {
+    if (item.doi) {
+      // WE do not allow update of mentions with DOI from FE
+      // Dusan 2022-10-19
+      // html.push(
+      //   <IconButton
+      //     key="update-button"
+      //     title={`Update from DOI: ${item.doi}`}
+      //     onClick={() => onUpdate(item)}>
+      //       <UpdateIcon />
+      //   </IconButton>
+      // )
+    } else if (user?.role==='rsd_admin') {
       // manual items without DOI can be edited
       html.push(
         <IconButton

--- a/frontend/components/mention/MentionEditSection.tsx
+++ b/frontend/components/mention/MentionEditSection.tsx
@@ -37,8 +37,7 @@ export default function MentionEditSection() {
       {
         higlightedMentions
         .sort((a, b) => sortOnNumProp(a, b, 'publication_year', 'desc'))
-          .map((item, pos) => {
-
+          .map((item) => {
             return (
               <MentionEditFeatured
                 key={item.id}

--- a/frontend/components/organisation/metadata/OrganisationLogo.tsx
+++ b/frontend/components/organisation/metadata/OrganisationLogo.tsx
@@ -149,9 +149,7 @@ export default function OrganisationLogo({id,name,logo_id,isMaintainer}:
   if (isMaintainer) {
     return (
       <div className="pt-12 pb-2 flex relative">
-        <div className="">
-          {renderAvatar()}
-        </div>
+        {renderAvatar()}
         <div style={{
           position: 'absolute',
           top: '0rem',

--- a/frontend/utils/editKeywords.ts
+++ b/frontend/utils/editKeywords.ts
@@ -3,8 +3,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// import {SoftwareKeyword} from '~/components/software/edit/information/softwareKeywordsChanges'
-import {Keyword} from '~/components/keyword/FindKeyword'
 import {createJsonHeaders, extractReturnMessage} from './fetchHelpers'
 import logger from './logger'
 
@@ -15,7 +13,7 @@ export type ProjectKeyword = {
   keyword: string
 }
 
-type KeywordItem = {
+export type KeywordItem = {
   id: string,
   value: string
 }


### PR DESCRIPTION
# Minor bugs discovered during testing of next v13

Changes proposed in this pull request:
* Import keywords on software edit page from concept DOI was failing due to last changes in keyword component.
* Rsd admin was not able to edit highlighted (manual) item while it was able to edit other types of manually created mentions
* Svg logo (some) was not visible in the organisation card (noticed with Bayer svg logo from their website).

How to test:
* `make start` to rebuild all
* login as rsd_admin to be able to edit software
* edit or create software item. Provide a valid concept DOI (10.5281/zenodo.6379973) and use import keywords button. This should work properly
* edit or create project. Create new impact item of type highlight. After saving you should be able to edit the item if you are logged in as rsd_admin role
* Navigate to organisation as rsd_admin. Upload [Bayer svg logo](https://www.bayer.com/themes/custom/bayer_cpa/logo.svg). The logo should be displayed 

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
