### PR TITLE
663 delete last maintainer

### DIFF
--- a/frontend/components/projects/edit/maintainers/ProjectMaintainersList.tsx
+++ b/frontend/components/projects/edit/maintainers/ProjectMaintainersList.tsx
@@ -1,11 +1,12 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 import List from '@mui/material/List'
+import {useSession} from '~/auth'
 import logger from '~/utils/logger'
 
 import ProjectMaintainer from './ProjectMaintainer'
@@ -17,6 +18,7 @@ type ProjectMaintainerListProps = {
 }
 
 export default function ProjectMaintainersList({maintainers,onDelete}:ProjectMaintainerListProps) {
+  const {user} = useSession()
 
   if (maintainers.length === 0) {
     return (
@@ -31,6 +33,17 @@ export default function ProjectMaintainersList({maintainers,onDelete}:ProjectMai
     logger('onEdit...NOT SUPPORTED FOR MAINTAINERS','info')
   }
 
+  function isDeleteDisabled() {
+    // we allow rsd_admin to remove last mantainer too
+    if (user?.role === 'rsd_admin' && maintainers?.length > 0) {
+      return false
+    } else if (maintainers?.length > 1) {
+      // common maintainer can remove untill the last mantainer
+      return false
+    }
+    return true
+  }
+
   function renderList() {
     return maintainers.map((item, pos) => {
       return (
@@ -41,7 +54,7 @@ export default function ProjectMaintainersList({maintainers,onDelete}:ProjectMai
           onEdit={onEdit}
           onDelete={onDelete}
           // disable delete when last maintainer
-          disableDelete={maintainers?.length < 2}
+          disableDelete={isDeleteDisabled()}
         />
       )
     })

--- a/frontend/components/software/AboutLanguageItem.tsx
+++ b/frontend/components/software/AboutLanguageItem.tsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import SearchIcon from '@mui/icons-material/Search'
+import Link from 'next/link'
+import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
+
+type AboutLanguageItemProps = {
+  language: string,
+  val: number,
+  pct: number
+}
+
+export default function AboutLanguageItem(props: AboutLanguageItemProps) {
+  const {language, pct} = props
+
+  if (language.toLowerCase() === 'other') {
+    // Other item has no search link
+    return (
+      <li>
+        <div className="flex justify-between">
+          <span>{language} {pct}%</span>
+        </div>
+        <div
+          className="bg-primary"
+          style={{
+            width: `${pct}%`,
+            height: '0.5rem',
+            opacity: 0.5
+          }}>
+        </div>
+      </li>
+    )
+  }
+
+  // construct url
+  const url = ssrSoftwareUrl({prog_lang: [language]})
+
+  return (
+    <li>
+      <div className="flex justify-between">
+        <span>{language} {pct}%</span>
+        <Link
+          title={`Click to filter for software using ${language}`}
+          href={url}
+          passHref
+        >
+          <SearchIcon sx={{
+            marginRight: '0.5rem',
+            color:'text.secondary'
+          }} />
+        </Link>
+      </div>
+      <div
+        className="bg-primary"
+        style={{
+          width: `${pct}%`,
+          height: '0.5rem',
+          opacity: 0.5
+        }}>
+      </div>
+    </li>
+  )
+}

--- a/frontend/components/software/AboutLanguages.tsx
+++ b/frontend/components/software/AboutLanguages.tsx
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
@@ -7,11 +7,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Code from '@mui/icons-material/Code'
-import SearchIcon from '@mui/icons-material/Search'
-import Link from 'next/link'
-import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
-import {ProgramingLanguages} from '../../types/SoftwareTypes'
-import logger from '../../utils/logger'
+
+import {sortOnNumProp} from '~/utils/sortFn'
+import logger from '~/utils/logger'
+import {CodePlatform, ProgramingLanguages} from '~/types/SoftwareTypes'
+import AboutLanguageItem from './AboutLanguageItem'
 
 /**
  * Calculate programming languages percentages.
@@ -55,14 +55,31 @@ function calculateStats(languages: ProgramingLanguages) {
     return stats
   } catch (e:any) {
     logger(`AboutLanguages: Failed to calculateStats. Error: ${e.message}`, 'error')
+    return []
   }
 }
 
+export default function AboutLanguages({languages, platform}:
+  { languages: ProgramingLanguages, platform: CodePlatform }) {
 
-export default function AboutLanguages({languages}: {languages: ProgramingLanguages }) {
   // don't render section if no languages
   if (typeof languages == 'undefined' || languages === null) return null
-  const stats = calculateStats(languages)
+
+  let stats = []
+  if (platform === 'gitlab') {
+    // GitLab api stats already in %
+    // we only map and sort by %
+    stats = Object.keys(languages)
+      .map(key => ({
+        language: key,
+        val: languages[key],
+        pct: Math.round(languages[key])
+      }))
+      .sort((a,b)=>sortOnNumProp(a,b,'pct','desc'))
+  } else {
+    stats = calculateStats(languages)
+  }
+
   // don't render if stats failed
   if (typeof stats == 'undefined') return null
 
@@ -73,34 +90,9 @@ export default function AboutLanguages({languages}: {languages: ProgramingLangua
       <span className="text-primary pl-2">Programming language</span>
     </div>
     <ul className="py-1">
-      {/* show only stat selection pct > 0*/}
-      {stats?.map((entry) => {
-        const url = ssrSoftwareUrl({prog_lang: [entry.language]})
-        return (
-          <li key={entry.language}>
-            <div className="flex justify-between">
-              <span>{entry.language} {entry.pct}%</span>
-              <Link
-                title={`Click to filter for software using ${entry.language}`}
-                href={url}
-                passHref
-              >
-                <SearchIcon sx={{
-                  marginRight: '0.5rem',
-                  color:'text.secondary'
-                }} />
-              </Link>
-            </div>
-            <div
-              className="bg-primary"
-              style={{
-                width: `${entry.pct}%`,
-                height: '0.5rem',
-                opacity: 0.5
-              }}>
-            </div>
-          </li>
-        )
+      {/* show only stat selection pct > 0 and exclude other category */}
+      {stats?.map((props) => {
+        return <AboutLanguageItem key={props.language} {...props} />
       })}
     </ul>
     </>

--- a/frontend/components/software/AboutSection.tsx
+++ b/frontend/components/software/AboutSection.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -59,7 +59,7 @@ export default function AboutSection(props:AboutSectionType) {
       <div className="flex-1">
         {getSoftwareLogo()}
         <SoftwareKeywords keywords={keywords || []} />
-        <AboutLanguages languages={languages} />
+        <AboutLanguages languages={languages} platform={platform} />
         <AboutLicense license={license || []} />
         <AboutSourceCode
           repository={repository ?? null}


### PR DESCRIPTION
# Delete last maintainer

Closes #663 

Changes proposed in this pull request:
* User with rsd_admin role is able to delete last maintainer of software or project
* Fix programming language link for GitHub and Other categorie, 

How to test:
* `make start` to build everything
* Login as professor 1 and create new software to become maintainer of the software
* Now login as rsd_admin. Check env variable RSD_ADMIN_EMAIL_LIST. In **env.example** professor3 is defined as rsd_admin
* Edit software you created, as rsd_admin you will be able to remove first maintainer
* The same should work with project maintainers

## Example programming languages - other category
Use https://github.com/umple/umple as example:
![image](https://user-images.githubusercontent.com/9204081/212734436-3e7928d8-d847-4eaf-a796-ab52a21a7cf6.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
