### PR TITLE
Do not set scrapedAt if rate limit is exceeded

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/RsdRateLimitException.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/RsdRateLimitException.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper;
+
+public class RsdRateLimitException extends RuntimeException {
+	public RsdRateLimitException(String message) {
+		super(message);
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitLabSI.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitLabSI.java
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -9,6 +11,8 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+
+import nl.esciencecenter.rsd.scraper.RsdRateLimitException;
 import nl.esciencecenter.rsd.scraper.Utils;
 
 import java.io.IOException;
@@ -91,6 +95,7 @@ public class GitLabSI implements SoftwareInfo {
 				System.out.println("An error occurred fetching data from: " + request.uri());
 				throw new RuntimeException(e);
 			}
+			if (response.statusCode() == 429) throw new RsdRateLimitException("API rate limit exceeded for endpoint " + request.uri() + " with response: " + response.body());
 			if (response.statusCode() == 404) return null;
 
 			JsonArray thisPageCommits = JsonParser.parseString(response.body()).getAsJsonArray();

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GithubSI.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GithubSI.java
@@ -10,6 +10,7 @@ package nl.esciencecenter.rsd.scraper.git;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import nl.esciencecenter.rsd.scraper.Config;
+import nl.esciencecenter.rsd.scraper.RsdRateLimitException;
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
 import nl.esciencecenter.rsd.scraper.Utils;
 
@@ -97,6 +98,9 @@ public class GithubSI implements SoftwareInfo {
 			if (e.getStatusCode() == 404) {
 				// Repository does not exist
 				contributions = null;
+			} else if (e.getStatusCode() == 403) {
+				// Forbidden, mostly when the rate limit was exceeded
+				throw new RsdRateLimitException("403 Forbidden. This error occurrs mostly when the API rate limit is exceeded. Error message: " + e.getMessage());
 			} else throw e;
 		}
 		return contributions;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainCommits.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainCommits.java
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -6,6 +8,7 @@
 package nl.esciencecenter.rsd.scraper.git;
 
 import nl.esciencecenter.rsd.scraper.Config;
+import nl.esciencecenter.rsd.scraper.RsdRateLimitException;
 
 import java.net.URI;
 import java.time.ZonedDateTime;
@@ -41,6 +44,9 @@ public class MainCommits {
 						scrapedCommits, scrapedAt,
 						commitData.languages(), commitData.languagesScrapedAt());
 				updatedDataAll.add(updatedData);
+			} catch (RsdRateLimitException e) {
+				System.out.println("Exception when handling data from url " + commitData.url() + ":");
+				e.printStackTrace();
 			} catch (RuntimeException  e) {
 				System.out.println("Exception when handling data from url " + commitData.url() + ":");
 				e.printStackTrace();
@@ -75,6 +81,9 @@ public class MainCommits {
 						scrapedCommits, scrapedAt,
 						commitData.languages(), commitData.languagesScrapedAt());
 				updatedDataAll.add(updatedData);
+			} catch (RsdRateLimitException e) {
+				System.out.println("Exception when handling data from url " + commitData.url() + ":");
+				e.printStackTrace();
 			} catch (RuntimeException e) {
 				System.out.println("Exception when handling data from url " + commitData.url() + ":");
 				e.printStackTrace();


### PR DESCRIPTION
Fixes #686 

Changes proposed in this pull request:

* if the response code indicates that the API rate limit is exceeded (403 for github, 429 for GitLab), do not update the entry so that it will still be listed as a repo that has not been scraped yet

How to test:

* make sure that `API_CREDENTIALS_GITHUB` in `.env` is unset
* `docker compose build scrapers && docker compose up`
* reach the rate limit by running
  ```
  for i in {1..60}; do curl -I https://api.github.com/users/octocat ; done
  ```
* If the rate limit is reached, create a new software with url `https://github.com/research-software-directory/RSD-as-a-service`
* Run the scrapers `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits`
* Open the corresponding software page, the graph should show the "we did not scrape the history yet" message

The check is also integrated for GitLab repositories, however, I could not manage to reach a limit.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
