### PR TITLE
feat: configurable headers for mailto links

### DIFF
--- a/frontend/components/AppFooter/ContactEmail.tsx
+++ b/frontend/components/AppFooter/ContactEmail.tsx
@@ -1,16 +1,24 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Mail from '@mui/icons-material/Mail'
 
-export default function ContactEmail({email}:{email?:string}) {
+export default function ContactEmail({email, headers}:{email?:string, headers?:string[]}) {
   if (email) {
+    let mailTo = email
+    if (headers && headers.length > 0) {
+      let encodedHeaders: string[] = []
+      headers.forEach(d => encodedHeaders.push(encodeURIComponent(d)))
+      mailTo += '?' + headers.join('&')
+    }
     return (
       <div className="mt-8">
         {/* <div className="mt-4 text-lg">Questions or comments?</div> */}
-        <a href={`mailto:${email}`}
+        <a href={`mailto:${mailTo}`}
           className="flex text-accent hover:text-accent-content"
         >
           <Mail className="mr-2"/> {email}

--- a/frontend/components/AppFooter/index.tsx
+++ b/frontend/components/AppFooter/index.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2021 - 2022 dv4all
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +26,7 @@ export default function AppFooter () {
             The Research Software Directory promotes the impact, re-use and citation of research software.
           </p>
 
-          <ContactEmail email={host?.email} />
+          <ContactEmail email={host?.email} headers={host?.emailHeaders} />
           <div className="py-4"></div>
           <OrganisationLogo host={host} />
         </div>

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -20,6 +20,7 @@ export type RsdSettingsState = {
 export type RsdHost = {
   name: string,
   email: string,
+  emailHeaders?: string[],
   website?: string,
   logo_url?: string,
   feedback?: {

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -2,6 +2,7 @@
   "host": {
     "name": "rsd",
     "email": "rsd@esciencecenter.nl",
+    "emailHeaders": [],
     "logo_url": "/images/logo-escience.svg",
     "website": "https://www.esciencecenter.nl",
     "feedback": {


### PR DESCRIPTION
To optimise the handling of mails we receive in our helpdesk, we would like to add default subjects to the mail links in our RSD instance.

This PR adds the ability to add headers to the eMail link in the app footer.

Changes proposed in this pull request:

* adds an optional `emailHeaders: []` to `settings.json` that will be used to construct the mailto link in the app footer

How to test:

* `docker compose build --parallel && docker compose up --scale scrapers=0`
* open http://localhost and verify that the email link in the app footer does not contain any extra headers
* add headers to `emailHeaders`, e.g.
  ```yml
  "emailHeaders": ["subject=Default subject", "body=Default body"`],
  ```
* `docker compose down && docker compose build frontend && docker compose up --scale scrapers=0`
* verify that the mail link contains the added headers

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
