### PR TITLE
828 fix: change order to title when search value is provided

### DIFF
--- a/database/103-software-views.sql
+++ b/database/103-software-views.sql
@@ -17,34 +17,31 @@ CREATE FUNCTION software_overview() RETURNS TABLE (
 	keywords CITEXT[],
 	keywords_text TEXT,
 	prog_lang TEXT[]
-) LANGUAGE plpgsql STABLE AS
+) LANGUAGE sql STABLE AS
 $$
-BEGIN
-	RETURN QUERY
-	SELECT
-		software.id,
-		software.slug,
-		software.brand_name,
-		software.short_statement,
-		software.updated_at,
-		count_software_countributors.contributor_cnt,
-		count_software_mentions.mention_cnt,
-		software.is_published,
-		keyword_filter_for_software.keywords,
-		keyword_filter_for_software.keywords_text,
-		prog_lang_filter_for_software.prog_lang
-	FROM
-		software
-	LEFT JOIN
-		count_software_countributors() ON software.id=count_software_countributors.software
-	LEFT JOIN
-		count_software_mentions() ON software.id=count_software_mentions.software
-	LEFT JOIN
-		keyword_filter_for_software() ON software.id=keyword_filter_for_software.software
-	LEFT JOIN
-		prog_lang_filter_for_software() ON software.id=prog_lang_filter_for_software.software
-	;
-END
+SELECT
+	software.id,
+	software.slug,
+	software.brand_name,
+	software.short_statement,
+	software.updated_at,
+	count_software_countributors.contributor_cnt,
+	count_software_mentions.mention_cnt,
+	software.is_published,
+	keyword_filter_for_software.keywords,
+	keyword_filter_for_software.keywords_text,
+	prog_lang_filter_for_software.prog_lang
+FROM
+	software
+LEFT JOIN
+	count_software_countributors() ON software.id=count_software_countributors.software
+LEFT JOIN
+	count_software_mentions() ON software.id=count_software_mentions.software
+LEFT JOIN
+	keyword_filter_for_software() ON software.id=keyword_filter_for_software.software
+LEFT JOIN
+	prog_lang_filter_for_software() ON software.id=prog_lang_filter_for_software.software
+;
 $$;
 
 
@@ -65,49 +62,49 @@ CREATE FUNCTION software_search(search VARCHAR) RETURNS TABLE (
 ) LANGUAGE sql STABLE AS
 $$
 SELECT
-  software.id,
-  software.slug,
-  software.brand_name,
-  software.short_statement,
-  software.updated_at,
-  count_software_countributors.contributor_cnt,
-  count_software_mentions.mention_cnt,
-  software.is_published,
-  keyword_filter_for_software.keywords,
-  keyword_filter_for_software.keywords_text,
-  prog_lang_filter_for_software.prog_lang
+	software.id,
+	software.slug,
+	software.brand_name,
+	software.short_statement,
+	software.updated_at,
+	count_software_countributors.contributor_cnt,
+	count_software_mentions.mention_cnt,
+	software.is_published,
+	keyword_filter_for_software.keywords,
+	keyword_filter_for_software.keywords_text,
+	prog_lang_filter_for_software.prog_lang
 FROM
-  software
+	software
 LEFT JOIN
-  count_software_countributors() ON software.id=count_software_countributors.software
+	count_software_countributors() ON software.id=count_software_countributors.software
 LEFT JOIN
-  count_software_mentions() ON software.id=count_software_mentions.software
+	count_software_mentions() ON software.id=count_software_mentions.software
 LEFT JOIN
-  keyword_filter_for_software() ON software.id=keyword_filter_for_software.software
+	keyword_filter_for_software() ON software.id=keyword_filter_for_software.software
 LEFT JOIN
-  prog_lang_filter_for_software() ON software.id=prog_lang_filter_for_software.software
+	prog_lang_filter_for_software() ON software.id=prog_lang_filter_for_software.software
 WHERE
-  software.brand_name ILIKE CONCAT('%', search, '%')
-  OR
-  software.slug ILIKE CONCAT('%', search, '%')
-  OR
-  software.short_statement ILIKE CONCAT('%', search, '%')
-  OR
-  keyword_filter_for_software.keywords_text ILIKE CONCAT('%', search, '%')
+	software.brand_name ILIKE CONCAT('%', search, '%')
+	OR
+	software.slug ILIKE CONCAT('%', search, '%')
+	OR
+	software.short_statement ILIKE CONCAT('%', search, '%')
+	OR
+	keyword_filter_for_software.keywords_text ILIKE CONCAT('%', search, '%')
 ORDER BY
-  CASE
+	CASE
 		WHEN brand_name ILIKE search THEN 0
 		WHEN brand_name ILIKE CONCAT(search, '%') THEN 1
 		WHEN brand_name ILIKE CONCAT('%', search, '%') THEN 2
 		ELSE 3
 	END,
-  CASE
+	CASE
 		WHEN slug ILIKE search THEN 0
 		WHEN slug ILIKE CONCAT(search, '%') THEN 1
 		WHEN slug ILIKE CONCAT('%', search, '%') THEN 2
 		ELSE 3
 	END,
-  CASE
+	CASE
 		WHEN short_statement ILIKE search THEN 0
 		WHEN short_statement ILIKE CONCAT(search, '%') THEN 1
 		WHEN short_statement ILIKE CONCAT('%', search, '%') THEN 2

--- a/database/103-software-views.sql
+++ b/database/103-software-views.sql
@@ -1,0 +1,117 @@
+-- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+-- SPDX-FileCopyrightText: 2023 dv4all
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- SOFTWARE OVERVIEW LIST
+-- WITH COUNTS and KEYWORDS for filtering
+CREATE FUNCTION software_overview() RETURNS TABLE (
+	id UUID,
+	slug VARCHAR,
+	brand_name VARCHAR,
+	short_statement VARCHAR,
+	updated_at TIMESTAMPTZ,
+	contributor_cnt BIGINT,
+	mention_cnt BIGINT,
+	is_published BOOLEAN,
+	keywords CITEXT[],
+	keywords_text TEXT,
+	prog_lang TEXT[]
+) LANGUAGE plpgsql STABLE AS
+$$
+BEGIN
+	RETURN QUERY
+	SELECT
+		software.id,
+		software.slug,
+		software.brand_name,
+		software.short_statement,
+		software.updated_at,
+		count_software_countributors.contributor_cnt,
+		count_software_mentions.mention_cnt,
+		software.is_published,
+		keyword_filter_for_software.keywords,
+		keyword_filter_for_software.keywords_text,
+		prog_lang_filter_for_software.prog_lang
+	FROM
+		software
+	LEFT JOIN
+		count_software_countributors() ON software.id=count_software_countributors.software
+	LEFT JOIN
+		count_software_mentions() ON software.id=count_software_mentions.software
+	LEFT JOIN
+		keyword_filter_for_software() ON software.id=keyword_filter_for_software.software
+	LEFT JOIN
+		prog_lang_filter_for_software() ON software.id=prog_lang_filter_for_software.software
+	;
+END
+$$;
+
+
+-- SOFTWARE OVERVIEW LIST FOR SEARCH
+-- WITH COUNTS and KEYWORDS for filtering
+CREATE FUNCTION software_search(search VARCHAR) RETURNS TABLE (
+	id UUID,
+	slug VARCHAR,
+	brand_name VARCHAR,
+	short_statement VARCHAR,
+	updated_at TIMESTAMPTZ,
+	contributor_cnt BIGINT,
+	mention_cnt BIGINT,
+	is_published BOOLEAN,
+	keywords CITEXT[],
+	keywords_text TEXT,
+	prog_lang TEXT[]
+) LANGUAGE sql STABLE AS
+$$
+SELECT
+  software.id,
+  software.slug,
+  software.brand_name,
+  software.short_statement,
+  software.updated_at,
+  count_software_countributors.contributor_cnt,
+  count_software_mentions.mention_cnt,
+  software.is_published,
+  keyword_filter_for_software.keywords,
+  keyword_filter_for_software.keywords_text,
+  prog_lang_filter_for_software.prog_lang
+FROM
+  software
+LEFT JOIN
+  count_software_countributors() ON software.id=count_software_countributors.software
+LEFT JOIN
+  count_software_mentions() ON software.id=count_software_mentions.software
+LEFT JOIN
+  keyword_filter_for_software() ON software.id=keyword_filter_for_software.software
+LEFT JOIN
+  prog_lang_filter_for_software() ON software.id=prog_lang_filter_for_software.software
+WHERE
+  software.brand_name ILIKE CONCAT('%', search, '%')
+  OR
+  software.slug ILIKE CONCAT('%', search, '%')
+  OR
+  software.short_statement ILIKE CONCAT('%', search, '%')
+  OR
+  keyword_filter_for_software.keywords_text ILIKE CONCAT('%', search, '%')
+ORDER BY
+  CASE
+		WHEN brand_name ILIKE search THEN 0
+		WHEN brand_name ILIKE CONCAT(search, '%') THEN 1
+		WHEN brand_name ILIKE CONCAT('%', search, '%') THEN 2
+		ELSE 3
+	END,
+  CASE
+		WHEN slug ILIKE search THEN 0
+		WHEN slug ILIKE CONCAT(search, '%') THEN 1
+		WHEN slug ILIKE CONCAT('%', search, '%') THEN 2
+		ELSE 3
+	END,
+  CASE
+		WHEN short_statement ILIKE search THEN 0
+		WHEN short_statement ILIKE CONCAT(search, '%') THEN 1
+		WHEN short_statement ILIKE CONCAT('%', search, '%') THEN 2
+		ELSE 3
+	END
+;
+$$;

--- a/e2e/helpers/userAgreement.ts
+++ b/e2e/helpers/userAgreement.ts
@@ -59,7 +59,7 @@ export async function acceptUserAgreement(page: Page) {
     }
 
     // get OK button
-    const okBtn = uaModal.getByRole('button', {name: 'OK'})
+    const okBtn = uaModal.getByRole('button', {name: 'Accept'})
     // we need to wait a bit for state to change
     okBtn.waitFor({state:'visible'})
     expect(await okBtn.isEnabled()).toBe(true)

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {MouseEvent, ChangeEvent} from 'react'
-import Head from 'next/head'
 import {GetServerSidePropsContext} from 'next'
 import {useRouter} from 'next/router'
 
@@ -17,6 +16,7 @@ import {ProjectSearchRpc} from '~/types/Project'
 import {getProjectList} from '~/utils/getProjects'
 import {ssrProjectsParams} from '~/utils/extractQueryParam'
 import {projectListUrl, ssrProjectsUrl} from '~/utils/postgrestUrl'
+import {getBaseUrl} from '~/utils/fetchHelpers'
 import Searchbox from '~/components/form/Searchbox'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import PageTitle from '~/components/layout/PageTitle'
@@ -26,6 +26,7 @@ import {getResearchDomainInfo, ResearchDomain} from '~/components/projects/filte
 import {useAdvicedDimensions} from '~/components/layout/FlexibleGridSection'
 import PageMeta from '~/components/seo/PageMeta'
 import CanonicalUrl from '~/components/seo/CanonicalUrl'
+import {sortBySearchFor} from '~/utils/sortFn'
 
 type ProjectsIndexPageProps = {
   count: number,
@@ -39,7 +40,6 @@ type ProjectsIndexPageProps = {
 
 const pageTitle = `Projects | ${app.title}`
 const pageDesc = 'The list of research projects registerd in the Research Software Directory.'
-
 
 export default function ProjectsIndexPage(
   {projects=[], count, page, rows, search, keywords,domains}: ProjectsIndexPageProps
@@ -173,16 +173,16 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const {search, rows, page, keywords, domains} = ssrProjectsParams(context.query)
 
   const url = projectListUrl({
-    baseUrl: process.env.POSTGREST_URL || 'http://localhost:3500',
+    baseUrl: getBaseUrl(),
     search,
     keywords,
     domains,
-    order: 'current_state.desc,date_start.desc,title',
+    // when search is used the order is already applied in the rpc
+    order: search ? undefined : 'current_state.desc,date_start.desc,title',
     limit: rows,
     offset: rows * page,
   })
 
-  // console.log('projects...url...', url)
   // get project list and domains filter info,
   // 1. we do not pass the token
   // when token is passed it will return not published items too

--- a/frontend/utils/postgrestUrl.test.ts
+++ b/frontend/utils/postgrestUrl.test.ts
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -87,31 +87,32 @@ describe('ssrSoftwareUrl', () => {
 })
 
 describe('softwareListUrl', () => {
-  it('returns postgrest endpoint url when only baseUrl provided', () => {
+  it('returns overview rpc endpoint url when only baseUrl provided', () => {
     const baseUrl = 'http://test-base-url'
-    const expectUrl = `${baseUrl}/rpc/software_search?limit=12&offset=0`
+    const expectUrl = `${baseUrl}/rpc/software_overview?limit=12&offset=0`
     const url = softwareListUrl({
       baseUrl
     } as PostgrestParams)
     expect(url).toEqual(expectUrl)
   })
 
-  it('returns postgrest endpoint url with search params', () => {
+  it('returns search rpc endpoint url with search params', () => {
     const baseUrl = 'http://test-base-url'
+    const searchTerm = 'test-search'
     // if you change search value then change expectedUrl values too
-    const expectUrl = `${baseUrl}/rpc/software_search?limit=12&offset=0&or=(brand_name.ilike.*test-search*,short_statement.ilike.*test-search*,keywords_text.ilike.*test-search*)`
+    const expectUrl = `${baseUrl}/rpc/software_search?limit=12&offset=0&search=${searchTerm}`
     const url = softwareListUrl({
       baseUrl,
       // if you change search value then change expectedUrl values too
-      search: 'test-search'
+      search: searchTerm
     } as PostgrestParams)
     expect(url).toEqual(expectUrl)
   })
 
-  it('returns postgrest endpoint url with keywords params', () => {
+  it('returns overview rpc endpoint url with keywords params', () => {
     const baseUrl = 'http://test-base-url'
     // if you change search value then change expectedUrl values too
-    const expectUrl = `${baseUrl}/rpc/software_search?keywords=cs.%7B\"test-filter\"%7D&limit=12&offset=0`
+    const expectUrl = `${baseUrl}/rpc/software_overview?keywords=cs.%7B\"test-filter\"%7D&limit=12&offset=0`
     const url = softwareListUrl({
       baseUrl,
       keywords: ['test-filter']
@@ -148,31 +149,32 @@ describe('ssrProjectsUrl', () => {
 })
 
 describe('projectListUrl', () => {
-  it('returns postgrest endpoint url when only baseUrl provided', () => {
+  it('returns overview rpc endpoint url when only baseUrl provided', () => {
     const baseUrl = 'http://test-base-url'
-    const expectUrl = `${baseUrl}/rpc/project_search?limit=12&offset=0`
+    const expectUrl = `${baseUrl}/rpc/project_overview?limit=12&offset=0`
     const url = projectListUrl({
       baseUrl
     } as PostgrestParams)
     expect(url).toEqual(expectUrl)
   })
 
-  it('returns postgrest endpoint url with search params', () => {
+  it('returns search rpc endpoint url with search param', () => {
     const baseUrl = 'http://test-base-url'
+    const searchTerm = 'test-search'
     // if you change search value then change expectedUrl values too
-    const expectUrl = `${baseUrl}/rpc/project_search?limit=12&offset=0&or=(title.ilike.*test-search*,subtitle.ilike.*test-search*,keywords_text.ilike.*test-search*,research_domain_text.ilike.*test-search*)`
+    const expectUrl = `${baseUrl}/rpc/project_search?limit=12&offset=0&search=${searchTerm}`
     const url = projectListUrl({
       baseUrl,
       // if you change search value then change expectedUrl values too
-      search: 'test-search'
+      search: searchTerm
     } as PostgrestParams)
     expect(url).toEqual(expectUrl)
   })
 
-  it('returns postgrest endpoint url with keywords params', () => {
+  it('returns overview rpc endpoint url with keywords params', () => {
     const baseUrl = 'http://test-base-url'
     // if you change search value then change expectedUrl values too
-    const expectUrl = `${baseUrl}/rpc/project_search?keywords=cs.%7B\"test-filter\"%7D&limit=12&offset=0`
+    const expectUrl = `${baseUrl}/rpc/project_overview?keywords=cs.%7B\"test-filter\"%7D&limit=12&offset=0`
     const url = projectListUrl({
       baseUrl,
       keywords: ['test-filter']
@@ -180,10 +182,10 @@ describe('projectListUrl', () => {
     expect(url).toEqual(expectUrl)
   })
 
-  it('returns postgrest endpoint url with research_domain params', () => {
+  it('returns overview rpc endpoint url with research_domain params', () => {
     const baseUrl = 'http://test-base-url'
     // if you change values then change expectedUrl values too
-    const expectUrl = `${baseUrl}/rpc/project_search?research_domain=cs.%7B\"test-filter\"%7D&limit=12&offset=0`
+    const expectUrl = `${baseUrl}/rpc/project_overview?research_domain=cs.%7B\"test-filter\"%7D&limit=12&offset=0`
     const url = projectListUrl({
       baseUrl,
       domains: ['test-filter']

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -231,47 +231,43 @@ export function baseQueryString(props: baseQueryStringProps) {
 }
 
 export function softwareListUrl(props: PostgrestParams) {
-  const {baseUrl, search, keywords} = props
+  const {baseUrl, search} = props
   let query = baseQueryString(props)
 
   if (search) {
     // console.log('softwareListUrl...keywords...', props.keywords)
     const encodedSearch = encodeURIComponent(search)
-    query += `&or=(brand_name.ilike.*${encodedSearch}*,short_statement.ilike.*${encodedSearch}*`
-    // if keyword filter is not used we search in keywords_text too!
-    if (typeof keywords === 'undefined' || keywords === null) {
-      query += `,keywords_text.ilike.*${encodedSearch}*`
-    }
-    // close or clause
-    query += ')'
+    // search query is performed in software_search RPC
+    // we search in title,subtitle,slug,keywords_text and prog_lang
+    // check rpc in 105-project-views.sql for exact filtering
+    query += `&search=${encodedSearch}`
+
+    const url = `${baseUrl}/rpc/software_search?${query}`
+    // console.log('softwareListUrl...', url)
+    return url
   }
 
-  const url = `${baseUrl}/rpc/software_search?${query}`
+  const url = `${baseUrl}/rpc/software_overview?${query}`
   // console.log('softwareListUrl...', url)
   return url
 }
 
 
 export function projectListUrl(props: PostgrestParams) {
-  const {baseUrl, search, keywords, domains} = props
+  const {baseUrl, search} = props
   let query = baseQueryString(props)
 
   if (search) {
     const encodedSearch = encodeURIComponent(search)
-    query += `&or=(title.ilike.*${encodedSearch}*,subtitle.ilike.*${encodedSearch}*`
-    // if keyword filter is not applied we search in keyword_text too!
-    if (typeof keywords === 'undefined' || keywords === null) {
-      query += `,keywords_text.ilike.*${encodedSearch}*`
-    }
-    // if domains filter is not applied we search in research_domain_text too!
-    if (typeof domains === 'undefined' || domains === null) {
-      query += `,research_domain_text.ilike.*${encodedSearch}*`
-    }
-    // close or clause
-    query+=')'
-  }
+    // search query is performed in project_search RPC
+    // we search in title,subtitle,slug,keywords_text and research domains_text
+    // check rpc in 105-project-views.sql for exact filtering
+    query += `&search=${encodedSearch}`
 
-  const url = `${baseUrl}/rpc/project_search?${query}`
-  // console.log('projectListUrl...',url)
+    const url = `${baseUrl}/rpc/project_search?${query}`
+    return url
+  }
+  // if search term is not used we use different RPC (more performant)
+  const url = `${baseUrl}/rpc/project_overview?${query}`
   return url
 }


### PR DESCRIPTION
# Change card order when search term is applied in software and project overview

Closes #828

Changes proposed in this pull request:
* The card order on project overview page is set on start date and project status by default etc. When search term is applied this order is not logical. More logical order is "best match" of used search term in project title or subtitle.
* The card order on software overview page is set on mentions and contributors count by default. When search term is applied this order is not logical. More logical order is "best match" of used search term in project title or subtitle.
* To facilitate logical order when search is used we introduced new rpc with built in order when search is used.

How to test:
* `make start` to build app
* navigate to project overview page. Use search for `project: a`, the software with matching title should be listed first
* test used of filters too
* navigate to software overview page. Use search for specific software name `real software: a` and observe the order of the cards.
* test use of filters too

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
