### PR TITLE
Add link to release page of doi.org

### DIFF
--- a/frontend/components/layout/ContributorPrivacyHint.tsx
+++ b/frontend/components/layout/ContributorPrivacyHint.tsx
@@ -1,9 +1,11 @@
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {Alert} from '@mui/material'
+import Alert from '@mui/material/Alert'
 import Link from 'next/link'
 import useRsdSettings from '~/config/useRsdSettings'
 

--- a/frontend/components/software/CitationDoi.tsx
+++ b/frontend/components/software/CitationDoi.tsx
@@ -1,12 +1,15 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2021 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useState, useContext} from 'react'
+import Link from 'next/link'
 import Button from '@mui/material/Button'
 import CopyIcon from '@mui/icons-material/ContentCopy'
-import {copyToClipboard,canCopyToClipboard} from '../../utils/copyToClipboard'
+import LinkIcon from '@mui/icons-material/Link'
+
+import {copyToClipboard, canCopyToClipboard} from '../../utils/copyToClipboard'
 import snackbarContext from '../snackbar/MuiSnackbarContext'
 import Box from '@mui/material/Box'
 
@@ -46,16 +49,25 @@ export default function CitationDoi({doi}:{doi:string}) {
     <div className="py-4 md:pb-8">
       <h3 className="text-sm pb-1">DOI:</h3>
       <div className="flex flex-col md:flex-row items-center">
-        <Box
-          sx={{
-            flex: 1,
-            width: '100%',
-            padding: '1rem',
-            backgroundColor:'secondary.light'
-          }}
-        >
-          {doi}
-        </Box>
+        <Link
+          href={`https://doi.org/${doi}`}
+          target="_blank"
+          className="w-full"
+          >
+          <Box
+            sx={{
+              flex: 1,
+              display: 'flex',
+              justifyContent: 'space-between',
+              width: '100%',
+              padding: '1rem 0.5rem',
+              backgroundColor:'secondary.light'
+            }}
+          >
+            {doi}
+            <LinkIcon />
+          </Box>
+        </Link>
         <Button
           disabled={!canCopy}
           startIcon={<CopyIcon/>}
@@ -68,7 +80,7 @@ export default function CitationDoi({doi}:{doi:string}) {
           }}
           onClick={toClipboard}
         >
-          Copy to clipboard
+          Copy DOI
         </Button>
       </div>
     </div>

--- a/frontend/components/software/CitationDownload.tsx
+++ b/frontend/components/software/CitationDownload.tsx
@@ -57,7 +57,7 @@ export default function CitationDownload({doi}: {doi:string}) {
             p:2,
           }}
         >
-          Download file
+          Download citation
         </Button>
       )
     }
@@ -76,7 +76,7 @@ export default function CitationDownload({doi}: {doi:string}) {
         href={`/api/fe/cite/?doi=${encodeURI(doi)}&f=${selected}&n=${encodeURI(fileName)}`}
         download={fileName}
       >
-        Download file
+        Download citation
       </Button>
     )
   }

--- a/frontend/components/software/CitationSection.test.tsx
+++ b/frontend/components/software/CitationSection.test.tsx
@@ -49,19 +49,19 @@ describe('with dummy data',()=>{
     expect(dropwdowns.length).toEqual(2)
   })
 
-  it('should have "Copy to clipboard" button',()=>{
+  it('should have "Copy DOI" button',()=>{
     // find it
     const copyButton = screen.getByRole('button',{
-      name:'Copy to clipboard'
+      name:'Copy DOI'
     })
     // assert
     expect(copyButton).toBeInTheDocument()
   })
 
-  it('should have "Download file" button initialy disabled',()=>{
+  it('should have "Download citation" button initialy disabled',()=>{
     // find it
     const downloadButton = screen.getByRole('button',{
-      name:'Download file'
+      name:'Download citation'
     })
     // assert
     // it exists

--- a/frontend/components/software/CitationSection.tsx
+++ b/frontend/components/software/CitationSection.tsx
@@ -66,7 +66,7 @@ export default function CitationSection({citationInfo,concept_doi}:
           {
             versions?.length > 0 ?
               <CiteDropdown
-                label="Choose a version:"
+                label="Software version:"
                 options={versions}
                 value={version}
                 onChange={onVersionChange}


### PR DESCRIPTION
# Pull request Title

Closes #719

Changes proposed in this pull request:
* Labels changed as proposed in #719    
* Link to DOI page (opens in new tab) added as proposed in #719    

How to test:
* `make start` to rebuild everything
* `docker-compose down && docker-compose up` to start scrapers
* wait ca. 10min. to have release scraper do its job
* navigate to software page that has releases
* validate: 
  * Copy DOI button works
  * Download citation button works
  * DOI link works

## Example citation section

![image](https://user-images.githubusercontent.com/9204081/217253727-c4475bc5-84a5-46ee-a72b-ef35b938c356.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
