### PR TITLE
Link to getting access documentation page in login modal

### DIFF
--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -9,7 +9,7 @@
       "url": "rsd@esciencecenter.nl",
       "issues_page_url": "https://github.com/research-software-directory/RSD-as-a-service/issues"
     },
-    "login_info_url":"https://research-software-directory.github.io/documentation/getting-started.html#signing-in"
+    "login_info_url":"https://research-software-directory.github.io/documentation/getting-access.html"
   },
   "links": [
     {


### PR DESCRIPTION
# Link to getting access page from login modal for more information

Changes proposed in this pull request:
*  Link to getting access page from login modal for more information     

How to test:
* `make start` to rebuild all
* use Sign in button, the login modal should appear
* At the bottom of the login the documentation link should open getting access page in new tab

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
