### PR TITLE
feat: collect and show journal/book/book series of mentions

### DIFF
--- a/database/009-create-mention-table.sql
+++ b/database/009-create-mention-table.sql
@@ -35,6 +35,7 @@ CREATE TABLE mention (
 	publisher VARCHAR(255),
 	publication_year SMALLINT,
 	publication_date DATE,
+	journal VARCHAR(500),
 	page VARCHAR(50),
 	image_url VARCHAR(500) CHECK (image_url ~ '^https?://'),
 	mention_type mention_type NOT NULL,

--- a/frontend/components/mention/EditMentionModal.tsx
+++ b/frontend/components/mention/EditMentionModal.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -205,6 +205,18 @@ export default function EditMentionModal({open, onCancel, onSubmit, item, pos, t
               rules={config.publication_year.validation}
             />
           </div>
+          <ControlledTextField
+            control={control}
+            options={{
+              name: 'journal',
+              label: config.journal.label,
+              useNull: true,
+              defaultValue: formData?.journal,
+              helperTextMessage: config.journal.help,
+              helperTextCnt: `${formData?.journal?.length || 0}/${config.journal.validation.maxLength.value}`,
+            }}
+            rules={config.journal.validation}
+          />
           <ControlledTextField
             control={control}
             options={{

--- a/frontend/components/mention/MentionEditFeatured.tsx
+++ b/frontend/components/mention/MentionEditFeatured.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -86,6 +88,7 @@ export default function MentionEditFeatured({item}: MentionListItem) {
           publisher={item?.publisher ?? ''}
           page={item?.page ?? ''}
           publication_year={item.publication_year}
+          journal = {item.journal}
           className="text-sm"
         />
       </div>

--- a/frontend/components/mention/MentionItemBase.tsx
+++ b/frontend/components/mention/MentionItemBase.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -62,6 +64,7 @@ export default function MentionItemBase({item,pos,nav,type,role='find'}:MentionI
         publisher={item?.publisher}
         page={item?.page}
         publication_year={item.publication_year}
+        journal = {item.journal}
         className="text-sm"
       />
       <MentionDoi

--- a/frontend/components/mention/MentionItemFeatured.tsx
+++ b/frontend/components/mention/MentionItemFeatured.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -35,6 +37,7 @@ export default function MentionItemFeatured({mention}: { mention: MentionItemPro
             publisher={mention?.publisher ?? ''}
             page={mention?.page ?? ''}
             publication_year={mention.publication_year}
+            journal = {mention.journal}
             className="text-md py-2"
           />
         </div>

--- a/frontend/components/mention/MentionPublisherItem.tsx
+++ b/frontend/components/mention/MentionPublisherItem.tsx
@@ -1,52 +1,26 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 type MentionPublisherItemProps = {
   publisher: string | null
   page: string | null
-  publication_year: number | null
+  publication_year: number | null,
+  journal: string | null,
   className?:string
 }
 export default function MentionPublisherItem(
-  {publisher, page, publication_year, className}: MentionPublisherItemProps
+  {publisher, page, publication_year, journal, className}: MentionPublisherItemProps
 ) {
 
-  if (publisher && page && publication_year) {
+  if (publisher || publication_year || journal) {
     return (
       <div className={className}>
-        Published by {publisher} in {publication_year}, page: {page}
+        Published {journal && `in ${journal}`} {publisher && `by ${publisher}`} {publication_year && `in ${publication_year}`}{page && `, page: ${page}`}
       </div>
     )
-  }
-  if (publisher && publication_year) {
-    return (
-      <div className={className}>
-        Published by {publisher} in {publication_year}
-      </div>
-    )
-  }
-  if (publisher && page) {
-    return (
-      <div className={className}>
-        Published by {publisher}, page: {page}
-      </div>
-    )
-  }
-  if (publisher) {
-    return (
-      <div className={className}>
-        Published by {publisher}
-      </div>
-    )
-  }
-  if (publication_year) {
-    return (
-      <div className={className}>
-        Published in {publication_year}
-      </div>
-    )
-  }
-  return null
+  } else return null
 }

--- a/frontend/components/mention/MentionViewItem.tsx
+++ b/frontend/components/mention/MentionViewItem.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -33,6 +35,7 @@ export default function MentionViewItem({item, pos}: {item: MentionItemProps, po
             publisher={item?.publisher ?? ''}
             page={item?.page ?? ''}
             publication_year={item.publication_year}
+            journal = {item.journal}
             className="text-sm"
           />
           <MentionDoi

--- a/frontend/components/mention/config.ts
+++ b/frontend/components/mention/config.ts
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -48,9 +48,20 @@ export const mentionModal = {
   },
   publisher: {
     label: 'Publisher',
-    help: 'Name of publisher, journal, website...',
+    help: 'Name of publisher',
     validation: {
       required: false
+    }
+  },
+  journal: {
+    label: 'Journal',
+    help: 'Name of journal, book series, website...',
+    validation: {
+      required: false,
+      maxLength: {
+        value: 500,
+        message: 'Maximum length is 500'
+      }
     }
   },
   page: {

--- a/frontend/components/projects/edit/impact/EditProjectImpactIndex.test.tsx
+++ b/frontend/components/projects/edit/impact/EditProjectImpactIndex.test.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -232,6 +234,7 @@ describe('frontend/components/project/edit/impact/index.tsx', () => {
          'doi': null,
          'id': null,
          'image_url': null,
+         'journal': null,
          'mention_type': 'book',
          'note': null,
          'page': null,

--- a/frontend/components/projects/edit/output/EditProjectOutputIndex.test.tsx
+++ b/frontend/components/projects/edit/output/EditProjectOutputIndex.test.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -231,6 +233,7 @@ describe('frontend/components/projects/edit/output/index.tsx', () => {
          'doi': null,
          'id': null,
          'image_url': null,
+         'journal': null,
          'mention_type': 'book',
          'note': null,
          'page': null,

--- a/frontend/components/software/edit/mentions/EditSoftwareMentionsIndex.test.tsx
+++ b/frontend/components/software/edit/mentions/EditSoftwareMentionsIndex.test.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -244,6 +246,7 @@ describe('frontend/components/software/edit/maintainers/index.tsx', () => {
          'doi': null,
          'id': null,
          'image_url': null,
+         'journal': null,
          'mention_type': 'book',
          'note': null,
          'page': null,

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -85,7 +86,7 @@ module.exports = {
         error:`var(--rsd-error,${colors.error})`,
         'error-content':`var(--rsd-error-content,${colors['error-content']})`,
         warning:`var(--rsd-warning,${colors.warning})`,
-        'warning-content':`var(--rsd-warning-content.${colors['warning-content']})`,
+        'warning-content':`var(--rsd-warning-content,${colors['warning-content']})`,
         info:`var(--rsd-info,${colors.info})`,
         'info-content':`var(--rsd-info-content,${colors['info-content']})`,
         success:`var(--rsd-success,${colors.success})`,

--- a/frontend/types/Crossref.ts
+++ b/frontend/types/Crossref.ts
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,6 +30,7 @@ export type CrossrefSelectItem = {
     'date-parts': DatePart[]
   }
   publisher: string
+  'container-title': string[]
   subject: string[]
   title: string[]
   type: string

--- a/frontend/types/Mention.ts
+++ b/frontend/types/Mention.ts
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -18,6 +18,7 @@ export type MentionType = {
 }
 
 // as in mention table
+// if you update this type, also update the field 'mentionColumns' below
 export type MentionItemProps = {
   id: string | null
   doi: string | null
@@ -26,6 +27,7 @@ export type MentionItemProps = {
   authors: string | null
   publisher: string | null
   publication_year: number | null
+  journal: string | null
   page: string | null
   // url to external image
   image_url: string | null
@@ -34,6 +36,8 @@ export type MentionItemProps = {
   source: string
   note: string | null
 }
+
+export const mentionColumns ='id,doi,url,title,authors,publisher,publication_year,journal,page,image_url,mention_type,source,note'
 
 export type MentionByType = {
   [key in MentionTypeKeys]?: MentionItemProps[]
@@ -50,4 +54,3 @@ export type MentionForProject = MentionItemProps & {
   impact_for_project?: any[]
 }
 
-export const mentionColumns ='id,doi,url,title,authors,publisher,publication_year,page,image_url,mention_type,source,note'

--- a/frontend/utils/editMentions.ts
+++ b/frontend/utils/editMentions.ts
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -301,6 +301,7 @@ export function newMentionItem(title?: string) {
     authors: null,
     publisher: null,
     publication_year: null,
+    journal: null,
     page: null,
     // url to external image
     image_url: null,

--- a/frontend/utils/getCrossref.ts
+++ b/frontend/utils/getCrossref.ts
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -56,6 +56,7 @@ export function crossrefItemToMentionItem(item: CrossrefSelectItem) {
     publisher: item.publisher,
     // extract only Year
     publication_year: extractYearPublished(item),
+    journal: item['container-title']?.length ? item['container-title'].join(', ') : null,
     page: item.page ?? null,
     image_url: null,
     mention_type: crossrefToRsdType(item.type),

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -137,6 +137,7 @@ export function dataCiteGraphQLItemToMentionItem(item: WorkResponse) {
     authors: extractAuthors(item),
     publisher: item.publisher,
     publication_year: item.publicationYear,
+    journal: null,
     page: null,
     image_url: null,
     mention_type: dataciteToRsdType(item),

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionRecord.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionRecord.java
@@ -19,6 +19,7 @@ public class MentionRecord {
 	String publisher;
 	Integer publicationYear;
 	LocalDate publicationDate;
+	String journal;
 	String page;
 	URI imageUrl;
 	MentionType mentionType;


### PR DESCRIPTION
# Show journal for mentions

Changes proposed in this pull request:

* We collect, if it exists, the journal/book/book series a mention is published in and show it

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=1`.
* Run the mention scraper a few times: `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions`
* On http://localhost/api/v1/mention?select=journal some of the entries should have non-null values
* Login, create a software page and add mentions with the following DOIs: `10.1007/978-3-030-14350-3_5`, `10.1109/escience.2018.00013`, `10.1016/j.diin.2018.09.002`
* Look at the mentions both on the admin view as on the public view, all three should have a journal (`Published in ...`)
* Add a manual mention to the page without a DOI and fill in the journal field, it shoud be processed and shown correctly 

Closes #304

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests