### PR TITLE
fix: get DOI registration timestamp instead of date only for releases

### DIFF
--- a/database/009-create-mention-table.sql
+++ b/database/009-create-mention-table.sql
@@ -29,12 +29,12 @@ CREATE TYPE mention_type AS ENUM (
 CREATE TABLE mention (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
 	doi CITEXT UNIQUE CHECK (doi ~ '^10(\.\w+)+/\S+$' AND LENGTH(doi) <= 255),
+	doi_registration_date TIMESTAMPTZ,
 	url VARCHAR(500) CHECK (url ~ '^https?://'),
 	title VARCHAR(500) NOT NULL,
 	authors VARCHAR(15000),
 	publisher VARCHAR(255),
 	publication_year SMALLINT,
-	publication_date DATE,
 	journal VARCHAR(500),
 	page VARCHAR(50),
 	image_url VARCHAR(500) CHECK (image_url ~ '^https?://'),

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -450,7 +450,7 @@ CREATE FUNCTION releases_by_organisation() RETURNS TABLE (
 	software_name VARCHAR,
 	release_doi CITEXT,
 	release_tag VARCHAR,
-	release_date DATE,
+	release_date TIMESTAMPTZ,
 	release_year SMALLINT,
 	release_authors VARCHAR
 ) LANGUAGE plpgsql STABLE AS
@@ -463,7 +463,7 @@ BEGIN RETURN QUERY
 		software.brand_name AS software_name,
 		mention.doi AS release_doi,
 		mention.version AS release_tag,
-		mention.publication_date AS release_date,
+		mention.doi_registration_date AS release_date,
 		mention.publication_year AS release_year,
 		mention.authors AS release_authors
 	FROM

--- a/frontend/components/software/__mocks__/softwareReleases.json
+++ b/frontend/components/software/__mocks__/softwareReleases.json
@@ -2,21 +2,21 @@
   {
     "doi": "10.5281/zenodo.3258170",
     "version": "v0.3.5",
-    "publication_date": "2019-06-27"
+    "doi_registration_date": "2019-06-27"
   },
   {
     "doi": "10.5281/zenodo.1168400",
     "version": "v0.3.4",
-    "publication_date": "2018-02-07"
+    "doi_registration_date": "2018-02-07"
   },
   {
     "doi": "10.5281/zenodo.1043813",
     "version": "v0.3.3",
-    "publication_date": "2017-11-08"
+    "doi_registration_date": "2017-11-08"
   },
   {
     "doi": "10.5281/zenodo.997273",
     "version": "v0.3.2",
-    "publication_date": "2017-09-26"
+    "doi_registration_date": "2017-09-26"
   }
 ]

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -148,13 +148,13 @@ export async function getTagsWithCount(){
 export type SoftwareVersion = {
   doi: string,
   version: string,
-  publication_date: string
+  doi_registration_date: string
 }
 
 export async function getReleasesForSoftware(uuid:string,token?:string){
   try{
     // the releases are ordered by date descending
-    const query = `select=release(mention(doi,version,publication_date))&id=eq.${uuid}&release.mention.order=publication_date.desc`
+    const query = `select=release(mention(doi,version,doi_registration_date))&id=eq.${uuid}&release.mention.order=doi_registration_date.desc`
     const url = `${getBaseUrl()}/software?${query}`
     const resp = await fetch(url, {
       method: 'GET',
@@ -162,19 +162,19 @@ export async function getReleasesForSoftware(uuid:string,token?:string){
     })
     if (resp.status===200){
       const data: any[] = await resp.json()
-      if (data.length === 1) {
+      if (data.length === 1 && data[0]?.release?.mention) {
         const releases: SoftwareVersion[] = data[0]['release']['mention']
         return releases
       }
       return null
     } else if (resp.status===404){
-      logger(`getSoftwareVersions: 404 [${url}]`,'error')
+      logger(`getReleasesForSoftware: 404 [${url}]`,'error')
       // query not found
       return null
     }
     return null
   }catch(e:any){
-    logger(`getSoftwareVersions: ${e?.message}`,'error')
+    logger(`getReleasesForSoftware: ${e?.message}`,'error')
     return null
   }
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataCiteReleaseRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataCiteReleaseRepository.java
@@ -42,9 +42,7 @@ public class DataCiteReleaseRepository {
 			          }
 			          publisher
 			          publicationYear
-			          dates {
-			            date
-			          }
+			          registered
 			          creators {
 			            givenName
 			            familyName

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -13,7 +13,7 @@ import nl.esciencecenter.rsd.scraper.Utils;
 
 import java.net.URI;
 import java.time.Instant;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -47,9 +47,7 @@ public class DataciteMentionRepository implements MentionRepository {
 			      }
 			      publisher
 			      publicationYear
-			      dates {
-			        date
-			      }
+			      registered
 			      creators {
 			        givenName
 			        familyName
@@ -154,9 +152,9 @@ public class DataciteMentionRepository implements MentionRepository {
 
 		result.publisher = Utils.stringOrNull(work.get("publisher"));
 		result.publicationYear = Utils.integerOrNull(work.get("publicationYear"));
-		JsonArray dates = work.getAsJsonArray("dates");
-		if (!dates.isEmpty()) {
-			result.publicationDate = LocalDate.parse(dates.get(0).getAsJsonObject().getAsJsonPrimitive("date").getAsString());
+		String doiRegistrationDateString = Utils.stringOrNull(work.get("registered"));
+		if (doiRegistrationDateString != null) {
+			result.doiRegistrationDate = ZonedDateTime.parse(doiRegistrationDateString);
 		}
 
 		String dataciteResourceTypeGeneral = Utils.stringOrNull(work.getAsJsonObject("types").get("resourceTypeGeneral"));

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionRecord.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionRecord.java
@@ -7,7 +7,7 @@ package nl.esciencecenter.rsd.scraper.doi;
 
 import java.net.URI;
 import java.time.Instant;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.UUID;
 
 public class MentionRecord {
@@ -18,7 +18,7 @@ public class MentionRecord {
 	String authors;
 	String publisher;
 	Integer publicationYear;
-	LocalDate publicationDate;
+	ZonedDateTime doiRegistrationDate;
 	String journal;
 	String page;
 	URI imageUrl;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/PostgrestMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/PostgrestMentionRepository.java
@@ -19,7 +19,7 @@ import nl.esciencecenter.rsd.scraper.Utils;
 
 import java.net.URI;
 import java.time.Instant;
-import java.time.LocalDate;
+import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -38,7 +38,7 @@ public class PostgrestMentionRepository implements MentionRepository {
 		return new GsonBuilder()
 				.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
 				.registerTypeAdapter(Instant.class, (JsonDeserializer<Instant>) (json, typeOfT, context) -> Instant.parse(json.getAsString()))
-				.registerTypeAdapter(LocalDate.class, (JsonDeserializer<LocalDate>) (json, typeOfT, context) -> LocalDate.parse(json.getAsString()))
+				.registerTypeAdapter(ZonedDateTime.class, (JsonDeserializer<ZonedDateTime>) (json, typeOfT, context) -> ZonedDateTime.parse(json.getAsString()))
 				.registerTypeAdapter(URI.class, (JsonDeserializer<URI>) (json, typeOfT, context) -> {
 					try {
 						return URI.create(json.getAsString());
@@ -69,7 +69,7 @@ public class PostgrestMentionRepository implements MentionRepository {
 				.serializeNulls()
 				.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
 				.registerTypeAdapter(Instant.class, (JsonSerializer<Instant>) (src, typeOfSrc, context) -> new JsonPrimitive(src.toString()))
-				.registerTypeAdapter(LocalDate.class, (JsonSerializer<LocalDate>) (src, typeOfSrc, context) -> new JsonPrimitive(src.toString()))
+				.registerTypeAdapter(ZonedDateTime.class, (JsonSerializer<ZonedDateTime>) (src, typeOfSrc, context) -> new JsonPrimitive(src.toString()))
 				.create().toJson(mentions);
 		String response = Utils.postAsAdmin(Config.backendBaseUrl() + "/mention?on_conflict=doi&select=doi,id", scrapedMentionsJson, "Prefer", "resolution=merge-duplicates,return=representation");
 


### PR DESCRIPTION
# Scrape DOI registration timestamp for releases

Changes proposed in this pull request:

* For releases, we scrape the DOI registration timestamp, so that releases can be properly sorted, even if multiple releases were made on the same day

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=1`.
* Login and add a software page with concept DOI `10.5281/zenodo.7638662`
* Run the releases scraper a few times: `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases`
* http://localhost/api/v1/mention?select=doi_registration_date should have some non-null values
* Visit some organisation pages and look at the releases, they should be shown correctly
* Visit some software pages, including the one you made manually, and check that the release versions are in the correct order

Closes #734

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests