### PR TITLE
Change homepage title

### DIFF
--- a/frontend/components/AppFooter/ContactEmail.tsx
+++ b/frontend/components/AppFooter/ContactEmail.tsx
@@ -8,12 +8,12 @@ import Mail from '@mui/icons-material/Mail'
 export default function ContactEmail({email}:{email?:string}) {
   if (email) {
     return (
-      <div>
-        <div className="mt-4 text-lg">Questions or comments?</div>
+      <div className="mt-8">
+        {/* <div className="mt-4 text-lg">Questions or comments?</div> */}
         <a href={`mailto:${email}`}
-            className="flex mt-2 text-primary hover:text-primary-content"
+          className="flex text-primary hover:text-primary-content"
         >
-        <Mail className="mr-2"/> {email}
+          <Mail className="mr-2"/> {email}
         </a>
       </div>
     )

--- a/frontend/components/AppFooter/index.tsx
+++ b/frontend/components/AppFooter/index.tsx
@@ -21,8 +21,7 @@ export default function AppFooter () {
       <div className="grid grid-cols-1 gap-8 px-4 md:grid-cols-[2fr,1fr] lg:container lg:mx-auto">
         <div className="pt-8 md:py-8">
           <p className="text-lg">
-            The Research Software Directory aims to promote the impact,
-            the exchange and re-use of research software.
+            The Research Software Directory promotes the impact, re-use and citation of research software.
           </p>
 
           <ContactEmail email={host?.email} />

--- a/frontend/components/home/rsd/OrganisationSignUp.tsx
+++ b/frontend/components/home/rsd/OrganisationSignUp.tsx
@@ -103,7 +103,7 @@ export default function OrganisationSignUp({minWidth = '9rem'}:{minWidth:string}
               {config.button.register.label}
             </div>
             <div className="text-sm text-[#B7B7B7] pb-4">
-              You can find more information about registering your organisation in our <a href="https://research-software-directory.github.io/documentation/register-organization.html" target="_blank" rel="noreferrer">documentation</a>.
+              You can find more information about registering your organisation in our <u><a href="https://research-software-directory.github.io/documentation/register-organization.html" target="_blank" rel="noreferrer">documentation</a></u>.
             </div>
             {/* INPUTS */}
             <input type="text"

--- a/frontend/components/home/rsd/PersonalSignUp.tsx
+++ b/frontend/components/home/rsd/PersonalSignUp.tsx
@@ -107,7 +107,7 @@ export default function PersonalSignUp({minWidth = '9rem'}:{minWidth:string}) {
               {config.button.signUp.label}
             </div>
             <div className="text-sm text-[#B7B7B7] pb-4">
-              You can find more information about how to get access in our <a href="https://research-software-directory.github.io/documentation/getting-access.html" target="_blank" rel="noreferrer">documentation</a>.
+              You can find more information about how to get access in our <u><a href="https://research-software-directory.github.io/documentation/getting-access.html" target="_blank" rel="noreferrer">documentation</a></u>.
             </div>
             {/* INPUTS */}
             <input type="text"

--- a/frontend/components/home/rsd/index.tsx
+++ b/frontend/components/home/rsd/index.tsx
@@ -84,7 +84,7 @@ export default function RsdHome({software_cnt, project_cnt, organisation_cnt, co
               data-aos="fade" data-aos-offset="200" data-aos-delay="50" data-aos-duration="1000"
         >
           <h1 className="text-5xl font-rsd-titles font-bold">
-            Showing the impact of research software
+            Show your research software to the world
           </h1>
           <div className="mt-8 text-lg">
             The<span
@@ -196,7 +196,7 @@ export default function RsdHome({software_cnt, project_cnt, organisation_cnt, co
           id="our-goals"
           className="p-5 md:p-10 w-full max-w-screen-xl mx-auto">
           <h2
-            className="flex justify-start text-3xl font-rsd-titles font-bold mt-6"
+            className="flex justify-start text-4xl font-rsd-titles font-bold mt-6"
             data-aos="fade" data-aos-duration="400" data-aos-easing="ease-in-out">
             Our goals
           </h2>
@@ -270,7 +270,7 @@ export default function RsdHome({software_cnt, project_cnt, organisation_cnt, co
             <p className="text-center text-lg mt-5" data-aos="fade"
                data-aos-delay="100" data-aos-duration="400" data-aos-easing="ease-in-out">
               Try out our online demo, or get more detailed information in our documentation and
-              faq.
+              FAQ.
             </p>
 
             <div
@@ -321,7 +321,7 @@ export default function RsdHome({software_cnt, project_cnt, organisation_cnt, co
           <p className="text-center text-lg mt-5" data-aos="fade"
              data-aos-delay="100" data-aos-duration="400" data-aos-easing="ease-in-out">
             The Research Software Directory is an open source project initiated by the Netherlands
-            eScience Center. We are always open for improvements and discussions. Feel free to
+            eScience Center and jointly developed with Helmholtz. Feel free to
             contact us or join our effort!
           </p>
 

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -18,7 +18,7 @@
       "target": "_self"
     },
     {
-      "label": "Documentation",
+      "label": "User Documentation",
       "url": "https://research-software-directory.github.io/documentation",
       "target": "_blank"
     },


### PR DESCRIPTION
# Homepage title

Changes proposed in this pull request:
*  Homepage title changed to "Show your research software to the world"    
*  Few other textual changes on the homepage and in the footer

How to test:
*  `make start` to rebuild everything
*  navigate to home page and confirm title change

![image](https://user-images.githubusercontent.com/9204081/202540811-d7705ec6-13f6-4466-a8e8-9760ee8a8feb.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
