### PR TITLE
fix: meta description of organisation uses 0 instead of null when no software packages

### DIFF
--- a/frontend/pages/organisations/[...slug].tsx
+++ b/frontend/pages/organisations/[...slug].tsx
@@ -71,12 +71,19 @@ export default function OrganisationPage({organisation,slug,page,ror}:Organisati
     }
   }
 
+  function getMetaDescription() {
+    // use organisation (short) description if available
+    if (organisation.description) return organisation.description
+    // else generate description message
+    return `${organisation?.name ?? 'The organisation'} participates in the RSD with ${organisation.software_cnt ?? 0} software package(s) and ${organisation.project_cnt ?? 0} project(s).`
+  }
+
   return (
     <DefaultLayout>
       {/* Page Head meta tags */}
       <PageMeta
         title={`${organisation?.name} | ${app.title}`}
-        description={organisation.description ?? `The organisation participates in RSD with ${organisation.software_cnt} registered software item(s).`}
+        description={getMetaDescription()}
       />
       <SearchProvider>
       <PaginationProvider>


### PR DESCRIPTION
# Fix null to be 0 in meta description

Fixes #821

Changes proposed in this pull request:
* Meta data description on the organisation page:
     * uses the value from organisation description (later should be updated to short_description)
     * if description is null then the following text is generated:
`{OrganisationName} participates in the RSD with X software package(s) and Y project(s).`

How to test:
* `make start` to build app
* navigate to organisation page and paginate until you find an organisation with 0 software items.
* navigate to page, open developer tools (usually F12), Elements tab (see printscreen). Confirm that html head has meta tag description with the appropriate content (uses 0 instead of null) 

## Developer tools, Elements tab, meta tag description
![image](https://user-images.githubusercontent.com/9204081/229772867-b3ae04ee-031d-40d7-b883-beadc29147e1.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
