### PR TITLE
fix: set maximum item count in the badge to 999

### DIFF
--- a/frontend/components/mention/MentionEditList.tsx
+++ b/frontend/components/mention/MentionEditList.tsx
@@ -58,6 +58,7 @@ export default function MentionEditList({title, type, items}: MentionSectionList
       >
         <Badge
           badgeContent={items.length ?? null}
+          max={999}
           color="primary"
           sx={{
             '& .MuiBadge-badge': {

--- a/frontend/components/mention/MentionViewList.tsx
+++ b/frontend/components/mention/MentionViewList.tsx
@@ -56,6 +56,7 @@ export default function MentionViewList({title, type, items}: MentionSectionList
       >
         <Badge
           badgeContent={items.length ?? null}
+          max={999}
           color="secondary"
           sx={{
             '& .MuiBadge-badge': {


### PR DESCRIPTION
# Set maximum number in the badge in mentions/output/impact to 999

Closes #751 

Changes proposed in this pull request:
* The mentions/output/impact item count per categorie shown in the badge is increased to 999. By default max is set to 99.     

How to test:
* Difficult to test, because tester needs to add 1000 items of same mention type to see `999+` label.
* See printscreen bellow, which is created by passing fake value in the state

## Example software mentions

![image](https://user-images.githubusercontent.com/9204081/222519791-201f0baf-91e1-4928-b0c3-19210b9d9502.png)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
