### PR TITLE
Change global search placeholder text and privacy hint position

### DIFF
--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -142,7 +142,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
         </div>
         <input className="px-2 pl-8 py-2 bg-transparent rounded-sm border border-white border-opacity-50 focus:outline-0 w-full focus:bg-white focus:text-black duration-200"
           data-testid="global-search"
-          placeholder="Search in RSD or jump to..."
+          placeholder="Search or jump to..."
           autoComplete="off"
           value={inputValue}
           onChange={handleChange}

--- a/frontend/components/layout/ContributorPrivacyHint.tsx
+++ b/frontend/components/layout/ContributorPrivacyHint.tsx
@@ -12,7 +12,7 @@ import useRsdSettings from '~/config/useRsdSettings'
 export default function ContributorPrivacyHint() {
   const {host} = useRsdSettings()
   return (
-    <Alert severity="info" sx={{marginTop:'0.5rem'}}>
+    <Alert severity="info" sx={{marginTop:'1rem'}}>
       Before adding an individual, make sure to ask for their permission to appear in the RSD. Please see our <strong><u><Link href={host?.terms_of_service_url ?? ''} target="_blank">Terms of Service</Link></u></strong> for more information.
     </Alert>
   )

--- a/frontend/components/projects/edit/team/index.tsx
+++ b/frontend/components/projects/edit/team/index.tsx
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
@@ -204,12 +204,12 @@ export default function ProjectTeam({slug}: { slug: string }) {
             title={cfgTeamMembers.find.title}
             subtitle={cfgTeamMembers.find.subtitle}
           />
-          <ContributorPrivacyHint />
           <FindMember
             project={project.id}
             token={token}
             onAdd={onEditMember}
           />
+          <ContributorPrivacyHint />
         </div>
       </EditSection>
 

--- a/frontend/components/software/edit/contributors/index.tsx
+++ b/frontend/components/software/edit/contributors/index.tsx
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
@@ -223,11 +223,11 @@ export default function SoftwareContributors() {
             title={config.findContributor.title}
             subtitle={config.findContributor.subtitle}
           />
-          <ContributorPrivacyHint />
           <FindContributor
             software={software?.id ?? ''}
             onAdd={loadContributorIntoModal}
           />
+          <ContributorPrivacyHint />
           {
             software?.concept_doi &&
             <div className="pt-8 pb-0">


### PR DESCRIPTION
# Minor UX changes

Closes #737

Changes proposed in this pull request:
*   Placeholder text is changed from 'Search in RSD or jump to' to 'Search or jump to'. I believe we explicitly added RSD word to distinct between searches for organisation or contributors which do use external sources beside RSD.
*  Privacy hint info box, which previously was above input box of contributors/team members is moved below the input. I think this is more in line with other pages: mentions, output and impact.

How to test:
* `make start` to build app
* confirm that global search placeholder is `Search or jump to...`
* navigate to software edit page, contributors. Confirm that info is below input box.
* navigate to project edit page, team. Confirm that info is below input box.


## Example UX changes
![image](https://user-images.githubusercontent.com/9204081/220907975-c595e04a-9365-417e-bef1-8517eaf0b88d.png)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
