### PR TITLE
607 profile name

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
@@ -5,7 +5,6 @@
 
 package nl.esciencecenter.rsd.authentication;
 
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 
@@ -17,12 +16,6 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 
 public class Utils {
-
-	public static String jsonElementToString(JsonElement elementToConvert) {
-		if (elementToConvert == null || elementToConvert.isJsonNull()) return null;
-		if (!elementToConvert.isJsonPrimitive()) return null;
-		return elementToConvert.getAsString();
-	}
 
 	public static URI getTokenUrlFromWellKnownUrl(URI wellKnownUrl) {
 		HttpClient client = HttpClient.newHttpClient();

--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -511,9 +511,11 @@ CREATE POLICY admin_all_rights ON account TO rsd_admin
 
 ALTER TABLE login_for_account ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY maintainer_all_rights ON login_for_account TO rsd_user
-	USING (account IN (SELECT id FROM account))
-	WITH CHECK (account IN (SELECT id FROM account));
+CREATE POLICY maintainer_select ON login_for_account FOR SELECT TO rsd_user
+	USING (account IN (SELECT id FROM account));
+
+CREATE POLICY maintainer_delete ON login_for_account FOR DELETE TO rsd_user
+	USING (account IN (SELECT id FROM account));
 
 CREATE POLICY admin_all_rights ON login_for_account TO rsd_admin
 	USING (TRUE)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:2.0.1
+    image: rsd/database:2.0.2
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"
@@ -52,7 +52,7 @@ services:
 
   auth:
     build: ./authentication
-    image: rsd/auth:1.2.1
+    image: rsd/auth:1.2.2
     expose:
       - 7000
     environment:


### PR DESCRIPTION
# Update login info on each login

Changes proposed in this pull request:

* On every login, we update the `name`, `email` and `home_organisation` fields on the `login_for_account` table
* Remove update and insert rights on the `login_for_account` table

How to test:

* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=0`  
* Login in your preferred way (or try them all out)
* Using something like DBeaver, run `SELECT * FROM login_for_account;`
* Now remove the values: `UPDATE login_for_account SET name = NULL, email = NULL, home_organisation = NULL;`
* Login again with the same credentials, the values should be restored (see the `SELECT` statement above)


Closes #607

PR Checklist:

*   [X] Increase version numbers in `docker-compose.yml`
*   [X] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
