### PR TITLE
docs: adds info about logging in with admin rights

### DIFF
--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -1,5 +1,7 @@
 <!--
+SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 
@@ -59,6 +61,29 @@ docker-compose up
 ```
 
 The application can be viewed at http://localhost
+
+### Logging in with admin rights
+
+The default role assigned to a logged in user is `rsd_user`. To obtain the `rsd_admin` role, you need to update the `RSD_ADMIN_EMAIL_LIST` variable in `.env`.
+
+#### Local accounts
+
+::: danger
+Local accounts should only be used in development mode.
+:::
+
+If you activated local login by adding `LOCAL` to `RSD_AUTH_PROVIDERS`, admin rights can be obtained by adding `<name>@example.com` to `RSD_ADMIN_EMAIL_LIST`, where `<names>` is the name entered when logging in. Here is an example:
+
+```bash
+RSD_AUTH_PROVIDERS=LOCAL
+RSD_ADMIN_EMAIL_LIST=admin@example.com
+```
+
+If you now login as the user `admin`, you will be assigned the role `rsd_admin`.
+
+#### Other IDPs
+
+If you are using other IDPs, make sure to add the mail address that is being provided by the IDP. If you are using the SURFconext development instance, have a look at [this list](https://idp.diy.surfconext.nl/showusers.php) to obtain the email addresses that are provided for the test accounts.
 
 ### Frontend with hot-module-replacement (HMR)
 


### PR DESCRIPTION
# Instructions how to login with admin rights

Due to an unforeseen downtime of the dev instance of Helmholtz AAI, I was forced to use other login methods. I used the opportunity and updated the docs accordingly.

Changes proposed in this pull request:

* adds a section about 'Logging in with admin rights'

How to test:

```
cd documentation
yarn install
yarn dev
```

or `make dev-docs`

Open http://localhost:3030 and navigate to "Getting Started" -> "Running locally" -> "Logging in with admin rights"

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
