### PR TITLE
ci: update set-output in ghcr action

### DIFF
--- a/.github/workflows/_ghcr.yml
+++ b/.github/workflows/_ghcr.yml
@@ -57,7 +57,7 @@ jobs:
           IMAGE_TAG_LASTEST=${{inputs.base_image_name}}:latest
           echo image_tag_version $IMAGE_TAG_VERSION
           docker build -t $IMAGE_TAG_VERSION -t $IMAGE_TAG_LASTEST -f ${{inputs.dockerfile}} ${{inputs.docker_context}}
-          echo "::set-output name=image_build::$IMAGE_TAG_VERSION"
+          echo "{image_build}={$IMAGE_TAG_VERSIONvalue}" >> $GITHUB_OUTPUT
       - name: push to ghcr.io
         id: push_image
         run: |
@@ -65,5 +65,5 @@ jobs:
           echo "${{secrets.token}}" | docker login https://ghcr.io -u ${{inputs.ghcr_user}} --password-stdin
           echo push auth image with all tags
           docker push ${{inputs.base_image_name}} --all-tags
-          echo "::set-output name=image_pushed::true"
+          echo "{image_build}={$IMAGE_TAG_VERSIONvalue}" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
# Update deprecated set-output command

Fixes #618 

Changes proposed in this pull request:
* Updated deprecated set-ouput command in ghcr action. However, we also depend on some other actions that need to perform this update.       

How to test:
* As far as I know it can be only tested by creating a new release draft. I propose to wait until next release and confirm improvements (as mentioned other gh actions we use also need to make this update)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
