### PR TITLE
build: replace docker-compose with the docker compose CLI plugin

### DIFF
--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: "newman tests with docker-compose"
+      - name: "newman tests with docker compose"
         working-directory: backend-postgrest/tests
         run: |
-          docker-compose up \
+          docker compose up \
             --abort-on-container-exit \
             --exit-code-from postgrest-tests
 
@@ -85,11 +85,11 @@ jobs:
       working-directory: .
       run: |
         cp e2e/.env.e2e .env
-        docker-compose build --parallel database backend auth frontend nginx
+        docker compose build --parallel database backend auth frontend nginx
     - name: start rsd
       working-directory: .
       run: |
-        docker-compose up --detach database backend auth frontend nginx swagger
+        docker compose up --detach database backend auth frontend nginx swagger
         sleep 5
     - name: run e2e tests in chrome
       working-directory: e2e

--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -1,6 +1,6 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 dv4all
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -24,9 +24,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: "newman tests with docker-compose"
+      - name: "newman tests with docker compose"
         working-directory: backend-postgrest/tests
         run: |
-          docker-compose up \
+          docker compose up \
             --abort-on-container-exit \
             --exit-code-from postgrest-tests

--- a/.github/workflows/e2e_tests_chrome.yml
+++ b/.github/workflows/e2e_tests_chrome.yml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -61,11 +61,11 @@ jobs:
       working-directory: .
       run: |
         cp e2e/.env.e2e .env
-        docker-compose build --parallel database backend auth frontend nginx
+        docker compose build --parallel database backend auth frontend nginx
     - name: start rsd
       working-directory: .
       run: |
-        docker-compose up --detach database backend auth frontend nginx swagger
+        docker compose up --detach database backend auth frontend nginx swagger
         sleep 5
     - name: run e2e tests in chrome
       working-directory: e2e

--- a/.github/workflows/e2e_tests_firefox.yml
+++ b/.github/workflows/e2e_tests_firefox.yml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -43,11 +43,11 @@ jobs:
       working-directory: .
       run: |
         cp e2e/.env.e2e .env
-        docker-compose build --parallel database backend auth frontend nginx
+        docker compose build --parallel database backend auth frontend nginx
     - name: start rsd
       working-directory: .
       run: |
-        docker-compose up --detach database backend auth frontend nginx swagger
+        docker compose up --detach database backend auth frontend nginx swagger
         sleep 5
     - name: run e2e tests in firefox
       working-directory: e2e

--- a/.github/workflows/e2e_tests_ubuntu.yml
+++ b/.github/workflows/e2e_tests_ubuntu.yml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -44,11 +44,11 @@ jobs:
       working-directory: .
       run: |
         cp e2e/.env.e2e .env
-        docker-compose build --parallel database backend auth frontend nginx
+        docker compose build --parallel database backend auth frontend nginx
     - name: start rsd
       working-directory: .
       run: |
-        docker-compose up --detach database backend auth frontend nginx swagger
+        docker compose up --detach database backend auth frontend nginx swagger
         sleep 5
     - name: run e2e tests
       working-directory: e2e

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,10 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -28,39 +28,39 @@ export DGID
 # Main commands
 # ----------------------------------------------------------------
 start: clean
-	docker-compose build # build all services
-	docker-compose up --scale data-generation=1 --scale scrapers=0 -d
+	docker compose build # build all services
+	docker compose up --scale data-generation=1 --scale scrapers=0 --detach
 	# open http://localhost to see the application running
 
 install: clean
-	docker-compose build database backend auth scrapers nginx   # exclude frontend and wait for the build to finish
-	docker-compose up --scale scrapers=0 -d
-	cd frontend && yarn install -d
-	cd documentation && yarn install -d
-	# Sleep 10 seconds to be sure that docker-compose up is running
+	docker compose build database backend auth scrapers nginx   # exclude frontend and wait for the build to finish
+	docker compose up --scale scrapers=0 --detach
+	cd frontend && yarn install
+	cd documentation && yarn install
+	# Sleep 10 seconds to be sure that docker compose up is running
 	sleep 10
-	docker-compose up --scale data-generation=1 -d
+	docker compose up --scale data-generation=1 --detach
 	# All dependencies are installed. The data migration is runing in the background. You can now run `make dev' to start the application
 
 clean:
-	docker-compose down --volumes
+	docker compose down --volumes
 
 
 dev:
-	docker-compose up --scale scrapers=0 -d
+	docker compose up --scale scrapers=0 --detach
 	make -j 2 dev-docs dev-frontend # Run concurrently
 
 stop:
-	docker-compose down
+	docker compose down
 
 frontend-docker: frontend/.env.local
-	docker-compose build frontend-dev
-	docker-compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
+	docker compose build frontend-dev
+	docker compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
 
 data:
-	docker-compose up --scale data-generation=1 --scale scrapers=0
+	docker compose up --scale data-generation=1 --scale scrapers=0
 	sleep 60
-	docker-compose down
+	docker compose down
 
 # Helper commands
 # -
@@ -78,11 +78,11 @@ dev-frontend: frontend/.env.local
 
 # run end-to-end test locally
 e2e-tests:
-	docker-compose down --volumes
-	docker-compose build --parallel database backend auth frontend nginx
-	docker-compose up --detach --scale scrapers=0
+	docker compose down --volumes
+	docker compose build --parallel database backend auth frontend nginx
+	docker compose up --detach --scale scrapers=0
 	sleep 10
-	docker-compose --file e2e/docker-compose.yml build
-	docker-compose --file e2e/docker-compose.yml up
-	docker-compose down
-	docker-compose --file e2e/docker-compose.yml down --volumes
+	docker compose --file e2e/docker-compose.yml build
+	docker compose --file e2e/docker-compose.yml up
+	docker compose down
+	docker compose --file e2e/docker-compose.yml down --volumes

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ This repo contains the new RSD-as-a-service implementation. The service can be f
 
 ### Building from source code
 
-1. Before installing the dependencies ensure that you have `docker` and `docker compose` locally.
+1. Before installing the dependencies ensure that you have `docker` and `docker compose` V2 (see the [documentation of Docker Compose](https://docs.docker.com/compose/compose-v2/)) locally.
 2. You will also need `make` and [`yarn`](https://yarnpkg.com) to automate the configuration and installation process.
 3. Set the required environment variables:
    Copy the file `.env.example` to `.env` file at the root of the project

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 <!--
 SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
-SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2021 - 2022 Jason Maassen (Netherlands eScience Center) <j.maassen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
 SPDX-FileCopyrightText: 2021 - 2022 dv4all
+SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
 SPDX-FileCopyrightText: 2021 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -37,7 +37,7 @@ This repo contains the new RSD-as-a-service implementation. The service can be f
 
 ### Building from source code
 
-1. Before installing the dependencies ensure that you have `Docker` and `docker-compose` locally.
+1. Before installing the dependencies ensure that you have `docker` and `docker compose` locally.
 2. You will also need `make` and [`yarn`](https://yarnpkg.com) to automate the configuration and installation process.
 3. Set the required environment variables:
    Copy the file `.env.example` to `.env` file at the root of the project
@@ -51,8 +51,8 @@ This repo contains the new RSD-as-a-service implementation. The service can be f
 ```
 # Start the containers via the make file
 make start
-# OR directly use docker-compose
-docker-compose up
+# OR directly use docker compose
+docker compose up
 ```
 
 ### Stopping the services
@@ -60,8 +60,8 @@ docker-compose up
 ```
 # Stop all services via the makefile
 make stop
-# OR directly use docker-compose
-docker-compose down
+# OR directly use docker compose
+docker compose down
 ```
 
 ## Developing the frontend
@@ -71,8 +71,8 @@ You can run frontend in development mode as docker a service (called frontend-de
 ```
 # Run frontend development using docker at http://localhost:3000
 make frontend-docker
-# OR use docker-compose directly
-docker-compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
+# OR use docker compose directly
+docker compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
 ```
 
 It is possible to directly run the frontend too (without using a docker container). You must then have NodeJS installed, preferably v18.
@@ -82,7 +82,7 @@ It is possible to directly run the frontend too (without using a docker containe
 make install
 # Run the frontend and the documentation on localhost:3000 and localhost:3030
 make dev
-# Stop all services with `docker-compose down`
+# Stop all services with `docker compose down`
 make down
 ```
 

--- a/backend-postgrest/tests/README.md
+++ b/backend-postgrest/tests/README.md
@@ -1,35 +1,37 @@
 <!--
 SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2022 dv4all
+SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
 # Research Software Directory (RSD) - PostgREST tests
 
-This service can automatically be build and started with `docker-compose`. It does not work in conjunction with the `data-migration` service. It also assumes that the database is empty at the start.
+This service can automatically be build and started with `docker compose`. It does not work in conjunction with the `data-migration` service. It also assumes that the database is empty at the start.
 
 The service runs its tests using the `newman` npm package. Postman can be used as a GUI for running and editing tests by importing the json file from this directory.
 
 In order to use the collection on Postman, you need to set two (global) variables first:
 
 * `jwt_secret` should have the same value as `PGRST_JWT_SECRET` (as is used by PostgREST)
-* `backend_url` should have the value of the PostgREST url, currently `http://localhost:3500`
+* `backend_url` should have the value of the PostgREST url, currently `http://localhost/api/v1`
 
 ## Build test container
 
 ```bash
-docker-compose build
+docker compose build
 ```
 
 ## Run test locally
 
-From the backend-postgrest directory run the following docker-compose command. It will run tests and remove containers and volumes after performing the tests.
+From the backend-postgrest/tests directory run the following `docker compose` command. It will run tests and remove containers and volumes after performing the tests.
 
 ```bash
 # run test and clean up the containers on exit
-docker-compose up \
+docker compose up \
   --abort-on-container-exit \
   --exit-code-from postgrest-tests \
-  && docker-compose down --volumes
+  && docker compose down --volumes
 ```

--- a/backend-postgrest/tests/docker-compose.yml
+++ b/backend-postgrest/tests/docker-compose.yml
@@ -1,8 +1,8 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 dv4all
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -24,7 +24,7 @@ services:
       - POSTGRES_AUTHENTICATOR_PASSWORD=simplepassword
     volumes:
       # persist data in named docker volume
-      # to remove use: docker-compose down --volumes
+      # to remove use: docker compose down --volumes
       # to inspect use: docker volume ls
       - pgdb-test:/var/lib/postgresql/data/
     networks:
@@ -69,7 +69,7 @@ services:
 networks:
   net-test:
 
-# named volumes can be managed easier using docker-compose
+# named volumes can be managed easier using docker compose
 # volume should have name rsd-as-a-service_pgdb
 volumes:
   pgdb-test:

--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -695,5 +695,5 @@ await postToBackend('/release', idsSoftware.map(id => ({software: id})))
 	.then(() => console.log('releases done'));
 
 console.log('Done');
-// This is unfortunately needed, because when using docker-compose, the node process might hang for a long time
+// This is unfortunately needed, because when using docker compose, the node process might hang for a long time
 process.exit(0);

--- a/data-migration/README.md
+++ b/data-migration/README.md
@@ -1,13 +1,13 @@
 <!--
-SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
+SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2022 dv4all
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
-#DEPRECATED
+# DEPRECATED
 This script is now deprecated and should not be used anymore.
 
 # Data migration

--- a/deployment/.gitignore
+++ b/deployment/.gitignore
@@ -1,11 +1,13 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
-# docker-compose default .env file
+# docker compose default .env file
 .env
 .env.*
 !.env.example

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,33 +1,35 @@
 <!--
 SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2022 dv4all
+SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
 # Deployment of RSD
 
-This readme describes RSD deployment with provided docker-compose.yml and .env.example file.
+This readme describes RSD deployment with provided `docker-compose.yml` and `.env.example` file.
 
 ## Requirements
 
-You need machine with the Docker and Docker-Compose. To validate you can check the versions
+You need a machine with Docker and the Docker Compose CLI plugin. To validate you can check the versions
 
 ```bash
 # check docker exists
 docker --version
-# check docker-compose exists
-docker-compose --version
+# check docker compose exists
+docker compose --version
 ```
 
 ## Environment variables
 
-RSD modules require a number of environment variables to work properly. The values should be provided in .env file which should be at the same location as the docker-compose.yml file. An example environment file `.env.example` is provided. Rename this file to `.env` and provide required secrets.
+RSD modules require a number of environment variables to work properly. The values should be provided in `.env` file which should be at the same location as the `docker-compose.yml` file. An example environment file `.env.example` is provided. Rename this file to `.env` and provide the required secrets.
 
 ## NGINX configuration
 
-The default nginx.conf file is provided. The nginx image is based on nginx:1.21.6 with certbot already installed.
-To enable certbox certificate for your domain you will need to add your domains to nginx.conf file. docker-compose file expects nginx.conf file to be in the same folder.
+The default `nginx.conf` file is provided. The nginx image is based on nginx:1.21.6 with certbot already installed.
+To enable certbox certificate for your domain you will need to add your domains to `nginx.conf file`. The `docker-compose.yml` file expects `nginx.conf` file to be in the same folder.
 
 ## Custom theme
 
@@ -82,29 +84,29 @@ The default index.css and settings.json are already in the frontend image. If yo
 
 ### Start
 
-After you provided required values in .env file and updated domain names in nginx.conf file you can start RSD using `docker-compose up`
+After you provided required values in .env file and updated domain names in nginx.conf file you can start RSD using `docker compose up`
 
 ```bash
-# start solution
-docker-compose up
+# start RSD
+docker compose up
 ```
 
-### Stop solution
+### Stop RSD
 
 ```bash
-docker-compose stop
+docker compose stop
 ```
 
 ### Remove solution
 
 ```bash
 # remove RSD and volumes
-docker-compose down --volumes
+docker compose down --volumes
 ```
 
 ## Volumes and network
 
-In the provided docker-compose file we defined a volume where the database will store the data.
+In the provided `docker-compose.yml` file we define a volume where the database will store the data.
 The internal docker network is also defined.
 
 You can use volume mount in the frontend image to provide custom settings that will overwrite default theme and styles.

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -25,7 +25,7 @@ services:
       - POSTGRES_AUTHENTICATOR_PASSWORD
     volumes:
       # persist data in named docker volume
-      # to remove use: docker-compose down --volumes
+      # to remove use: docker compose down --volumes
       # to inspect use: docker volume ls
       - pgdb:/var/lib/postgresql/data/
     networks:
@@ -176,7 +176,7 @@ services:
 networks:
   net:
 
-# named volumes can be managed easier using docker-compose
+# named volumes can be managed easier using docker compose
 # volume should have name rsd-as-a-service_pgdb
 volumes:
   pgdb:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - POSTGRES_AUTHENTICATOR_PASSWORD
     volumes:
       # persist data in named docker volume
-      # to remove use: docker-compose down --volumes
+      # to remove use: docker compose down --volumes
       # to inspect use: docker volume ls
       - pgdb:/var/lib/postgresql/data/
     networks:
@@ -243,7 +243,7 @@ services:
 networks:
   net:
 
-# named volumes can be managed easier using docker-compose
+# named volumes can be managed easier using docker compose
 # volume should have name rsd-as-a-service_pgdb
 volumes:
   pgdb:

--- a/documentation/docs/getting-started.md
+++ b/documentation/docs/getting-started.md
@@ -1,9 +1,9 @@
 <!--
+SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
-SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
@@ -39,7 +39,7 @@ The RSD-as-a-Service project is a divided into different services included in th
 
 ### Environment variables
 
-The environment variables should be stored in a .env file, which is automatically loaded by docker-compose. To validate loading of env variables use `docker-compose config`. More info about the use of environment variables in docker-compose is available at [official documentation](https://docs.docker.com/compose/environment-variables/)
+The environment variables should be stored in a .env file, which is automatically loaded by docker compose. To validate loading of env variables use `docker compose config`. More info about the use of environment variables in docker compose is available at [official documentation](https://docs.docker.com/compose/environment-variables/)
 
 *   copy the file `.env.example` to `.env` file at the root of the project
 
@@ -53,16 +53,16 @@ cp .env.example .env
 
 ```bash
 # from project root dir
-docker-compose build
+docker compose build
 ```
 
 ## Running locally
 
-Run the command `docker-compose up`.
+Run the command `docker compose up`.
 
 ```bash
 # from project root dir
-docker-compose up
+docker compose up
 ```
 
 The application can be viewed at http://localhost
@@ -131,7 +131,7 @@ Any file `markdown file` added indie the `docs` folder will be available on buil
 To clear the database, if the database structure has changed or you need to run data migration again, run the command:
 
 ```bash
-docker-compose down --volumes
+docker compose down --volumes
 ```
 
 ## Tech Stack

--- a/e2e/README.MD
+++ b/e2e/README.MD
@@ -2,6 +2,8 @@
 SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2021 - 2023 dv4all
 SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: CC-BY-4.0
@@ -13,28 +15,28 @@ The project uses Playwright for end-to-end tests.
 
 ## Running end to end tests
 
-Use `make e2e-test` from the root. It will perform all docker-compose tasks and run all tests.
+Use `make e2e-test` from the root. It will perform all docker compose tasks and run all tests.
 
 To run using the separate steps:
 
-- Run RSD on the localhost using docker-compose
+- Run RSD on the localhost using docker compose
 
 ```bash
 # build
-docker-compose build
+docker compose build
 # start in detached
-docker-compose up -d
+docker compose up --detach
 ```
 
-- Run e2e tests using docker-compose from e2e folder
+- Run e2e tests using docker compose from e2e folder
 
 ```bash
 # navigate to e2e folder
 cd e2e
 # build tests
-docker-compose build
+docker compose build
 # start tests
-docker-compose up
+docker compose up
 ```
 
 ## View test report
@@ -109,7 +111,7 @@ The specific tests are created for generating json files. These test files are i
 1. **Start RSD**
 
 ```bash
-docker-compose up -d
+docker compose up --detach
 ```
 
 2. **Start generate project in headed mode**

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -3,6 +3,8 @@ SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2021 - 2023 dv4all
 SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
@@ -21,7 +23,7 @@ Based on the features in the legacy application and the current requirements we 
 
 - intall dependencies `yarn install`
 - create `.env.local` file. Use `.env.example` from the project root as template.
-- run all app modules `docker-compose up`
+- run all app modules `docker compose up`
 - open another terminal and run `yarn dev` to start frontend in development mode
 
 ### Frontend dev mode via Docker
@@ -40,8 +42,8 @@ Alternatively you can run
 # Export your user and group ids to the variables so Docker will correctly build the frontend-dev container. This is required only if you build the container
 export DUID=$(id -u)
 export DGID=$(id -g)
-docker-compose build frontend-dev
-docker-compose up --scale frontend=0 --scale frontend-dev=1 --scale scrapers=0
+docker compose build frontend-dev
+docker compose up --scale frontend=0 --scale frontend-dev=1 --scale scrapers=0
 ```
 
 ### Environment variables


### PR DESCRIPTION
# Switch to `docker compose` CLI plugin

Changes proposed in this pull request:

* Switch from `docker-compose` to the `docker compose` CLI plugin, see #830 for more info
* Some small textual improvements in the documentation

How to test:

* Follow the installation instructions linked in #830 to install the `docker compose` CLI plugin
* Check that the various commands in the `Makefile` still work, e.g. `make e2e-tests` and `make start`
* Check that I updated the documentation and scripts everywhere, by e.g. doing a global regex-enabled search on `docker-compose(?!\.yml)` (this finds `docker-compose` but not if it is `docker-compose.yml`). I skipped the `data-migration` directory on purpose since it is deprecated.


Closes #830

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [X] Link to a GitHub issue
*   [X] Update documentation
*   [ ] Tests
