### PR TITLE
fix: organisation detection for Helmholtz AAI

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLogin.java
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -34,13 +35,21 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Objects;
+import java.util.Set;
 
 public class HelmholtzAaiLogin implements Login {
 
 	private final String code;
 	private final String redirectUrl;
-	static final String DEFAULT_ORGANISATION = "Helmholtz";
+	static final String DEFAULT_ORGANISATION = "Unknown";
+
+	// See https://hifis.net/doc/helmholtz-aai/list-of-vos/#vos-representing-helmholtz-centres
+	static private final Collection<String> knownHgfOrganisations = Set.<String>of(new String[] {
+		"AWI", "CISPA", "DESY", "DKFZ", "DLR", "DZNE", "FZJ", "GEOMAR", "GFZ", "GSI", "hereon", "HMGU", "HZB", "KIT", "MDC", "UFZ"
+	});
 
 	public HelmholtzAaiLogin(String code, String redirectUrl) {
 		this.code = Objects.requireNonNull(code);
@@ -55,10 +64,16 @@ public class HelmholtzAaiLogin implements Login {
 			return allowExternal ? DEFAULT_ORGANISATION : null;
 		}
 
-		String organisation = DEFAULT_ORGANISATION;
+		String returnOrganisation = DEFAULT_ORGANISATION;
+		ArrayList<String> organisationsDelivered = new ArrayList<String>();
 		boolean helmholtzmemberFound = false;
 
+		// Collect all organisations delivered, because the home organisation
+		// must not be the first one in the list. This assumes that a person
+		// is only member of one organisation
+		String organisation;
 		for (Object element : entitlements.toArray()) {
+			organisation = null;
 			String ent = element.toString();
 
 			// we expect this for logins from Helmholtz centres
@@ -72,6 +87,7 @@ public class HelmholtzAaiLogin implements Login {
 			if (ent.matches("urn:geant:helmholtz\\.de:group:.*")) {
 				String withoutHash = ent;
 
+				// remove everything behind the hash
 				if (ent.contains("#")) {
 					String[] splitHash = ent.split("#");
 
@@ -93,6 +109,7 @@ public class HelmholtzAaiLogin implements Login {
 
 				// get organisation from last element
 				organisation = splitGroup[splitGroup.length - 1];
+				organisationsDelivered.add(organisation);
 			}
 		}
 
@@ -101,9 +118,19 @@ public class HelmholtzAaiLogin implements Login {
 			return null;
 		}
 
+		// Detect whether one of the delivered organisations is in the list of known HGF centres
+		organisationsDelivered.retainAll(knownHgfOrganisations);
+		if (organisationsDelivered.size() == 0) {
+			// No known HGF organisation could be found
+			returnOrganisation = DEFAULT_ORGANISATION;
+		} else {
+			// Always return the first element in the list, even if there were multiple centres found
+			returnOrganisation = organisationsDelivered.get(0);
+		};
+
 		// else: we either return the found the Helmholtz centre name
 		// or the default organisation
-		return organisation;
+		return returnOrganisation;
 	}
 
 	@Override

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLoginTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLoginTest.java
@@ -7,6 +7,7 @@
 package nl.esciencecenter.rsd.authentication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -20,9 +21,8 @@ public class HelmholtzAaiLoginTest {
 		JSONArray arr = new JSONArray();
 
 		arr.add("urn:geant:h-df.de:group:test-vo#login-dev.helmholtz.de");
-		assertEquals(
-			"Unknown",
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, true)
+		assertNull(
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr)
 		);
 
 		arr.add("urn:geant:helmholtz.de:group:Helmholtz-member#login-dev.helmholtz.de");
@@ -32,19 +32,14 @@ public class HelmholtzAaiLoginTest {
 
 		assertEquals(
 			"GFZ",
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, false)
-		);
-
-		assertEquals(
-			"GFZ",
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, true)
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr)
 		);
 
 		arr.add("urn:geant:helmholtz.de:group:UFZ#login-dev.helmholtz.de");
 		assertTrue(
-			"GFZ".equals(HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, false))
+			"GFZ".equals(HelmholtzAaiLogin.getOrganisationFromEntitlements(arr))
 			||
-			"UFZ".equals(HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, false))
+			"UFZ".equals(HelmholtzAaiLogin.getOrganisationFromEntitlements(arr))
 		);
 
 		JSONArray nohash = new JSONArray();
@@ -54,7 +49,7 @@ public class HelmholtzAaiLoginTest {
 
 		assertEquals(
 			"GFZ",
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(nohash, false)
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(nohash)
 		);
 	}
 
@@ -68,17 +63,17 @@ public class HelmholtzAaiLoginTest {
 
 		assertEquals(
 			"GFZ",
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, true)
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr)
 		);
 
 		assertNull(
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(null, false)
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(null)
 		);
 
 		JSONArray empty = new JSONArray();
 
 		assertNull(
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(empty, false)
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(empty)
 		);
 	}
 
@@ -94,7 +89,7 @@ public class HelmholtzAaiLoginTest {
 
 		assertEquals(
 			HelmholtzAaiLogin.DEFAULT_ORGANISATION,
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, false)
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr)
 		);
 	}
 
@@ -102,9 +97,29 @@ public class HelmholtzAaiLoginTest {
 	void testOrganisationFromEntitlementsDefaultValue() {
 		JSONArray arr = new JSONArray();
 
+		// No entitlements -> Null
+		assertNull(
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(null)
+		);
+
+		assertNull(
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr)
+		);
+
+		// Default value should be returned if user is part of the Helmholtz
+		// association but no fitting centre could be found
+		arr.add("urn:geant:helmholtz.de:group:Helmholtz-member#login.helmholtz.de");
+
 		assertEquals(
 			HelmholtzAaiLogin.DEFAULT_ORGANISATION,
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, true)
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr)
+		);
+
+		// Unknown or new institution
+		arr.add("urn:geant:helmholtz.de:group:NoRealCentre#login-dev.helmholtz.de");
+		assertEquals(
+			HelmholtzAaiLogin.DEFAULT_ORGANISATION,
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr)
 		);
 
 		arr.add("");
@@ -112,19 +127,14 @@ public class HelmholtzAaiLoginTest {
 
 		assertEquals(
 			HelmholtzAaiLogin.DEFAULT_ORGANISATION,
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, true)
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr)
 		);
 
-		assertEquals(
+		// Actual centre does not return default value
+		arr.add("urn:geant:helmholtz.de:group:GFZ#login-dev.helmholtz.de");
+		assertNotEquals(
 			HelmholtzAaiLogin.DEFAULT_ORGANISATION,
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(null, true)
-		);
-
-		arr.add("urn:geant:helmholtz.de:group:Helmholtz-member#login-dev.helmholtz.de");
-
-		assertEquals(
-			HelmholtzAaiLogin.DEFAULT_ORGANISATION,
-			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, false)
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr)
 		);
 	}
 }

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLoginTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/HelmholtzAaiLoginTest.java
@@ -1,5 +1,6 @@
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,6 +8,7 @@ package nl.esciencecenter.rsd.authentication;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
@@ -18,13 +20,31 @@ public class HelmholtzAaiLoginTest {
 		JSONArray arr = new JSONArray();
 
 		arr.add("urn:geant:h-df.de:group:test-vo#login-dev.helmholtz.de");
+		assertEquals(
+			"Unknown",
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, true)
+		);
+
 		arr.add("urn:geant:helmholtz.de:group:Helmholtz-member#login-dev.helmholtz.de");
 		arr.add("urn:geant:helmholtz.de:group:GFZ#login-dev.helmholtz.de");
+		arr.add("urn:geant:helmholtz.de:group:HIFIS#login-dev.helmholtz.de");
 		arr.add("urn:mace:dir:entitlement:common-lib-terms");
 
 		assertEquals(
 			"GFZ",
 			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, false)
+		);
+
+		assertEquals(
+			"GFZ",
+			HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, true)
+		);
+
+		arr.add("urn:geant:helmholtz.de:group:UFZ#login-dev.helmholtz.de");
+		assertTrue(
+			"GFZ".equals(HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, false))
+			||
+			"UFZ".equals(HelmholtzAaiLogin.getOrganisationFromEntitlements(arr, false))
 		);
 
 		JSONArray nohash = new JSONArray();


### PR DESCRIPTION
We have an issue where the home organisation of a user is not correctly determined. The reason is that we are looking for organisations in `eduperson_entitlement` where not necessarily the first organisation in the list represents the user's actual home organisation.

Changes proposed in this pull request:

* fixes detection by comparing the organisation list delivered by the AAI with a list of known VOs/Centres
* sets the organisation to `Null` if no known organisation could be found
* sets the organisation to `Helmholtz` if user is a Helmholtz member but no known centre could be found in the entitlements
* adjust corresponding tests

How to test:

* `docker compose build auth`
* `docker compose up --scale scrapers=0`
* set `HELMHOLTZAAI_ALLOW_EXTERNAL_USERS=true` and login using a social IdP from the AAI (Google, GitHub or ORCID)
* check that for the newly created `login_for_account.home_organisation` is now `Null`

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
