### PR TITLE
feat: add env vars to specify db host and port

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2021 - 2022 dv4all
+# SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 #
 # SPDX-License-Identifier: CC-BY-4.0
 #
@@ -25,6 +26,10 @@ COMPOSE_PROJECT_NAME="rsd"
 # ---- PUBLIC ENV VARIABLES -------------
 
 # postgresql
+# consumed by services: backend
+POSTGRES_DB_HOST=database
+# consumed by services: backend
+POSTGRES_DB_HOST_PORT=5432
 # consumed by services: database, backend
 POSTGRES_DB=rsd-db
 # consumed by services: database

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -4,6 +4,7 @@
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -38,7 +39,7 @@ services:
       - 3500
     environment:
       # it needs to be here to use values from .env file
-      - PGRST_DB_URI=postgres://authenticator:${POSTGRES_AUTHENTICATOR_PASSWORD}@database:5432/${POSTGRES_DB}
+      - PGRST_DB_URI=postgres://authenticator:${POSTGRES_AUTHENTICATOR_PASSWORD}@${POSTGRES_DB_HOST}:${POSTGRES_DB_HOST_PORT}/${POSTGRES_DB}
       - PGRST_DB_ANON_ROLE
       - PGRST_DB_SCHEMA
       - PGRST_SERVER_PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@
 # SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -38,7 +39,7 @@ services:
       - 3500
     environment:
       # it needs to be here to use values from .env file
-      - PGRST_DB_URI=postgres://authenticator:${POSTGRES_AUTHENTICATOR_PASSWORD}@database:5432/${POSTGRES_DB}
+      - PGRST_DB_URI=postgres://authenticator:${POSTGRES_AUTHENTICATOR_PASSWORD}@${POSTGRES_DB_HOST}:${POSTGRES_DB_HOST_PORT}/${POSTGRES_DB}
       - PGRST_DB_ANON_ROLE
       - PGRST_DB_SCHEMA
       - PGRST_SERVER_PORT


### PR DESCRIPTION
# feat: add env vars to specify db host and port

Related to #671

Changes proposed in this pull request:

* introduces two env variables for docker-compose.yml in order to change the Postgres DB Host and Port

How to test:

* copy `.env.example` to `.env`
* change `POSTGRES_DB_HOST` and enter the database hostname
* change `POSTGRES_DB_HOST_PORT` and specify the port under which the DB host is available
* Start the services: `docker-compose up`

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
