### PR TITLE
feat: suggest code platform based on existing entries

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1608,3 +1608,35 @@ LEFT JOIN
 	keyword_count_for_projects() ON keyword.value = keyword_count_for_projects.keyword
 ;
 $$;
+
+--  Suggest a platform type based on the input of other users in the RSD
+CREATE FUNCTION suggest_platform(hostname VARCHAR(200)) RETURNS platform_type
+LANGUAGE SQL STABLE AS
+$$
+SELECT
+	code_platform
+FROM
+	(
+		SELECT
+			url,
+			code_platform
+		FROM
+			repository_url
+	) AS sub
+WHERE
+	(
+		-- Returns the hostname of sub.url
+		SELECT
+			TOKEN
+		FROM
+			ts_debug(sub.url)
+		WHERE
+			alias = 'host'
+	) = hostname
+GROUP BY
+	sub.code_platform
+ORDER BY
+	COUNT(*)
+DESC LIMIT
+	1;
+$$;


### PR DESCRIPTION
Fixes #781 

Changes proposed in this pull request:

* automatically suggest a code platform based on currently publicly visible software entries
* if there exist several repositories referring to the same host, but set to different code platforms, the code platform with the most references will be suggested

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale scrapers=0`
* login as normal user
* create a new software entry, e.g. using url `https://something.com/test1` and specifiy GitLab; publish the software entry
* create a new software entry and type (not copy paste) `https://something.com/test2` into the url field. The platform should be suggested as soon as `https://something.com/` is typed into the field; publish the entry

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests