### PR TITLE
Correct lower case button labels

### DIFF
--- a/frontend/components/admin/orcid-users/AddOrcidUser.tsx
+++ b/frontend/components/admin/orcid-users/AddOrcidUser.tsx
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Button from '@mui/material/Button'
+import AddIcon from '@mui/icons-material/Add'
+
 import TextField from '@mui/material/TextField'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 
@@ -25,7 +27,12 @@ export default function AddOrcidUser({onSubmitOrcid}:{onSubmitOrcid:Function}) {
           inputProps={{pattern: '^\\d{4}-\\d{4}-\\d{4}-\\d{3}[0-9X]$'}}
           required
         />
-        <Button variant="text" type='submit'>Add user</Button>
+        <Button
+          startIcon={<AddIcon />}
+          variant="text"
+          type='submit'>
+          Add
+        </Button>
       </form>
     </div>
   )

--- a/frontend/components/layout/EditPageButton.tsx
+++ b/frontend/components/layout/EditPageButton.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -62,7 +62,7 @@ export default function EditPageButton({title, url, isMaintainer, variant}: Edit
             router.push(url)
           }}
         >
-          edit page
+          Edit page
         </Button>
       </PageContainer>
     )

--- a/frontend/components/layout/ViewPageButton.tsx
+++ b/frontend/components/layout/ViewPageButton.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,7 +29,7 @@ export default function ViewPageButton({title,url,disabled}:ViewButtonProps) {
       }}
       disabled={disabled}
     >
-      view page
+      View page
     </Button>
   )
 }

--- a/frontend/components/organisation/units/ResearchUnitModal.tsx
+++ b/frontend/components/organisation/units/ResearchUnitModal.tsx
@@ -228,7 +228,7 @@ export default function ResearchUnitModal({
                   disabled={!formData.logo_b64 && !formData.logo_id}
                   onClick={deleteLogo}
                 >
-                  remove <DeleteIcon/>
+                  Remove <DeleteIcon/>
                 </Button>
               </div>
             </div>

--- a/frontend/components/organisation/units/ResearchUnitModal.tsx
+++ b/frontend/components/organisation/units/ResearchUnitModal.tsx
@@ -224,11 +224,12 @@ export default function ResearchUnitModal({
               <div className="flex pt-4">
                 <Button
                   title="Remove image"
+                  endIcon={<DeleteIcon/>}
                   // color='primary'
                   disabled={!formData.logo_b64 && !formData.logo_id}
                   onClick={deleteLogo}
                 >
-                  Remove <DeleteIcon/>
+                  Remove
                 </Button>
               </div>
             </div>

--- a/frontend/components/projects/edit/impact/AddImpact.tsx
+++ b/frontend/components/projects/edit/impact/AddImpact.tsx
@@ -1,9 +1,11 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Button from '@mui/material/Button'
+import AddIcon from '@mui/icons-material/Add'
+
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
 import AddNewItemInfo from '~/components/software/edit/mentions/AddNewItemInfo'
@@ -29,8 +31,9 @@ export default function AddImpact() {
         </div>
         <div className="px-4"></div>
         <Button
+          startIcon={<AddIcon />}
           onClick={onNewImpact}>
-          add
+          Add
         </Button>
       </div>
       <AddNewItemInfo />

--- a/frontend/components/projects/edit/impact/EditProjectImpactIndex.test.tsx
+++ b/frontend/components/projects/edit/impact/EditProjectImpactIndex.test.tsx
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
@@ -180,7 +180,7 @@ describe('frontend/components/project/edit/impact/index.tsx', () => {
     await waitForElementToBeRemoved(screen.getByRole('progressbar'))
 
     const addBtn = screen.getByRole('button', {
-      name:'add'
+      name:'Add'
     })
     expect(addBtn).toBeInTheDocument()
 

--- a/frontend/components/projects/edit/information/AutosaveFundingOrganisations.tsx
+++ b/frontend/components/projects/edit/information/AutosaveFundingOrganisations.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -112,7 +112,7 @@ export default function AutosaveFundingOrganisations({id,items}:FundingOrganisat
         return(
           <div
             key={item.id}
-            className="py-1 pr-1"
+            className="py-1 pr-1 overflow-hidden"
           >
             <Chip
               data-testid="funding-organisation-chip"

--- a/frontend/components/projects/edit/information/AutosaveProjectLinks.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectLinks.tsx
@@ -1,11 +1,12 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useState} from 'react'
 
 import Button from '@mui/material/Button'
+import AddIcon from '@mui/icons-material/Add'
 
 import {useSession} from '~/auth'
 import useSnackbar from '~/components/snackbar/useSnackbar'
@@ -130,6 +131,7 @@ export default function AutosaveProjectLinks({project_id, url_for_project}: Proj
         subtitle={config.url_for_project.sectionSubtitle}
       >
         <Button
+          startIcon={<AddIcon />}
           onClick={addLink}
           sx={{margin:'0rem 0rem 0.5rem 1rem'}}
         >

--- a/frontend/components/projects/edit/information/AutosaveResearchDomains.tsx
+++ b/frontend/components/projects/edit/information/AutosaveResearchDomains.tsx
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,7 @@ import Select from '@mui/material/Select'
 import MenuItem from '@mui/material/MenuItem'
 import Button from '@mui/material/Button'
 import Chip from '@mui/material/Chip'
+import AddIcon from '@mui/icons-material/Add'
 
 import {useSession} from '~/auth'
 import useSnackbar from '~/components/snackbar/useSnackbar'
@@ -317,6 +318,7 @@ export default function AutosaveResearchDomains({project_id, research_domains}: 
       <div className="flex justify-end py-4">
         <Button
           data-testid="add-research-domains"
+          startIcon={<AddIcon />}
           onClick={addDomains}
           sx={{margin: '0rem 0rem 0.5rem 1rem'}}
           disabled={l1Domains===null}

--- a/frontend/components/projects/edit/output/AddOutput.tsx
+++ b/frontend/components/projects/edit/output/AddOutput.tsx
@@ -1,9 +1,11 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Button from '@mui/material/Button'
+import AddIcon from '@mui/icons-material/Add'
+
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
 import AddNewItemInfo from '~/components/software/edit/mentions/AddNewItemInfo'
@@ -29,8 +31,9 @@ export default function AddOutput() {
         </div>
         <div className="px-4"></div>
         <Button
+          startIcon={<AddIcon />}
           onClick={onNewOutput}>
-          add
+          Add
         </Button>
       </div>
       <AddNewItemInfo />

--- a/frontend/components/projects/edit/output/EditProjectOutputIndex.test.tsx
+++ b/frontend/components/projects/edit/output/EditProjectOutputIndex.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
@@ -179,7 +180,7 @@ describe('frontend/components/projects/edit/output/index.tsx', () => {
     await waitForElementToBeRemoved(screen.getByRole('progressbar'))
 
     const addBtn = screen.getByRole('button', {
-      name:'add'
+      name:'Add'
     })
     expect(addBtn).toBeInTheDocument()
 

--- a/frontend/components/projects/edit/team/EditProjectTeamIndex.test.tsx
+++ b/frontend/components/projects/edit/team/EditProjectTeamIndex.test.tsx
@@ -363,7 +363,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
 
     // click on remove image
     const removeImage = within(modal).getByRole('button', {
-      name: 'remove'
+      name: 'Remove'
     })
 
     await waitFor(() => {
@@ -425,7 +425,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
 
     // click on remove image
     const removeImage = within(modal).getByRole('button', {
-      name: 'remove'
+      name: 'Remove'
     })
 
     await waitFor(() => {

--- a/frontend/components/projects/edit/team/TeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberModal.tsx
@@ -244,7 +244,7 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
                   disabled={!formData.avatar_b64 && !formData.avatar_id}
                   onClick={deleteAvatar}
                 >
-                  remove <DeleteIcon/>
+                  Remove <DeleteIcon/>
                 </Button>
               </div>
             </div>

--- a/frontend/components/projects/edit/team/TeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/TeamMemberModal.tsx
@@ -243,8 +243,9 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
                   // color='primary'
                   disabled={!formData.avatar_b64 && !formData.avatar_id}
                   onClick={deleteAvatar}
+                  endIcon={<DeleteIcon/>}
                 >
-                  Remove <DeleteIcon/>
+                  Remove
                 </Button>
               </div>
             </div>

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -243,7 +243,7 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
                   disabled={!formData.avatar_b64 && !formData.avatar_id}
                   onClick={deleteAvatar}
                 >
-                  remove <DeleteIcon/>
+                  Remove <DeleteIcon/>
                 </Button>
               </div>
             </div>

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -242,8 +242,9 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
                   // color='primary'
                   disabled={!formData.avatar_b64 && !formData.avatar_id}
                   onClick={deleteAvatar}
+                  endIcon={<DeleteIcon/>}
                 >
-                  Remove <DeleteIcon/>
+                  Remove
                 </Button>
               </div>
             </div>

--- a/frontend/components/software/edit/contributors/EditSoftwareContributorsIndex.test.tsx
+++ b/frontend/components/software/edit/contributors/EditSoftwareContributorsIndex.test.tsx
@@ -414,7 +414,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
 
     // click on remove image
     const removeImage = within(modal).getByRole('button', {
-      name: 'remove'
+      name: 'Remove'
     })
 
     await waitFor(() => {
@@ -484,7 +484,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
 
     // click on remove image
     const removeImage = within(modal).getByRole('button', {
-      name: 'remove'
+      name: 'Remove'
     })
     await waitFor(() => {
       expect(removeImage).toBeEnabled()

--- a/frontend/components/software/edit/information/AutosaveConceptDoi.tsx
+++ b/frontend/components/software/edit/information/AutosaveConceptDoi.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -43,7 +43,7 @@ export default function AutosaveConceptDoi() {
         token
       })
       if (resp?.status !== 200) {
-        showErrorMessage(`Failed to update concept doi. ${resp?.message}`)
+        showErrorMessage(`Failed to update concept DOI. ${resp?.message}`)
       } else {
         // debugger
         resetField('concept_doi', {
@@ -63,12 +63,12 @@ export default function AutosaveConceptDoi() {
         <Button
           startIcon={<UpdateIcon />}
           onClick={updateConceptDoi}
-          title={'Update Concept DOI'}
+          title={'Update concept DOI'}
           sx={{
             marginTop:'1rem'
           }}
         >
-          update concept doi
+          Update concept DOI
         </Button>
       )
     }

--- a/frontend/components/software/edit/information/AutosaveRemoteMarkdown.tsx
+++ b/frontend/components/software/edit/information/AutosaveRemoteMarkdown.tsx
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -130,7 +130,7 @@ export default function AutosaveRemoteMarkdown({control,rules,options,onSaveFiel
         rules={rules}
         onSaveField={onSaveField}
       />
-      <h2 className="py-4 text-sm font-medium text-primary tracking-[0.125rem] uppercase">PREVIEW</h2>
+      <h2 className="py-4 text-sm font-medium text-primary tracking-[0.125rem]">Preview</h2>
       <div className="border rounded-sm min-h-[33rem] flex">
         {renderContent()}
       </div>

--- a/frontend/components/software/edit/mentions/AddMention.tsx
+++ b/frontend/components/software/edit/mentions/AddMention.tsx
@@ -1,10 +1,11 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Button from '@mui/material/Button'
+import AddIcon from '@mui/icons-material/Add'
 
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
@@ -31,8 +32,9 @@ export default function AddMention() {
         </div>
         <div className="px-4"></div>
         <Button
+          startIcon={<AddIcon />}
           onClick={onNewImpact}>
-          add
+          Add
         </Button>
       </div>
       <AddNewItemInfo />

--- a/frontend/components/software/edit/mentions/EditSoftwareMentionsIndex.test.tsx
+++ b/frontend/components/software/edit/mentions/EditSoftwareMentionsIndex.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
@@ -194,7 +195,7 @@ describe('frontend/components/software/edit/maintainers/index.tsx', () => {
 
     // hit add button
     const addBtn = screen.getByRole('button', {
-      name:'add'
+      name:'Add'
     })
     fireEvent.click(addBtn)
 

--- a/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
+++ b/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
@@ -205,7 +205,7 @@ export default function EditOrganisationModal({open, onCancel, onSubmit, organis
                   disabled={!formData.logo_b64 && !formData.logo_id}
                   onClick={deleteLogo}
                 >
-                  remove <DeleteIcon/>
+                  Remove <DeleteIcon/>
                 </Button>
               </div>
             </div>

--- a/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
+++ b/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
@@ -204,8 +204,9 @@ export default function EditOrganisationModal({open, onCancel, onSubmit, organis
                   // color='primary'
                   disabled={!formData.logo_b64 && !formData.logo_id}
                   onClick={deleteLogo}
+                  endIcon={<DeleteIcon/>}
                 >
-                  Remove <DeleteIcon/>
+                  Remove
                 </Button>
               </div>
             </div>

--- a/frontend/pages/logout.tsx
+++ b/frontend/pages/logout.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -33,7 +33,7 @@ export default function Logout({redirect}: { redirect: RedirectProps }) {
           You can now do something else :-)
         </p>
         <Button onClick={() => window.location.href = '/'}>
-           Home
+          Home
         </Button>
       </div>
     </ContentInTheMiddle>


### PR DESCRIPTION
# Correct button labels after global style change

Changes proposed in this pull request:
* We decided to remove "uppercase" button formatting from mui button component.
* Some of the button labels were not starting with the capital letter (as it was not required)
* By further inspection of pages, I discovered that funding organisation chip with very long organisation name would break the layout. This is also fixed in this PR

How to test:
* `make start` to rebuild app
* login as rsd_admin (proferssor3 if you have same definitions in .env file as I have). 
* Create software, examine buttons on add software page
* On edit software page confirm all buttons in all sections have desired "casing".
* Create project, examine buttons on add project page
* On edit project page confirm all buttons in all sections have desired "casing".
* Navigate to admin section (only if you are logged in as rsd_admin) and confirm all buttons in all sections have desired "casing".
* Navigate to  My settings and confirm that all button have desired "casing".

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
