### PR TITLE
Specify required dependencies in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ This repo contains the new RSD-as-a-service implementation
 
 ### Building from source code
 
-1. Before installing the dependencies ensure that you have Docker and docker-compose locally.
-2. Set the required environment variables:
+1. Before installing the dependencies ensure that you have `Docker` and `docker-compose` locally.
+2. You will also need `make` and [`yarn`](https://yarnpkg.com) to automate the configuration and installation process.
+3. Set the required environment variables:
    Copy the file `.env.example` to `.env` file at the root of the project
    and fill the secrets and passwords. Check if the secrets are correct.
    The `Makefile` will take care about creating an appropriate `frontend/.env.local`
    from the `.env` file.
-3. Run `make install` to install all dependencies and build the docker images.
+4. Run `make install` to install all dependencies and build the docker images.
 
 ### Running the services
 

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -14,7 +14,12 @@ SPDX-License-Identifier: CC-BY-4.0
 
 To run the application locally you need to install the following dependencies:
 
-*   Docker
+* [Docker](https://docs.docker.com/get-docker/)
+* [`yarn`](https://yarnpkg.com)
+* `make`
+  * Available in most Linux distributions.
+  * Often also in MacOS systems but, if not, you can get it by installing the command line tools with `xcode-select --install`.
+  * For Windows, you can install it via [`chocolatey`](https://community.chocolatey.org/packages/make).
 
 ## Get Started
 


### PR DESCRIPTION
# Specify required dependencies in documentation

Fixes https://github.com/research-software-directory/RSD-as-a-service/issues/796

Changes proposed in this pull request:

* Update the README and the Getting Started section of the documentation to include `make` and `yarn` as dependencies.
* Documentation gets built correctly with `make dev` but I had to run `yarn install` in the docs folder, first. This updated `yarn.lock` and created a couple of other `yarn` related files. I've not committed those files, but let me know if you want them.

How to test:

* Just check if the documentation is there.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [x] Tests
