### PR TITLE
fix: ownership changes

### DIFF
--- a/frontend/Dockerfile.dev
+++ b/frontend/Dockerfile.dev
@@ -12,12 +12,12 @@ ARG DUNAME=node
 RUN export OUID=$(id -u);\
     if [ $DUID != $OUID ];\
     then usermod -u $DUID $DUNAME &&\
-    find / -user 1000 -ignore_readdir_race -exec chown -h $DUNAME {} \; ;\
+    find / -path /sys -prune -o -user 1000 -ignore_readdir_race -exec chown -h $DUNAME {} \; ;\
     fi
 RUN export OGID=$(id -g);\
     if [ $DGID != $OGID ];\
-    then groupmod -g $DGID $DUNAME &&\
-    find / -group 1000 -ignore_readdir_race -exec chgrp -h $DUNAME {} \; ;\
+    then groupmod -g $DGID $DUNAME || usermod -g $DGID $DUNAME &&\
+    find / -path /sys -prune -o -group 1000 -ignore_readdir_race -exec chgrp -h $DUNAME {} \; ;\
     fi
 USER $DUNAME
 


### PR DESCRIPTION
This commit by @seth0r fixes some issues when detecting ownership in the frontend Docker container.

This PR changes:

- excludes /sys, somtimes there are io errors
- if group id already used, changing the primary group of user

How to test:

* `make frontend-docker` and verify that the files that are generated by this container have the owner of the currently logged in user of the host system

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
