### PR TITLE
fix: improve performance of the slow function

### DIFF
--- a/frontend/components/organisation/releases/useSoftwareReleases.tsx
+++ b/frontend/components/organisation/releases/useSoftwareReleases.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -31,7 +33,7 @@ type UseSoftwareReleaseProps = {
 
 async function getReleasesForOrganisation({organisation_id,release_year,token}:UseSoftwareReleaseProps) {
   try {
-    const query = `organisation_id=${organisation_id}&release_year=eq.${release_year}&order=release_date.desc`
+    const query = `organisation_id=eq.${organisation_id}&release_year=eq.${release_year}&order=release_date.desc`
     const url = `${getBaseUrl()}/rpc/releases_by_organisation?${query}`
     // make request
     const resp = await fetch(url, {


### PR DESCRIPTION
# Fix slow organisations_overview function

Changes proposed in this pull request:

* Change some functions in Postgres, to improve their performance.We changed the functions form having a parameter, and thus only showing data for the given argument, to having no parameter, and thus showing all data, which is then restricted by an `ON` clause when joining.

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=1`.
* Run the releases scraper a few times: `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases`
* Visit some organisation pages and look at the releases. The correct number of releases should be shown on the left and per year. These pages should not be slow anymore.
* We will now test it out against a backup: `docker-compose down --volumes && git checkout v1.17.0 && docker-compose build --parallel && docker-compose up --scale data-generation=0`
* Download and restore a backup, see the instructions [here](https://github.com/research-software-directory/RSD-production/blob/main/aws-instructions.md#restoring-a-backup)
* (The organisation pages should be fast but should show `0` as the number of releaes, even though there are releases)
* Run the following SQL, which reflect the changes in the PR:
```SQL
DROP FUNCTION releases_by_organisation;
CREATE FUNCTION releases_by_organisation() RETURNS TABLE (
	organisation_id UUID,
	software_id UUID,
	software_slug VARCHAR,
	software_name VARCHAR,
	release_doi CITEXT,
	release_tag VARCHAR,
	release_date DATE,
	release_year SMALLINT,
	release_authors VARCHAR
) LANGUAGE plpgsql STABLE AS
$$
BEGIN RETURN QUERY
	SELECT
		organisation.id AS organisation_id,
		software.id AS software_id,
		software.slug AS software_slug,
		software.brand_name AS software_name,
		mention.doi AS release_doi,
		mention.version AS release_tag,
		mention.publication_date AS release_date,
		mention.publication_year AS release_year,
		mention.authors AS release_authors
	FROM
		organisation
	CROSS JOIN
		list_child_organisations(organisation.id)
	INNER JOIN
		software_for_organisation ON list_child_organisations.organisation_id = software_for_organisation.organisation
	INNER JOIN
		software ON software.id = software_for_organisation.software
	INNER JOIN
		"release" ON "release".software = software.id
	INNER JOIN
		release_version ON release_version.release_id = "release".software
	INNER JOIN
		mention ON mention.id = release_version.mention_id
;
END
$$;


DROP FUNCTION release_cnt_by_organisation;
CREATE FUNCTION release_cnt_by_organisation() RETURNS TABLE (
	organisation_id UUID,
	release_cnt BIGINT
) LANGUAGE plpgsql STABLE AS
$$
BEGIN RETURN QUERY
	SELECT
		releases_by_organisation.organisation_id AS organisation_id,
		COUNT(releases_by_organisation.*) AS release_cnt
	FROM
		organisation
	INNER JOIN
		releases_by_organisation() ON releases_by_organisation.organisation_id = organisation.id
	GROUP BY
		releases_by_organisation.organisation_id
	;
END
$$;


DROP FUNCTION release_cnt_by_year;
CREATE FUNCTION release_cnt_by_year(organisation_id UUID) RETURNS TABLE (
	release_year SMALLINT,
	release_cnt BIGINT
) LANGUAGE plpgsql STABLE AS
$$
BEGIN RETURN QUERY
	SELECT
		releases_by_organisation.release_year,
		COUNT(releases_by_organisation.*) AS release_cnt
	FROM
		releases_by_organisation()
	WHERE
		releases_by_organisation.organisation_id = release_cnt_by_year.organisation_id
	GROUP BY
		releases_by_organisation.release_year
	;
END
$$;


DROP FUNCTION organisations_overview;
CREATE FUNCTION organisations_overview(public BOOLEAN DEFAULT TRUE) RETURNS TABLE (
	id UUID,
	slug VARCHAR,
	parent UUID,
	primary_maintainer UUID,
	name VARCHAR,
	ror_id VARCHAR,
	website VARCHAR,
	is_tenant BOOLEAN,
	rsd_path VARCHAR,
	parent_names VARCHAR,
	logo_id VARCHAR,
	software_cnt BIGINT,
	project_cnt BIGINT,
	children_cnt BIGINT,
	release_cnt BIGINT,
	score BIGINT
) LANGUAGE plpgsql STABLE AS
$$
BEGIN
	RETURN QUERY
	SELECT
		organisation.id,
		organisation.slug,
		organisation.parent,
		organisation.primary_maintainer,
		organisation.name,
		organisation.ror_id,
		organisation.website,
		organisation.is_tenant,
		organisation_route.rsd_path,
		organisation_route.parent_names,
		organisation.logo_id,
		software_count_by_organisation.software_cnt,
		project_count_by_organisation.project_cnt,
		children_count_by_organisation.children_cnt,
		release_cnt_by_organisation.release_cnt,
		(
			COALESCE(software_count_by_organisation.software_cnt,0) +
			COALESCE(project_count_by_organisation.project_cnt,0)
		) as score
	FROM
		organisation
	LEFT JOIN
		organisation_route(organisation.id) ON organisation_route.organisation = organisation.id
	LEFT JOIN
		software_count_by_organisation(public) ON software_count_by_organisation.organisation = organisation.id
	LEFT JOIN
		project_count_by_organisation(public) ON project_count_by_organisation.organisation = organisation.id
	LEFT JOIN
		children_count_by_organisation() ON children_count_by_organisation.parent = organisation.id
	LEFT JOIN
		release_cnt_by_organisation() ON release_cnt_by_organisation.organisation_id = organisation.id
	;
END
$$;
```
* Run `docker-compose kill -s SIGUSR1 backend`
* The count should now be there and these pages should be fast. Releases will *not* be shown though, because the frontend is not adapted to the new database functions.


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests