### PR TITLE
fix: commit and programming languages scraper now store unescaped JSON

### DIFF
--- a/frontend/components/software/AboutLanguages.tsx
+++ b/frontend/components/software/AboutLanguages.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -25,26 +27,26 @@ function calculateStats(languages: ProgramingLanguages) {
       total+=languages[key]
     })
     // calculate stats
-    const stats:any = {}
+    const stats: {language: string, val: number, pct: number}[] = []
     keys.map(key => {
       const pct = Math.round((languages[key] / total) * 100)
-      totPct += pct
-      totVal += languages[key]
       if (pct > 0) {
+        totPct += pct
+        totVal += languages[key]
         totLang.push(key)
-        stats[key] = {
-          val: languages[key],
-          pct
-        }
+        stats.push({language: key, val: languages[key], pct: pct})
       }
     })
+
+    // order stats by percentage before adding 'Other'
+    stats.sort((a, b) => {
+      return a.pct !== b.pct ? b.pct - a.pct : a.language.localeCompare(b.language)
+    })
+
     // do we need Other category?
     if (totPct < 100 && (keys.length - totLang.length > 1)) {
       // add other to stats
-      stats['Other'] = {
-        val: total - totVal,
-        pct: 100 - totPct
-      }
+      stats.push({language: 'Other', val: total - totVal, pct: 100 - totPct})
     }
     return stats
   } catch (e:any) {
@@ -68,14 +70,14 @@ export default function AboutLanguages({languages}: {languages: ProgramingLangua
     </div>
     <ul className="py-1">
       {/* show only stat selection pct > 0*/}
-      {Object?.keys(stats)?.map((key) => {
+      {stats?.map((entry) => {
         return (
-          <li key={key}>
-            {key} <span className="ml-2">{stats[key].pct}%</span>
+          <li key={entry.language}>
+            {entry.language} <span className="ml-2">{entry.pct}%</span>
             <div
               className="bg-primary"
               style={{
-                width: `${stats[key].pct}%`,
+                width: `${entry.pct}%`,
                 height: '0.5rem',
                 opacity: 0.5
               }}>

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -95,15 +95,17 @@ export async function getRepostoryInfoForSoftware(software: string | undefined, 
         const info: RepositoryInfo = {
           ...data[0],
           // parse JSONB
-          languages: JSON.parse(data[0].languages),
-          commit_history: JSON.parse(data[0].commit_history)
+          // languages: JSON.parse(data[0].languages),
+          languages: data[0].languages,
+          // commit_history: JSON.parse(data[0].commit_history)
+          commit_history: data[0].commit_history
         }
         return info
       }
       return null
     }
   } catch (e: any) {
-    logger(`getSoftwareItem: ${e?.message}`, 'error')
+    logger(`getRepostoryInfoForSoftware: ${e?.message}`, 'error')
     return null
   }
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/PostgrestSIR.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/PostgrestSIR.java
@@ -7,6 +7,7 @@ package nl.esciencecenter.rsd.scraper.git;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import nl.esciencecenter.rsd.scraper.Utils;
@@ -77,12 +78,12 @@ public class PostgrestSIR implements SoftwareInfoRepository {
 			ZonedDateTime licensScrapedAt = jsonLicenseScrapedAt.isJsonNull() ? null : ZonedDateTime.parse(jsonLicenseScrapedAt.getAsString());
 
 			JsonElement jsonCommits = jsonObject.get("commit_history");
-			String commits = jsonCommits.isJsonNull() ? null : jsonCommits.getAsString();
+			String commits = jsonCommits.isJsonNull() ? null : jsonCommits.toString();
 			JsonElement jsonCommitsScrapedAt = jsonObject.get("commit_history_scraped_at");
 			ZonedDateTime commitsScrapedAt = jsonCommitsScrapedAt.isJsonNull() ? null : ZonedDateTime.parse(jsonCommitsScrapedAt.getAsString());
 
 			JsonElement jsonLanguages = jsonObject.get("languages");
-			String languages = jsonLanguages.isJsonNull() ? null : jsonLanguages.getAsString();
+			String languages = jsonLanguages.isJsonNull() ? null : jsonLanguages.toString();
 			JsonElement jsonLanguagesScrapedAt = jsonObject.get("languages_scraped_at");
 			ZonedDateTime languagesScrapedAt = jsonLanguagesScrapedAt.isJsonNull() ? null : ZonedDateTime.parse(jsonLanguagesScrapedAt.getAsString());
 
@@ -109,10 +110,10 @@ public class PostgrestSIR implements SoftwareInfoRepository {
 			newDataJson.addProperty("license", repositoryUrlData.license());
 			newDataJson.addProperty("license_scraped_at", repositoryUrlData.licenseScrapedAt() == null ? null : repositoryUrlData.licenseScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
 
-			newDataJson.addProperty("commit_history", repositoryUrlData.commitHistory());
+			newDataJson.add("commit_history", repositoryUrlData.commitHistory() == null ? JsonNull.INSTANCE : JsonParser.parseString(repositoryUrlData.commitHistory()));
 			newDataJson.addProperty("commit_history_scraped_at", repositoryUrlData.commitHistoryScrapedAt() == null ? null : repositoryUrlData.commitHistoryScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
 
-			newDataJson.addProperty("languages", repositoryUrlData.languages());
+			newDataJson.add("languages", repositoryUrlData.languages() == null ? JsonNull.INSTANCE : JsonParser.parseString(repositoryUrlData.languages()));
 			newDataJson.addProperty("languages_scraped_at", repositoryUrlData.languagesScrapedAt() == null ? null : repositoryUrlData.languagesScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
 			dataAsJsonArray.add(newDataJson);
 		}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/PostgrestSIRTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/PostgrestSIRTest.java
@@ -38,9 +38,9 @@ public class PostgrestSIRTest {
 						"url": "https://www.example.com",
 						"license": "My license",
 						"license_scraped_at": "2022-04-25T14:48:02.911546Z",
-						"commit_history": "Commit history",
+						"commit_history": {"123": 5},
 						"commit_history_scraped_at": "2022-04-25T14:48:02.911546Z",
-						"languages": "Java, JavaScript",
+						"languages": {"Java": 100, "JavaScript": 20},
 						"languages_scraped_at": "2022-04-25T14:48:02.911546Z"
 					}
 				]""";
@@ -55,9 +55,10 @@ public class PostgrestSIRTest {
 		Assertions.assertEquals(CodePlatformProvider.GITHUB, dataToInspect.code_platform());
 		Assertions.assertEquals("My license", dataToInspect.license());
 		Assertions.assertEquals(Month.APRIL, dataToInspect.licenseScrapedAt().getMonth());
-		Assertions.assertEquals("Commit history", dataToInspect.commitHistory());
+		Assertions.assertEquals(5, JsonParser.parseString(dataToInspect.commitHistory()).getAsJsonObject().getAsJsonPrimitive("123").getAsInt());
 		Assertions.assertEquals(2022, dataToInspect.commitHistoryScrapedAt().getYear());
-		Assertions.assertEquals("Java, JavaScript", dataToInspect.languages());
+		Assertions.assertEquals(100, JsonParser.parseString(dataToInspect.languages()).getAsJsonObject().getAsJsonPrimitive("Java").getAsInt());
+		Assertions.assertEquals(20, JsonParser.parseString(dataToInspect.languages()).getAsJsonObject().getAsJsonPrimitive("JavaScript").getAsInt());
 		Assertions.assertEquals(25, dataToInspect.languagesScrapedAt().getDayOfMonth());
 	}
 
@@ -70,7 +71,7 @@ public class PostgrestSIRTest {
 						"url": "https://www.example.com",
 						"license": "My license",
 						"license_scraped_at": "2022-04-25T14:48:02.911546Z",
-						"commit_history": "Commit history",
+						"commit_history": {"123": 5},
 						"commit_history_scraped_at": null,
 						"languages": null,
 						"languages_scraped_at": "2022-04-25T14:48:02.911546Z"
@@ -87,7 +88,7 @@ public class PostgrestSIRTest {
 		Assertions.assertEquals(CodePlatformProvider.GITHUB, dataToInspect.code_platform());
 		Assertions.assertEquals("My license", dataToInspect.license());
 		Assertions.assertEquals(Month.APRIL, dataToInspect.licenseScrapedAt().getMonth());
-		Assertions.assertEquals("Commit history", dataToInspect.commitHistory());
+		Assertions.assertEquals(5, JsonParser.parseString(dataToInspect.commitHistory()).getAsJsonObject().getAsJsonPrimitive("123").getAsInt());
 		Assertions.assertNull(dataToInspect.commitHistoryScrapedAt());
 		Assertions.assertNull(dataToInspect.languages());
 		Assertions.assertEquals(25, dataToInspect.languagesScrapedAt().getDayOfMonth());
@@ -103,7 +104,7 @@ public class PostgrestSIRTest {
 						"url": "https://www.example.com",
 						"license": "My license",
 						"license_scraped_at": "2022-04-25T14:48:02.911546Z",
-						"commit_history": "Commit history",
+						"commit_history": {"123": 5},
 						"commit_history_scraped_at": null,
 						"languages" null
 						"languages_scraped_at": "2022-04-25T14:48:02.911546Z"
@@ -122,7 +123,7 @@ public class PostgrestSIRTest {
 						"software": "Test software",
 						"url": "https://www.example.com",
 						"license_scraped_at": "2022-04-25T14:48:02.911546",
-						"commit_history": "Commit history",
+						"commit_history": {"123": 5},
 						"commit_history_scraped_at": null,
 						"languages" null,
 						"languages_scraped_at": "2022-04-25T14:48:02.911546"
@@ -148,8 +149,8 @@ public class PostgrestSIRTest {
 		Collection<RepositoryUrlData> collectionWithOneEntry = new ArrayList<>();
 		RepositoryUrlData entry = new RepositoryUrlData("My software", "https://www.example.com", CodePlatformProvider.GITHUB,
 				"My license", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
-				"Commit history", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
-				"Java, JavaScript", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"));
+				"{\"123\": 5}", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
+				"{\"Java\": 100, \"JavaScript\": 20}", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"));
 		collectionWithOneEntry.add(entry);
 
 		String json = PostgrestSIR.repositoryUrlDataToJson(collectionWithOneEntry);
@@ -163,9 +164,10 @@ public class PostgrestSIRTest {
 		Assertions.assertEquals("github", entryJson.getAsJsonPrimitive("code_platform").getAsString());
 		Assertions.assertEquals("My license", entryJson.getAsJsonPrimitive("license").getAsString());
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson.getAsJsonPrimitive("license_scraped_at").getAsString());
-		Assertions.assertEquals("Commit history", entryJson.getAsJsonPrimitive("commit_history").getAsString());
+		Assertions.assertEquals(5, entryJson.getAsJsonObject("commit_history").getAsJsonPrimitive("123").getAsInt());
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson.getAsJsonPrimitive("commit_history_scraped_at").getAsString());
-		Assertions.assertEquals("Java, JavaScript", entryJson.getAsJsonPrimitive("languages").getAsString());
+		Assertions.assertEquals(100, entryJson.getAsJsonObject("languages").getAsJsonPrimitive("Java").getAsInt());
+		Assertions.assertEquals(20, entryJson.getAsJsonObject("languages").getAsJsonPrimitive("JavaScript").getAsInt());
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson.getAsJsonPrimitive("languages_scraped_at").getAsString());
 	}
 
@@ -175,7 +177,7 @@ public class PostgrestSIRTest {
 		RepositoryUrlData entry = new RepositoryUrlData("My software", "https://www.example.com", CodePlatformProvider.GITHUB,
 				"My license", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
 				null, ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
-				"Java, JavaScript", null);
+				"{\"Java\": 100, \"JavaScript\": 20}", null);
 		collectionWithOneEntry.add(entry);
 
 		String json = PostgrestSIR.repositoryUrlDataToJson(collectionWithOneEntry);
@@ -191,7 +193,8 @@ public class PostgrestSIRTest {
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson.getAsJsonPrimitive("license_scraped_at").getAsString());
 		Assertions.assertTrue(entryJson.get("commit_history").isJsonNull());
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson.getAsJsonPrimitive("commit_history_scraped_at").getAsString());
-		Assertions.assertEquals("Java, JavaScript", entryJson.getAsJsonPrimitive("languages").getAsString());
+		Assertions.assertEquals(100, entryJson.getAsJsonObject("languages").getAsJsonPrimitive("Java").getAsInt());
+		Assertions.assertEquals(20, entryJson.getAsJsonObject("languages").getAsJsonPrimitive("JavaScript").getAsInt());
 		Assertions.assertTrue(entryJson.get("languages_scraped_at").isJsonNull());
 	}
 
@@ -201,11 +204,11 @@ public class PostgrestSIRTest {
 		RepositoryUrlData entry1 = new RepositoryUrlData("My software", "https://www.example.com", CodePlatformProvider.GITHUB,
 				"My license", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
 				null, ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
-				"Java, JavaScript", null);
+				"{\"Java\": 100, \"JavaScript\": 20}", null);
 		RepositoryUrlData entry2 = new RepositoryUrlData("My software 2", "https://www.example.com", CodePlatformProvider.GITHUB,
 				"My license", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
-				"Commit history", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
-				"Java, JavaScript", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"));
+				"{\"123\": 5}", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"),
+				"{\"Java\": 100, \"JavaScript\": 20}", ZonedDateTime.parse("2022-04-25T14:48:02.911546Z"));
 		collectionWithOneEntry.add(entry1);
 		collectionWithOneEntry.add(entry2);
 
@@ -222,7 +225,8 @@ public class PostgrestSIRTest {
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson.getAsJsonPrimitive("license_scraped_at").getAsString());
 		Assertions.assertTrue(entryJson.get("commit_history").isJsonNull());
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson.getAsJsonPrimitive("commit_history_scraped_at").getAsString());
-		Assertions.assertEquals("Java, JavaScript", entryJson.getAsJsonPrimitive("languages").getAsString());
+		Assertions.assertEquals(100, entryJson.getAsJsonObject("languages").getAsJsonPrimitive("Java").getAsInt());
+		Assertions.assertEquals(20, entryJson.getAsJsonObject("languages").getAsJsonPrimitive("JavaScript").getAsInt());
 		Assertions.assertTrue(entryJson.get("languages_scraped_at").isJsonNull());
 		JsonObject entryJson2 = arrayWithOneEntry.get(1).getAsJsonObject();
 		Assertions.assertEquals("My software 2", entryJson2.getAsJsonPrimitive("software").getAsString());
@@ -230,9 +234,10 @@ public class PostgrestSIRTest {
 		Assertions.assertEquals("github", entryJson2.getAsJsonPrimitive("code_platform").getAsString());
 		Assertions.assertEquals("My license", entryJson2.getAsJsonPrimitive("license").getAsString());
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson2.getAsJsonPrimitive("license_scraped_at").getAsString());
-		Assertions.assertEquals("Commit history", entryJson2.getAsJsonPrimitive("commit_history").getAsString());
+		Assertions.assertEquals(5, entryJson2.getAsJsonObject("commit_history").getAsJsonPrimitive("123").getAsInt());
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson2.getAsJsonPrimitive("commit_history_scraped_at").getAsString());
-		Assertions.assertEquals("Java, JavaScript", entryJson2.getAsJsonPrimitive("languages").getAsString());
+		Assertions.assertEquals(100, entryJson.getAsJsonObject("languages").getAsJsonPrimitive("Java").getAsInt());
+		Assertions.assertEquals(20, entryJson.getAsJsonObject("languages").getAsJsonPrimitive("JavaScript").getAsInt());
 		Assertions.assertEquals("2022-04-25T14:48:02.911546Z", entryJson2.getAsJsonPrimitive("languages_scraped_at").getAsString());
 	}
 }


### PR DESCRIPTION
# Scrapers store proper JSON

Changes proposed in this pull request:

* Store programming language and commit history as proper JSON objects instead of strings

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=0`
* Add two software pages, with repo URLs https://github.com/research-software-directory/RSD-as-a-service and https://gitlab.com/cyber5k/mistborn respectively
* Make sure the two relevant scrapers have run: 
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages`
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits`
* View the two software pages
* The commit history and languages should be properly displayed (the languages in descending order of percentage, with `Other` being last)
* Run `SELECT JSONB_TYPEOF(languages), JSONB_TYPEOF(commit_history) FROM repository_url;`, the result should be `object`s (this used to be `string`s)

**These changes are not compatible with existing data,so we have to clear the columns `languages` and `commit_history` from the `repository_url` table, otherwise garbage is displayed**

Closes #669

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests