### PR TITLE
Adds API view for user count by home_organisation

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1561,3 +1561,13 @@ BEGIN
 END
 $$;
 
+-- Display amount of users per home_organisation
+CREATE VIEW user_count_per_home_organisation AS
+	SELECT
+		home_organisation,
+		COUNT(*)
+	FROM
+		login_for_account
+	GROUP BY
+		home_organisation
+	;


### PR DESCRIPTION
For our RSD instance to be listed in helmholtz.cloud, we need to provide a couple of statistics to a public gitlab repository. Amongst these statistics, we need to know how many user accounts exist per centre. For this use case, we need a publicly available API endpoint that delivers this data.

Changes proposed in this pull request:

* adds a `VIEW` named `user_count_per_home_organisation` that lists the amount of users by `home_organisation`
* create fake accounts and login_for_account in `data-generation` (one `login_for_account` per `account`)

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale scrapers=0 --scale data-generation=1`
* open http://localhost/api/v1/user_count_per_home_organisation and verify that it returns a json like this one

```
[
  {
    "home_organisation": "Organisation for ratio",
    "count": 8
  },
  {
    "home_organisation": null,
    "count": 11
  },
  {
    "home_organisation": "Organisation for noodle",
    "count": 5
  },
  {
    "home_organisation": "Organisation for understanding",
    "count": 5
  },
...
]
```

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
