### PR TITLE
Software release section for organisations

### DIFF
--- a/frontend/components/organisation/OrganisationNavItems.tsx
+++ b/frontend/components/organisation/OrganisationNavItems.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,6 +9,7 @@ import AccountTreeIcon from '@mui/icons-material/AccountTree'
 import ListAltIcon from '@mui/icons-material/ListAlt'
 import PersonIcon from '@mui/icons-material/Person'
 import SettingsIcon from '@mui/icons-material/Settings'
+import StyleOutlinedIcon from '@mui/icons-material/StyleOutlined'
 
 import AboutOrganisation from './about'
 import OrganisationSoftware from './software'
@@ -17,6 +18,7 @@ import OrganisationUnits from './units'
 import OrganisationMaintainers from './maintainers'
 import OrganisationSettings from './settings'
 import {OrganisationForOverview} from '~/types/Organisation'
+import SoftwareReleases from './releases'
 
 export type OrganisationComponentsProps = {
   organisation: OrganisationForOverview,
@@ -60,6 +62,15 @@ export const organisationMenu: OrganisationMenuProps[] = [
     status: 'Participating organisation',
     isVisible: (props) => true,
     showSearch: true
+  },
+  {
+    id:'releases',
+    label:({release_cnt})=>`Releases (${release_cnt ?? 0})`,
+    icon: <StyleOutlinedIcon />,
+    component: (props) => <SoftwareReleases {...props} />,
+    status: 'Software releases',
+    isVisible: (props) => true,
+    showSearch: false
   },
   {
     id:'projects',

--- a/frontend/components/organisation/releases/ReleaseItem.tsx
+++ b/frontend/components/organisation/releases/ReleaseItem.tsx
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Chip from '@mui/material/Chip'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import Link from 'next/link'
+import {SoftwareReleaseInfo} from './useSoftwareReleases'
+
+export default function ReleaseItem({release}: { release: SoftwareReleaseInfo }) {
+  const releaseDate = new Date(release.release_date)
+  return (
+    <article className="py-2">
+      <div className="flex gap-4">
+        {/* release date */}
+        <div className="text-base-content-disabled whitespace-nowrap font-mono tracking-tighter text-sm leading-6">{
+          releaseDate.toLocaleDateString(undefined, {
+            day: '2-digit',
+            month: 'short',
+            year: 'numeric'
+          })}
+        </div>
+
+        <div className='flex-1'>
+          {/* name and version */}
+          <div className="flex flex-wrap gap-4 justify-between">
+            <Link
+              title="Link to RSD page"
+              href={`/software/${release.software_slug}`}
+              target="_blank"
+              passHref
+            >
+              {release.software_name}
+              <OpenInNewIcon sx={{
+                height: '1rem',
+                width: '1rem',
+                marginLeft: '0.5rem'
+              }} />
+            </Link>
+            <Link
+              href={`https://doi.org/${release.release_doi}`}
+              target="_blank"
+              passHref
+            >
+            <Chip
+              title="Link to DOI page"
+              label={release.release_tag}
+              icon={<OpenInNewIcon />}
+              size="small"
+              clickable
+              sx={{
+                maxWidth: '15rem',
+                borderRadius: '0rem 0.5rem',
+                // textTransform: 'capitalize',
+                '& .MuiChip-icon': {
+                  order: 1,
+                  margin:'0rem 0.25rem 0rem 0rem',
+                  height: '1rem',
+                  width: '1rem'
+                }
+              }}
+            />
+            </Link>
+          </div>
+          {/* authors, contributors */}
+          {release.person.length > 0 ?
+            <div className="text-sm text-base-content-secondary pt-1">{ release.person.join(', ')}</div>
+            : null
+          }
+          {/* DOI */}
+          <div className="text-sm text-base-content-secondary pt-1">
+            DOI: {release.release_doi}
+          </div>
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/frontend/components/organisation/releases/ReleaseNavButton.tsx
+++ b/frontend/components/organisation/releases/ReleaseNavButton.tsx
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+type ReleaseNavProps = {
+  year: string,
+  release_cnt: number
+}
+
+export default function ReleaseNavButton({year,release_cnt}:ReleaseNavProps) {
+  return (
+    <a key={year} href={`#id_${year}`}>
+      <div className="border rounded-md">
+        <div className="bg-primary py-1 px-2 text-primary-content">{year}</div>
+        <div className="text-center p-2 font-medium text-primary">{release_cnt}</div>
+      </div>
+    </a>
+  )
+}

--- a/frontend/components/organisation/releases/ReleaseYear.tsx
+++ b/frontend/components/organisation/releases/ReleaseYear.tsx
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import ReleaseItem from './ReleaseItem'
+import {SoftwareReleaseInfo} from './useSoftwareReleases'
+
+type ReleaseYearProps = {
+  year: string,
+  releases: SoftwareReleaseInfo[]
+}
+
+const smoothScrollSection = {
+  padding: '0.5rem 0rem',
+  // TODO! make this dynamic - for mobiles
+  scrollMarginTop: '7rem'
+}
+
+
+export default function ReleaseYear({year,releases}:ReleaseYearProps) {
+  return (
+    <section id={`id_${year}`} style={smoothScrollSection}>
+      <div>
+        <h3 className="text-primary">
+          {year}
+        </h3>
+        <div className="pb-2 border-b text-sm text-base-content-secondary">
+          {releases.length} {releases.length === 1 ? 'release' : 'releases'}
+        </div>
+      </div>
+      <section>
+        {releases.map(release=><ReleaseItem key={release.release_doi} release={release} />)}
+      </section>
+    </section>
+  )
+}

--- a/frontend/components/organisation/releases/ScrollToTopButton.tsx
+++ b/frontend/components/organisation/releases/ScrollToTopButton.tsx
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useCallback, useEffect, useState} from 'react'
+import Fab from '@mui/material/Fab'
+import NavigationIcon from '@mui/icons-material/Navigation'
+
+type ScrollToTopProps = {
+  minOffset: number,
+  sx?: any
+}
+
+export default function ScrollToTopButton({minOffset, sx}:ScrollToTopProps) {
+  const [show, setShow] = useState(false)
+
+  const handleScroll = useCallback(() => {
+    const position = window.pageYOffset
+    if (minOffset < position) {
+      setShow(true)
+    }
+    if (show === true && minOffset >= position) {
+      setShow(false)
+    }
+  }, [minOffset, show])
+
+  useEffect(() => {
+    window.addEventListener('scroll', handleScroll, {passive: true})
+    return () => {
+      window.removeEventListener('scroll', handleScroll)
+    }
+  }, [handleScroll])
+
+  // return null when not to show
+  if (show===false) return null
+
+  return (
+    <Fab
+      title="Back to top"
+      color='primary'
+      onClick={()=>window.scrollTo(0,0)}
+      sx={{
+        position: 'fixed',
+        right: '3rem',
+        ...sx ?? {bottom: '3rem'}
+      }}
+    >
+      <NavigationIcon />
+    </Fab>
+  )
+}

--- a/frontend/components/organisation/releases/index.tsx
+++ b/frontend/components/organisation/releases/index.tsx
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useSession} from '~/auth'
+import ContentLoader from '~/components/layout/ContentLoader'
+import {OrganisationComponentsProps} from '../OrganisationNavItems'
+import useSoftwareRelease from './useSoftwareReleases'
+import ReleaseYear from './ReleaseYear'
+import NoContent from '~/components/layout/NoContent'
+import ReleaseNavButton from './ReleaseNavButton'
+import ScrollToTopButton from './ScrollToTopButton'
+
+export default function SoftwareReleases({organisation, isMaintainer}: OrganisationComponentsProps) {
+  const {token} = useSession()
+  const {loading, releases} = useSoftwareRelease({
+    organisation_slug: organisation.slug,
+    token
+  })
+  // extact year keys in descending order
+  const years = Object.keys(releases ?? {}).sort((a,b)=>parseInt(b) - parseInt(a))
+
+  // console.group('SoftwareReleases')
+  // console.log('loading...', loading)
+  // console.log('releases...', releases)
+  // console.log('years...', years)
+  // console.groupEnd()
+
+  // show loader
+  if (loading===true) return <ContentLoader />
+  // no content
+  if (typeof releases === 'undefined') return <NoContent />
+  if (years.length === 0) return <NoContent />
+  // releases per year
+  return (
+    <section className="relative">
+      <h2 className="py-2">Releases per year</h2>
+      <nav id="period_nav"
+        className="flex flex-wrap justify-start items-center mb-4"
+        style={{gap: '0.5rem 0.25rem'}}>
+        {years
+          .map(year => {
+            return <ReleaseNavButton key={year} year={year} release_cnt={releases[year].length} />
+          })
+        }
+      </nav>
+      {years
+        .map(year => {
+          return <ReleaseYear key={year} year={year} releases={releases[year]} />
+        })}
+      <ScrollToTopButton minOffset={200} />
+      <div className="py-8"></div>
+    </section>
+  )
+}

--- a/frontend/components/organisation/releases/useSoftwareReleases.tsx
+++ b/frontend/components/organisation/releases/useSoftwareReleases.tsx
@@ -1,0 +1,190 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import logger from '~/utils/logger'
+
+type SoftwareReleaseBase = {
+  software_id: string
+  software_slug: string
+  software_name: string
+  release_doi: string
+  release_tag: string
+  release_date: string
+  release_year: number
+  organisation_slug: string[]
+}
+
+
+type SoftwareReleaseApi = SoftwareReleaseBase & {
+  // source: release_content.schema_dot_org
+  // json object stored as string
+  release_info: string
+}
+
+export type SoftwareReleaseInfo = SoftwareReleaseBase & {
+  // we extract all persons from release_info object
+  person: string[]
+}
+
+export type SoftwareReleasedByYear = {
+  [key: string]: SoftwareReleaseInfo[]
+}
+
+type ReleasePerson = {
+  // "https://orcid.org/0000-0002-5821-2060"
+  '@id': string
+  '@type': 'Person',
+  'affiliation': {
+    '@type': 'Organization',
+    'legalName': string
+  },
+  'familyName': string
+  'givenName': string
+}
+
+type ReleaseInfo={
+  '@context': 'https://schema.org',
+  '@type': 'SoftwareSourceCode',
+  author: ReleasePerson[],
+  contributor?: ReleasePerson[]
+  // "https://github.com/3D-e-Chem/knime-silicos-it"
+  'codeRepository': string,
+  // "2019-06-27",
+  'datePublished': string
+  // "https://doi.org/10.5281/zenodo.3258131",
+  'identifier': string
+  // "http://www.apache.org/licenses/LICENSE-2.0",
+  'license': string
+  // "KNIME nodes and example workflows for software made by Silicos-it, ie. align-it, shape-it",
+  'name': string
+  // "v1.1.3"
+  'version': string
+}
+
+
+type UseSoftwareReleaseProps = {
+  organisation_slug: string,
+  token: string
+}
+
+
+function displayNameFromPerson(person: ReleasePerson) {
+  try {
+    return `${person?.givenName} ${person?.familyName}`
+  } catch (e) {
+    return ''
+  }
+}
+
+function extractPersonsFromReleaseInfo(info: string) {
+  try {
+    if (info === null) return []
+
+    const persons: string[] = []
+    const releaseInfo: ReleaseInfo = JSON.parse(info)
+
+    if (releaseInfo.hasOwnProperty('author') === true) {
+      releaseInfo.author.forEach(item => {
+        const name = displayNameFromPerson(item)
+        // push only names with some content
+        if (name!=='') persons.push(name)
+      })
+    }
+
+    if (releaseInfo.hasOwnProperty('contributor') === true) {
+      releaseInfo.author.forEach(item => {
+        const name = displayNameFromPerson(item)
+        // push only names with some content
+        if (name!=='') persons.push(name)
+      })
+    }
+
+    return persons
+  } catch (e:any) {
+    logger(`extractPersonsFromReleaseInfo...error: ${e.message}`)
+    return []
+  }
+}
+
+
+function softwareReleaseByYear(data: SoftwareReleaseApi[]) {
+  const releaseByYear:SoftwareReleasedByYear = {}
+
+  data.forEach(item => {
+    if (releaseByYear.hasOwnProperty(item.release_year.toString())===false) {
+      // create new key
+      releaseByYear[item.release_year.toString()] = []
+    }
+    // parse info
+    // item.release_info = JSON.parse(item.release_info)
+    releaseByYear[item.release_year.toString()].push({
+      ...item,
+      person: extractPersonsFromReleaseInfo(item.release_info)
+    })
+  })
+
+  return releaseByYear
+}
+
+async function getReleasesForOrganisation({organisation_slug, token}:UseSoftwareReleaseProps) {
+  try {
+    const query = `organisation_slug=cs.{${organisation_slug}}&order=release_date.desc`
+    const url = `${getBaseUrl()}/rpc/software_release?${query}`
+    // make request
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token)
+      },
+    })
+
+    if (resp.status === 200) {
+      const data:SoftwareReleaseApi[] = await resp.json()
+      return softwareReleaseByYear(data)
+    }
+    // some other errors
+    logger(`getReleasesForOrganisation...${resp.status} ${resp.statusText}`)
+    return null
+  } catch(e:any) {
+    logger(`getReleasesForOrganisation...error...${e.message}`)
+    return null
+  }
+}
+
+export default function useSoftwareRelease({organisation_slug, token}:UseSoftwareReleaseProps) {
+  const [loading, setLoading] = useState(true)
+  const [releases, setReleases] = useState<SoftwareReleasedByYear>()
+
+
+  // console.group('useSoftwareRelease')
+  // console.log('loading...', loading)
+  // console.log('releases...', releases)
+  // console.log('organisation_slug...', organisation_slug)
+  // console.log('token...', token)
+  // console.groupEnd()
+
+  useEffect(() => {
+    async function getReleases() {
+      setLoading(true)
+      // make request
+      const releases = await getReleasesForOrganisation({organisation_slug, token})
+      // update releases
+      if (releases) setReleases(releases)
+      setLoading(false)
+    }
+
+    if (organisation_slug) {
+      getReleases()
+    }
+
+  },[organisation_slug,token])
+
+  return {
+    loading,
+    releases
+  }
+}

--- a/frontend/components/projects/edit/related/RelatedProjectList.tsx
+++ b/frontend/components/projects/edit/related/RelatedProjectList.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -101,7 +101,7 @@ export function RelatedProjectItem({project,onDelete}:ProjectItemProps) {
         </>
         }
       sx={{
-          height:itemHeight,
+          minHeight:itemHeight,
           // this makes space for buttons
           paddingRight:'5rem',
           '&:hover': {

--- a/frontend/components/projects/edit/related/RelatedSoftwareList.tsx
+++ b/frontend/components/projects/edit/related/RelatedSoftwareList.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -105,7 +105,7 @@ export function RelatedSoftwareItem({software,onDelete}:SoftwareItemProps) {
         </IconButton>
       }
       sx={{
-        height:itemHeight,
+        minHeight:itemHeight,
         // this makes space for buttons
         paddingRight:'5rem',
         '&:hover': {

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -1,6 +1,6 @@
 /*
- * SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
- * SPDX-FileCopyrightText: 2021 - 2022 dv4all
+ * SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
+ * SPDX-FileCopyrightText: 2021 - 2023 dv4all
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -12,6 +12,10 @@
 /** ------------------------------------
   Default values
 -------------------------------------**/
+
+html {
+  scroll-behavior: smooth;
+}
 
 body{
   font-size: 1rem;

--- a/frontend/types/Organisation.ts
+++ b/frontend/types/Organisation.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -114,6 +114,7 @@ export type OrganisationForOverview = Organisation & {
   software_cnt: number | null
   project_cnt: number | null
   children_cnt: number | null
+  release_cnt: number | null
   rsd_path: string
 }
 


### PR DESCRIPTION
# Software release section for organisation

Closes #708 

Changes proposed in this pull request:
*  Additional section "Releases" is added to organisation page. It shows total release count, release count per year and list all releases .
* Each release contains two links that open in new tab: 
   * link to software page on RSD, by clicking on software name
   * link to DOI page of the relase (usually Zenodo page)

How to test:
* `make start` to build everything and create test cases
* `docker-compose down && docker-compose up` to restart with scrapers. We need release scraper to scrape info about releases
* After scraper is done it's work there will be releases listed. Before that the count will be 0 and page will message 'Nothing to show"

## Points of attention
- The information used is provided by "release scraper". The contributors information is extracted from `schema_dot_org` column, the property `author`. Not every release entry has `schema_dot_org` or `author` property in it. We should investigate improvements of scraped information.
- Release count different for rsd_admin role. I noticed that release count increases when the user is logged in as rsd_admin. This is (high likely) related to releases scraped for the software which is not published. Further investigation is needed. 

## Example releases per organisation page
![image](https://user-images.githubusercontent.com/9204081/215085195-90273c42-1440-4153-8082-9f9200903979.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
