### PR TITLE
Fix commit scraper no commits

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,7 +131,7 @@ services:
 
   scrapers:
     build: ./scrapers
-    image: rsd/scrapers:1.3.0
+    image: rsd/scrapers:1.3.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
@@ -31,8 +31,9 @@ public class Utils {
 
 	/**
 	 * Urlencode a string.
+	 *
 	 * @param value The string to be encoded
-	 * @return      The urlencoded string.
+	 * @return The urlencoded string.
 	 */
 	public static String urlEncode(String value) {
 		return URLEncoder.encode(value, StandardCharsets.UTF_8);
@@ -41,9 +42,10 @@ public class Utils {
 	/**
 	 * Performs a GET request with given headers and returns the response body
 	 * as a String.
+	 *
 	 * @param uri     The encoded URI
 	 * @param headers (Optional) Variable amount of headers. Number of arguments must be a multiple of two.
-	 * @return        The response as a String.
+	 * @return The response as a String.
 	 */
 	public static String get(String uri, String... headers) {
 		HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
@@ -66,45 +68,29 @@ public class Utils {
 		return response.body();
 	}
 
-	public static String getWithRetryOn202(int retries, long timeoutMillis, String uri, String... headers) {
-		if (retries < 0) retries = 0;
-
-		String result = null;
-		for (int tryNumber = 0; tryNumber < retries + 1; tryNumber++) {
-			HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
-					.GET()
-					.uri(URI.create(uri));
-			if (headers != null && headers.length > 0 && headers.length % 2 == 0) {
-				httpRequestBuilder.headers(headers);
-			}
-			HttpRequest request = httpRequestBuilder.build();
-			HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
-			HttpResponse<String> response;
-			try {
-				response = client.send(request, HttpResponse.BodyHandlers.ofString());
-			} catch (IOException | InterruptedException e) {
-				throw new RuntimeException(e);
-			}
-			if (response.statusCode() == 202) {
-				try {
-					Thread.sleep(timeoutMillis);
-				} catch (InterruptedException e) {
-					throw new RuntimeException(e);
-				}
-			} else if (response.statusCode() == 200) {
-				result = response.body();
-				break;
-			} else {
-				throw new RsdResponseException(response.statusCode(), "Error fetching data from endpoint " + uri + " with response: " + response.body());
-			}
+	public static HttpResponse<String> getAsHttpResponse(String uri, String... headers) {
+		HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
+				.GET()
+				.uri(URI.create(uri));
+		if (headers != null && headers.length > 0 && headers.length % 2 == 0) {
+			httpRequestBuilder.headers(headers);
 		}
-		return result;
+		HttpRequest request = httpRequestBuilder.build();
+		HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+		HttpResponse<String> response;
+		try {
+			response = client.send(request, HttpResponse.BodyHandlers.ofString());
+			return response;
+		} catch (IOException | InterruptedException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 	/**
 	 * Retrieve data from PostgREST as an admin user and retrieve the response body.
-	 * @param uri  The URI
-	 * @return     Returns the content of the HTTP response
+	 *
+	 * @param uri The URI
+	 * @return Returns the content of the HTTP response
 	 */
 	public static String getAsAdmin(String uri) {
 		String jwtString = adminJwt();
@@ -130,10 +116,11 @@ public class Utils {
 	/**
 	 * Performs a POST request with given headers and returns the response body
 	 * as a String.
-	 * @param uri           The URI
-	 * @param body          the request body as a string
-	 * @param extraHeaders  Additional headers (amount must be multiple of two)
-	 * @return              The response body as a string
+	 *
+	 * @param uri          The URI
+	 * @param body         the request body as a string
+	 * @param extraHeaders Additional headers (amount must be multiple of two)
+	 * @return The response body as a string
 	 */
 	public static String post(String uri, String body, String... extraHeaders) {
 		HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
@@ -158,10 +145,11 @@ public class Utils {
 
 	/**
 	 * Post data to the database.
-	 * @param uri           The URI
-	 * @param json          JSON as a string containing the values
-	 * @param extraHeaders  Additional headers (amount must be multiple of two)
-	 * @return              ???
+	 *
+	 * @param uri          The URI
+	 * @param json         JSON as a string containing the values
+	 * @param extraHeaders Additional headers (amount must be multiple of two)
+	 * @return ???
 	 */
 	public static String postAsAdmin(String uri, String json, String... extraHeaders) {
 		String jwtString = adminJwt();

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeekTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeekTest.java
@@ -69,7 +69,14 @@ public class CommitsPerWeekTest {
 
 	@Test
 	void givenInstance_whenValidOperations_thenCorrectJsonProduced() {
+		Gson gson = new GsonBuilder()
+				.registerTypeAdapter(Instant.class, (JsonDeserializer<Instant>) (json, typeOfT, context) -> Instant.ofEpochSecond(Long.parseLong(json.getAsString())))
+				.create();
+		TypeToken<Map<Instant, Long>> mapTypeToken = new TypeToken<>(){};
 		CommitsPerWeek commitsPerWeek = new CommitsPerWeek();
+
+		Map<Instant, Long> shouldBeEmptyMap = gson.fromJson(commitsPerWeek.toJson(), mapTypeToken.getType());
+		Assertions.assertTrue(shouldBeEmptyMap.isEmpty());
 
 		Instant sundayMidnight1 = Instant.ofEpochSecond(1670716800);
 		commitsPerWeek.addCommits(sundayMidnight1, 10);
@@ -81,11 +88,8 @@ public class CommitsPerWeekTest {
 		Instant sundayMidnight2 = sundayMidnight1.plus(Period.ofWeeks(5));
 		commitsPerWeek.addCommits(sundayMidnight2, 5);
 
-		Gson gson = new GsonBuilder()
-				.registerTypeAdapter(Instant.class, (JsonDeserializer<Instant>) (json, typeOfT, context) -> Instant.ofEpochSecond(Long.parseLong(json.getAsString())))
-				.create();
 
-		Map<Instant, Long> dataFromJson = gson.fromJson(commitsPerWeek.toJson(), new TypeToken<Map<Instant, Long>>(){}.getType());
+		Map<Instant, Long> dataFromJson = gson.fromJson(commitsPerWeek.toJson(), mapTypeToken.getType());
 		Assertions.assertEquals(2, dataFromJson.size());
 		Assertions.assertEquals(40, dataFromJson.get(sundayMidnight1));
 		Assertions.assertEquals(5, dataFromJson.get(sundayMidnight2));


### PR DESCRIPTION
# Fix empty commit graph for GitHub

Changes proposed in this pull request:

* The GitHub scraper now properly pushes an empty JSON object when the commit history is empty

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=0`
* Add one software page with repo URL https://github.com/cmeessen/empty
* Wait or run the commit scraper manually: 
	* `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits`
* The commit graph should say `We cannot display this graph because the repository is empty.`
* You can check that in the db an empty JSON object (`{}`) is stored under the commit history (`SELECT commit_history, url FROM repository_url;`)

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests