### PR TITLE
fix: change RPCs to use SQL instead of PL/pgSQL to increase performance

### DIFF
--- a/database/009-create-mention-table.sql
+++ b/database/009-create-mention-table.sql
@@ -80,7 +80,7 @@ CREATE TABLE mention_for_software (
 );
 
 
-CREATE OR REPLACE FUNCTION search_mentions_for_software(software_id UUID, search_text VARCHAR) RETURNS SETOF mention STABLE LANGUAGE plpgsql AS
+CREATE FUNCTION search_mentions_for_software(software_id UUID, search_text VARCHAR) RETURNS SETOF mention STABLE LANGUAGE plpgsql AS
 $$
 BEGIN
 	RETURN QUERY SELECT * FROM mention
@@ -111,7 +111,7 @@ CREATE TABLE impact_for_project (
 );
 
 
-CREATE OR REPLACE FUNCTION search_impact_for_project(project_id UUID, search_text VARCHAR) RETURNS SETOF mention STABLE LANGUAGE plpgsql AS
+CREATE FUNCTION search_impact_for_project(project_id UUID, search_text VARCHAR) RETURNS SETOF mention STABLE LANGUAGE plpgsql AS
 $$
 BEGIN
 	RETURN QUERY SELECT * FROM mention
@@ -126,7 +126,7 @@ END
 $$;
 
 
-CREATE OR REPLACE FUNCTION search_output_for_project(project_id UUID, search_text VARCHAR) RETURNS SETOF mention STABLE LANGUAGE plpgsql AS
+CREATE FUNCTION search_output_for_project(project_id UUID, search_text VARCHAR) RETURNS SETOF mention STABLE LANGUAGE plpgsql AS
 $$
 BEGIN
 	RETURN QUERY SELECT * FROM mention

--- a/frontend/utils/getOrganisations.ts
+++ b/frontend/utils/getOrganisations.ts
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -16,7 +16,8 @@ import {paginationUrlParams} from './postgrestUrl'
 export function organisationListUrl({search, rows = 12, page = 0}:
   { search: string | undefined, rows: number, page: number }) {
   // by default order is on software count and name
-  let url = `${process.env.POSTGREST_URL}/rpc/organisations_overview?parent=is.null&score=gt.0&order=is_tenant.desc,score.desc.nullslast,name.asc`
+  const selectList = 'parent,name,website,is_tenant,rsd_path,logo_id,software_cnt,project_cnt,score'
+  let url = `${process.env.POSTGREST_URL}/rpc/organisations_overview?parent=is.null&score=gt.0&order=is_tenant.desc,score.desc.nullslast,name.asc&select=${selectList}`
   // add search params
   if (search) {
     url += `&or=(name.ilike.*${search}*, website.ilike.*${search}*)`


### PR DESCRIPTION
# Improve RPC performance

Changes proposed in this pull request:

* Change language of the function `organisations_overview`, and all its dependencies, from `PL/pgSQL` to `SQL`, so they can be inlined. This increases performance when only a subset of the columns or rows is requested.
* Adapt the frontend organisation overview page so that it only requests the columns it needs, in particular, don't request `release_cnt`, since this is an expensive operation.

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=1`.
* Check http://localhost/organisations, and check various organisation pages
* Navigation should be quicker than on https://research-software.dev/organisations, which you can also see on the network tab of your browser's devtools.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests