### PR TITLE
Remove order from software overview FE code

### DIFF
--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 - 2023 dv4all
 # SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 Netherlands eScience Center
-# SPDX-FileCopyrightText: 2022 dv4all
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -51,8 +51,10 @@ jobs:
         run: |
           JAVA_HOME=$JAVA_HOME_17_X64 mvn test
 
-  e2e-tests:
-    timeout-minutes: 60
+  e2e-chrome:
+    # wait fe test to finish first
+    needs: fe-tests
+    timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
@@ -61,26 +63,49 @@ jobs:
         node-version: 18.5
         cache: 'npm'
         cache-dependency-path: e2e/package-lock.json
+    - name: get playwright version
+      id: playwright-version
+      working-directory: e2e
+      run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+    - name: cache playwright binaries
+      uses: actions/cache@v3
+      id: playwright-cache
+      with:
+        path: |
+          ~/.cache/ms-playwright
+        key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
     - name: install dependencies
       working-directory: e2e
       run: npm ci
     - name: install browsers
       working-directory: e2e
-      run: npx playwright install --with-deps
+      run: npx playwright install chromium chrome --with-deps
+      if: steps.playwright-cache.outputs.cache-hit != 'true'
     - name: build rsd
+      working-directory: .
       run: |
         cp e2e/.env.e2e .env
-        docker-compose build --parallel database backend auth frontend nginx swagger
+        docker-compose build --parallel database backend auth frontend nginx
     - name: start rsd
+      working-directory: .
       run: |
         docker-compose up --detach database backend auth frontend nginx swagger
-        sleep 10
-    - name: run e2e tests
+        sleep 5
+    - name: run e2e tests in chrome
       working-directory: e2e
-      run: npm run e2e:all
+      run: npm run e2e:chrome:action
     - uses: actions/upload-artifact@v3
       if: always()
       with:
         name: playwright-report
         path: e2e/playwright-report/
         retention-days: 30
+    - uses: actions/upload-artifact@v3
+      if: failure()
+      with:
+        name: browser state and .env file
+        path: |
+          e2e/state/
+          .env
+        retention-days: 30
+

--- a/.github/workflows/e2e_tests_chrome.yml
+++ b/.github/workflows/e2e_tests_chrome.yml
@@ -55,7 +55,7 @@ jobs:
       run: npm ci
     - name: install browsers
       working-directory: e2e
-      run: npx playwright install chromium chrome firefox --with-deps
+      run: npx playwright install chromium chrome --with-deps
       if: steps.playwright-cache.outputs.cache-hit != 'true'
     - name: build rsd
       working-directory: .
@@ -65,7 +65,7 @@ jobs:
     - name: start rsd
       working-directory: .
       run: |
-        docker-compose up --detach --scale scrapers=0
+        docker-compose up --detach database backend auth frontend nginx swagger
         sleep 5
     - name: run e2e tests in chrome
       working-directory: e2e

--- a/.github/workflows/e2e_tests_firefox.yml
+++ b/.github/workflows/e2e_tests_firefox.yml
@@ -47,7 +47,7 @@ jobs:
     - name: start rsd
       working-directory: .
       run: |
-        docker-compose up --detach --scale scrapers=0
+        docker-compose up --detach database backend auth frontend nginx swagger
         sleep 5
     - name: run e2e tests in firefox
       working-directory: e2e

--- a/.github/workflows/e2e_tests_ubuntu.yml
+++ b/.github/workflows/e2e_tests_ubuntu.yml
@@ -48,7 +48,7 @@ jobs:
     - name: start rsd
       working-directory: .
       run: |
-        docker-compose up --detach --scale scrapers=0
+        docker-compose up --detach database backend auth frontend nginx swagger
         sleep 5
     - name: run e2e tests
       working-directory: e2e

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -196,13 +196,6 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // when token is passed it will return not published items too
   const software = await getSoftwareList({url})
 
-  // order returned selection by best match on search term
-  // NOTE! this is not complete database order, only items of returned page
-  let data = software.data
-  if (search && data.length > 0) {
-    data = data.sort((a, b) => sortBySearchFor(a, b, 'brand_name', search))
-  }
-
   // will be passed as props to page
   // see params of SoftwareIndexPage function
   return {
@@ -213,7 +206,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       count: software.count,
       page,
       rows,
-      software: data,
+      software: software.data,
     },
   }
 }


### PR DESCRIPTION
# Remove order from software overview FE code

We created rpc for software search which implements order on the best match of used search term.

Changes proposed in this pull request:
* Remove FE order from software overview page
* Update all_test CI action to use only e2e tests in chrome (improved performance and reliability)
* Do not install firefox in e2e chrome action (not needed)      

How to test:
* `make start` to build app
* navigate to software and use search. The order of "cards" should be by best match on used search term
* manually run all_test action from github actions

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
