### PR TITLE
feat: add rpc new_accounts_count_since_timestamp

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1571,3 +1571,16 @@ CREATE VIEW user_count_per_home_organisation AS
 	GROUP BY
 		home_organisation
 	;
+
+
+-- Return the number of accounts since specified time stamp
+CREATE FUNCTION new_accounts_count_since_timestamp(timestmp TIMESTAMPTZ) RETURNS INTEGER
+LANGUAGE sql SECURITY DEFINER STABLE AS
+$$
+SELECT
+	COUNT(account.created_at)
+FROM
+	account
+WHERE
+	created_at > timestmp;
+$$;


### PR DESCRIPTION
Related to #763, this PR adds one more RPC call that will return the number of new accounts since a given date.

Changes proposed in this pull request:

* adds `new_accounts_count_since_timestamp(timestmp)` that can be queried via a POST request without authentication

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale scrapers=0 --scale data-generation=1`
* Make a POST request with curl, e.g.
  ```
  curl "http://localhost/api/v1/rpc/new_accounts_count_since_timestamp" \
       -X POST -H "Content-Type: application/json" \
       -d '{"timestmp":"2023-03-03 00:00:00.0000"}'
  ```
  Which should return 100, that is equal to the amounts of accounts created with the data-generation script


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
