### PR TITLE
Remove default for capitalized buttons

### DIFF
--- a/frontend/styles/rsdMuiTheme.ts
+++ b/frontend/styles/rsdMuiTheme.ts
@@ -206,6 +206,7 @@ function applyThemeConfig({colors, action, typography}: ThemeConfig) {
       button: {
         fontWeight: 400,
         letterSpacing: '0.125rem',
+        textTransform: 'none' // Remove default for capitalized buttons
       },
       // change headers typography
       h1: {


### PR DESCRIPTION
We are using different button capitalization across the application. Some buttons have capitalized text, and some others do not. This PR sets to non-capilazied buttons by default in the MUI theme provider.

 
![image](https://user-images.githubusercontent.com/4195550/223085362-0e3deeb8-29a9-4210-8da0-455f74b84eec.png)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
