### PR TITLE
fix: select distinct releases per organisation

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -430,7 +430,7 @@ CREATE FUNCTION releases_by_organisation() RETURNS TABLE (
 	release_authors VARCHAR
 ) LANGUAGE sql STABLE AS
 $$
-SELECT
+SELECT DISTINCT
 	organisation.id AS organisation_id,
 	software.id AS software_id,
 	software.slug AS software_slug,


### PR DESCRIPTION
# Deduplicate releases

Changes proposed in this pull request:

* Change the `releases_by_organisation` function in the database so that it deduplicates releases

How to test:
* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=0`.
* Login as admin, create a software page with concept DOI `10.5281/zenodo.6379973`, add it to some organisation
* Run the releases scraper once: `docker-compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases`
* Create a research unit of the organisation you added above
* Add the software to that research unit as well
* Visit the releases of the parent organisation, each release should only be listed once
* If you want, you can (using DBeaver for example), replace the new function with the old version and refresh the page, everything should be duplicated then

Closes #766

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [X] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests