### PR TITLE
Whitelist names

### DIFF
--- a/frontend/pages/admin/orcid-whitelist.tsx
+++ b/frontend/pages/admin/orcid-whitelist.tsx
@@ -18,7 +18,7 @@ import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import {useSession} from '~/auth'
 import {useEffect, useState} from 'react'
 import Link from '@mui/material/Link'
-import {Button, CircularProgress, TextField} from '@mui/material'
+import {Button, CircularProgress, ListItemText, TextField} from '@mui/material'
 import {PageTitleSticky} from '~/components/layout/PageTitle'
 
 export default function OrcidWitelistPage() {
@@ -153,14 +153,20 @@ function OrcidWhitelist({orcids, onDeleteCallback, token}:
     setFetchingNames(false)
   }
 
+
   return (
     <>
-      {!fetchingNames &&
-        <Button variant="contained" onClick={() => setAllNames()}>
-          Fetch names
-        </Button>
-      }
-      {fetchingNames && <CircularProgress/>}
+      <div className='h-[2rem] mb-4'>
+        {fetchingNames ?
+          <CircularProgress size="2rem" />
+          :
+          <Button
+            variant="contained"
+            onClick={() => setAllNames()}>
+            Fetch names
+          </Button>
+        }
+      </div>
       <List>
         {orcids.map(orcid => {
           return (
@@ -170,10 +176,16 @@ function OrcidWhitelist({orcids, onDeleteCallback, token}:
                 <IconButton onClick={() => deleteOrcid(orcid)}><DeleteIcon/></IconButton>
               }
             >
-              <Link href={`https://orcid.org/${orcid}`} underline="always" target="_blank" rel="noreferrer">
-                {orcid}
-              </Link>
-              {names.has(orcid) && names.get(orcid)}
+              <ListItemText
+                primary={
+                  <Link href={`https://orcid.org/${orcid}`} underline="always" target="_blank" rel="noreferrer">
+                    {orcid}
+                  </Link>
+                }
+                secondary={
+                  <span>{names.get(orcid) ?? ''}</span>
+                }
+              />
             </ListItem>
           )
         })}

--- a/frontend/pages/admin/orcid-whitelist.tsx
+++ b/frontend/pages/admin/orcid-whitelist.tsx
@@ -18,7 +18,7 @@ import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import {useSession} from '~/auth'
 import {useEffect, useState} from 'react'
 import Link from '@mui/material/Link'
-import {Button, TextField} from '@mui/material'
+import {Button, CircularProgress, TextField} from '@mui/material'
 import {PageTitleSticky} from '~/components/layout/PageTitle'
 
 export default function OrcidWitelistPage() {
@@ -110,6 +110,8 @@ export default function OrcidWitelistPage() {
 function OrcidWhitelist({orcids, onDeleteCallback, token}:
   { orcids: string[], onDeleteCallback: Function, token: string }) {
   const {showErrorMessage} = useSnackbar()
+  const [names, setNames] = useState<Map<string, string>>(new Map())
+  const [fetchingNames, setFetchingNames] = useState<boolean>(false)
 
   async function deleteOrcid(orcid: string) {
     const resp = await fetch(`/api/v1/orcid_whitelist?orcid=eq.${orcid}`, {
@@ -120,22 +122,62 @@ function OrcidWhitelist({orcids, onDeleteCallback, token}:
     onDeleteCallback()
   }
 
+  async function fetchNameFromOrcids(orcids: string[]): Promise<Map<string, string>> {
+    if(orcids.length === 0) return new Map()
+
+    const orcidsJoined = orcids.join('+')
+    const url = `https://pub.orcid.org/v3.0/expanded-search/?q=orcid:(${orcidsJoined})`
+    const response = await fetch(url, {headers: {...createJsonHeaders(undefined)}})
+
+    if((response).status !== 200) return new Map()
+
+    const json = await response.json()
+    const results = json['expanded-result']
+    const orcidNameMap = new Map()
+    for (const result of results) {
+      orcidNameMap.set(result['orcid-id'], result['given-names'] + ' ' + result['family-names'])
+    }
+    return orcidNameMap
+  }
+
+  async function setAllNames() {
+    setFetchingNames(true)
+    const oldNames = names
+    const newNames = await fetchNameFromOrcids(orcids)
+
+    for (const orcid of Array.from(oldNames.keys())) {
+      if(!newNames.has(orcid) && typeof oldNames.get(orcid) === 'string') newNames.set(orcid, oldNames.get(orcid) as string)
+    }
+
+    setNames(newNames)
+    setFetchingNames(false)
+  }
+
   return (
-    <List>
-      {orcids.map(orcid => {
-        return (
-          <ListItem
-            key={orcid} disableGutters
-            secondaryAction={
-              <IconButton onClick={() => deleteOrcid(orcid)}><DeleteIcon/></IconButton>
-            }
-          >
-            <Link href={`https://orcid.org/${orcid}`} underline="always" target="_blank" rel="noreferrer">
-              {orcid}
-            </Link>
-          </ListItem>
-        )
-      })}
-    </List>
+    <>
+      {!fetchingNames &&
+        <Button variant="contained" onClick={() => setAllNames()}>
+          Fetch names
+        </Button>
+      }
+      {fetchingNames && <CircularProgress/>}
+      <List>
+        {orcids.map(orcid => {
+          return (
+            <ListItem
+              key={orcid} disableGutters
+              secondaryAction={
+                <IconButton onClick={() => deleteOrcid(orcid)}><DeleteIcon/></IconButton>
+              }
+            >
+              <Link href={`https://orcid.org/${orcid}`} underline="always" target="_blank" rel="noreferrer">
+                {orcid}
+              </Link>
+              {names.has(orcid) && names.get(orcid)}
+            </ListItem>
+          )
+        })}
+      </List>
+    </>
   )
 }


### PR DESCRIPTION
# Fetch ORCID whitelist names

Changes proposed in this pull request:

* On the ORCID whitelist page, a button is added that, when clicked, fetches all the names of the whitelisted ORCIDs and shows them.

How to test:
* `docker-compose build frontend && docker-compose up`
* Login as admin
* Add some ORCIDs to the whitelist, both real and fake
* Click the button, it should be replaced by a spinner
* When fetching is done, the names should be displayed and the button should be back

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests