### PR TITLE
fix: add software, project use null instead of empty string

### DIFF
--- a/frontend/__tests__/SoftwareEditPage.test.tsx
+++ b/frontend/__tests__/SoftwareEditPage.test.tsx
@@ -97,7 +97,7 @@ describe('pages/software/[slug]/edit/[page].tsx', () => {
     expect(p403).toBeInTheDocument()
   })
 
-  it.only('renders info content when isMaintainer=true', async () => {
+  it('renders info content when isMaintainer=true', async () => {
     // return isMaintainer
     mockIsMaintainer.mockResolvedValueOnce(true)
     // render components

--- a/frontend/components/projects/add/addProjectConfig.ts
+++ b/frontend/components/projects/add/addProjectConfig.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +21,6 @@ export const addConfig = {
     label: 'Subtitle',
     help: 'Provide short description of your project to use as page subtitle.',
     validation: {
-      // required: 'Name is required',
       minLength: {value: 3, message: 'Minimum length is 3'},
       maxLength: {value: 300, message: 'Maximum length is 300'},
     }

--- a/frontend/components/software/add/addConfig.ts
+++ b/frontend/components/software/add/addConfig.ts
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,8 +23,7 @@ export const addConfig = {
     label: 'Short description',
     help: 'Provide a short description of your software to use as page subtitle.',
     validation: {
-      // required: 'Name is required',
-      minLength: {value: 10, message: 'Minimum length is 10'},
+      minLength: {value: 3, message: 'Minimum length is 3'},
       maxLength: {value: 300, message: 'Maximum length is 300'},
     }
   },

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -1,10 +1,10 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -37,8 +37,7 @@ export const softwareInformation = {
     label: 'Short description',
     help: 'Provide a short description of your software to use as page subtitle.',
     validation: {
-      required: 'Short description is required',
-      minLength: {value: 10, message: 'Minimum length is 10'},
+      minLength: {value: 3, message: 'Minimum length is 3'},
       maxLength: {value: 300, message: 'Maximum length is 300'},
     }
   },


### PR DESCRIPTION
# Use null on create software and project

Closes #798

Changes proposed in this pull request:
* Use null for missing value when creating software
* Use null for missing value when creating project
* Subtitle is not required prop for software
* Min value is set to 3 charts
* Tests are updated

How to test:
* `make start` to rebuild app
* login as user 
* create new software without subtitle and verify that `short_statement` property has null value instead of ""
* create new project without subtitle and verify that `project_subtitle` property has null value instead of ""

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
