### PR TITLE
Change organisation order to officially registered first

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1171,7 +1171,13 @@ $$
 BEGIN
 	SELECT count(id) FROM software INTO software_cnt;
 	SELECT count(id) FROM project INTO project_cnt;
-	SELECT count(id) FROM organisation WHERE parent IS NULL INTO organisation_cnt;
+	SELECT
+		count(id) AS organisation_cnt
+	FROM
+		organisations_overview(true)
+	WHERE
+		organisations_overview.parent IS NULL AND organisations_overview.score>0
+	INTO organisation_cnt;
 	SELECT count(display_name) FROM unique_contributors() INTO contributor_cnt;
 	SELECT count(mention) FROM mention_for_software INTO software_mention_cnt;
 END

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -16,7 +16,7 @@ import {paginationUrlParams} from './postgrestUrl'
 export function organisationListUrl({search, rows = 12, page = 0}:
   { search: string | undefined, rows: number, page: number }) {
   // by default order is on software count and name
-  let url = `${process.env.POSTGREST_URL}/rpc/organisations_overview?parent=is.null&order=score.desc.nullslast,name.asc`
+  let url = `${process.env.POSTGREST_URL}/rpc/organisations_overview?parent=is.null&score=gt.0&order=is_tenant.desc,score.desc.nullslast,name.asc`
   // add search params
   if (search) {
     url += `&or=(name.ilike.*${search}*, website.ilike.*${search}*)`


### PR DESCRIPTION
The order of organisation on organisation overview page is changed to officially registered organisation first, then by software + projects count and last by name (ascending). In addition we only show organisation with at least one published software or project.

**The organisation count on the homepage and on the organisations overview page are identical.**

How to test:
* `make start` to rebuild everything
*  visit organisations page. Officially registered organisations (is_tenant=true) should be listed as first
*  organisation without software and projects (score=0) are not shown in the overview

## Example 

![image](https://user-images.githubusercontent.com/9204081/201970429-e17c9006-0550-4ef7-a052-408696e38b0e.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
