### PR TITLE
fix: order global search results by search term

### DIFF
--- a/frontend/components/GlobalSearchAutocomplete/globalSearchAutocomplete.api.ts
+++ b/frontend/components/GlobalSearchAutocomplete/globalSearchAutocomplete.api.ts
@@ -1,5 +1,11 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import logger from '~/utils/logger'
 import {createJsonHeaders} from '~/utils/fetchHelpers'
+import {sortBySearchFor} from '~/utils/sortFn'
 
 export type GlobalSearchResults = {
   slug: string,
@@ -28,7 +34,9 @@ export async function getGlobalSearch(searchText: string, token: string,) {
     })
     if (resp.status === 200) {
       const rawData: GlobalSearchResults[] = await resp.json()
-      return rawData
+      // sort by search value based on name property
+      const sorted = rawData.sort((a, b) => sortBySearchFor(a,b,'name',searchText))
+      return sorted
     }
   } catch (e: any) {
     logger(`getGlobalSearch: ${e?.message}`, 'error')

--- a/frontend/utils/sortFn.test.ts
+++ b/frontend/utils/sortFn.test.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -30,6 +30,7 @@ const orderSearchFor = [
   {id: 1, name: 'defg', amount: 96.5, datum: '2020-12-15'},
   {id: 1, name: 'efgh', amount: 94, datum: '2020-12-7'},
   {id: 1, name: 'fghi', amount: 89, datum: '2018-11-1'},
+  {id: 1, name: 'cd', amount: 98, datum: '2019-12-26'},
 ]
 
 describe('sortFn',()=>{
@@ -71,15 +72,20 @@ describe('sortFn',()=>{
   })
 
   it('order by searchFor', () => {
-    const resp = orderSearchFor.sort((a, b) => sortBySearchFor(a, b, 'name', 'c'))
+    const resp = orderSearchFor.sort((a, b) => sortBySearchFor(a, b, 'name', 'cd'))
     const first = resp[0]
     const second = resp[1]
     const third = resp[2]
-    // first if starts with
-    expect(first.name).toEqual('cdef')
-    // second and third contain it
-    expect(second.name).toEqual('abcd')
+    const fourth = resp[3]
+
+    // first exact match
+    expect(first.name).toEqual('cd')
+    // second starts with
+    expect(second.name).toEqual('cdef')
+    // third contains it closer to left then fourth
     expect(third.name).toEqual('bcde')
+    // fourth contains it further to left then third
+    expect(fourth.name).toEqual('abcd')
   })
 
 })

--- a/frontend/utils/sortFn.ts
+++ b/frontend/utils/sortFn.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -58,35 +58,41 @@ export function sortBySearchFor(itemA: any, itemB: any, prop: string, searchFor:
   const valA:string = itemA[prop]
   const valB:string = itemB[prop]
 
+  // exact match
   if (
-    valA.toLowerCase().startsWith(searchFor.toLowerCase()) === true &&
-    valB.toLowerCase().startsWith(searchFor.toLowerCase()) === false
+    valA.toLowerCase() == searchFor.toLowerCase()
   ) {
     return -1
   }
 
   if (
-    valA.toLowerCase().startsWith(searchFor.toLowerCase()) === false &&
-    valB.toLowerCase().startsWith(searchFor.toLowerCase()) === true
+    valB.toLowerCase() == searchFor.toLowerCase()
   ) {
     return 1
   }
 
-  if (
-    valA.toLowerCase().includes(searchFor.toLowerCase()) === true &&
-    valB.toLowerCase().includes(searchFor.toLowerCase()) === false
-  ) {
+  // get position of term, -1 = not found
+  const posA = valA.toLowerCase().indexOf(searchFor.toLowerCase())
+  const posB = valB.toLowerCase().indexOf(searchFor.toLowerCase())
+
+  // both items contain the term
+  if (posA > -1 && posB > -1) {
+    // found in A closer to left
+    if (posA < posB) return -1
+    // found in B closer to left
+    return 1
+  }
+  // found only in A
+  if (posA > -1 && posB === -1) {
     return -1
   }
-
-  if (
-    valA.toLowerCase().includes(searchFor.toLowerCase()) === false &&
-    valB.toLowerCase().includes(searchFor.toLowerCase()) === true
-  ) {
+  // found only in B
+  if (posA === -1 && posB > -1) {
+    // found in B
     return 1
   }
 
-  // values are equal
+  // no change of order
   return 0
 }
 


### PR DESCRIPTION
# Order global search results by match of search item

Closes #749

Changes proposed in this pull request:
*   Improved sort fn to order items by exact match first, then partial match closer to the left position in the string

How to test:
* `make start` to rebuild app
* create four additional software items: 'Xenon', 'Xenon gRPC server', 'Xenon command line interface' and 'PyXenon', then publish these items to be able to search for these
* use global search with the term `xenon`
* The order returned should be: Xenon (exact match), Xenon command line interface,  Xenon gRPC server, PyXenon, etc...

**Discussion point**
I reused JavaScript sort function to order items returned from api. In this case we might consider to extend RPC with order as we do not use this endpoint to dynamically change order.

## Example 

![image](https://user-images.githubusercontent.com/9204081/222428526-40ed08af-c8ad-493a-9778-6362ecd2d206.png)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
