### PR TITLE
Improve display of "Programming languages" info

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
-# SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 #
@@ -27,14 +27,12 @@ export DGID
 
 # Main commands
 # ----------------------------------------------------------------
-start:
-	docker-compose down --volumes #cleanup phase
+start: clean
 	docker-compose build # build all services
 	docker-compose up --scale data-generation=1 --scale scrapers=0 -d
 	# open http://localhost to see the application running
 
-install:
-	docker-compose down --volumes #cleanup phase
+install: clean
 	docker-compose build database backend auth scrapers nginx   # exclude frontend and wait for the build to finish
 	docker-compose up --scale scrapers=0 -d
 	cd frontend && yarn install -d
@@ -44,6 +42,8 @@ install:
 	docker-compose up --scale data-generation=1 -d
 	# All dependencies are installed. The data migration is runing in the background. You can now run `make dev' to start the application
 
+clean:
+	docker-compose down --volumes
 
 
 dev:

--- a/frontend/components/software/AboutLanguages.tsx
+++ b/frontend/components/software/AboutLanguages.tsx
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -61,6 +63,7 @@ function calculateStats(languages: ProgramingLanguages) {
 
 export default function AboutLanguages({languages, platform}:
   { languages: ProgramingLanguages, platform: CodePlatform }) {
+  let label = 'Programming language'
 
   // don't render section if no languages
   if (typeof languages == 'undefined' || languages === null) return null
@@ -81,13 +84,17 @@ export default function AboutLanguages({languages, platform}:
   }
 
   // don't render if stats failed
-  if (typeof stats == 'undefined') return null
+  if (typeof stats == 'undefined' || stats.length == 0) {
+    return null
+  } else if (stats.length > 1) {
+    label += 's'
+  }
 
   return (
     <>
     <div className="pt-8 pb-2">
       <Code color="primary" />
-      <span className="text-primary pl-2">Programming language</span>
+      <span className="text-primary pl-2">{label}</span>
     </div>
     <ul className="py-1">
       {/* show only stat selection pct > 0 and exclude other category */}


### PR DESCRIPTION
Fixes #754 

Changes proposed in this pull request:

* do not display the "Programming language" if the stats array is empty (i.e. no information on languages exist)
* distinguish between one or multiple languages and adjust title (plural/singular)
* minor: adds a `clean` stage to the make fiel that runs `docker compose down --volumes`

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up`
* create a new software A with repo url `https://git.gfz-potsdam.de/igmas/igmas-releases` (GitLab)
* create a new software B with repo url `https://github.com/wadpac/GGIR`
* create a new software C with repo url `https://github.com/research-software-directory/RSD-as-a-service`
* run the scraper `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages`
* verify that A does not display the "Programming language" info
* verify that B/C use the correct nouns

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
