### PR TITLE
Organisation card fix, incl. 2 other fixes

### DIFF
--- a/database/012-create-organisation-table.sql
+++ b/database/012-create-organisation-table.sql
@@ -1,4 +1,5 @@
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+-- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 -- SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 dv4all
@@ -152,8 +153,8 @@ STABLE LANGUAGE plpgsql AS
 $$
 DECLARE
 	current_org UUID := id;
-	route varchar := '';
-	slug varchar;
+	route VARCHAR := '';
+	slug VARCHAR;
 BEGIN
 	WHILE current_org IS NOT NULL LOOP
 		SELECT

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -517,10 +517,10 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_start IS NULL THEN 'Starting'::varchar
-			WHEN project.date_start > now() THEN 'Starting'::varchar
-			WHEN project.date_end < now() THEN 'Finished'::varchar
-			ELSE 'Running'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::VARCHAR
+			WHEN project.date_start > now() THEN 'Starting'::VARCHAR
+			WHEN project.date_end < now() THEN 'Finished'::VARCHAR
+			ELSE 'Running'::VARCHAR
 		END AS current_state,
 		project.date_start,
 		project.updated_at,
@@ -620,10 +620,10 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_start IS NULL THEN 'Starting'::varchar
-			WHEN project.date_start > now() THEN 'Starting'::varchar
-			WHEN project.date_end < now() THEN 'Finished'::varchar
-			ELSE 'Running'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::VARCHAR
+			WHEN project.date_start > now() THEN 'Starting'::VARCHAR
+			WHEN project.date_end < now() THEN 'Finished'::VARCHAR
+			ELSE 'Running'::VARCHAR
 		END AS current_state,
 		project.date_start,
 		project.updated_at,
@@ -668,10 +668,10 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_start IS NULL THEN 'Starting'::varchar
-			WHEN project.date_start > now() THEN 'Starting'::varchar
-			WHEN project.date_end < now() THEN 'Finished'::varchar
-			ELSE 'Running'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::VARCHAR
+			WHEN project.date_start > now() THEN 'Starting'::VARCHAR
+			WHEN project.date_end < now() THEN 'Finished'::VARCHAR
+			ELSE 'Running'::VARCHAR
 		END AS current_state,
 		project.date_start,
 		project.updated_at,
@@ -1007,10 +1007,10 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_start IS NULL THEN 'Starting'::varchar
-			WHEN project.date_start > now() THEN 'Starting'::varchar
-			WHEN project.date_end < now() THEN 'Finished'::varchar
-			ELSE 'Running'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::VARCHAR
+			WHEN project.date_start > now() THEN 'Starting'::VARCHAR
+			WHEN project.date_end < now() THEN 'Finished'::VARCHAR
+			ELSE 'Running'::VARCHAR
 		END AS current_state,
 		project.date_start,
 		project.updated_at,
@@ -1278,10 +1278,10 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_start IS NULL THEN 'Starting'::varchar
-			WHEN project.date_start > now() THEN 'Starting'::varchar
-			WHEN project.date_end < now() THEN 'Finished'::varchar
-			ELSE 'Running'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::VARCHAR
+			WHEN project.date_start > now() THEN 'Starting'::VARCHAR
+			WHEN project.date_end < now() THEN 'Finished'::VARCHAR
+			ELSE 'Running'::VARCHAR
 		END AS current_state,
 		project.date_start,
 		project.updated_at,

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1,5 +1,6 @@
 -- SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2021 - 2022 dv4all
+-- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 -- SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 --
@@ -516,7 +517,8 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_end IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start > now() IS NULL THEN 'Starting'::varchar
 			WHEN project.date_end < now() THEN 'Finished'::varchar
 			ELSE 'Running'::varchar
 		END AS current_state,

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -518,7 +518,7 @@ BEGIN
 		project.subtitle,
 		CASE
 			WHEN project.date_start IS NULL THEN 'Starting'::varchar
-			WHEN project.date_start > now() IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start > now() THEN 'Starting'::varchar
 			WHEN project.date_end < now() THEN 'Finished'::varchar
 			ELSE 'Running'::varchar
 		END AS current_state,
@@ -620,7 +620,8 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_end IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start > now() THEN 'Starting'::varchar
 			WHEN project.date_end < now() THEN 'Finished'::varchar
 			ELSE 'Running'::varchar
 		END AS current_state,
@@ -667,7 +668,8 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_end IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start > now() THEN 'Starting'::varchar
 			WHEN project.date_end < now() THEN 'Finished'::varchar
 			ELSE 'Running'::varchar
 		END AS current_state,
@@ -1005,7 +1007,8 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_end IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start > now() THEN 'Starting'::varchar
 			WHEN project.date_end < now() THEN 'Finished'::varchar
 			ELSE 'Running'::varchar
 		END AS current_state,
@@ -1275,7 +1278,8 @@ BEGIN
 		project.title,
 		project.subtitle,
 		CASE
-			WHEN project.date_end IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start IS NULL THEN 'Starting'::varchar
+			WHEN project.date_start > now() THEN 'Starting'::varchar
 			WHEN project.date_end < now() THEN 'Finished'::varchar
 			ELSE 'Running'::varchar
 		END AS current_state,

--- a/frontend/components/layout/CardTitle.tsx
+++ b/frontend/components/layout/CardTitle.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -10,14 +11,14 @@ type CardTitleProps = {
 }
 
 /**
- * Card title max 3 lines with line clamp
+ * Card title max 2 lines with line clamp
  * @returns
  */
 export default function CardTitle({title,children,className=''}:CardTitleProps) {
   return (
     <h2
       title={title}
-      className={`group-hover:text-white line-clamp-3 max-h-[6.5rem] ${className}`}
+      className={`group-hover:text-white line-clamp-2 h-[4rem] ${className}`}
     >
       {children}
     </h2>

--- a/frontend/components/layout/StatCounter.tsx
+++ b/frontend/components/layout/StatCounter.tsx
@@ -18,7 +18,7 @@ export default function StatCounter({label,value}:{label:string,value:number|und
         >
           {value}
         </div>
-        <div className="text-base-content-secondary">
+        <div>
           {label}
         </div>
       </div>

--- a/frontend/components/layout/StatCounter.tsx
+++ b/frontend/components/layout/StatCounter.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,8 +9,18 @@ export default function StatCounter({label,value}:{label:string,value:number|und
   if (typeof value!=='undefined' && label){
     return (
       <div className="text-center">
-        <div className="text-[4rem] font-light">{value}</div>
-        <div className="">{label}</div>
+        <div
+          style={{
+            fontSize: '3.5rem',
+            fontWeight: '200',
+            lineHeight: 1.25
+          }}
+        >
+          {value}
+        </div>
+        <div className="text-base-content-secondary">
+          {label}
+        </div>
       </div>
     )
   }

--- a/frontend/components/organisation/OrganisationCard.tsx
+++ b/frontend/components/organisation/OrganisationCard.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -33,7 +34,6 @@ export default function OrganisationCard(organisation: OrganisationForOverview) 
     >
       <article
         className="flex flex-col border h-full min-h-[16rem] overflow-hidden">
-        {/* <h2 className='h-[5rem]'>{organisation.name}</h2> */}
         <div className="pl-8 pt-8 flex">
           <CardTitle
             title={organisation.name}
@@ -41,16 +41,6 @@ export default function OrganisationCard(organisation: OrganisationForOverview) 
           >
             {organisation.name}
           </CardTitle>
-          {/* <SingleLineTitle
-            title={organisation.name}
-            sx={{
-              padding: '1.5rem 0rem',
-              // place for verified
-              margin: organisation.is_tenant ? '0rem 6rem 0rem 0rem' : '0rem 2rem 0rem 0rem',
-            }}
-          >
-            {organisation.name}
-          </SingleLineTitle> */}
           {
             organisation.is_tenant && <span title="Officially registered organisation">
               <VerifiedIcon
@@ -66,23 +56,20 @@ export default function OrganisationCard(organisation: OrganisationForOverview) 
             /></span>
           }
         </div>
-        <div className="flex-1 grid gap-8 lg:grid-cols-[2fr,3fr] p-8 overflow-hidden">
+        <div className="flex-1 grid gap-8 lg:grid-cols-[1fr,1fr] p-8 overflow-hidden">
           <LogoAvatar
             name={organisation.name ?? ''}
             src={getImageUrl(organisation.logo_id) ?? undefined}
             sx={{
-              // remove line-height=1
-              lineHeight: 'inherit',
               fontSize: '4rem',
               '& img': {
-                height: 'auto',
-                // maxHeight: '10rem',
-                width: 'auto',
-                maxWidth: '100%'
+                objectFit: 'contain',
+                minHeight: '4rem',
+                minWidth: '4rem'
               }
             }}
           />
-          <div className="flex-1 flex gap-4 justify-between items-center">
+          <div className="flex-1 flex gap-8 justify-center items-end">
             <StatCounter
               label={label}
               value={count}

--- a/frontend/components/projects/edit/information/index.tsx
+++ b/frontend/components/projects/edit/information/index.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -29,17 +30,16 @@ import PublishingProjectInfo from './PublishingProjectInfo'
 export default function EditProjectInformation({slug}: {slug: string}) {
   const {token,user} = useSession()
   const {loading, setLoading, setProjectInfo} = useProjectContext()
-  const {reset, register, getValues, formState} = useFormContext<EditProject>()
+  const {reset, register, formState, watch} = useFormContext<EditProject>()
   const {project} = useProjectToEdit({
     slug,
     token
   })
-  // form data provided by react-hook-form
-  const formValues = getValues()
   // NOTE! need to "subscribe" to dirty fields state
   // in order to detect first change using isDirty prop
   const {dirtyFields} = formState
-
+  // watch form data changes (we use reset in useEffect)
+  const formData = watch()
   // load form and set copy of project info state
   useEffect(() => {
     if (project && loading===true) {
@@ -90,14 +90,14 @@ export default function EditProjectInformation({slug}: {slug: string}) {
             <>
               <div className="py-2"></div>
               <AutosaveProjectTextField
-                project_id={formValues.id}
+                project_id={formData.id}
                 options={{
                   name: 'slug',
                   label: config.slug.label,
                   useNull: true,
                   defaultValue: project?.slug,
                   helperTextMessage: config.slug.help,
-                  helperTextCnt: `${formValues?.slug?.length || 0}/${config.slug.validation.maxLength.value}`,
+                  helperTextCnt: `${formData?.slug?.length || 0}/${config.slug.validation.maxLength.value}`,
                 }}
                 rules={config.slug.validation}
               />
@@ -109,7 +109,7 @@ export default function EditProjectInformation({slug}: {slug: string}) {
           }
           <div className="py-2"></div>
           <AutosaveProjectTextField
-            project_id={formValues.id}
+            project_id={formData.id}
             rules={config.title.validation}
             options={{
               name: 'title',
@@ -117,12 +117,12 @@ export default function EditProjectInformation({slug}: {slug: string}) {
               useNull: true,
               defaultValue: project?.title,
               helperTextMessage: config.title.help,
-              helperTextCnt: `${formValues?.title?.length || 0}/${config.title.validation.maxLength.value}`,
+              helperTextCnt: `${formData?.title?.length || 0}/${config.title.validation.maxLength.value}`,
             }}
           />
           <div className="py-2"></div>
           <AutosaveProjectTextField
-            project_id={formValues.id}
+            project_id={formData.id}
             options={{
               name: 'subtitle',
               label: config.subtitle.label,
@@ -131,7 +131,7 @@ export default function EditProjectInformation({slug}: {slug: string}) {
               useNull: true,
               defaultValue: project?.subtitle,
               helperTextMessage: config.subtitle.help,
-              helperTextCnt: `${formValues?.subtitle?.length || 0}/${config.subtitle.validation.maxLength.value}`,
+              helperTextCnt: `${formData?.subtitle?.length || 0}/${config.subtitle.validation.maxLength.value}`,
             }}
             rules={config.subtitle.validation}
           />
@@ -142,7 +142,7 @@ export default function EditProjectInformation({slug}: {slug: string}) {
           />
           <AutosaveProjectImage />
           <AutosaveControlledMarkdown
-            id={formValues.id}
+            id={formData.id}
             name="description"
             maxLength={config.description.validation.maxLength.value}
             patchFn={patchProjectTable}
@@ -156,10 +156,10 @@ export default function EditProjectInformation({slug}: {slug: string}) {
             subtitle={config.pageStatus.subtitle}
           />
           <AutosaveProjectSwitch
-            project_id={formValues.id}
+            project_id={formData.id}
             name='is_published'
             label={config.is_published.label}
-            defaultValue={formValues.is_published}
+            defaultValue={formData.is_published}
           />
           <PublishingProjectInfo />
           <div className="py-4"></div>
@@ -173,7 +173,7 @@ export default function EditProjectInformation({slug}: {slug: string}) {
           />
           <div className="py-1"></div>
           <AutosaveProjectTextField
-            project_id={formValues.id}
+            project_id={formData.id}
             options={{
               name:'grant_id',
               label: '',

--- a/frontend/components/projects/edit/organisations/index.tsx
+++ b/frontend/components/projects/edit/organisations/index.tsx
@@ -323,22 +323,26 @@ export default function ProjectOrganisations({slug}: { slug: string }) {
           />
         </section>
       </EditSection>
-      <EditOrganisationModal
-        open={modal.edit.open}
-        pos={modal.edit.pos}
-        organisation={modal.edit.organisation}
-        onCancel={closeModals}
-        onSubmit={saveOrganisation}
-      />
-      <ConfirmDeleteModal
-        title="Remove organisation"
-        open={modal.delete.open}
-        body={
-          <p>Are you sure you want to remove <strong>{modal.delete.displayName ?? ''}</strong>?</p>
-        }
-        onCancel={closeModals}
-        onDelete={()=>deleteOrganisation(modal.delete.pos)}
-      />
+      {modal.edit.open &&
+        <EditOrganisationModal
+          open={modal.edit.open}
+          pos={modal.edit.pos}
+          organisation={modal.edit.organisation}
+          onCancel={closeModals}
+          onSubmit={saveOrganisation}
+        />
+      }
+      {modal.delete.open &&
+        <ConfirmDeleteModal
+          title="Remove organisation"
+          open={modal.delete.open}
+          body={
+            <p>Are you sure you want to remove <strong>{modal.delete.displayName ?? ''}</strong>?</p>
+          }
+          onCancel={closeModals}
+          onDelete={()=>deleteOrganisation(modal.delete.pos)}
+        />
+      }
     </>
   )
 }

--- a/frontend/components/software/SoftwareCard.tsx
+++ b/frontend/components/software/SoftwareCard.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -83,16 +84,10 @@ export default function SoftwareCard({href, brand_name, short_statement, is_feat
         <div className="relative flex">
           <CardTitle
             title={brand_name}
-            className="p-4 mr-[4rem]"
+            className="m-4 mr-[4rem]"
           >
             {renderPublished()} {brand_name}
           </CardTitle>
-          {/* <h2
-            title={brand_name}
-            className="p-4 flex-1 mr-[4rem] group-hover:text-white line-clamp-3 max-h-[7rem]"
-          >
-            {renderPublished()} {brand_name}
-          </h2> */}
           <div
             className="flex w-[4rem] h-[4rem] justify-center items-center bg-white text-base text-[1.5rem] absolute top-0 right-0 group-hover:text-secondary">
             {getInitals()}

--- a/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
+++ b/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
@@ -20,7 +20,7 @@ import ControlledTextField from '../../../form/ControlledTextField'
 import {EditOrganisation} from '../../../../types/Organisation'
 import {organisationInformation as config} from '../editSoftwareConfig'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
-import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
+import {deleteImage, getImageUrl} from '~/utils/editImage'
 import {handleFileUpload} from '~/utils/handleFileUpload'
 
 type EditOrganisationModalProps = {
@@ -39,7 +39,7 @@ export default function EditOrganisationModal({open, onCancel, onSubmit, organis
   const {token} = useSession()
   const {showWarningMessage,showErrorMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
-  const {handleSubmit, watch, formState, reset, control, register, setValue} = useForm<EditOrganisation>({
+  const {handleSubmit, watch, formState, reset, control, register, setValue, trigger} = useForm<EditOrganisation>({
     mode: 'onChange',
     defaultValues: {
       ...organisation
@@ -47,18 +47,34 @@ export default function EditOrganisationModal({open, onCancel, onSubmit, organis
   })
 
   // extract
-  const {isValid, isDirty} = formState
+  const {isValid, isDirty, isSubmitSuccessful} = formState
   const formData = watch()
 
   // console.group('EditOrganisationModal')
   // console.log('formData...', formData)
+  // console.log('errors...', errors)
+  // console.log('isSubmitSuccessful...', isSubmitSuccessful)
   // console.groupEnd()
 
   useEffect(() => {
-    if (organisation) {
-      reset(organisation)
+    setTimeout(() => {
+      // validate name on opening of the form
+      // we validate organisation name because we take it
+      // over from ROR or user input (which might not be valid entry)
+      // it needs to be at the end of the cicle, so we need to use setTimeout
+      trigger('name')
+    }, 0)
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[])
+
+  useEffect(() => {
+    if (isSubmitSuccessful) {
+      // console.group('EditOrganisationModal')
+      // console.log('reset form...', isSubmitSuccessful)
+      // console.groupEnd()
+      reset()
     }
-  }, [organisation,reset])
+  }, [isSubmitSuccessful,reset])
 
   function handleCancel() {
     // hide

--- a/frontend/components/software/edit/organisations/index.tsx
+++ b/frontend/components/software/edit/organisations/index.tsx
@@ -319,22 +319,26 @@ export default function SoftwareOganisations() {
           />
         </section>
       </EditSoftwareSection>
-      <EditOrganisationModal
-        open={modal.edit.open}
-        pos={modal.edit.pos}
-        organisation={modal.edit.organisation}
-        onCancel={closeModals}
-        onSubmit={saveOrganisation}
-      />
-      <ConfirmDeleteModal
-        title="Remove organisation"
-        open={modal.delete.open}
-        body={
-          <p>Are you sure you want to remove <strong>{modal.delete.displayName ?? ''}</strong>?</p>
-        }
-        onCancel={closeModals}
-        onDelete={()=>deleteOrganisation(modal.delete.pos)}
-      />
+      {modal.edit.open &&
+        <EditOrganisationModal
+          open={modal.edit.open}
+          pos={modal.edit.pos}
+          organisation={modal.edit.organisation}
+          onCancel={closeModals}
+          onSubmit={saveOrganisation}
+        />
+      }
+      {modal.delete.open &&
+        <ConfirmDeleteModal
+          title="Remove organisation"
+          open={modal.delete.open}
+          body={
+            <p>Are you sure you want to remove <strong>{modal.delete.displayName ?? ''}</strong>?</p>
+          }
+          onCancel={closeModals}
+          onDelete={()=>deleteOrganisation(modal.delete.pos)}
+        />
+      }
     </>
   )
 }

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 //
@@ -72,7 +73,8 @@ module.exports = {
         'base-100':`var(--rsd-base-100,${colors['base-100']})`,
         'base-200':`var(--rsd-base-200,${colors['base-200']})`,
         'base-300':`var(--rsd-base-300,${colors['base-300']})`,
-        'base-content':`var(--rsd-base-content,${colors['base-content']})`,
+        'base-content': `var(--rsd-base-content,${colors['base-content']})`,
+        'base-content-secondary':`var(--rsd-base-content-secondary,${colors['base-content-secondary']})`,
         'base-content-disabled':`var(--rsd-base-content-disabled,${colors['base-content-disabled']})`,
         primary:`var(--rsd-primary,${colors.primary})`,
         'primary-content':`var(--rsd-primary-content,${colors['primary-content']})`,


### PR DESCRIPTION
# Organisation card overflow when using long organisation name

Closes #696 

Based on the test from HMZ the organisation card did not show all values. See image

![image](https://user-images.githubusercontent.com/9204081/205915859-2d2d5cc2-acf9-4b51-8755-377553f2e18d.png)

Changes proposed in this pull request:
*  limited card title to 2 lines, the complete name is show on mouseover
*  reduced font size of the score to 3.5 from 4.5
*  reduced line height of the score from 1.5 to 1.25
*  set the image object fit to contain complete logo 

Unrelated fixes:
* The project status when the start date is in the future should be "Starting"
* The character counter on the inputs of the edit project info section should show input length while typed (as in software edit info)
* The organisation name input is additionally validated on modal load because it can contain invalid value taken over from the search input

How to test:
* `make start` to rebuild everything
* navigate to organisation with a very long name or create one
* use different orientation logos like: [GFZ](https://www.gfz-potsdam.de/), [NWO](https://www.nwo.nl/en), [Digital Research Alliance of Canada](https://research-software-directory.org/organisations/digital-research-alliance-of-canada)
* Confirm that these entries look OK in the organisation card
* The project status check:
  * the project without start date should have status "Starting"
  * the project with start date in the future should have status "Starting"
  * the project with the end date in the past should have status "Finished"
  * project with other date values have status "Running"
* Character counter for inputs on the project edit info page should count the input length while typing

## Desktop
![image](https://user-images.githubusercontent.com/9204081/205920937-548e4bbb-eabb-4da8-abda-2a040d7a1a70.png)

## Tablet 
![image](https://user-images.githubusercontent.com/9204081/205921072-6d9b030a-efeb-4a9e-a3c2-12c268798e64.png)

## Mobile
![image](https://user-images.githubusercontent.com/9204081/205921191-d930ea52-7b66-4881-907e-353b489438a2.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
