### PR TITLE
589 token url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -82,8 +82,6 @@ NEXT_PUBLIC_SURFCONEXT_WELL_KNOWN_URL=https://connect.test.surfconext.nl/.well-k
 NEXT_PUBLIC_SURFCONEXT_SCOPES=openid
 # consumed by: frontend/utils/loginHelpers
 NEXT_PUBLIC_SURFCONEXT_RESPONSE_MODE=form_post
-# consumed by services: authentication
-AUTH_SURFCONEXT_TOKEN_URL=https://connect.test.surfconext.nl/oidc/token
 
 # Helmholtz AAI
 # consumed by: authentication, frontend/utils/loginHelpers
@@ -96,8 +94,6 @@ NEXT_PUBLIC_HELMHOLTZAAI_WELL_KNOWN_URL=https://login-dev.helmholtz.de/oauth2/.w
 NEXT_PUBLIC_HELMHOLTZAAI_SCOPES=openid+profile+email+eduperson_principal_name
 # consumed by: frontend/utils/loginHelpers
 NEXT_PUBLIC_HELMHOLTZAAI_RESPONSE_MODE=query
-# consumed by services: authentication
-AUTH_HELMHOLTZAAI_TOKEN_URL=https://login-dev.helmholtz.de/oauth2/token
 # consumed by: authentication
 # uncomment if you want to allow users from non-Helmholtz centres or social IdPs:
 #HELMHOLTZAAI_ALLOW_EXTERNAL_USERS=true
@@ -113,8 +109,6 @@ NEXT_PUBLIC_ORCID_WELL_KNOWN_URL=https://sandbox.orcid.org/.well-known/openid-co
 NEXT_PUBLIC_ORCID_SCOPES=openid
 # consumed by: frontend/utils/loginHelpers
 NEXT_PUBLIC_ORCID_RESPONSE_MODE=query
-# consumed by services: authentication
-AUTH_ORCID_TOKEN_URL=https://sandbox.orcid.org/oauth/token
 
 # max requests to the GitHub API per run, runs 10 times per hour
 # optional, comment out if not available, a default of 6 will be used

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
@@ -65,6 +65,7 @@ public class Config {
 		return System.getenv("POSTGREST_URL");
 	}
 
+
 //	SURFconext
 	public static String surfconextRedirect() {
 		return System.getenv("NEXT_PUBLIC_SURFCONEXT_REDIRECT");
@@ -82,13 +83,10 @@ public class Config {
 		return System.getenv("AUTH_SURFCONEXT_CLIENT_SECRET");
 	}
 
-	public static String surfconextTokenUrl() {
-		return System.getenv("AUTH_SURFCONEXT_TOKEN_URL");
-	}
-
 	public static String surfconextScopes() {
 		return System.getenv("NEXT_PUBLIC_SURFCONEXT_SCOPES");
 	}
+
 
 //	Helmholtz AAI
 	public static String helmholtzAaiRedirect() {
@@ -107,10 +105,6 @@ public class Config {
 		return System.getenv("AUTH_HELMHOLTZAAI_CLIENT_SECRET");
 	}
 
-	public static String helmholtzAaiTokenUrl() {
-		return System.getenv("AUTH_HELMHOLTZAAI_TOKEN_URL");
-	}
-
 	public static String helmholtzAaiScopes() {
 		return System.getenv("NEXT_PUBLIC_HELMHOLTZAAI_SCOPES");
 	}
@@ -120,6 +114,7 @@ public class Config {
 			System.getenv("HELMHOLTZAAI_ALLOW_EXTERNAL_USERS")
 		);
 	}
+
 
 //	ORCID
 	public static String orcidRedirect() {
@@ -136,10 +131,6 @@ public class Config {
 
 	public static String orcidClientSecret() {
 		return System.getenv("AUTH_ORCID_CLIENT_SECRET");
-	}
-
-	public static String orcidTokenUrl() {
-		return System.getenv("AUTH_ORCID_TOKEN_URL");
 	}
 
 	public static String orcidScopes() {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLogin.java
@@ -135,7 +135,7 @@ public class HelmholtzAaiLogin implements Login {
 			ClientID clientID = new ClientID(Config.helmholtzAaiClientId());
 			Secret clientSecret = new Secret(Config.helmholtzAaiClientSecret());
 			ClientAuthentication clientAuth = new ClientSecretBasic(clientID, clientSecret);
-			URI tokenEndpoint = new URI(Config.helmholtzAaiTokenUrl());
+			URI tokenEndpoint = Utils.getTokenUrlFromWellKnownUrl(URI.create(Config.helmholtzAaiWellknown()));
 
 			Scope scopes = new Scope();
 
@@ -181,7 +181,7 @@ public class HelmholtzAaiLogin implements Login {
 		if (organisation == null) {
 			// login denied by missing entitlements
 			// or external providers are not allowed
-			throw new RuntimeException("User is not allowed to login");
+			throw new RsdAuthenticationException("You are not allowed to login");
 		}
 
 		return new OpenIdInfo(

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OrcidLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OrcidLogin.java
@@ -61,7 +61,8 @@ public class OrcidLogin implements Login {
 
 	private String getTokensFromOrcidconext(Map<String, String> form) {
 		String body = formMapToxWwwFormUrlencoded(form);
-		return postForm(URI.create(Config.orcidTokenUrl()), body);
+		URI tokenEndpoint = Utils.getTokenUrlFromWellKnownUrl(URI.create(Config.orcidWellknown()));
+		return postForm(tokenEndpoint, body);
 	}
 
 	private String formMapToxWwwFormUrlencoded(Map<String, String> form) {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
@@ -60,7 +60,8 @@ public class SurfconextLogin implements Login {
 
 	private String getTokensFromSurfconext(Map<String, String> form) {
 		String body = formMapToxWwwFormUrlencoded(form);
-		return postForm(URI.create(Config.surfconextTokenUrl()), body);
+		URI tokenEndpoint = Utils.getTokenUrlFromWellKnownUrl(URI.create(Config.surfconextWellknown()));
+		return postForm(tokenEndpoint, body);
 	}
 
 	private String formMapToxWwwFormUrlencoded(Map<String, String> form) {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
@@ -6,6 +6,15 @@
 package nl.esciencecenter.rsd.authentication;
 
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 
 public class Utils {
 
@@ -14,4 +23,25 @@ public class Utils {
 		if (!elementToConvert.isJsonPrimitive()) return null;
 		return elementToConvert.getAsString();
 	}
+
+	public static URI getTokenUrlFromWellKnownUrl(URI wellKnownUrl) {
+		HttpClient client = HttpClient.newHttpClient();
+		HttpRequest request = HttpRequest.newBuilder(wellKnownUrl).build();
+		HttpResponse<String> response;
+
+		try {
+			response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+		} catch (IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
+
+		return extractTokenUrlFromWellKnownData(response.body());
+	}
+
+	static URI extractTokenUrlFromWellKnownData(String jsonData) {
+		JsonObject dataAsObject = JsonParser.parseString(jsonData).getAsJsonObject();
+		String tokenUrl = dataAsObject.getAsJsonPrimitive("token_endpoint").getAsString();
+		return URI.create(tokenUrl);
+	}
+
 }

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/UtilsTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/UtilsTest.java
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.authentication;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+
+public class UtilsTest {
+
+	@Test
+	void givenValidWellKnownData_whenExtractingTokenEndpoint_correctResultReturned() {
+		String data = """
+				{
+				  "token_endpoint_auth_signing_alg_values_supported": [
+				    "RS256"
+				  ],
+				  "id_token_signing_alg_values_supported": [
+				    "RS256"
+				  ],
+				  "userinfo_endpoint": "https://sandbox.orcid.org/oauth/userinfo",
+				  "authorization_endpoint": "https://sandbox.orcid.org/oauth/authorize",
+				  "token_endpoint": "https://sandbox.orcid.org/oauth/token",
+				  "jwks_uri": "https://sandbox.orcid.org/oauth/jwks",
+				  "claims_supported": [
+				    "family_name",
+				    "given_name",
+				    "name",
+				    "auth_time",
+				    "iss",
+				    "sub"
+				  ],
+				  "scopes_supported": [
+				    "openid"
+				  ],
+				  "subject_types_supported": [
+				    "public"
+				  ],
+				  "response_types_supported": [
+				    "code",
+				    "id_token",
+				    "id_token token"
+				  ],
+				  "claims_parameter_supported": false,
+				  "token_endpoint_auth_methods_supported": [
+				    "client_secret_post"
+				  ],
+				  "grant_types_supported": [
+				    "authorization_code",
+				    "implicit",
+				    "refresh_token"
+				  ],
+				  "issuer": "https://sandbox.orcid.org"
+				}""";
+
+		URI tokenEndpoint = Utils.extractTokenUrlFromWellKnownData(data);
+
+		Assertions.assertEquals(URI.create("https://sandbox.orcid.org/oauth/token"), tokenEndpoint);
+	}
+
+	@Test
+	void givenInvalidJson_whenExtractingTokenEndpoint_thenExceptionThrown() {
+		String data = "{";
+
+		Assertions.assertThrows(RuntimeException.class, () -> Utils.extractTokenUrlFromWellKnownData(data));
+	}
+
+	@Test
+	void givenDataWithoutTokenEndpoint_whenExtractingTokenEndpoint_thenExceptionThrown() {
+		String data = "{\"token_endpoint\": null}";
+
+		Assertions.assertThrows(ClassCastException.class, () -> Utils.extractTokenUrlFromWellKnownData(data));
+	}
+
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,7 @@ services:
 
   auth:
     build: ./authentication
-    image: rsd/auth:1.2.0
+    image: rsd/auth:1.2.1
     expose:
       - 7000
     environment:


### PR DESCRIPTION
# Remove token endpoints from config

Changes proposed in this pull request:

* Remove the `*_TOKEN_URL` env variables and adapt the auth module so that the token URL is queried from the well known URL on every request
* Give the reason when you login with e.g. GitHub through Helmholtz AAI and `HELMHOLTZAAI_ALLOW_EXTERNAL_USERS=false`

How to test:
* Remove `*_TOKEN_URL` values from your `.env` (see `env.example`)
* `docker-compose build auth && docker-compose up`
* Set `HELMHOLTZAAI_ALLOW_EXTERNAL_USERS=true`
* Login with all three providers, this should work
* Set `HELMHOLTZAAI_ALLOW_EXTERNAL_USERS=false`
* Login with Helmholtz AAI through GitHub or ORCID, you should see in red text `You are not allowed to login`

### Discussion point
Maybe we should cache the token URL instead of querying it on every login. On my tests, ORCID was slow, taking 200 -- 900 ms. Helmholtz and SURF were below 100 ms.

Closes #589

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests