### PR TITLE
644 logos for software

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -35,4 +35,9 @@
   "java.test.config": {
     "envFile": "${workspaceFolder}/.env",
   },
+  "[typescript]": {
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
+    "editor.detectIndentation": false
+  }
 }

--- a/database/003-create-software-table.sql
+++ b/database/003-create-software-table.sql
@@ -1,6 +1,8 @@
 -- SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+-- SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 -- SPDX-FileCopyrightText: 2022 dv4all
 --
 -- SPDX-License-Identifier: Apache-2.0
@@ -24,6 +26,7 @@ CREATE TABLE software (
 	description_url VARCHAR(200) CHECK (description_url ~ '^https?://'),
 	description_type description_type DEFAULT 'markdown' NOT NULL,
 	get_started_url VARCHAR(200) CHECK (get_started_url ~ '^https?://'),
+	image_id VARCHAR(40) REFERENCES image(id),
 	is_published BOOLEAN DEFAULT FALSE NOT NULL,
 	short_statement VARCHAR(300),
 	created_at TIMESTAMPTZ NOT NULL,

--- a/frontend/components/layout/CardTitle.tsx
+++ b/frontend/components/layout/CardTitle.tsx
@@ -11,7 +11,7 @@ type CardTitleProps = {
 
 /**
  * Card title max 3 lines with line clamp
- * @returns 
+ * @returns
  */
 export default function CardTitle({title,children,className=''}:CardTitleProps) {
   return (

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @next/next/no-img-element */
+import PhotoSizeSelectActualOutlinedIcon from '@mui/icons-material/PhotoSizeSelectActualOutlined'
+
+type ImageWithPlaceholderProps = {
+  src: string | null | undefined
+  alt: string,
+  className?: string,
+  bgSize?: 'fill' | 'contain' | 'cover' | 'none' | 'scale-down',
+  bgPosition?: string
+  placeholder?: string
+}
+
+export default function ImageWithPlaceholder(
+  {src, alt, className, bgSize = 'contain', bgPosition = 'center',
+  placeholder}: ImageWithPlaceholderProps
+) {
+
+  if (!src) {
+    return (
+      <div
+        className={`${className} flex flex-col justify-center items-center text-grey-500 rounded-sm`}
+      >
+        <PhotoSizeSelectActualOutlinedIcon
+          sx={{
+            width: '4rem',
+            height: '4rem'
+          }}
+        />
+        <div className="uppercase text-center">{placeholder}</div>
+      </div>
+    )
+  }
+
+  return (
+    <img
+      title={placeholder ?? alt}
+      role="img"
+      src={src}
+      style={{
+        objectFit: bgSize,
+        objectPosition: bgPosition
+      }}
+      aria-label={alt}
+      alt={alt}
+      className={`rounded-sm ${className ?? ''}`}
+    ></img>
+  )
+}

--- a/frontend/components/organisation/OrganisationGrid.tsx
+++ b/frontend/components/organisation/OrganisationGrid.tsx
@@ -5,7 +5,7 @@
 
 import {OrganisationForOverview} from '../../types/Organisation'
 import OrganisationCard from './OrganisationCard'
-import FlexibleGridSection, { useAdvicedDimensions } from '../layout/FlexibleGridSection'
+import FlexibleGridSection, {useAdvicedDimensions} from '../layout/FlexibleGridSection'
 import NoContent from '../layout/NoContent'
 
 // render organisation cards

--- a/frontend/components/projects/edit/information/config.ts
+++ b/frontend/components/projects/edit/information/config.ts
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -42,7 +44,7 @@ export const projectInformation = {
   },
   description: {
     title: 'Project description',
-    subtitle: 'The image will apear above the description.',
+    subtitle: 'The image will appear above the description.',
     validation: {
       maxLength: {value: 10000},
     }

--- a/frontend/components/software/AboutSection.tsx
+++ b/frontend/components/software/AboutSection.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +12,7 @@ import SoftwareKeywords from './SoftwareKeywords'
 import AboutLanguages from './AboutLanguages'
 import AboutLicense from './AboutLicense'
 import AboutSourceCode from './AboutSourceCode'
+import SoftwareLogo from './SoftwareLogo'
 
 type AboutSectionType = {
   brand_name: string
@@ -19,19 +22,30 @@ type AboutSectionType = {
   licenses: License[]
   repository: string | null
   platform: CodePlatform
-  languages: ProgramingLanguages
+  languages: ProgramingLanguages,
+  image_id: string | null
 }
 
 
-export default function AboutSection({
-  brand_name = '', description = '', keywords, licenses,
-  repository, languages, platform, description_type='markdown'
-}:AboutSectionType) {
-
+export default function AboutSection(props:AboutSectionType) {
+  const {
+    brand_name = '', description = '', keywords, licenses,
+    repository, languages, platform, description_type = 'markdown',
+    image_id
+  } = props
   if (brand_name==='') return null
 
   // extract only license text
   const license = licenses?.map(item => item.license)
+
+  function getSoftwareLogo() {
+    if (image_id !== null) {
+      return (
+        <SoftwareLogo image_id={image_id} brand_name={brand_name} />
+      )
+    }
+    return null
+  }
 
   return (
     <PageContainer className="flex flex-col px-4 py-12 lg:flex-row lg:pt-0 lg:pb-12">
@@ -43,6 +57,7 @@ export default function AboutSection({
         />
       </div>
       <div className="flex-1">
+        {getSoftwareLogo()}
         <SoftwareKeywords keywords={keywords || []} />
         <AboutLanguages languages={languages} />
         <AboutLicense license={license || []} />

--- a/frontend/components/software/SoftwareLogo.tsx
+++ b/frontend/components/software/SoftwareLogo.tsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {DesignServices} from '@mui/icons-material'
+import Image from 'next/image'
+import {getImageUrl} from '~/utils/editImage'
+import ImageAsBackground from '../layout/ImageAsBackground'
+
+export default function SoftwareLogo(
+    {image_id, brand_name}: {image_id:string, brand_name:string}
+  ) {
+  const image_path = getImageUrl(image_id)
+
+  if (image_path !== null ){
+    return (
+      <div className="pt-8 pb-2">
+        <DesignServices color='primary' />
+        <span className="text-primary pl-2">Logo</span>
+        <div className="relative w-full">
+          {/*Temporarily disable check until we find a better solution*/}
+          {/* eslint-disable @next/next/no-img-element */}
+          <img
+            src={image_path}
+            alt={'Logo of ' + brand_name}
+            className={'w-full pt-10'}
+          />
+          {/* <Image
+            alt={'Logo of ' + brand_name}
+            src={image_path}
+            fill={true}
+            objectFit={'contain'}
+          /> */}
+        {/* <ImageAsBackground
+          alt={'Logo of' + brand_name}
+          bgSize={'contain'}
+          bgPosition={'bottom center'}
+          src={image_path}
+          className="pt-10 pr-4"
+        /> */}
+        </div>
+      </div>
+    )
+  } else {
+    return (
+      <div>Image not found</div>
+    )
+  }
+}

--- a/frontend/components/software/SoftwareLogo.tsx
+++ b/frontend/components/software/SoftwareLogo.tsx
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {DesignServices} from '@mui/icons-material'
-import Image from 'next/image'
 import {getImageUrl} from '~/utils/editImage'
-import ImageAsBackground from '../layout/ImageAsBackground'
+import ImageWithPlaceholder from '../layout/ImageWithPlaceholder'
 
 export default function SoftwareLogo(
     {image_id, brand_name}: {image_id:string, brand_name:string}
@@ -15,36 +15,15 @@ export default function SoftwareLogo(
 
   if (image_path !== null ){
     return (
-      <div className="pt-8 pb-2">
-        <DesignServices color='primary' />
-        <span className="text-primary pl-2">Logo</span>
-        <div className="relative w-full">
-          {/*Temporarily disable check until we find a better solution*/}
-          {/* eslint-disable @next/next/no-img-element */}
-          <img
-            src={image_path}
-            alt={'Logo of ' + brand_name}
-            className={'w-full pt-10'}
-          />
-          {/* <Image
-            alt={'Logo of ' + brand_name}
-            src={image_path}
-            fill={true}
-            objectFit={'contain'}
-          /> */}
-        {/* <ImageAsBackground
-          alt={'Logo of' + brand_name}
-          bgSize={'contain'}
-          bgPosition={'bottom center'}
-          src={image_path}
-          className="pt-10 pr-4"
-        /> */}
-        </div>
-      </div>
-    )
-  } else {
-    return (
-      <div>Image not found</div>
+      <ImageWithPlaceholder
+        alt={`Logo of ${brand_name}`}
+        bgSize={'contain'}
+        bgPosition={'left center'}
+        src={image_path}
+        className="h-[9rem]"
+      />
     )
   }
+  // else return nothing
+  return null
 }

--- a/frontend/components/software/add/AddSoftwareCard.test.tsx
+++ b/frontend/components/software/add/AddSoftwareCard.test.tsx
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -158,6 +160,7 @@ it('validate, save and redirect', async () => {
         'is_published': false,
         'short_statement': inputValue,
         'slug': slug,
+        'image_id': null
       },
       'token': 'TEST_TOKEN',
     })

--- a/frontend/components/software/add/AddSoftwareCard.tsx
+++ b/frontend/components/software/add/AddSoftwareCard.tsx
@@ -152,7 +152,8 @@ export default function AddSoftwareCard() {
       description_type: 'markdown',
       description_url: null,
       get_started_url: null,
-      concept_doi: null
+      concept_doi: null,
+      image_id: null
     }
     // add software to database
     addSoftware({

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -81,6 +82,11 @@ export const softwareInformation = {
       // we do not show error message for this one, we use only maxLength value
       maxLength: {value: 10000, message: 'Maximum length is 10000'},
     }
+  },
+  // field for logo upload
+  logo: {
+    label: 'Logo',
+    help: 'Upload a logo of your software.'
   },
   // field for markdown URL
   description_url: {

--- a/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
@@ -7,18 +7,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {ChangeEvent} from 'react'
+import Button from '@mui/material/Button'
+import DeleteIcon from '@mui/icons-material/Delete'
+import {useFormContext} from 'react-hook-form'
+
 import {softwareInformation as config} from '../editSoftwareConfig'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import ImageAsBackground from '~/components/layout/ImageAsBackground'
-import {ChangeEvent} from 'react'
+import ImageWithPlaceholder from '~/components/layout/ImageWithPlaceholder'
 import {handleFileUpload} from '~/utils/handleFileUpload'
 import {useSession} from '~/auth'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import {useFormContext} from 'react-hook-form'
 import {EditSoftwareItem} from '~/types/SoftwareTypes'
 import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
-import {IconButton} from '@mui/material'
-import DeleteIcon from '@mui/icons-material/Delete'
 import {patchSoftwareTable} from './patchSoftwareTable'
 
 export default function AutosaveSoftwareLogo() {
@@ -139,22 +141,13 @@ export default function AutosaveSoftwareLogo() {
       return null
     }
     return (
-      <>
-        <div className="flex pt-4">
-          <div className="flex items-center text-primary">
-            <IconButton
-              color="primary"
-              aria-label="remove picture"
-              component="span"
-              title="Delete image"
-              onClick={removeImage}
-            >
-              <DeleteIcon />
-            </IconButton>
-            Delete logo
-          </div>
-        </div>
-      </>
+      <Button
+        startIcon={<DeleteIcon />}
+        onClick={removeImage}
+        aria-label="Delete logo"
+      >
+        Delete logo
+      </Button>
     )
   }
 
@@ -164,23 +157,23 @@ export default function AutosaveSoftwareLogo() {
         title={config.logo.label}
         subtitle={config.logo.help}
       />
-      <div>
-        <label htmlFor='upload-avatar-image'
+
+        <label htmlFor='upload-software-logo'
           style={{cursor: 'pointer'}}
-          title="Click to upload a logo."
+          title="Click to upload a logo"
         >
-          <ImageAsBackground
+          <ImageWithPlaceholder
+            placeholder="Click to upload a logo < 2MB"
             src={imageUrl()}
             alt={'logo'}
             bgSize={'contain'}
-            bgPosition={'center'}
-            className="w-full h-[12rem]"
-            noImgMsg="Click to upload a logo."
+            bgPosition={'left center'}
+            className="w-full h-[9rem]"
           />
         </label>
 
         <input
-          id="upload-avatar-image"
+          id="upload-software-logo"
           type="file"
           accept="image/*"
           onChange={onFileUpload}
@@ -189,7 +182,7 @@ export default function AutosaveSoftwareLogo() {
 
         {renderImageAttributes()}
 
-      </div>
+
     </>
   )
 }

--- a/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {softwareInformation as config} from '../editSoftwareConfig'
+import EditSectionTitle from '~/components/layout/EditSectionTitle'
+import ImageAsBackground from '~/components/layout/ImageAsBackground'
+import {ChangeEvent} from 'react'
+import {handleFileUpload} from '~/utils/handleFileUpload'
+import {useSession} from '~/auth'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {useFormContext} from 'react-hook-form'
+import {EditSoftwareItem} from '~/types/SoftwareTypes'
+import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
+import {IconButton} from '@mui/material'
+import DeleteIcon from '@mui/icons-material/Delete'
+import {patchSoftwareTable} from './patchSoftwareTable'
+
+export default function AutosaveSoftwareLogo() {
+  const {token} = useSession()
+  const {showWarningMessage, showErrorMessage} = useSnackbar()
+  const {watch, setValue} = useFormContext<EditSoftwareItem>()
+
+  const [
+    form_id, form_image_id, form_image_b64, form_image_mime_type
+  ] = watch([
+    'id', 'image_id', 'image_b64', 'image_mime_type'
+  ])
+
+  function imageUrl() {
+    if (form_image_b64 && form_image_b64.length > 10) {
+      return form_image_b64
+    }
+    if (form_image_id && form_image_id.length > 10) {
+      return getImageUrl(form_image_id)
+    }
+    return null
+  }
+
+  async function saveImage(image_b64: string, mime_type: string) {
+    let resp
+    // split base64 to use only encoded content
+    const data = image_b64.split(',')[1]
+    if (form_image_id) {
+      const patch = await patchSoftwareTable({
+        id: form_id,
+        data: {
+          image_id: null
+        },
+        token
+      })
+      if (patch.status === 200) {
+        // try to remove old image
+        // but don't wait for results
+        const del = await deleteImage({
+          id: form_image_id,
+          token
+        })
+      }
+    }
+    // add new image to db
+    resp = await upsertImage({
+      data,
+      mime_type,
+      token
+    })
+    if (resp.status !== 201) {
+      showErrorMessage(`Failed to save image. ${resp.message}`)
+      return
+    }
+    const patch = await patchSoftwareTable({
+      id:form_id,
+      data: {
+        image_id:resp.message
+      },
+      token
+    })
+    if (patch.status === 200) {
+      // setValue works while resetField doesn't, not sure why?
+      // setValue('image_b64', image_b64 as string)
+      // setValue('image_mime_type', mime_type)
+      // remove id for now
+      setValue('image_id', resp.message)
+      // debugger
+    } else {
+      showErrorMessage(`Failed to save image. ${resp.message}`)
+    }
+  }
+
+  async function removeImage() {
+    // remove image
+    const resp = await patchSoftwareTable({
+      id: form_id,
+      data: {
+        image_id: null,
+      },
+      token
+    })
+    if (resp.status === 200) {
+      // clear all image values in the form
+      if (form_image_b64) setValue('image_b64', null)
+      if (form_image_mime_type) setValue('image_mime_type', null)
+      if (form_image_id) {
+        // try to remove old image
+        // but don't wait for results
+        const del = await deleteImage({
+          id: form_image_id,
+          token
+        })
+        setValue('image_id', null)
+      }
+    } else {
+      showErrorMessage(`Failed to remove image. ${resp.message}`)
+      return
+    }
+  }
+
+  async function onFileUpload(e:ChangeEvent<HTMLInputElement>|undefined) {
+    if (typeof e !== 'undefined') {
+      const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
+      if (status === 200 && image_b64 && image_mime_type) {
+        saveImage(image_b64, image_mime_type)
+      } else if (status===413) {
+        showWarningMessage(message)
+      } else {
+        showErrorMessage(message)
+      }
+    }
+  }
+
+  function renderImageAttributes() {
+    // debugger
+    if (form_image_b64 === null && form_image_id === null) {
+      return null
+    }
+    return (
+      <>
+        <div className="flex pt-4">
+          <div className="flex items-center text-primary">
+            <IconButton
+              color="primary"
+              aria-label="remove picture"
+              component="span"
+              title="Delete image"
+              onClick={removeImage}
+            >
+              <DeleteIcon />
+            </IconButton>
+            Delete logo
+          </div>
+        </div>
+      </>
+    )
+  }
+
+  return (
+    <>
+      <EditSectionTitle
+        title={config.logo.label}
+        subtitle={config.logo.help}
+      />
+      <div>
+        <label htmlFor='upload-avatar-image'
+          style={{cursor: 'pointer'}}
+          title="Click to upload a logo."
+        >
+          <ImageAsBackground
+            src={imageUrl()}
+            alt={'logo'}
+            bgSize={'contain'}
+            bgPosition={'center'}
+            className="w-full h-[12rem]"
+            noImgMsg="Click to upload a logo."
+          />
+        </label>
+
+        <input
+          id="upload-avatar-image"
+          type="file"
+          accept="image/*"
+          onChange={onFileUpload}
+          style={{display:'none'}}
+        />
+
+        {renderImageAttributes()}
+
+      </div>
+    </>
+  )
+}

--- a/frontend/components/software/edit/information/index.tsx
+++ b/frontend/components/software/edit/information/index.tsx
@@ -152,8 +152,6 @@ export default function SoftwareInformation({slug}: {slug: string}) {
           <div className="py-2"></div>
           <AutosaveRepositoryUrl />
           <div className="py-2"></div>
-          <AutosaveSoftwareLogo />
-          <div className="py-2"></div>
           <AutosaveSoftwareMarkdown />
           {/* add white space at the bottom */}
           <div className="xl:py-4"></div>
@@ -162,6 +160,8 @@ export default function SoftwareInformation({slug}: {slug: string}) {
           <AutosaveSoftwarePageStatus />
           <div className="py-4"></div>
           <AutosaveConceptDoi />
+          <div className="py-4"></div>
+          <AutosaveSoftwareLogo />
           <div className="py-4"></div>
           <AutosaveSoftwareKeywords
             software_id={formData.id}

--- a/frontend/components/software/edit/information/index.tsx
+++ b/frontend/components/software/edit/information/index.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -25,6 +26,7 @@ import AutosaveSoftwareKeywords from './AutosaveSoftwareKeywords'
 import AutosaveRepositoryUrl from './AutosaveRepositoryUrl'
 import AutosaveSoftwareLicenses from './AutosaveSoftwareLicenses'
 import AutosaveSoftwareMarkdown from './AutosaveSoftwareMarkdown'
+import AutosaveSoftwareLogo from './AutosaveSoftwareLogo'
 
 export default function SoftwareInformation({slug}: {slug: string}) {
   const {token,user} = useSession()
@@ -149,6 +151,8 @@ export default function SoftwareInformation({slug}: {slug: string}) {
           />
           <div className="py-2"></div>
           <AutosaveRepositoryUrl />
+          <div className="py-2"></div>
+          <AutosaveSoftwareLogo />
           <div className="py-2"></div>
           <AutosaveSoftwareMarkdown />
           {/* add white space at the bottom */}

--- a/frontend/components/software/edit/information/useSoftwareToEdit.tsx
+++ b/frontend/components/software/edit/information/useSoftwareToEdit.tsx
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -30,12 +32,14 @@ export async function getSoftwareInfoForEdit({slug, token}: { slug: string, toke
       getLicenseForSoftware(software.id, true, token)
     ]
     // other api requests
-    const [keywords, respLicense] = await Promise.all(requests)
+    const [keywords, respLicense,] = await Promise.all(requests)
 
     const data:EditSoftwareItem = {
       ...software,
       keywords: keywords as KeywordForSoftware[],
-      licenses: prepareLicenses(respLicense as License[])
+      licenses: prepareLicenses(respLicense as License[]),
+      image_b64: null,
+      image_mime_type: null,
     }
 
     return data

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -160,6 +160,7 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
         languages={repositoryInfo?.languages}
         repository={repositoryInfo?.url}
         platform={repositoryInfo?.code_platform}
+        image_id={software.image_id}
       />
       {/* Participating organisations */}
       <OrganisationsSection

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -23,7 +23,7 @@ import {getSoftwareList} from '../../utils/getSoftware'
 import {ssrSoftwareParams} from '../../utils/extractQueryParam'
 import {softwareListUrl,ssrSoftwareUrl} from '../../utils/postgrestUrl'
 import SoftwareFilter from '~/components/software/filter'
-import { useAdvicedDimensions } from '~/components/layout/FlexibleGridSection'
+import {useAdvicedDimensions} from '~/components/layout/FlexibleGridSection'
 
 type SoftwareIndexPageProps = {
   count: number,
@@ -42,7 +42,7 @@ export default function SoftwareIndexPage(
   // use next router (hook is only for browser)
   const router = useRouter()
   const {itemHeight, minWidth, maxWidth} = useAdvicedDimensions('software')
-  
+
   // next/previous page button
   function handleTablePageChange(
     event: MouseEvent<HTMLButtonElement> | null,

--- a/frontend/types/SoftwareTypes.ts
+++ b/frontend/types/SoftwareTypes.ts
@@ -42,6 +42,7 @@ export type NewSoftwareItem = {
   get_started_url: string | null,
   is_published: boolean,
   short_statement: string | null,
+  image_id: string | null,
 }
 
 export type SoftwareTableItem = NewSoftwareItem & {
@@ -86,6 +87,7 @@ export const SoftwarePropsToSave = [
   'description_type',
   'description_url',
   'get_started_url',
+  'image_id',
   'is_published',
   'short_statement'
 ]
@@ -93,6 +95,8 @@ export const SoftwarePropsToSave = [
 export type EditSoftwareItem = SoftwareItem & {
   keywords: KeywordForSoftware[]
   licenses: AutocompleteOption<License>[]
+  image_b64: string | null
+  image_mime_type: string | null
 }
 
 /**


### PR DESCRIPTION
# Allow uploading logos for software

Fixes #644

Changes proposed in this pull request:

* allow uploading logos for software
* display software logo in the About Section

I decided to treat the uploaded image as logo, because I think uploading regular images, e.g. screenshots or diagrams, may have more implications (e.g. how many could be uploaded, how should they be integrated).

![Uploaded logo](https://user-images.githubusercontent.com/14222414/205285865-b8052518-0867-489b-9127-5818a8ee4d07.png)

![Logo displayed on software page](https://user-images.githubusercontent.com/14222414/205286088-25d9db42-b2ec-4183-aee6-1d928ba5da81.png)


How to test:

* ```
  docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1 --scale scrapers=0
  ```
* login as administrator
* edit an existing software and upload a logo in the information section
* view the page, the logo shows in the about section
* remove the logo, and view page again
* no logo is shown in the about section

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
