### PR TITLE
677 cancel image delete

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,12 @@
 # SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2021 - 2022 dv4all
 # SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2023 dv4all
 # SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -92,7 +93,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:1.11.2
+    image: rsd/frontend:1.11.3
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/projects/edit/team/EditProjectTeamIndex.test.tsx
+++ b/frontend/components/projects/edit/team/EditProjectTeamIndex.test.tsx
@@ -59,9 +59,25 @@ jest.mock('./editTeamMembers', () => ({
 
 // MOCK deleteImage
 const mockDeleteImage = jest.fn(props => Promise.resolve('OK'))
+const mockUpsertImage = jest.fn(props => Promise.resolve({
+  status: 201,
+  message: 'uploaded-image-id'
+}))
 jest.mock('~/utils/editImage', () => ({
   ...jest.requireActual('~/utils/editImage'),
-  deleteImage: jest.fn(props=>mockDeleteImage(props))
+  deleteImage: jest.fn(props => mockDeleteImage(props)),
+  upsertImage: jest.fn(props => mockUpsertImage(props))
+}))
+
+// MOCK handleFileUpload
+const mockHandleFileUpload = jest.fn(props => Promise.resolve({
+  status: 200,
+  message: 'OK',
+  image_b64: 'png,base64-encoded-image-content',
+  image_mime_type: 'image/png'
+}))
+jest.mock('~/utils/handleFileUpload', () => ({
+  handleFileUpload: jest.fn(props=>mockHandleFileUpload(props))
 }))
 
 describe('frontend/components/projects/edit/team/index.tsx', () => {
@@ -380,13 +396,6 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
     })
   })
   it('can CANCEL remove avatar (change)', async () => {
-    const editedMember = {
-      ...mockTeamMembers[0],
-      // we remove avatar id
-      avatar_id: null,
-      // we use project id from context
-      project: editProjectState.project.id
-    }
     // mock no members
     mockGetTeamForProject.mockResolvedValueOnce(mockTeamMembers)
     // mock patch
@@ -445,6 +454,90 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
       expect(mockPatchTeamMember).toBeCalledTimes(0)
       // delete image NOT called
       expect(mockDeleteImage).toBeCalledTimes(0)
+    })
+  })
+
+  it('can replace avatar image', async () => {
+    const oldAvatarId = mockTeamMembers[0].avatar_id
+    const newAvatarId = 'new-avatar-test-id-with-length-10-or-more'
+    const fileToUpload = 'test-file-name.png'
+    const base64data = 'base64-encoded-image-content'
+    const fileType = 'image/png'
+    const editedMember = {
+      ...mockTeamMembers[0],
+      // we use project id from context
+      project: editProjectState.project.id,
+      // new avatar
+      avatar_id: newAvatarId
+    }
+    // mock no members
+    mockGetTeamForProject.mockResolvedValueOnce(mockTeamMembers)
+    // mock patch
+    mockPatchTeamMember.mockResolvedValueOnce({
+      status: 200,
+      message: 'OK'
+    })
+    // mock image upload
+    mockUpsertImage.mockResolvedValueOnce({
+      status: 201,
+      message: newAvatarId
+    })
+
+    // render component
+    const {container} = render(
+      <WithAppContext options={{session: mockSession}}>
+        <WithProjectContext state={editProjectState}>
+          <ProjectTeam slug="test-slug" />
+        </WithProjectContext>
+      </WithAppContext>
+    )
+    // wait for loader to be removed
+    await waitForElementToBeRemoved(screen.getByRole('progressbar'))
+    // get all members
+    const members = screen.getAllByTestId('team-member-item')
+    // edit first member
+    const editBtn = within(members[0]).getByTestId('EditIcon')
+    fireEvent.click(editBtn)
+
+    const modal = screen.getByRole('dialog')
+
+    // simulate upload action
+    const imageInput:any = within(modal).getByTestId('upload-avatar-input')
+    // set file to upload
+    fireEvent.change(imageInput, {target: {file: fileToUpload}})
+
+    // expect file upload to be called
+    expect(mockHandleFileUpload).toBeCalledTimes(1)
+
+    // save
+    const saveBtn = within(modal).getByRole('button', {
+      name: 'Save'
+    })
+    await waitFor(() => {
+      expect(saveBtn).toBeEnabled()
+      fireEvent.click(saveBtn)
+    })
+
+    await waitFor(() => {
+      // validate new avatar upload
+      expect(mockUpsertImage).toBeCalledTimes(1)
+      expect(mockUpsertImage).toBeCalledWith({
+        'data': base64data,
+        'mime_type': fileType,
+        'token': mockSession.token,
+      })
+      // confirm member patched called
+      expect(mockPatchTeamMember).toBeCalledTimes(1)
+      expect(mockPatchTeamMember).toBeCalledWith({
+        member: editedMember,
+        token: mockSession.token
+      })
+      // validate delete image called
+      expect(mockDeleteImage).toBeCalledTimes(1)
+      expect(mockDeleteImage).toBeCalledWith({
+        'id': oldAvatarId,
+        'token': mockSession.token,
+      })
     })
   })
 })

--- a/frontend/components/projects/edit/team/TeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberModal.tsx
@@ -1,11 +1,12 @@
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEvent, useEffect} from 'react'
+import {ChangeEvent, useEffect, useState} from 'react'
 import {
   Button, Dialog, DialogActions, DialogContent,
   DialogTitle, useMediaQuery
@@ -15,7 +16,7 @@ import {useForm} from 'react-hook-form'
 
 import {useSession} from '~/auth'
 import {getDisplayInitials, getDisplayName} from '~/utils/getDisplayName'
-import {TeamMember} from '~/types/Project'
+import {SaveTeamMember, TeamMember} from '~/types/Project'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import ControlledTextField from '~/components/form/ControlledTextField'
 import ControlledSwitch from '~/components/form/ControlledSwitch'
@@ -24,13 +25,15 @@ import ControlledAffiliation from '~/components/form/ControlledAffiliation'
 import {cfgTeamMembers as config} from './config'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
 import {handleFileUpload} from '~/utils/handleFileUpload'
-import {deleteImage, getImageUrl} from '~/utils/editImage'
-import {patchTeamMember} from './editTeamMembers'
+import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
+import {patchTeamMember, postTeamMember} from './editTeamMembers'
+import {getPropsFromObject} from '~/utils/getPropsFromObject'
+import {TeamMemberProps} from '~/types/Contributor'
 
 type TeamMemberModalProps = {
   open: boolean,
   onCancel: () => void,
-  onSubmit: ({data, pos}: { data: TeamMember, pos?: number }) => void,
+  onSubmit: ({member, pos}: { member: SaveTeamMember, pos?: number }) => void,
   member?: TeamMember,
   pos?: number
 }
@@ -41,6 +44,7 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
   const {token} = useSession()
   const {showWarningMessage,showErrorMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
+  const [removeAvatar, setRemoveAvatar] = useState<null|string>(null)
   const {handleSubmit, watch, formState, reset, control, register, setValue} = useForm<TeamMember>({
     mode: 'onChange',
     defaultValues: {
@@ -113,34 +117,77 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
     setValue('avatar_mime_type', avatar_mime_type, {shouldDirty: true})
   }
 
-   async function deleteAvatar() {
-     if (formData.id && formData.avatar_id) {
-      // remove refrence to avatar first
-      const patch = await patchTeamMember({
-        member: {
-          id: formData.id,
-          avatar_id: null
-        },
-        token
-      })
-      // debugger
-      if (patch.status !== 200) {
-        showErrorMessage('Failed to remove image')
-        return
-      }
-      // then try to remove avatar from db
-      // without waiting for result
-      const del = await deleteImage({
-        id: formData.avatar_id,
-        token
-      })
+  function deleteAvatar() {
+    if (formData.id && formData.avatar_id) {
+      // mark image for deletion
+      setRemoveAvatar(formData.avatar_id)
       // update form
       setValue('avatar_id', null, {shouldDirty: true,shouldValidate:true})
      } else {
       // just remove uploaded image from form
-      // because it is not save yet to DB
+      // because it is not saved yet to DB
       setValue('avatar_b64', null)
       setValue('avatar_mime_type', null, {shouldDirty: true})
+    }
+  }
+
+  async function onSave(data: TeamMember) {
+    // UPLOAD avatar
+    if (data.avatar_b64 && data.avatar_mime_type) {
+      // split base64 to use only encoded content
+      const b64data = data.avatar_b64.split(',')[1]
+      const upload = await upsertImage({
+        data: b64data,
+        mime_type: data.avatar_mime_type,
+        token
+      })
+      // debugger
+      if (upload.status === 201) {
+        // update data values
+        data.avatar_id = upload.message
+      } else {
+        showErrorMessage(`Failed to upload image. ${upload.message}`)
+        return
+      }
+    }
+    // prepare member object for save (remove helper props)
+    const member:SaveTeamMember = getPropsFromObject(data, TeamMemberProps)
+    // CREATE or UPDATE
+    if (member.id && typeof pos !== 'undefined') {
+      const resp = await patchTeamMember({
+        member,
+        token
+      })
+      // debugger
+      if (resp.status === 200) {
+        if (removeAvatar) {
+          // try to remove avatar from db
+          // without waiting for result
+          deleteImage({
+            id: removeAvatar,
+            token
+          })
+        }
+        // pass member to parent
+        onSubmit({member, pos})
+      } else {
+        showErrorMessage(`Failed to update member. ${resp.message}`)
+      }
+    } else {
+      // new team member we need to add
+      const resp = await postTeamMember({
+        member,
+        token
+      })
+      // debugger
+      if (resp.status === 201) {
+        // get id out of message
+        member.id = resp.message
+        // pass member to parent
+        onSubmit({member, pos})
+      } else {
+        showErrorMessage(`Failed to add member. ${resp.message}`)
+      }
     }
   }
 
@@ -162,7 +209,7 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
       </DialogTitle>
       <form
         id={formId}
-        onSubmit={handleSubmit((data: TeamMember) => onSubmit({data, pos}))}
+        onSubmit={handleSubmit((data: TeamMember) => onSave(data))}
         autoComplete="off"
       >
         {/* hidden inputs */}

--- a/frontend/components/projects/edit/team/TeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberModal.tsx
@@ -89,26 +89,10 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
 
   async function replaceImage(avatar_b64:string, avatar_mime_type:string) {
     if (formData.id && formData.avatar_id) {
-      // remove refrence to avatar first
-      const patch = await patchTeamMember({
-        member: {
-          id: formData.id,
-          avatar_id: null
-        },
-        token
-      })
-      // debugger
-      if (patch.status !== 200) {
-        showErrorMessage('Failed to remove image')
-        return
-      }
-      // then try to remove avatar from db
-      // without waiting for result
-      const del = await deleteImage({
-        id: formData.avatar_id,
-        token
-      })
-      // remove id in the form too
+      // mark old image for deletion
+      // we will remove it on Save
+      setRemoveAvatar(formData.avatar_id)
+      // and remove id in the form too
       setValue('avatar_id', null)
     }
     // write new logo to logo_b64

--- a/frontend/components/projects/edit/team/TeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberModal.tsx
@@ -125,6 +125,7 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
         mime_type: data.avatar_mime_type,
         token
       })
+
       // debugger
       if (upload.status === 201) {
         // update data values
@@ -226,6 +227,7 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
                 />
               </label>
               <input
+                data-testid="upload-avatar-input"
                 id="upload-avatar-image"
                 type="file"
                 accept="image/*"

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -88,26 +88,10 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
 
   async function replaceImage(avatar_b64:string, avatar_mime_type:string) {
     if (formData.id && formData.avatar_id) {
-      // remove refrence to avatar first
-      const patch = await patchContributor({
-        contributor: {
-          id: formData.id,
-          avatar_id: null
-        },
-        token
-      })
-      // debugger
-      if (patch.status !== 200) {
-        showErrorMessage('Failed to remove image')
-        return
-      }
-      // then try to remove avatar from db
-      // without waiting for result
-      const del = await deleteImage({
-        id: formData.avatar_id,
-        token
-      })
-      // remove id in the form too
+      // mark old image for deletion
+      // we will remove it on Save
+      setRemoveAvatar(formData.avatar_id)
+      // and remove id in the form too
       setValue('avatar_id', null)
     }
     // write new logo to logo_b64

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -226,6 +226,7 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
                 />
               </label>
               <input
+                data-testid="upload-avatar-input"
                 id="upload-avatar-image"
                 type="file"
                 accept="image/*"

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -1,11 +1,12 @@
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEvent, useEffect} from 'react'
+import {ChangeEvent, useEffect, useState} from 'react'
 import {
   Button, Dialog, DialogActions, DialogContent,
   DialogTitle, useMediaQuery
@@ -15,7 +16,7 @@ import {useForm} from 'react-hook-form'
 
 import {useSession} from '~/auth'
 import useSnackbar from '../../../snackbar/useSnackbar'
-import {Contributor} from '../../../../types/Contributor'
+import {Contributor, ContributorProps, SaveContributor} from '../../../../types/Contributor'
 import ControlledTextField from '../../../form/ControlledTextField'
 import ControlledSwitch from '../../../form/ControlledSwitch'
 import ContributorAvatar from '../../ContributorAvatar'
@@ -24,13 +25,14 @@ import {getDisplayInitials, getDisplayName} from '../../../../utils/getDisplayNa
 import ControlledAffiliation from '~/components/form/ControlledAffiliation'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
 import {handleFileUpload} from '~/utils/handleFileUpload'
-import {deleteImage, getImageUrl} from '~/utils/editImage'
-import {patchContributor} from '~/utils/editContributors'
+import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
+import {patchContributor, postContributor} from '~/utils/editContributors'
+import {getPropsFromObject} from '~/utils/getPropsFromObject'
 
 type EditContributorModalProps = {
   open: boolean,
   onCancel: () => void,
-  onSubmit: ({data, pos}: { data: Contributor, pos?: number }) => void,
+  onSubmit: ({contributor, pos}: { contributor: SaveContributor, pos?: number }) => void,
   contributor?: Contributor,
   pos?: number
 }
@@ -41,6 +43,7 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
   const {token} = useSession()
   const {showWarningMessage,showErrorMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
+  const [removeAvatar, setRemoveAvatar] = useState<null|string>(null)
   const {handleSubmit, watch, formState, reset, control, register, setValue} = useForm<Contributor>({
     mode: 'onChange',
     defaultValues: {
@@ -57,11 +60,11 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
   // console.log('isValid...', isValid)
   // console.groupEnd()
 
-  useEffect(() => {
-    if (contributor) {
-      reset(contributor)
-    }
-  }, [contributor,reset])
+  // useEffect(() => {
+  //   if (contributor) {
+  //     reset(contributor)
+  //   }
+  // }, [contributor,reset])
 
   function handleCancel() {
     // reset form
@@ -113,34 +116,78 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
     setValue('avatar_mime_type', avatar_mime_type, {shouldDirty: true})
   }
 
-   async function deleteAvatar() {
-    if (formData.id && formData.avatar_id) {
-      // remove reference to avatar first
-      const patch = await patchContributor({
-        contributor: {
-          id: formData.id,
-          avatar_id: null
-        },
-        token
-      })
-      // debugger
-      if (patch.status !== 200) {
-        showErrorMessage('Failed to remove image')
-        return
-      }
-      // then try to remove avatar from db
-      // without waiting for result
-      const del = await deleteImage({
-        id: formData.avatar_id,
-        token
-      })
+  function deleteAvatar() {
+     if (formData.id && formData.avatar_id) {
+      // mark image for deletion
+      setRemoveAvatar(formData.avatar_id)
       // update form
-      setValue('avatar_id', null, {shouldDirty:true,shouldValidate:true})
+      setValue('avatar_id', null, {shouldDirty:true, shouldValidate:true})
      } else {
       // just remove uploaded image from form
       // because it is not save yet to DB
       setValue('avatar_b64', null)
       setValue('avatar_mime_type', null, {shouldDirty: true})
+    }
+  }
+
+  async function onSave(data: Contributor) {
+    // UPLOAD avatar
+    if (data.avatar_b64 && data.avatar_mime_type) {
+      // split base64 to use only encoded content
+      const b64data = data.avatar_b64.split(',')[1]
+      const upload = await upsertImage({
+        data: b64data,
+        mime_type: data.avatar_mime_type,
+        token
+      })
+      // debugger
+      if (upload.status === 201) {
+        // update data values
+        data.avatar_id = upload.message
+        data.avatar_b64 = null,
+        data.avatar_mime_type = null
+      } else {
+        showErrorMessage(`Failed to upload image. ${upload.message}`)
+        return
+      }
+    }
+
+    // prepare data object for save (remove helper props)
+    const contributor: SaveContributor = getPropsFromObject(data, ContributorProps)
+    // if id present we update
+    if (contributor?.id && typeof pos !== 'undefined') {
+      const resp = await patchContributor({
+        contributor,
+        token
+      })
+      if (resp.status === 200) {
+        if (removeAvatar) {
+          // try to remove avatar from db
+          // without waiting for result
+          deleteImage({
+            id: removeAvatar,
+            token
+          })
+        }
+        // call submit to pass data and close modal
+        onSubmit({contributor, pos})
+      } else {
+        showErrorMessage(`Failed to update ${getDisplayName(data)}. Error: ${resp.message}`)
+      }
+    } else {
+      // this is completely new contributor we need to add to DB
+      const resp = await postContributor({
+        contributor,
+        token
+      })
+      if (resp.status === 201) {
+        // id of created record is provided in returned in message
+        contributor.id = resp.message
+        // call submit to pass data and close modal
+        onSubmit({contributor,pos})
+      } else {
+        showErrorMessage(`Failed to add ${getDisplayName(contributor)}. Error: ${resp.message}`)
+      }
     }
   }
 
@@ -162,7 +209,7 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
       </DialogTitle>
       <form
         id={formId}
-        onSubmit={handleSubmit((data: Contributor) => onSubmit({data, pos}))}
+        onSubmit={handleSubmit((data: Contributor) => onSave(data))}
         autoComplete="off"
       >
         {/* hidden inputs */}

--- a/frontend/components/software/edit/contributors/__mocks__/softwareContributors.json
+++ b/frontend/components/software/edit/contributors/__mocks__/softwareContributors.json
@@ -1,5 +1,18 @@
 [
   {
+    "id": "45138b9b-42ef-4364-a9eb-a3bbe9ad050e",
+    "is_contact_person": false,
+    "email_address": "test1862@example.com",
+    "family_names": "Doe 33483",
+    "given_names": "John",
+    "affiliation": "Created by msedge 8350",
+    "role": "Senior Developer 12547",
+    "orcid": null,
+    "avatar_id": "f312b64a21770404f839beffdda250ea2acf7f2c",
+    "position": 10,
+    "software": "3406ca08-0fdd-46e6-ab01-c0c0c783775d"
+  },
+  {
     "id": "e79a09de-228e-478c-933b-ea61d20fe7d9",
     "is_contact_person": true,
     "email_address": "test7505@examle.com",
@@ -114,19 +127,6 @@
     "orcid": "0000-0001-7579-216X",
     "avatar_id": null,
     "position": 9,
-    "software": "3406ca08-0fdd-46e6-ab01-c0c0c783775d"
-  },
-  {
-    "id": "45138b9b-42ef-4364-a9eb-a3bbe9ad050e",
-    "is_contact_person": false,
-    "email_address": "test1862@example.com",
-    "family_names": "Doe 33483",
-    "given_names": "John",
-    "affiliation": "Created by msedge 8350",
-    "role": "Senior Developer 12547",
-    "orcid": null,
-    "avatar_id": "f312b64a21770404f839beffdda250ea2acf7f2c",
-    "position": 10,
     "software": "3406ca08-0fdd-46e6-ab01-c0c0c783775d"
   }
 ]

--- a/frontend/jest.setup.js
+++ b/frontend/jest.setup.js
@@ -11,7 +11,7 @@ import '@testing-library/jest-dom/extend-expect'
 
 // retry 2 times
 jest.retryTimes(2, {
-  logErrorsBeforeRetry: true
+  logErrorsBeforeRetry: false
 })
 
 // TODO! investigate other options beside mocking

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "1.11.2",
+  "version": "1.11.3",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/package.json.license
+++ b/frontend/package.json.license
@@ -2,6 +2,7 @@ SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2021 - 2023 dv4all
 SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
# Fix cancel avatar removal

Closes #677 

Changes proposed in this pull request:
* In the contributor section of edit software, the user can cancel avatar removal in the Edit contributor modal
* In team member section of edit project, the user can cancel avatar removal in the Edit team member modal
* unit test are extended

How to test:
* `make start` to build everything and create test cases
* login as rsd_admin to be able to edit existing software/project, or create new software and project where you are admin of
* navigate to edit software, contributors section. If there are contributors with image, edit the contributor
   * click on remove image button and then use CANCEL instead of SAVE. The avatar should not be removed
   * repeat the process but when using SAVE the avatar image should be removed
   * adding new contributors and removing should also work as expected
* the same fix is applied to team members section of edit project.

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
