### PR TITLE
Create dynamic robots.txt and sitemaps

### DIFF
--- a/frontend/components/AppHeader/index.tsx
+++ b/frontend/components/AppHeader/index.tsx
@@ -62,7 +62,7 @@ export default function AppHeader() {
       <div
         className="flex-1 flex flex-col px-4 xl:flex-row items-start lg:container lg:mx-auto">
         <div className="w-full flex-1 flex items-center justify-between">
-          <Link href="/" passHref className="hover:text-inherit">
+          <Link href="/" passHref className="hover:text-inherit" aria-label="Link to home page">
             <LogoApp className="hidden 2xl:block"/>
             <LogoAppSmall className="block 2xl:hidden"/>
           </Link>

--- a/frontend/components/organisation/OrganisationNav.tsx
+++ b/frontend/components/organisation/OrganisationNav.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,49 +24,50 @@ export default function OrganisationNav({isMaintainer, organisation}:Organisatio
   // console.log('description...', organisation.description)
   // console.groupEnd()
   return (
-    <nav>
-      <List sx={{
+    <List
+      component="nav"
+      sx={{
         width:'100%'
-      }}>
-        {organisationMenu.map((item, pos) => {
-          let selected = false
-          if (page && page!=='') {
-            selected = page === organisationMenu[pos].id
-          } else if (pos === 0 && organisation.description) {
-            // select about if description present by default
-            selected=true
-          } else if (pos === 1 && !organisation.description) {
-            // if no about page then first item is default
-            selected=true
-          }
-          // const selected = router.query['id'] ?? organisationMenu[0].id
-          if (item.isVisible({
-            isMaintainer,
-            organisation
-          }) === true) {
-            return (
-              <ListItemButton
-                data-testid="organisation-nav-item"
-                key={`step-${pos}`}
-                selected={selected}
-                onClick={() => {
-                  router.push({
-                    query: {
-                      slug:router.query['slug'],
-                      page:item.id
-                    }
-                  })
-                }}
-              >
-                <ListItemIcon>
-                  {item.icon}
-                </ListItemIcon>
-                <ListItemText primary={item.label(organisation)} secondary={item.status} />
-              </ListItemButton>
-            )
-          }
-        })}
-      </List>
-    </nav>
+      }}
+    >
+      {organisationMenu.map((item, pos) => {
+        let selected = false
+        if (page && page!=='') {
+          selected = page === organisationMenu[pos].id
+        } else if (pos === 0 && organisation.description) {
+          // select about if description present by default
+          selected=true
+        } else if (pos === 1 && !organisation.description) {
+          // if no about page then first item is default
+          selected=true
+        }
+        // const selected = router.query['id'] ?? organisationMenu[0].id
+        if (item.isVisible({
+          isMaintainer,
+          organisation
+        }) === true) {
+          return (
+            <ListItemButton
+              data-testid="organisation-nav-item"
+              key={`step-${pos}`}
+              selected={selected}
+              onClick={() => {
+                router.push({
+                  query: {
+                    slug:router.query['slug'],
+                    page:item.id
+                  }
+                })
+              }}
+            >
+              <ListItemIcon>
+                {item.icon}
+              </ListItemIcon>
+              <ListItemText primary={item.label(organisation)} secondary={item.status} />
+            </ListItemButton>
+          )
+        }
+      })}
+    </List>
   )
 }

--- a/frontend/components/organisation/metadata/UnderlinedTitle.tsx
+++ b/frontend/components/organisation/metadata/UnderlinedTitle.tsx
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 export default function UnderlinedTitle({title}: { title: string }) {
   return (
     <>
-      <h4 className="pt-2 text-base-content-disabled">{title}</h4>
+      <div className="pt-2 text-base-content-disabled">{title}</div>
       <hr className="pb-2" />
     </>
   )

--- a/frontend/components/seo/getOrganisationSitemap.ts
+++ b/frontend/components/seo/getOrganisationSitemap.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {getBaseUrl} from '~/utils/fetchHelpers'
+import {getRsdSettings} from '~/config/getSettingsServerSide'
+import {getSitemap, SitemapInfo} from './getSitemap'
+
+async function getOrganisationList() {
+  try {
+    const baseUrl = getBaseUrl()
+    // select only top level organisations (parent IS NULL)
+    const query = 'select=slug,updated_at&parent=is.NULL&limit=50000&offset=0'
+    const url = `${baseUrl}/organisation?${query}`
+
+    const resp = await fetch(url)
+
+    if (resp.status === 200) {
+      const json: SitemapInfo[] = await resp.json()
+      return json
+    }
+    logger(`getProjectsSitemap.getProjectsList...${resp.status} ${resp.statusText}`, 'warn')
+    return []
+  } catch (e: any) {
+    logger(`getProjectsSitemap.getProjectsList...${e.message}`, 'error')
+    return []
+  }
+}
+
+
+export async function getOrganisationSitemap(domain:string) {
+  // get software list
+  const items = await getOrganisationList()
+
+  return getSitemap({
+    baseUrl: `${domain}/organisations`,
+    items
+  })
+}

--- a/frontend/components/seo/getProjectsSitemap.ts
+++ b/frontend/components/seo/getProjectsSitemap.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {getBaseUrl} from '~/utils/fetchHelpers'
+import {getRsdSettings} from '~/config/getSettingsServerSide'
+import {getSitemap, SitemapInfo} from './getSitemap'
+
+async function getProjectsList() {
+  try {
+    const baseUrl = getBaseUrl()
+    const query = 'select=slug,updated_at&limit=50000&offset=0'
+    const url = `${baseUrl}/project?${query}`
+
+    const resp = await fetch(url)
+
+    if (resp.status === 200) {
+      const json: SitemapInfo[] = await resp.json()
+      return json
+    }
+    logger(`getProjectsSitemap.getProjectsList...${resp.status} ${resp.statusText}`, 'warn')
+    return []
+  } catch (e: any) {
+    logger(`getProjectsSitemap.getProjectsList...${e.message}`, 'error')
+    return []
+  }
+}
+
+
+export async function getProjectsSitemap(domain:string) {
+  // get software list
+  const items = await getProjectsList()
+  const {host} = await getRsdSettings()
+
+  return getSitemap({
+    baseUrl: `${domain}/projects`,
+    items
+  })
+}

--- a/frontend/components/seo/getSitemap.ts
+++ b/frontend/components/seo/getSitemap.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export type SitemapInfo = {
+  slug: string,
+  updated_at: string
+}
+
+type SitemapProps = {
+  baseUrl: string
+  items: SitemapInfo[]
+}
+
+export function getSitemap({baseUrl, items}: SitemapProps) {
+  // write sitemap.xml file
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  ${items.map(item => {
+    return `
+  <url>
+    <loc>${`${baseUrl}/${item.slug}`}</loc>
+    <lastmod>${item.updated_at}</lastmod>
+  </url>
+  `
+  }).join('')}
+</urlset>
+ `
+}

--- a/frontend/components/seo/getSoftwareSitemap.ts
+++ b/frontend/components/seo/getSoftwareSitemap.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {getBaseUrl} from '~/utils/fetchHelpers'
+import {getRsdSettings} from '~/config/getSettingsServerSide'
+import {getSitemap, SitemapInfo} from './getSitemap'
+
+async function getSoftwareList() {
+  try {
+    const baseUrl = getBaseUrl()
+    // we set max on 50k
+    const query = 'select=slug,updated_at&limit=50000&offset=0'
+    const url = `${baseUrl}/software?${query}`
+
+    const resp = await fetch(url)
+
+    if (resp.status === 200) {
+      const json: SitemapInfo[] = await resp.json()
+      return json
+    }
+    logger(`getSoftwareSitemap.getSoftwareList...${resp.status} ${resp.statusText}`, 'warn')
+    return []
+  } catch (e: any) {
+    logger(`getSoftwareSitemap.getSoftwareList...${e.message}`, 'error')
+    return []
+  }
+}
+
+
+export async function getSoftwareSitemap(domain:string) {
+  // get software list
+  const items = await getSoftwareList()
+  const {host} = await getRsdSettings()
+
+  return getSitemap({
+    baseUrl:`${domain}/software`,
+    items
+  })
+}

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -19,7 +19,7 @@ export type RsdSettingsState = {
 
 export type RsdHost = {
   name: string,
-  email?: string,
+  email: string,
   website?: string,
   logo_url?: string,
   feedback?: {
@@ -60,10 +60,10 @@ export type RsdSettingsAction = {
 
 export type RsdSettingsDispatch = (action: RsdSettingsAction)=>void
 
-export const defaultRsdSettings = {
+export const defaultRsdSettings: RsdSettingsState = {
   host: {
     name: 'rsd',
-    email: 'rsd@esciencecenter.nl',
+    email: 'rsd@esciencecenter.nl'
   },
   embed: false,
   theme: defaultSettings.theme,

--- a/frontend/pages/organisations/[...slug].tsx
+++ b/frontend/pages/organisations/[...slug].tsx
@@ -21,6 +21,7 @@ import {OrganisationForOverview} from '../../types/Organisation'
 import {SearchProvider} from '../../components/search/SearchContext'
 import {PaginationProvider} from '../../components/pagination/PaginationContext'
 import {getOrganisationMetadata, RORItem} from '~/utils/getROR'
+import PageMeta from '~/components/seo/PageMeta'
 
 export type OrganisationPageProps = {
   organisation: OrganisationForOverview,
@@ -73,9 +74,11 @@ export default function OrganisationPage({organisation,slug,page,ror}:Organisati
 
   return (
     <DefaultLayout>
-      <Head>
-        <title>{pageTitle}</title>
-      </Head>
+      {/* Page Head meta tags */}
+      <PageMeta
+        title={`${organisation?.name} | ${app.title}`}
+        description={organisation.description ?? `The organisation participates in RSD with ${organisation.software_cnt} registered software item(s).`}
+      />
       <SearchProvider>
       <PaginationProvider>
         <OrganisationTitle

--- a/frontend/pages/organisations/index.tsx
+++ b/frontend/pages/organisations/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,6 +20,7 @@ import {rowsPerPageOptions} from '../../config/pagination'
 import {ssrOrganisationParams} from '../../utils/extractQueryParam'
 import {getOrganisationsList} from '../../utils/getOrganisations'
 import OrganisationsGrid from '../../components/organisation/OrganisationGrid'
+import PageMeta from '~/components/seo/PageMeta'
 
 type OrganisationsIndexPageProps = {
   count: number,
@@ -30,6 +31,7 @@ type OrganisationsIndexPageProps = {
 }
 
 const pageTitle = `Organisations | ${app.title}`
+const pageDesc = 'The list of organisations participating in the development of research software registerd in the Research Software Directory.'
 
 export default function OrganisationsIndexPage({
   organisations = [], count, page, rows, search
@@ -84,10 +86,12 @@ export default function OrganisationsIndexPage({
   }
 
   return (
-     <DefaultLayout>
-      <Head>
-        <title>{pageTitle}</title>
-      </Head>
+    <DefaultLayout>
+      {/* Page Head meta tags */}
+      <PageMeta
+        title={pageTitle}
+        description={pageDesc}
+      />
       <PageTitle title="Organisations">
         <div className="md:flex flex-wrap justify-end">
           <div className="flex items-center lg:ml-4">

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2021 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,6 +24,7 @@ import ProjectsGrid from '~/components/projects/ProjectsGrid'
 import ProjectFilter from '~/components/projects/filter'
 import {getResearchDomainInfo, ResearchDomain} from '~/components/projects/filter/projectFilterApi'
 import {useAdvicedDimensions} from '~/components/layout/FlexibleGridSection'
+import PageMeta from '~/components/seo/PageMeta'
 
 type ProjectsIndexPageProps = {
   count: number,
@@ -36,6 +37,8 @@ type ProjectsIndexPageProps = {
 }
 
 const pageTitle = `Projects | ${app.title}`
+const pageDesc = 'The list of research projects registerd in the Research Software Directory.'
+
 
 export default function ProjectsIndexPage(
   {projects=[], count, page, rows, search, keywords,domains}: ProjectsIndexPageProps
@@ -105,9 +108,11 @@ export default function ProjectsIndexPage(
 
   return (
     <DefaultLayout>
-      <Head>
-        <title>{pageTitle}</title>
-      </Head>
+      {/* Page Head meta tags */}
+      <PageMeta
+        title={pageTitle}
+        description={pageDesc}
+      />
       <PageTitle title="Projects">
         <div className="md:flex flex-wrap justify-end">
           <div className="flex items-center lg:ml-4">

--- a/frontend/pages/robots.txt.tsx
+++ b/frontend/pages/robots.txt.tsx
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next'
+import {getDomain} from '~/utils/getDomain'
+
+export default function RobotsTxt() {
+  // getServerSideProps will create response
+}
+
+
+async function generateRobotsFile(domain:string) {
+
+  return `User-agent: *
+
+Disallow: /admin/
+Disallow: /auth/
+Disallow: /invite/
+Disallow: /login/
+Disallow: /user/
+
+Sitemap: ${domain}/sitemap/software.xml
+Sitemap: ${domain}/sitemap/projects.xml
+Sitemap: ${domain}/sitemap/organisations.xml
+`
+}
+
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  // We make an API call to gather the URLs for our site
+  // const request = await fetch(EXTERNAL_DATA_URL)
+  // const posts = await request.json()
+  const {req, res} = context
+  // use referer to extract the protocol
+  // const protocol = req.headers['referer']?.split(':')[0]
+  // console.log('getServerSideProps...req.headers...', req)
+  // extract domain info from request headers
+  const domain = getDomain(req)
+  // We generate the XML sitemap with the posts data
+  const content = await generateRobotsFile(domain)
+
+  res.setHeader('Content-Type', 'text/plain; charset=UTF-8')
+  res.setHeader('x-generator', 'custom-next-script')
+  // we send the XML to the browser
+  res.write(content)
+  res.end()
+
+  return {
+    props: {},
+  }
+}

--- a/frontend/pages/sitemap/organisations.xml.tsx
+++ b/frontend/pages/sitemap/organisations.xml.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next'
+import {getOrganisationSitemap} from '~/components/seo/getOrganisationSitemap'
+import {getDomain} from '~/utils/getDomain'
+
+export default function RobotsTxt() {
+  // getServerSideProps will create response
+}
+
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  // extract response object
+  const {req,res} = context
+  // extract domain info from request headers
+  const domain = getDomain(req)
+
+  // generate the XML sitemap for software
+  const content = await getOrganisationSitemap(domain)
+
+  res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
+
+  // send XML to the browser
+  res.write(content)
+  res.end()
+
+  return {
+    props: {},
+  }
+}

--- a/frontend/pages/sitemap/projects.xml.tsx
+++ b/frontend/pages/sitemap/projects.xml.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next'
+
+import {getProjectsSitemap} from '~/components/seo/getProjectsSitemap'
+import {getDomain} from '~/utils/getDomain'
+
+export default function RobotsTxt() {
+  // getServerSideProps will create response
+}
+
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  // extract response object
+  const {req,res} = context
+  // extract domain info from request headers
+  const domain = getDomain(req)
+  // generate the XML sitemap for software
+  const content = await getProjectsSitemap(domain)
+
+  res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
+
+  // send XML to the browser
+  res.write(content)
+  res.end()
+
+  return {
+    props: {},
+  }
+}

--- a/frontend/pages/sitemap/software.xml.tsx
+++ b/frontend/pages/sitemap/software.xml.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next'
+
+import {getSoftwareSitemap} from '~/components/seo/getSoftwareSitemap'
+import {getDomain} from '~/utils/getDomain'
+
+export default function RobotsTxt() {
+  // getServerSideProps will create response
+}
+
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  const {req,res} = context
+  // extract domain info from request headers
+  const domain = getDomain(req)
+
+  // generate the XML sitemap for software
+  const content = await getSoftwareSitemap(domain)
+
+  res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
+
+  // send XML to the browser
+  res.write(content)
+  res.end()
+
+  return {
+    props: {},
+  }
+}

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
@@ -23,6 +23,7 @@ import {ssrSoftwareParams} from '../../utils/extractQueryParam'
 import {softwareListUrl,ssrSoftwareUrl} from '../../utils/postgrestUrl'
 import SoftwareFilter from '~/components/software/filter'
 import {useAdvicedDimensions} from '~/components/layout/FlexibleGridSection'
+import PageMeta from '~/components/seo/PageMeta'
 
 type SoftwareIndexPageProps = {
   count: number,
@@ -35,6 +36,7 @@ type SoftwareIndexPageProps = {
 }
 
 const pageTitle = `Software | ${app.title}`
+const pageDesc = 'The list of research software registerd in the Research Software Directory.'
 
 export default function SoftwareIndexPage(
   {software=[], count, page, rows, keywords, prog_lang, search}: SoftwareIndexPageProps
@@ -113,9 +115,11 @@ export default function SoftwareIndexPage(
 
   return (
     <DefaultLayout>
-      <Head>
-        <title>{pageTitle}</title>
-      </Head>
+      {/* Page Head meta tags */}
+      <PageMeta
+        title={pageTitle}
+        description={pageDesc}
+      />
       <PageTitle title="Software">
         <div className="md:flex flex-wrap justify-end">
           <div className="flex items-center">

--- a/frontend/public/robots.txt
+++ b/frontend/public/robots.txt
@@ -1,4 +1,0 @@
-User-agent: *
-Disallow: /admin/
-Allow: /
-Sitemap: https://www.research-software.nl/sitemap.xml

--- a/frontend/public/robots.txt.license
+++ b/frontend/public/robots.txt.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
-SPDX-FileCopyrightText: 2021 - 2022 dv4all
-
-SPDX-License-Identifier: CC0-1.0

--- a/frontend/utils/getDomain.ts
+++ b/frontend/utils/getDomain.ts
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {IncomingMessage} from 'http'
+import logger from './logger'
+
+// NOTE! dynamic methods return http is node because
+// HTTPS is implemented in NGINX.
+// All props I tried in Next return http all the time
+export function getDomain(req: IncomingMessage) {
+  try {
+    const host = req.headers['host'] ?? 'localhost'
+    // by default we use https protocol
+    let protocol = 'https'
+
+    if (host.startsWith('localhost')===true) {
+      // we use http when local host
+      protocol = 'http'
+    }
+
+    return `${protocol}://${host}`
+
+  } catch (e: any) {
+    logger(`getDomain...${e.message}`, 'error')
+    return 'http://localhost:3000'
+  }
+}


### PR DESCRIPTION
# Create dynamic robots.txt

Closes #723

Changes proposed in this pull request:
* Robots.txt uses host property to automatically determine current domain name. The default value is "localhost". The robots.txt file specifies the location of sitemap files
* The sitemap files are created for software, projects and organisations. Maximum length is set to 50.000 items per file. The location is:
   * software: /sitemap/software.xml
   * projects: /sitemap/projects.xml
   * organisations: /sitemap/organisations.xml  
* The following props are included for each entry in sitemap.xml: 
   * loc: location of the page
   * lastmod: last modified date is based on `updated_at` 
*  Organisation page SEO: I added description to page head. Few other SEO suggestion were fixed based on Lighthouse page SEO audit.

How to test:
* `make start` to restart all
* navigate to /robots.txt it should list sitemap files
* navigate to sitemap locations.  It should return xml file with the list of pages and when the page was last modified
* validate the location is properly defined for pages in /sitemap/software.xml
* validate the location is properly defined for pages in /sitemap/projects.xml
* validate the location is properly defined for pages in /sitemap/organisations.xml
* For validation I have put 723-seo-sitemap branch on dev in order to be able to use online validaton tools. I have used [MERKLE](https://technicalseo.com/tools/robots-txt/). You might try some other tool (url of dev server is: https://research-software.dev)

## Validation of robots.txt using MERKLE

![image](https://user-images.githubusercontent.com/9204081/218512251-861d0505-2adf-4d16-bd47-d776b4eb2400.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
