### PR TITLE
fix: date in future test

### DIFF
--- a/frontend/utils/dateFn.test.ts
+++ b/frontend/utils/dateFn.test.ts
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -19,7 +21,7 @@ describe('dateFn.daysDiff',()=>{
   })
 
   it('returns 0 if date in future',()=>{
-    const date = new Date('2022-11-25')
+    const date = new Date('2122-11-25')
     const diff = daysDiff(date)
     expect(diff).toBe(0)
   })


### PR DESCRIPTION
# Fixes a test that fails  because date is not in the future anymore

The test `returns 0 if date in future` in `frontend/utils/dateFn.test.ts` was failing, because the date it was testing against is 2022-11-25, which is not in the future anymore.

Changes proposed in this pull request:

* use `2122-11-25` as date

How to test:

* make sure that all images that were compiled before 2022-11-25 are removed (e.g. by using `docker system prune`, `docker rmi` was not sufficient for me because of layer caching)
* `docker compose build frontend`

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
