### PR TITLE
707 Add terms of service info box

### DIFF
--- a/frontend/components/layout/ContributorPrivacyHint.tsx
+++ b/frontend/components/layout/ContributorPrivacyHint.tsx
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {Alert} from '@mui/material'
+import Link from 'next/link'
+import useRsdSettings from '~/config/useRsdSettings'
+
+export default function ContributorPrivacyHint() {
+  const {host} = useRsdSettings()
+  return (
+    <Alert severity="info" sx={{marginTop:'0.5rem'}}>
+      Before adding an individual, make sure to ask for their permission to appear in the RSD. Please see our <strong><u><Link href={host?.terms_of_service_url ?? ''} target="_blank">Terms of Service</Link></u></strong> for more information.
+    </Alert>
+  )
+}

--- a/frontend/components/projects/edit/team/EditProjectTeamIndex.test.tsx
+++ b/frontend/components/projects/edit/team/EditProjectTeamIndex.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -99,7 +100,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
     // wait for loader to be removed
     await waitForElementToBeRemoved(screen.getByRole('progressbar'))
     // shows no members alert message
-    const noMembersAlert = screen.getByRole('alert')
+    const noMembersAlert = screen.getByTestId('no-team-member-alert')
     const noMembersMsg = within(noMembersAlert).getByText('No team members')
     expect(noMembersMsg).toBeInTheDocument()
   })

--- a/frontend/components/projects/edit/team/SortableTeamMemberList.tsx
+++ b/frontend/components/projects/edit/team/SortableTeamMemberList.tsx
@@ -26,7 +26,9 @@ export default function SortableTeamMemberList({members, onEdit, onDelete, onSor
 	// show message when no members
 	if (members.length === 0) {
 		return (
-		  <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
+      <Alert
+        data-testid="no-team-member-alert"
+        severity="warning" sx={{marginTop: '0.5rem'}}>
         <AlertTitle sx={{fontWeight:500}}>No team members</AlertTitle>
         Add team member using the <strong>search form!</strong>
 		  </Alert>

--- a/frontend/components/projects/edit/team/SortableTeamMemberList.tsx
+++ b/frontend/components/projects/edit/team/SortableTeamMemberList.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -26,7 +28,7 @@ export default function SortableTeamMemberList({members, onEdit, onDelete, onSor
 		return (
 		  <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
         <AlertTitle sx={{fontWeight:500}}>No team members</AlertTitle>
-        Add team member using <strong>search form!</strong>
+        Add team member using the <strong>search form!</strong>
 		  </Alert>
 		)
 	}

--- a/frontend/components/projects/edit/team/index.tsx
+++ b/frontend/components/projects/edit/team/index.tsx
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -25,6 +27,7 @@ import TeamMemberModal from './TeamMemberModal'
 import useTeamMembers from './useTeamMembers'
 import SortableTeamMemberList from './SortableTeamMemberList'
 import {deleteImage} from '~/utils/editImage'
+import ContributorPrivacyHint from '~/components/layout/ContributorPrivacyHint'
 
 type EditMemberModal = ModalProps & {
   member?: TeamMember
@@ -201,6 +204,7 @@ export default function ProjectTeam({slug}: { slug: string }) {
             title={cfgTeamMembers.find.title}
             subtitle={cfgTeamMembers.find.subtitle}
           />
+          <ContributorPrivacyHint />
           <FindMember
             project={project.id}
             token={token}

--- a/frontend/components/software/edit/contributors/EditSoftwareContributorsIndex.test.tsx
+++ b/frontend/components/software/edit/contributors/EditSoftwareContributorsIndex.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -101,7 +102,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
     await waitForElementToBeRemoved(screen.getByRole('progressbar'))
 
     // shows no members alert message
-    const noContributorsAlert = screen.getByRole('alert')
+    const noContributorsAlert = screen.getByTestId('no-contributor-alert')
     const noContributorsMsg = within(noContributorsAlert).getByText('No contributors')
     expect(noContributorsMsg).toBeInTheDocument()
   })

--- a/frontend/components/software/edit/contributors/SortableContributorsList.tsx
+++ b/frontend/components/software/edit/contributors/SortableContributorsList.tsx
@@ -23,7 +23,9 @@ export default function SortableContributorsList({contributors, onEdit, onDelete
 
   if (contributors.length === 0) {
     return (
-      <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
+      <Alert
+        data-testid="no-contributor-alert"
+        severity="warning" sx={{marginTop: '0.5rem'}}>
         <AlertTitle sx={{fontWeight:500}}>No contributors</AlertTitle>
         Add contributors using the <strong>search form!</strong>
       </Alert>

--- a/frontend/components/software/edit/contributors/SortableContributorsList.tsx
+++ b/frontend/components/software/edit/contributors/SortableContributorsList.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +25,7 @@ export default function SortableContributorsList({contributors, onEdit, onDelete
     return (
       <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
         <AlertTitle sx={{fontWeight:500}}>No contributors</AlertTitle>
-        Add contributors using <strong>search form!</strong>
+        Add contributors using the <strong>search form!</strong>
       </Alert>
     )
   }

--- a/frontend/components/software/edit/contributors/index.tsx
+++ b/frontend/components/software/edit/contributors/index.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -29,6 +30,7 @@ import useSoftwareContext from '../useSoftwareContext'
 import useSoftwareContributors from './useSoftwareContributors'
 import SortableContributorsList from './SortableContributorsList'
 import {deleteImage} from '~/utils/editImage'
+import ContributorPrivacyHint from '~/components/layout/ContributorPrivacyHint'
 
 type EditContributorModal = ModalProps & {
   contributor?: Contributor
@@ -221,6 +223,7 @@ export default function SoftwareContributors() {
             title={config.findContributor.title}
             subtitle={config.findContributor.subtitle}
           />
+          <ContributorPrivacyHint />
           <FindContributor
             software={software?.id ?? ''}
             onAdd={loadContributorIntoModal}


### PR DESCRIPTION
# Remind users to have an individual's permission before mentioning them in the RSD

Fixes #707

Changes proposed in this pull request:

* Add an info box above the search form for adding team members (projects) or contributors (software)
* Example for contributors (same text for project team members):
* ![image](https://user-images.githubusercontent.com/14222414/216029104-59a37790-a00b-4ce1-984f-db6a2622af25.png)


Note: this PR depends on #712 and will be set to ready once #712 is merged.

How to test:

* Build and run
  ```
  docker compose down --volumes && docker compose build --parallel && docker compose up
  ```
  optionally add data
  ```
  make data
  ```
* Login as a user
* Add or edit a software and go to Contributors, verify the info box above the search form
* Add or edit a project and go to team members, verify the info box above the search form

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
