### PR TITLE
Hide ORCID Whitelist if ORCID is not used as a login provider

### DIFF
--- a/frontend/components/login/LoginButton.tsx
+++ b/frontend/components/login/LoginButton.tsx
@@ -1,6 +1,7 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
@@ -16,8 +17,10 @@ import useLoginProviders from '~/auth/api/useLoginProviders'
 import {getUserMenuItems} from '~/config/userMenuItems'
 import UserMenu from '~/components/layout/UserMenu'
 import LoginDialog from './LoginDialog'
+import useRsdSettings from '~/config/useRsdSettings'
 
 export default function LoginButton() {
+  const {host} = useRsdSettings()
   const providers = useLoginProviders()
   const {session} = useAuth()
   const status = session?.status || 'loading'
@@ -33,7 +36,13 @@ export default function LoginButton() {
 
   if (status === 'authenticated') {
     // when user is authenticated
-    const menuItems = getUserMenuItems(session.user?.role)
+    let hasOrcid = false
+    providers.forEach(provider => {
+      if ( provider.name === 'ORCID' ) {
+        hasOrcid = true
+      }
+    })
+    const menuItems = getUserMenuItems(session.user?.role, hasOrcid)
     // we show user menu with the avatar and user specific options
     return (
       <>

--- a/frontend/config/menuItems.ts
+++ b/frontend/config/menuItems.ts
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +16,6 @@ export type MenuItemType = {
   // optional, but fn is provided it will have higher priority
   // than path
   fn?: Function,
-  role?: RsdRole[]
 }
 // routes defined for nav/menu
 // used in components/AppHeader

--- a/frontend/config/userMenuItems.tsx
+++ b/frontend/config/userMenuItems.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,70 +17,76 @@ import Logout from '@mui/icons-material/Logout'
 
 import {MenuItemType} from './menuItems'
 
-const userMenuItems: MenuItemType[] = [
-  {
-    role:['rsd_admin','rsd_user'],
-    type: 'link',
-    label:'My software',
-    path:'/user/software',
-    icon: <TerminalIcon />
-  }, {
-    role:['rsd_admin','rsd_user'],
-    type: 'link',
-    label:'My projects',
-    path:'/user/projects',
-    icon: <ListAltIcon />
-  }, {
-    role:['rsd_admin','rsd_user'],
-    type: 'link',
-    label: 'My organisations',
-    path: '/user/organisations',
-    icon: <BusinessIcon />
-  }, {
-    role:['rsd_admin','rsd_user'],
-    type: 'divider',
-    label: 'divider1'
-  }, {
-    role:['rsd_admin','rsd_user'],
-    type: 'link',
-    label: 'My settings',
-    path: '/user/settings',
-    icon: <SettingsIcon />
-  }, {
-    role:['rsd_admin'],
-    type: 'divider',
-    label: 'divider2'
-  }, {
-    role:['rsd_admin'],
-    type: 'link',
-    label: 'Administration',
-    path: '/admin/pages',
-    icon: <ManageAccountsIcon />
-  }, {
-    role:['rsd_admin'],
-    type: 'link',
-    label: 'ORCID whitelist',
-    path: '/admin/orcid-whitelist',
-    icon: <PlaylistAddCheckIcon />
-  }, {
-    role:['rsd_admin','rsd_user'],
-    type: 'divider',
-    label: 'divider3'
-  }, {
-    role:['rsd_admin','rsd_user'],
-    label: 'Logout',
-    icon: <Logout/>,
-    fn: () => {
-      // forward to logout route
-      // it removes cookies and resets the authContext
-      location.href = '/logout'
-    }
-  },
-]
+export function getUserMenuItems(
+    role: 'rsd_admin' | 'rsd_user'='rsd_user',
+    orcidEnabled: boolean=false,
+  ) {
 
-export function getUserMenuItems(role: 'rsd_admin' | 'rsd_user'='rsd_user') {
+  const userMenuItems: MenuItemType[] = [
+    {
+      type: 'link',
+      label:'My software',
+      active: ['rsd_admin', 'rsd_user'].includes(role),
+      path:'/user/software',
+      icon: <TerminalIcon />
+    }, {
+      type: 'link',
+      label:'My projects',
+      active:['rsd_admin','rsd_user'].includes(role),
+      path:'/user/projects',
+      icon: <ListAltIcon />
+    }, {
+      type: 'link',
+      label: 'My organisations',
+      active:['rsd_admin','rsd_user'].includes(role),
+      path: '/user/organisations',
+      icon: <BusinessIcon />
+    }, {
+      type: 'divider',
+      label: 'divider1',
+      active: ['rsd_admin', 'rsd_user'].includes(role),
+    }, {
+      type: 'link',
+      label: 'My settings',
+      active: ['rsd_admin','rsd_user'].includes(role),
+      path: '/user/settings',
+      icon: <SettingsIcon />
+    }, {
+      type: 'divider',
+      label: 'divider2',
+      active: ['rsd_admin'].includes(role)
+    }, {
+      type: 'link',
+      label: 'Administration',
+      active: ['rsd_admin'].includes(role),
+      path: '/admin/pages',
+      icon: <ManageAccountsIcon />
+    }, {
+      type: 'link',
+      label: 'ORCID whitelist',
+      active: orcidEnabled && ['rsd_admin'].includes(role),
+      path: '/admin/orcid-whitelist',
+      icon: <PlaylistAddCheckIcon />
+    }, {
+      type: 'divider',
+      label: 'divider3',
+      active: ['rsd_admin'].includes(role)
+    }, {
+      label: 'Logout',
+      active: ['rsd_admin', 'rsd_user'].includes(role),
+      icon: <Logout/>,
+      fn: () => {
+        // forward to logout route
+        // it removes cookies and resets the authContext
+        location.href = '/logout'
+      }
+    },
+  ]
+
   const items = userMenuItems.filter(item => {
-    return item.role?.includes(role)
+    if ( item.active != false ) {
+      return item
+    }
   })
   return items
 }


### PR DESCRIPTION
Here are some minor improvements that I added to #630 a while ago. From my perspective it makes sense to merge them in a separate PR.

Changes proposed in this pull request:

* do not show the "ORCID whitelist" in the admin user menu, if the RSD instance does not use ORCID as a login provider

How to test:

* `docker compose down --volumes && docker compose build --parallel`
* add `ORCID` to `RSD_AUTH_PROVIDERS` in your `.env`
* `docker compose up --scale scrapers=0`
* login as an administrator
* verify that the ORCID Whitelist menu entry appears
* `docker compose down`
* remove `ORCID` from `RSD_AUTH_PROVIDERS` in your `.env`
* `docker compose up`
* login as an administrator
* verify that the ORCID whitelist menu entry is not present anymore

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
