### PR TITLE
Rpc wordpress improvement

### DIFF
--- a/database/012-create-organisation-table.sql
+++ b/database/012-create-organisation-table.sql
@@ -96,21 +96,23 @@ $$;
 CREATE TRIGGER sanitise_update_organisation BEFORE UPDATE ON organisation FOR EACH ROW EXECUTE PROCEDURE sanitise_update_organisation();
 
 -- including the parent itself
-CREATE FUNCTION list_child_organisations(parent_id UUID) RETURNS TABLE (organisation_id UUID) STABLE LANGUAGE plpgsql AS
+CREATE FUNCTION list_child_organisations(parent_id UUID) RETURNS TABLE (organisation_id UUID, organisation_name VARCHAR) STABLE LANGUAGE plpgsql AS
 $$
 DECLARE child_organisations UUID[];
-DECLARE search_child_organisations UUID[];
+DECLARE child_names VARCHAR[];
+DECLARE search_child_organisations UUID[]; -- used as a stack
 DECLARE current_organisation UUID;
 BEGIN
--- breadth-first search to find all child organisations
+-- depth-first search to find all child organisations
 	search_child_organisations = search_child_organisations || parent_id;
 	WHILE CARDINALITY(search_child_organisations) > 0 LOOP
 		current_organisation = search_child_organisations[CARDINALITY(search_child_organisations)];
 		child_organisations = child_organisations || current_organisation;
+		child_names = child_names || (SELECT name FROM organisation WHERE id = current_organisation);
 		search_child_organisations = trim_array(search_child_organisations, 1);
 		search_child_organisations = search_child_organisations || (SELECT ARRAY(SELECT organisation.id FROM organisation WHERE parent = current_organisation));
 	END LOOP;
-	RETURN QUERY SELECT UNNEST(child_organisations);
+	RETURN QUERY SELECT * FROM UNNEST(child_organisations, child_names);
 END
 $$;
 

--- a/database/021-create-global-triggers.sql
+++ b/database/021-create-global-triggers.sql
@@ -78,7 +78,8 @@ CREATE FUNCTION check_user_agreement_on_delete_action() RETURNS TRIGGER LANGUAGE
 $$
 BEGIN
 	IF
-		CURRENT_USER <> 'rsd_admin' AND
+		CURRENT_USER <> 'rsd_admin' AND NOT
+		(SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER) AND
 		(SELECT * FROM user_agreements_stored(uuid(current_setting('request.jwt.claims', FALSE)::json->>'account'))) = FALSE
 	THEN
 		RAISE EXCEPTION USING MESSAGE = 'You need to agree to our Terms of Service and the Privacy Statement before proceeding. Please open your user profile settings to agree.';


### PR DESCRIPTION
# Show child organisation names in child list RPC

Changes proposed in this pull request:

* The RPC called `list_child_organisations` also returns the organisation names
* Allow superusers to execute DELETE statements

How to test:.
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=0`.
* Run the following query and check that the results from the last two `SELECT` statements are correct:
```SQL
INSERT INTO organisation(slug, name, parent) VALUES
('parent', 'Parent organisation', NULL);

INSERT INTO organisation(slug, name, parent) VALUES
('child1', 'Child 1 organisation', (SELECT id FROM organisation WHERE slug = 'parent'));

INSERT INTO organisation(slug, name, parent) VALUES
('child1-1', 'Child 1.1 organisation', (SELECT id FROM organisation WHERE slug = 'child1'));

INSERT INTO organisation(slug, name, parent) VALUES
('child2', 'Child 2 organisation', (SELECT id FROM organisation WHERE slug = 'parent'));

SELECT * FROM list_child_organisations((SELECT id FROM organisation WHERE slug = 'parent'));

-- compare the data above with the data below
SELECT id, name FROM organisation;
```

Copy the UUID of the parent and fill it in the URL below, check that the results are correct:
http://localhost/api/v1/rpc/list_child_organisations?parent_id=uuid-of-parent

Run the following statement, it should run without errors:
```SQL
DELETE FROM organisation;
```

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests