### PR TITLE
Use icons in software card

### DIFF
--- a/frontend/components/software/SoftwareCard.tsx
+++ b/frontend/components/software/SoftwareCard.tsx
@@ -4,8 +4,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Link from 'next/link'
+import Tooltip from '@mui/material/Tooltip'
+import PeopleAltOutlinedIcon from '@mui/icons-material/PeopleAltOutlined'
+import InsertCommentOutlinedIcon from '@mui/icons-material/InsertCommentOutlined'
+
 import {getTimeAgoSince} from '../../utils/dateFn'
-// import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
 import FeaturedIcon from '~/components/icons/FeaturedIcon'
 import NotPublishedIcon from '~/components/icons/NotPublishedIcon'
 
@@ -56,24 +59,6 @@ export default function SoftwareCard({href, brand_name, short_statement, is_feat
     return ''
   }
 
-  function renderCounts() {
-    let message = mentionCntMessage()
-    if (message) {
-      message += `, ${contributorsMessage()}`
-    } else {
-      message = contributorsMessage()
-    }
-    if (message) {
-      return (
-        <div className="flex items-start justify-center">
-          {/* <StarIcon sx={{height:'1rem'}} /> */}
-          {message}
-        </div>
-      )
-    }
-    return null
-  }
-
   function renderPublished() {
     if (typeof is_published != 'undefined' && is_published === false) {
       return (
@@ -112,7 +97,22 @@ export default function SoftwareCard({href, brand_name, short_statement, is_feat
             <span className="last-update">
               Updated {getTimeAgoSince(today, updated_at)}
             </span>
-            {renderCounts()}
+            <div className="flex gap-2">
+            {mention_cnt &&
+              <Tooltip title={mentionCntMessage()} placement="top">
+                <span>
+                  <InsertCommentOutlinedIcon /> {mention_cnt}
+                </span>
+              </Tooltip>
+            }
+            {contributor_cnt &&
+              <Tooltip title={contributorsMessage()} placement="top">
+                <span>
+                  <PeopleAltOutlinedIcon /> {contributor_cnt}
+                </span>
+              </Tooltip>
+            }
+            </div>
           </div>
         </article>
       </a>


### PR DESCRIPTION
# Use icons in software card for mention and contributors stats 

Changes proposed in this pull request:
*  Based on @ctwhome suggestion for UI improvements, I added icons and the tooltip to show mention and contributor counts in the software card

How to test:
* `make start` to rebuild everything (when done use docker-compose down)
* navigate to software overview, the card should look like in the example 1
* on mouseover the message should shown with counts, like `3 mentions`  or `3 contributors` 
* navigate to organisation, software cards should have similar functionality
* login as rsd_admin in order to feature and block software. These action are also shown in example 2

## Example 1 (software overview, cards with icons)
![image](https://user-images.githubusercontent.com/9204081/200832563-79db868d-e4ee-40d4-99c9-e510fe697b8c.png)

## Example 2 (organisation software - rsd_admin view)
![image](https://user-images.githubusercontent.com/9204081/200833175-0c4c43c9-bbb8-4708-8dcf-1ff16f95517e.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
