### PR TITLE
Mention feedback

### DIFF
--- a/frontend/components/mention/BulkImport.tsx
+++ b/frontend/components/mention/BulkImport.tsx
@@ -1,0 +1,312 @@
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogTitle from '@mui/material/DialogTitle'
+import {ChangeEvent, useState} from 'react'
+import TextField from '@mui/material/TextField'
+import {extractSearchTerm} from '~/components/software/edit/mentions/utils'
+import {getMentionsByDoiFromRsd} from '~/utils/editMentions'
+import {useAuth} from '~/auth'
+import {MentionItemProps} from '~/types/Mention'
+import {getItemsFromCrossref, getItemsFromDatacite} from '~/utils/getDOI'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import ListItemText from '@mui/material/ListItemText'
+import Switch from '@mui/material/Switch'
+import {createJsonHeaders} from '~/utils/fetchHelpers'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import DialogContent from '@mui/material/DialogContent'
+import DialogActions from '@mui/material/DialogActions'
+
+export default function BulkImport({table, entityId}: {table: 'mention_for_software' | 'output_for_project' | 'impact_for_project', entityId: string}) {
+	const [dialogOpen, setDialogOpen] = useState<boolean>(false)
+	const [inputEnabled, setInbutEnabled] = useState<boolean>(true)
+	const [submitEnabled, setSubmitEnabled] = useState<boolean>(false)
+	const [searchResults, setSearchResults] = useState<Map<string, SearchResult> | null>(null)
+	const [lines, setLines] = useState<string[]>([])
+  const {session} = useAuth()
+  const token = session.token
+  const {showSuccessMessage} = useSnackbar()
+
+  type SearchResult = {
+    status: 'valid' | 'invalidDoi' | 'doiNotFound' |'unsupportedRA' | 'unknown',
+    include: boolean
+    source?: 'RSD' | 'Crossref' | 'DataCite',
+    mention?: MentionItemProps
+  }
+
+  function entityName(): string {
+    switch (table) {
+      case 'impact_for_project':
+      case 'output_for_project':
+        return 'project'
+      case 'mention_for_software':
+        return 'software'
+    }
+  }
+
+  async function saveMentions(mentions: MentionItemProps[]) {
+    const url = '/api/v1/mention'
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token),
+        'Prefer': 'return=representation'
+      },
+      body: JSON.stringify(mentions)
+    })
+    if (resp.status !== 201) {
+      throw new Error(`Unexpected response from ${resp.url} with status ${resp.status} and body ${await resp.text()}`)
+
+    }
+    return resp.json()
+  }
+
+  async function addMentions(ids: string[]) {
+    const url = `/api/v1/${table}`
+    const entityNameString = entityName()
+    const body = ids.map(id => ({[entityNameString]: entityId, mention: id}))
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token),
+        'Prefer': 'resolution=ignore-duplicates'
+      },
+      body: JSON.stringify(body)
+    })
+    if (resp.status !== 201) {
+      throw new Error(`Unexpected response from ${resp.url} with status ${resp.status} and body ${await resp.text()}`)
+
+    }
+  }
+
+  function cancelSubmit() {
+    setSearchResults(null)
+    setInbutEnabled(true)
+    setSubmitEnabled(true)
+  }
+
+  async function saveAndAddMentions() {
+    setSubmitEnabled(false)
+
+    try {
+      const mentionsToAdd: MentionItemProps[] = Array.from(searchResults!.values())
+      .filter(result => result.include)
+      .map(result => result.mention) as MentionItemProps[]
+
+    const newMentionsToSave: MentionItemProps[] = mentionsToAdd
+      .filter(mention => mention.id === null)
+      .map(m => m)
+
+    const existingIds: string[] = mentionsToAdd
+      .filter(mention => mention.id !== null)
+      .map(mention => mention.id!)
+
+    const savedMentions: MentionItemProps[] = await saveMentions(newMentionsToSave)
+
+    const idsToSave: string[] = existingIds.concat(savedMentions.map(mention => mention.id!))
+
+    await addMentions(idsToSave)
+
+    showSuccessMessage('Succesfully added mentions (refresh to see)')
+    setDialogOpen(false)
+    setInbutEnabled(true)
+    setSubmitEnabled(false)
+    setSearchResults(null)
+    setLines([])
+    } catch (error) {
+      setSubmitEnabled(true)
+      throw error
+    }
+  }
+
+
+  function generateErrorMessage(result: SearchResult): string {
+    switch (result.status) {
+      case 'valid':
+        throw new Error('This result is valid')
+      case 'invalidDoi':
+        return 'not a DOI'
+      case 'doiNotFound':
+        return 'DOI not found'
+      case 'unsupportedRA':
+        return 'registration agent of DOI not supported'
+      case 'unknown':
+        return 'unknown error'
+    }
+  }
+
+  function closeDialog() {
+    setDialogOpen(false)
+  }
+
+  function readInput(event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>) {
+    const newLines: string[] = event.target.value.split(/\r\n|\n|\r/)
+    setLines(newLines)
+    if (newLines.length === 0 || newLines.length > 75) setSubmitEnabled(false)
+    else setSubmitEnabled(true)
+  }
+
+  async function submitLines() {
+    setInbutEnabled(false)
+    setSubmitEnabled(false)
+    const searchData = []
+    for (const line of lines) {
+      searchData.push(extractSearchTerm(line))
+    }
+
+    searchData.forEach(entry => {
+      if(entry.type === 'doi') entry.term = entry.term.toLowerCase()
+    })
+
+    const mentionResultPerDoi: Map<string, SearchResult> = new Map()
+
+    searchData.forEach(entry => {
+      if(entry.type !== 'doi') mentionResultPerDoi.set(entry.term, {status: 'invalidDoi', include: false})
+    })
+
+    const dois: string[] = searchData
+      .filter(entry => entry.type === 'doi')
+      .map(entry => entry.term)
+    const existingMentionsResponse = await getMentionsByDoiFromRsd({dois, token})
+    const existingMentions: MentionItemProps[] = existingMentionsResponse.message
+    existingMentions.forEach(mention => {
+      if (mention.doi !== null) {
+        mentionResultPerDoi.set(mention.doi.toLowerCase(), {status: 'valid', include: true, source: 'RSD', mention: mention})
+      }
+    })
+
+    const doisNotInDatabase: string[] = searchData
+      .filter(entry => entry.type === 'doi')
+      .filter(entry => !mentionResultPerDoi.has(entry.term))
+      .map(entry => entry.term)
+
+
+    const doiRaQuery: string = doisNotInDatabase
+      .map(doi => encodeURIComponent(doi))
+      .join(',')
+
+    try {
+      if (doisNotInDatabase.length > 0) {
+        const doiRas: {DOI: string, status?: string, RA?: string}[] = await fetch(`https://doi.org/doiRA/${doiRaQuery}`)
+          .then(res => res.json())
+
+        const crossrefDois: string[] = []
+        const dataciteDois: string[] = []
+
+        doiRas.forEach(doiRa => {
+          const doi = doiRa.DOI.toLowerCase()
+          if (doiRa.status) {
+            mentionResultPerDoi.set(doi, {status: 'doiNotFound', include: false})
+          } else if (doiRa.RA === 'Crossref') {
+            crossrefDois.push(doi)
+          } else if (doiRa.RA === 'DataCite') {
+            dataciteDois.push(doi)
+          } else {
+            mentionResultPerDoi.set(doi, {status: 'unsupportedRA', include: false})
+          }
+        })
+
+
+        const crossrefPromise = getItemsFromCrossref(crossrefDois)
+          .then((res: MentionItemProps[]) => {
+            res.forEach((crossrefMention: MentionItemProps) => {
+              if (crossrefMention.doi !== null) mentionResultPerDoi.set(crossrefMention.doi.toLowerCase(), {status: 'valid', source: 'Crossref', include: true, mention: crossrefMention})
+            })
+          })
+
+
+        const datacitePromise = getItemsFromDatacite(dataciteDois)
+          .then((res: any) => {
+            res.message.forEach((dataciteMention: MentionItemProps) => {
+              if (dataciteMention.doi !== null) mentionResultPerDoi.set(dataciteMention.doi.toLowerCase(), {status: 'valid', source: 'DataCite', include: true, mention: dataciteMention})
+            })
+          })
+
+        await Promise.all([crossrefPromise, datacitePromise])
+
+        doisNotInDatabase.forEach(doi => {
+          if (!mentionResultPerDoi.has(doi)) {
+            mentionResultPerDoi.set(doi, {status: 'unknown', include: false})
+          }
+        })
+      }
+    } catch (error) {
+      setInbutEnabled(true)
+      setSubmitEnabled(true)
+      throw error
+    }
+
+    setSearchResults(mentionResultPerDoi)
+    setInbutEnabled(true)
+    setSubmitEnabled(true)
+  }
+
+
+	return (
+    <>
+        <Button onClick={() => setDialogOpen(true)}>
+          Bulk add mentions
+        </Button>
+        <Dialog maxWidth='md' sx={{minWidth: '40rem'}} open={dialogOpen} onClose={() => closeDialog()}>
+        {searchResults === null &&
+          <>
+            <DialogTitle>
+              Bulk import mentions
+            </DialogTitle>
+            <DialogContent sx={{minWidth: '40rem'}}>
+              <TextField sx={{margin: '1rem', width: '90%'}} label="Paste one DOI per line in the textbox (max 75):" defaultValue={lines.join('\n')} multiline disabled={!inputEnabled} onChange={event => readInput(event)}>
+              </TextField>
+            </DialogContent>
+            <DialogActions>
+              <Button disabled={!submitEnabled} onClick={() => submitLines()}>
+                Submit!
+              </Button>
+            </DialogActions>
+          </>
+        }
+        {searchResults !== null &&
+          <>
+            <DialogTitle>
+              Results
+            </DialogTitle>
+            <DialogContent>
+              <List>
+                {Array.from(searchResults.keys()).map(doi => {
+                  const result = searchResults.get(doi)!
+                  if (result?.status === 'valid') {
+                    const mention = searchResults.get(doi)?.mention!
+                    return (
+                      <ListItem key = {doi}>
+                        <ListItemText primary={`${doi}: ${mention.title}, ${mention.authors}, ${result.source}`}></ListItemText>
+                        <Switch defaultChecked={result.include} onChange={() => {result.include = !result.include}} />
+                      </ListItem>
+                    )
+                  } else {
+                    return (
+                      <ListItem key = {doi}>
+                        <ListItemText primary={`Error for ${doi}: ${generateErrorMessage(result)}`} sx={{color: 'red'}}></ListItemText>
+                      </ListItem>
+                    )
+                  }
+                })}
+              </List>
+            </DialogContent>
+            <DialogActions>
+              <Button disabled={!submitEnabled} onClick={() => saveAndAddMentions()}>
+                Add mentions
+              </Button>
+              <Button disabled={!submitEnabled} onClick={() => cancelSubmit()}>
+                Cancel
+              </Button>
+            </DialogActions>
+          </>
+        }
+        </Dialog>
+    </>
+  )
+}

--- a/frontend/components/projects/edit/impact/BulkImportImpact.tsx
+++ b/frontend/components/projects/edit/impact/BulkImportImpact.tsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useSession} from '~/auth'
+import BulkImport from '~/components/mention/BulkImport'
+import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
+import useProjectContext from '~/components/projects/edit/useProjectContext'
+import {getImpactForProject} from '~/utils/getProjects'
+
+
+export default function BulkImportImpact() {
+  const {project} = useProjectContext()
+  const {setMentions, setLoading} = useEditMentionReducer()
+  const {token} = useSession()
+
+  async function reloadImpact() {
+    setLoading(true)
+    const data = await getImpactForProject({project: project.id, token: token, frontend: true})
+    setMentions(data)
+    setLoading(false)
+  }
+
+  return <BulkImport table="impact_for_project" entityId={project.id!} onAdded={reloadImpact}></BulkImport>
+}

--- a/frontend/components/projects/edit/impact/FindImpact.tsx
+++ b/frontend/components/projects/edit/impact/FindImpact.tsx
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -16,17 +16,19 @@ import {getMentionByDoi} from '~/utils/getDOI'
 import useProjectContext from '../useProjectContext'
 import {cfgImpact as config} from './config'
 import {findPublicationByTitle} from './impactForProjectApi'
+import {extractSearchTerm} from '~/components/software/edit/mentions/utils'
+import useSnackbar from '~/components/snackbar/useSnackbar'
 
 export default function FindImpact() {
   const {session: {token}} = useAuth()
   const {onAdd} = useEditMentionReducer()
   const {project} = useProjectContext()
+  const {showErrorMessage} = useSnackbar()
 
   async function findPublication(searchFor: string) {
-    // regex validation if DOI string
-    const doiRegexMatch = searchFor.match(/^\s*((https?:\/\/)?(www\.)?(dx\.)?doi\.org\/)?(10(\.\w+)+\/\S+)\s*$/)
-    if (doiRegexMatch !== null && doiRegexMatch[5] !== undefined) {
-      searchFor = doiRegexMatch[5]
+    const searchData = extractSearchTerm(searchFor)
+    if (searchData.type === 'doi') {
+      searchFor = searchData.term
       // look first at RSD
       const rsd = await getMentionByDoiFromRsd({
         doi: searchFor,
@@ -43,7 +45,8 @@ export default function FindImpact() {
         return [resp.message as MentionItemProps]
       }
       return []
-    } else {
+    } else if (searchData.type === 'title') {
+      searchFor = searchData.term
       // find by title
       const mentions = await findPublicationByTitle({
         project: project.id,
@@ -51,6 +54,9 @@ export default function FindImpact() {
         token
       })
       return mentions
+    } else {
+      showErrorMessage('The URL does not contain a DOI')
+      return []
     }
   }
 

--- a/frontend/components/projects/edit/impact/index.tsx
+++ b/frontend/components/projects/edit/impact/index.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +12,7 @@ import ImpactByType from './ImpactByType'
 import FindImpact from './FindImpact'
 import AddImpact from './AddImpact'
 import useProjectContext from '../useProjectContext'
+import BulkImport from '~/components/mention/BulkImport'
 
 export default function ProjectImpact() {
   const {token} = useSession()
@@ -30,6 +33,7 @@ export default function ProjectImpact() {
           <div className="py-4"></div>
           <AddImpact />
           <div className="py-4"></div>
+          <BulkImport table="impact_for_project" entityId={project.id!}></BulkImport>
         </div>
       </EditSection>
     </EditImpactProvider>

--- a/frontend/components/projects/edit/impact/index.tsx
+++ b/frontend/components/projects/edit/impact/index.tsx
@@ -12,7 +12,7 @@ import ImpactByType from './ImpactByType'
 import FindImpact from './FindImpact'
 import AddImpact from './AddImpact'
 import useProjectContext from '../useProjectContext'
-import BulkImport from '~/components/mention/BulkImport'
+import BulkImportImpact from './BulkImportImpact'
 
 export default function ProjectImpact() {
   const {token} = useSession()
@@ -33,7 +33,7 @@ export default function ProjectImpact() {
           <div className="py-4"></div>
           <AddImpact />
           <div className="py-4"></div>
-          <BulkImport table="impact_for_project" entityId={project.id!}></BulkImport>
+          <BulkImportImpact/>
         </div>
       </EditSection>
     </EditImpactProvider>

--- a/frontend/components/projects/edit/output/BulkImportOutput.tsx
+++ b/frontend/components/projects/edit/output/BulkImportOutput.tsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useSession} from '~/auth'
+import BulkImport from '~/components/mention/BulkImport'
+import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
+import useProjectContext from '~/components/projects/edit/useProjectContext'
+import {getOutputForProject} from '~/utils/getProjects'
+
+
+export default function BulkImportOutput() {
+  const {project} = useProjectContext()
+  const {setMentions, setLoading} = useEditMentionReducer()
+  const {token} = useSession()
+
+  async function reloadOutput() {
+    setLoading(true)
+    const data = await getOutputForProject({project: project.id, token: token, frontend: true})
+    setMentions(data)
+    setLoading(false)
+  }
+
+  return <BulkImport table="output_for_project" entityId={project.id!} onAdded={reloadOutput}></BulkImport>
+}

--- a/frontend/components/projects/edit/output/FindOutput.tsx
+++ b/frontend/components/projects/edit/output/FindOutput.tsx
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -16,17 +16,19 @@ import {getMentionByDoi} from '~/utils/getDOI'
 import useProjectContext from '../useProjectContext'
 import {cfgOutput as config} from './config'
 import {findPublicationByTitle} from './outputForProjectApi'
+import {extractSearchTerm} from '~/components/software/edit/mentions/utils'
+import useSnackbar from '~/components/snackbar/useSnackbar'
 
 export default function FindOutput() {
   const {session: {token}} = useAuth()
   const {onAdd} = useEditMentionReducer()
   const {project} = useProjectContext()
+  const {showErrorMessage} = useSnackbar()
 
   async function findPublication(searchFor: string) {
-    // regex validation if DOI string
-    const doiRegexMatch = searchFor.match(/^\s*((https?:\/\/)?(www\.)?(dx\.)?doi\.org\/)?(10(\.\w+)+\/\S+)\s*$/)
-    if (doiRegexMatch !== null && doiRegexMatch[5] !== undefined) {
-      searchFor = doiRegexMatch[5]
+    const searchData = extractSearchTerm(searchFor)
+    if (searchData.type === 'doi') {
+      searchFor = searchData.term
       // look first at RSD
       const rsd = await getMentionByDoiFromRsd({
         doi: searchFor,
@@ -43,7 +45,8 @@ export default function FindOutput() {
         return [resp.message as MentionItemProps]
       }
       return []
-    } else {
+    } else if (searchData.type === 'title') {
+      searchFor = searchData.term
       // find by title
       const mentions = await findPublicationByTitle({
         project: project.id,
@@ -51,6 +54,9 @@ export default function FindOutput() {
         token
       })
       return mentions
+    } else {
+      showErrorMessage('The URL does not contain a DOI')
+      return []
     }
   }
 

--- a/frontend/components/projects/edit/output/index.tsx
+++ b/frontend/components/projects/edit/output/index.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +12,7 @@ import FindOutput from './FindOutput'
 import AddOutput from './AddOutput'
 import EditOutputProvider from './EditOutputProvider'
 import useProjectContext from '../useProjectContext'
+import BulkImport from '~/components/mention/BulkImport'
 
 export default function ProjectOutput() {
   const {token} = useSession()
@@ -30,6 +33,7 @@ export default function ProjectOutput() {
           <div className="py-4"></div>
           <AddOutput />
           <div className="py-4"></div>
+          <BulkImport table="output_for_project" entityId={project.id!}></BulkImport>
         </div>
       </EditSection>
     </EditOutputProvider>

--- a/frontend/components/projects/edit/output/index.tsx
+++ b/frontend/components/projects/edit/output/index.tsx
@@ -12,7 +12,7 @@ import FindOutput from './FindOutput'
 import AddOutput from './AddOutput'
 import EditOutputProvider from './EditOutputProvider'
 import useProjectContext from '../useProjectContext'
-import BulkImport from '~/components/mention/BulkImport'
+import BulkImportOutput from './BulkImportOutput'
 
 export default function ProjectOutput() {
   const {token} = useSession()
@@ -33,7 +33,7 @@ export default function ProjectOutput() {
           <div className="py-4"></div>
           <AddOutput />
           <div className="py-4"></div>
-          <BulkImport table="output_for_project" entityId={project.id!}></BulkImport>
+          <BulkImportOutput/>
         </div>
       </EditSection>
     </EditOutputProvider>

--- a/frontend/components/software/edit/mentions/BulkImportMentions.tsx
+++ b/frontend/components/software/edit/mentions/BulkImportMentions.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useSession} from '~/auth'
+import BulkImport from '~/components/mention/BulkImport'
+import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
+import useProjectContext from '~/components/projects/edit/useProjectContext'
+import {getImpactForProject} from '~/utils/getProjects'
+import useSoftwareContext from '../useSoftwareContext'
+import {getMentionsForSoftware} from '~/utils/editMentions'
+
+
+export default function BulkImportMentions() {
+  const {software} = useSoftwareContext()
+  const {setMentions, setLoading} = useEditMentionReducer()
+  const {token} = useSession()
+
+  async function reloadMentions() {
+    setLoading(true)
+    const data = await getMentionsForSoftware({software: software.id, token: token, frontend: true})
+    setMentions(data)
+    setLoading(false)
+  }
+
+  return <BulkImport table="mention_for_software" entityId={software.id!} onAdded={reloadMentions}></BulkImport>
+}

--- a/frontend/components/software/edit/mentions/index.tsx
+++ b/frontend/components/software/edit/mentions/index.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +12,7 @@ import MentionByType from './MentionByType'
 import FindSoftwareMention from './FindSoftwareMention'
 import AddMention from './AddMention'
 import useSoftwareContext from '../useSoftwareContext'
+import BulkImport from '~/components/mention/BulkImport'
 
 export default function SoftwareMentions() {
   const {token} = useSession()
@@ -30,6 +33,7 @@ export default function SoftwareMentions() {
           <div className="py-4"></div>
           <AddMention />
           <div className="py-4"></div>
+          <BulkImport table="mention_for_software" entityId={software.id!}></BulkImport>
         </div>
       </EditSection>
     </EditMentionsProvider>

--- a/frontend/components/software/edit/mentions/index.tsx
+++ b/frontend/components/software/edit/mentions/index.tsx
@@ -13,6 +13,7 @@ import FindSoftwareMention from './FindSoftwareMention'
 import AddMention from './AddMention'
 import useSoftwareContext from '../useSoftwareContext'
 import BulkImport from '~/components/mention/BulkImport'
+import BulkImportMentions from './BulkImportMentions'
 
 export default function SoftwareMentions() {
   const {token} = useSession()
@@ -33,7 +34,7 @@ export default function SoftwareMentions() {
           <div className="py-4"></div>
           <AddMention />
           <div className="py-4"></div>
-          <BulkImport table="mention_for_software" entityId={software.id!}></BulkImport>
+          <BulkImportMentions/>
         </div>
       </EditSection>
     </EditMentionsProvider>

--- a/frontend/components/software/edit/mentions/utils.ts
+++ b/frontend/components/software/edit/mentions/utils.ts
@@ -16,11 +16,11 @@ export function extractSearchTerm(query: string): {term: string, type: 'doi' | '
     new URL(query)
     return {term: query, type: 'url'}
   } catch (error: any) {
-    if (error.constructor.name === 'TypeError') {
-      // remove double spaces:
-      query = query.replaceAll(/\s+/g, ' ')
-      return {term: query, type: 'title'}
-    }
-    else throw error
+    // we assume the only error that can be caught is due to the query not being a URL
+    // if we get problems here, we need to handle different error types here
+    // with e.g. if (error.constructor.name === 'TypeError') {}
+    // remove double spaces:
+    query = query.replaceAll(/\s+/g, ' ')
+    return {term: query, type: 'title'}
   }
 }

--- a/frontend/components/software/edit/mentions/utils.ts
+++ b/frontend/components/software/edit/mentions/utils.ts
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+const doiRegex = /10(\.\w+)+\/\S+/
+
+export function extractSearchTerm(query: string): {term: string, type: 'doi' | 'title' | 'url'} {
+  const doiRegexMatch = query.match(doiRegex)
+  if (doiRegexMatch != null) {
+    return {term: doiRegexMatch[0], type: 'doi'}
+  }
+
+  query = query.trim()
+  try {
+    new URL(query)
+    return {term: query, type: 'url'}
+  } catch (error) {
+    if (error instanceof TypeError) return {term: query, type: 'title'}
+    else throw error
+  }
+}

--- a/frontend/components/software/edit/mentions/utils.ts
+++ b/frontend/components/software/edit/mentions/utils.ts
@@ -15,8 +15,8 @@ export function extractSearchTerm(query: string): {term: string, type: 'doi' | '
   try {
     new URL(query)
     return {term: query, type: 'url'}
-  } catch (error) {
-    if (error instanceof TypeError) return {term: query, type: 'title'}
+  } catch (error: any) {
+    if (error.constructor.name === 'TypeError') return {term: query, type: 'title'}
     else throw error
   }
 }

--- a/frontend/components/software/edit/mentions/utils.ts
+++ b/frontend/components/software/edit/mentions/utils.ts
@@ -16,7 +16,11 @@ export function extractSearchTerm(query: string): {term: string, type: 'doi' | '
     new URL(query)
     return {term: query, type: 'url'}
   } catch (error: any) {
-    if (error.constructor.name === 'TypeError') return {term: query, type: 'title'}
+    if (error.constructor.name === 'TypeError') {
+      // remove double spaces:
+      query = query.replaceAll(/\s+/g, ' ')
+      return {term: query, type: 'title'}
+    }
     else throw error
   }
 }

--- a/frontend/utils/editMentions.ts
+++ b/frontend/utils/editMentions.ts
@@ -79,6 +79,38 @@ export async function getMentionByDoiFromRsd({doi,token}:{doi: string, token: st
 }
 
 
+export async function getMentionsByDoiFromRsd({dois,token}:{dois: string[], token: string}) {
+  try {
+    const doisJoined: string = dois
+      .map(doi => encodeURIComponent(doi))
+      .map(encodedDoi => `doi.eq.%22${encodedDoi}%22`)
+      .join(',')
+    // we need to encode DOI because it supports "exotic" values
+    const url = `/api/v1/mention?select=${mentionColumns}&or=(${doisJoined})`
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token)
+      },
+    })
+    if (resp.status === 200) {
+      const json = await resp.json()
+      return {
+        status: 200,
+        message: json
+      }
+    }
+    return extractReturnMessage(resp)
+  } catch (e:any) {
+    logger(`getDoiFromRsd: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}
+
+
 export function clasifyMentionsByType(mentions: MentionItemProps[]) {
   let mentionByType: MentionByType = {}
   let featuredMentions: MentionItemProps[] = []

--- a/frontend/utils/getCrossref.ts
+++ b/frontend/utils/getCrossref.ts
@@ -12,7 +12,7 @@ import {makeDoiRedirectUrl} from './getDOI'
 import logger from './logger'
 
 
-function addPoliteEmail(url:string) {
+export function addPoliteEmail(url:string) {
   const mailto = process.env.CROSSREF_CONTACT_EMAIL
   // console.log('addPoliteEmail...',mailto)
   if (mailto) {
@@ -69,18 +69,17 @@ export function crossrefItemToMentionItem(item: CrossrefSelectItem) {
 
 export async function getCrossrefItemByDoi(doi: string) {
   try {
-    const filter = `filter=doi:${doi}`
-    const url = `https://api.crossref.org/works?${filter}`
+    const url = `https://api.crossref.org/works/${doi}`
 
     const resp = await fetch(url)
 
     if (resp.status === 200) {
       const json: CrossrefResponse = await resp.json()
       // if found return item
-      if (json.message.items.length > 0) {
+      if (json.message) {
         return {
           status: 200,
-          message: json.message.items[0]
+          message: json.message
         }
       } else {
         return {
@@ -99,6 +98,7 @@ export async function getCrossrefItemByDoi(doi: string) {
     }
   }
 }
+
 
 export async function getCrossrefItemsByTitle(title: string) {
   try {


### PR DESCRIPTION
# Various mention improvements

Changes proposed in this pull request:

* When a search term contains a DOI anywhere (URL or not), it is detected and we will search on that DOI only (#745)
* Bulk import of mentions with a DOI, up to 75 a time (#786)
* Remove double spaces when searching for a mention title (#795)

How to test:

* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=0`.
* Login, create a software page, go to mentions and add the following list:
```
https://doi.ieeecomputersociety.org/10.1109/PMBS56514.2022.00010
10.5281/zenodo.3734289doesnotexist
not a DOI
   10.5281/zenodo.3734289   
   10.5281/zenodo.5604609
10.1016/j.sleep.2019.02.008   
10.2139/ssrn.4090562
10.1109/eScience.2016.7870882
10.3389/fmars.2021.667591
10.5281/zenodo.3993242
10.1007/10704282_88
10.5281/zenodo.5788657
10.4233/uuid:4bb38399-9267-428f-b10a-80b86e101f23
10.5281/zenodo.3970975
10.1145/3514197.3551252
10.1016/j.dsr.2020.103427
10.5888/pcd16.180200
10.5281/zenodo.7524315
10.1007/s00198-019-04862-6
10.5281/zenodo.4274773
10.5281/zenodo.46572
10.5281/zenodo.58372
10.5281/zenodo.6010407
10.1088/1748-9326/ac5cf4
10.5281/zenodo.1168441
10.5281/zenodo.4017909
10.5281/zenodo.7274246
10.5281/zenodo.1045194
10.5281/zenodo.7274494
10.1007/s42001-021-00145-5
10.3390/children5100137
10.5281/zenodo.1305971
10.5281/zenodo.4290717
10.5281/zenodo.3686602
10.5281/zenodo.4293357
10.5281/zenodo.4027119
10.5281/zenodo.7010595
10.1103/physrevfluids.7.034501
10.5281/zenodo.4525749
10.5281/zenodo.7277738
10.5281/zenodo.3902723
10.5281/zenodo.7096809
10.5281/zenodo.7111441
10.5194/esd-11-751-2020
10.1016/j.ijmultiphaseflow.2022.104153
10.5281/zenodo.1135095
10.1038/nmeth.3959
10.1128/mSystems.00937-21
10.5281/zenodo.5842611
10.5281/zenodo.7150823
10.5281/zenodo.4242056
10.5281/zenodo.581179
10.5281/zenodo.823562
10.5281/zenodo.4584626
10.5281/zenodo.47144
10.1016/j.marpolbul.2018.09.019
10.5281/zenodo.997294
10.5281/zenodo.5800123
10.1016/j.jcp.2020.109979
10.5281/zenodo.5809671
10.5281/zenodo.47325
10.5281/zenodo.6821889
10.5281/zenodo.5957173
10.5281/zenodo.6344841
10.5281/zenodo.3829891
10.5281/zenodo.1168379
10.5281/zenodo.321917
10.5281/zenodo.572818
10.5281/zenodo.838671
10.5281/zenodo.7646708
10.5281/zenodo.5725301
10.5281/zenodo.2635591
10.4208/cicp.oa-2021-0182
```
This list contains 71 valid DOIs (of which one URL, some with extra white space surrounding the DOI), one DOI that does not exist and one line that does not contain a DOI. The wrong lines should generate an error. You can also disable adding some mentions after inspecting them.
* Create a project page and add the following 75 DataCite mentions as *impact*:
```
10.5281/zenodo.1429520
10.5281/zenodo.3244998
10.5281/zenodo.3383755
10.5281/zenodo.7421802
10.5281/zenodo.5864811
10.5281/zenodo.1420142
10.5281/zenodo.4679406
10.5281/zenodo.2638710
10.5281/zenodo.7015183
10.5281/zenodo.1219840
10.5281/zenodo.2639286
10.5281/zenodo.1435005
10.5281/zenodo.7746407
10.5281/zenodo.996374
10.5281/zenodo.1318953
10.5281/zenodo.3678631
10.5281/zenodo.4059590
10.5281/zenodo.7430545
10.5281/zenodo.5506884
10.5281/zenodo.7712054
10.5281/zenodo.1174017
10.5281/zenodo.2156236
10.5281/zenodo.5196084
10.5281/zenodo.5146351
10.5281/zenodo.1065436
10.5281/zenodo.7211883
10.5281/zenodo.7707606
10.5281/zenodo.7043054
10.5281/zenodo.6619933
10.5281/zenodo.4311332
10.5281/zenodo.6704011
10.5281/zenodo.1443228
10.5281/zenodo.854679
10.5281/zenodo.7387004
10.5281/zenodo.4055954
10.5281/zenodo.7687471
10.5281/zenodo.3873089
10.5281/zenodo.5873399
10.5281/zenodo.1050358
10.5281/zenodo.5068521
10.5281/zenodo.5534586
10.5281/zenodo.7680187
10.5281/zenodo.1443236
10.5281/zenodo.7055787
10.5281/zenodo.5638044
10.5281/zenodo.7275833
10.5281/zenodo.60929
10.5281/zenodo.6617131
10.5281/zenodo.6380951
10.5281/zenodo.7669373
10.5281/zenodo.1050359
10.5281/zenodo.1129323
10.5281/zenodo.7760575
10.5281/zenodo.910906
10.5281/zenodo.1308781
10.5281/zenodo.5790782
10.5281/zenodo.5790783
10.5281/zenodo.1064674
10.5281/zenodo.3813612
10.5281/zenodo.1064599
10.5281/zenodo.1175883
10.5281/zenodo.50388
10.5281/zenodo.4679411
10.5281/zenodo.5128614
10.5281/zenodo.3964548
10.5281/zenodo.5179931
10.5281/zenodo.23391
10.5281/zenodo.51692
10.5281/zenodo.1506510
10.5281/zenodo.5113904
10.5281/zenodo.13559
10.5281/zenodo.4201949
10.5281/zenodo.4770035
10.5281/zenodo.7685495
10.5281/zenodo.1402677
```
* Add the following 75 Crossref mentions as *output*:
```
10.1093/mnras/stx2721
10.1016/j.future.2018.12.026
10.1016/j.atherosclerosis.2015.09.005
10.1021/jacsau.1c00228
10.1021/acs.jcim.6b00686
10.1002/essoar.10501325.1
10.21105/joss.02411
10.5194/esd-12-253-2021
10.1117/12.2547459
10.1615/int.j.uncertaintyquantification.2022039993
10.1007/s00592-018-1161-8
10.1051/0004-6361/201732020
10.3390/jcm8071053
10.5117/ccr2022.2.007.hage
10.1093/nar/gkv303
10.1029/2021ms002892
10.1186/s13063-018-3067-8
10.1186/s13063-018-2923-x
10.3390/metabo12010087
10.1117/12.2608611
10.1111/tgis.12855
10.1145/3520304.3533995
10.1021/acs.analchem.8b05112
10.1145/3449639.3459306
10.1109/aciiw.2019.8925059
10.1111/tgis.12692
10.1175/jas-d-15-0215.1
10.21105/joss.04494
10.1103/physreve.99.043309
10.12688/f1000research.54159.1
10.5194/egusphere-egu23-9026
10.1145/3453141
10.1038/s41598-019-46771-y
10.1039/D1NP00023C
10.1038/s41589-021-00949-6
10.1007/978-3-030-22747-0_20
10.1002/qj.4401
10.1038/s41467-021-22616-z
10.1016/j.buildenv.2020.107109
10.5194/egusphere-egu23-13859
10.1017/S0033291717000186
10.1186/s12887-018-1301-x
10.5194/ems2022-407
10.1111/tgis.12939
10.3390/ijgi11120629
10.5194/esd-11-1233-2020
10.1007/s11332-019-00527-3
10.1098/rsta.2020.0221
10.1186/s13321-022-00656-x
10.1186/1471-2105-9-399
10.1016/j.apsusc.2020.148836
10.1016/j.phanu.2013.11.027
10.1145/2996913.2997005
10.1029/2021jc017372
10.1093/nar/gkr310
10.1093/bioinformatics/btac596
10.1016/j.softx.2020.100626
10.1145/3460210.3493559
10.1007/s00500-020-05243-6
10.1186/s13321-021-00529-9
10.1186/s13321-022-00620-9
10.7717/peerj.13712
10.1021/acs.biochem.9b00735
10.1021/acs.jctc.0c00147
10.1109/pmbs56514.2022.00010
10.1109/access.2021.3113892
10.1016/j.ygeno.2022.110280
10.1088/1742-6596/1525/1/012041
10.1021/acs.iecr.0c05845
10.1016/S1474-4422(18)30203-5
10.3897/rio.5.e35820
10.1109/eScience.2018.00069
10.1111/fog.12596
10.1186/s13321-021-00485-4
10.18174/551416
```
* Play around with the functionality a bit more
* Add a single mention by searching for the following title (which contains a double space): `Automatic extraction of  ingredient's substitutes`. A result should be found.


Closes #745
Closes #786
Closes #795

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [X] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
