### PR TITLE
804 project overview improvements

### DIFF
--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -336,7 +336,7 @@ async function generateProjects(amount=500) {
 			date_end: faker.helpers.maybe(() => dateEnd, {probability: 0.9}) ?? null,
 			date_start: faker.helpers.maybe(() => dateStart, {probability: 0.9}) ?? null,
 			description: faker.lorem.paragraphs(5, '\n\n'),
-			grant_id: faker.helpers.replaceSymbols('******'),
+			grant_id: faker.helpers.maybe(() => faker.helpers.replaceSymbols('******'), {probability: 0.8}) ?? null,
 			image_caption: faker.animal.cat(),
 			image_contain: !!faker.helpers.maybe(() => true, {probability: 0.5}),
 			image_id: localImageIds[index%localImageIds.length],

--- a/frontend/components/user/UserNavItems.tsx
+++ b/frontend/components/user/UserNavItems.tsx
@@ -70,7 +70,7 @@ export const userMenu:UserMenuItems = {
   },
   'project-quality':{
     id:'project-quality',
-    label: () => 'Project quality overview',
+    label: () => 'Project metadata overview',
     icon: <TableViewIcon />,
     component: (props?) => <ProjectQuality {...props} />,
     status: 'Overview of the completeness of project pages you maintain',

--- a/frontend/components/user/project-quality/FullScreenTable.tsx
+++ b/frontend/components/user/project-quality/FullScreenTable.tsx
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Dialog from '@mui/material/Dialog'
-import DialogActions from '@mui/material/DialogActions'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
 import IconButton from '@mui/material/IconButton'
@@ -31,7 +32,7 @@ export default function FullScreenTable({children,onClose}: FullScreenTableProps
         fontWeight: 500
       }}>
         <div className="flex justify-between">
-          <h2>Project quality overview</h2>
+          <h2>Project metadata overview</h2>
           <IconButton onClick={onClose}>
             <CloseIcon />
           </IconButton>

--- a/frontend/components/user/project-quality/SortableTable.tsx
+++ b/frontend/components/user/project-quality/SortableTable.tsx
@@ -103,11 +103,11 @@ export default function SortableTable({metadata, initialData, initialOrder=''}: 
         if (item[metadataKey] === true) return <CheckIcon sx={{color:'success.main'}} />
         else if (item[metadataKey] === false) return <CloseIcon sx={{color:'error.main'}} />
         else return <QuestionMarkIcon sx={{color: 'info.main'}} />
-      case 'text': return item[metadataKey]
+      case 'text': return item[metadataKey] === null ? <CloseIcon sx={{color:'error.main'}} /> : item[metadataKey]
       case 'pct':
         const value = item[metadataKey]
         return `${Math.round(value as number)}%`
-      case 'number': return item[metadataKey]
+      case 'number': return item[metadataKey] as number > 0 ? item[metadataKey] : <CloseIcon sx={{color:'error.main'}} />
       case 'link':
         const href = `/projects/${item['slug']}/edit`
         return <Link href={href} target="_blank">{item[metadataKey]}</Link>
@@ -129,10 +129,19 @@ export default function SortableTable({metadata, initialData, initialOrder=''}: 
     if (type === 'boolean' || type === 'number' || type === 'pct') {
       data.sort((a, b) => nowAscending ? a[label] - b[label] : b[label] - a[label])
     } else {
-      data.sort((a, b) => nowAscending ? a[label].localeCompare(b[label]) : b[label].localeCompare(a[label]))
+      data.sort((a, b) => compareStringNullsAware(a[label], b[label], nowAscending))
     }
     setAscending(nowAscending)
     setSortColumn(label)
     setData(data)
+  }
+
+  function compareStringNullsAware(s1: string | null, s2: string | null, ascending: boolean): number {
+    if (s1 === null && s2 === null) return 0
+
+    if (s1 === null && s2 !== null) return ascending ? -1 : 1
+    if (s1 !== null && s2 === null) return !ascending ? -1 : 1
+
+    return ascending ? s1!.localeCompare(s2!) : s2!.localeCompare(s1!)
   }
 }

--- a/frontend/components/user/project-quality/apiProjectQuality.tsx
+++ b/frontend/components/user/project-quality/apiProjectQuality.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -13,13 +15,16 @@ export type ProjectQualityProps = {
   title: string,
   has_subtitle: boolean,
   is_published: boolean,
-  has_start_date: boolean,
-  has_end_date: boolean,
+  date_start: string | null,
+  date_end: string | null,
+  grant_id: string | null,
   has_image: boolean,
   has_contact_person: boolean,
   team_member_cnt: number,
   participating_org_cnt: number,
   funding_org_cnt: number,
+  software_cnt: number,
+  project_cnt: number,
   keyword_cnt: number,
   research_domain_cnt: number,
   impact_cnt: number,
@@ -30,17 +35,20 @@ export type ProjectQualityProps = {
 export type ProjectQualityKeys = keyof ProjectQualityProps
 
 const realLabels = new Map<string, SortableTableProperties>()
-  realLabels.set('title', {'label': 'Title', 'type': 'link',sx:{minWidth:'14rem'}})
-  realLabels.set('score', {'label': 'Complete', 'type': 'pct'})
+  realLabels.set('title', {'label': 'Title', 'type': 'link', sx:{minWidth:'14rem'}})
+  realLabels.set('score', {'label': 'Metadata score', 'type': 'pct'})
   realLabels.set('has_subtitle', {'label': 'Subtitle', 'type': 'boolean'})
   realLabels.set('is_published', {'label': 'Published', 'type': 'boolean'})
-  realLabels.set('has_start_date', {'label': 'Start date', 'type': 'boolean'})
-  realLabels.set('has_end_date', {'label': 'End date', 'type': 'boolean'})
+  realLabels.set('date_start', {'label': 'Start date', 'type': 'text', sx:{'whiteSpace': 'nowrap'}})
+  realLabels.set('date_end', {'label': 'End date', 'type': 'text', sx:{'whiteSpace': 'nowrap'}})
+  realLabels.set('grant_id', {'label': 'Grant ID', 'type': 'text'})
   realLabels.set('has_image', {'label': 'Image', 'type': 'boolean'})
   realLabels.set('has_contact_person', {'label': 'Contact person', 'type': 'boolean'})
   realLabels.set('team_member_cnt', {'label': 'Team members', 'type': 'number'})
   realLabels.set('participating_org_cnt', {'label': 'Participating organisations', 'type': 'number'})
   realLabels.set('funding_org_cnt', {'label': 'Funding organisations', 'type': 'number'})
+  realLabels.set('software_cnt', {'label': 'Related software', 'type': 'number'})
+  realLabels.set('project_cnt', {'label': 'Related projects', 'type': 'number'})
   realLabels.set('keyword_cnt', {'label': 'Keywords', 'type': 'number'})
   realLabels.set('research_domain_cnt', {'label': 'Research domains', 'type': 'number'})
   realLabels.set('impact_cnt', {'label': 'Impact', 'type': 'number'})
@@ -80,16 +88,15 @@ function calculateScore(element:ProjectQualityProps) {
 
   const keys = Object.keys(element) as ProjectQualityKeys[]
   keys.forEach((key) => {
+    if (key === 'title' || key === 'slug' || key === 'score') return
     const value = element[key]
-    if (typeof value !== 'undefined' && (value === true || (Number.isInteger(value) && value > 0))){
+    if (typeof value !== 'undefined' && (value === true || (Number.isInteger(value) && value as number > 0) || typeof value === 'string')){
       score += 1
     }
-    if (value === true || value===false || Number.isInteger(value)){
-      kpiCount +=1
-    }
+    kpiCount +=1
   })
 
-  if (kpiCount===0) return 0
+  if (kpiCount === 0) return 0
   return Math.round((score/kpiCount)*100)
 }
 


### PR DESCRIPTION
# Project overview improvements

Changes proposed in this pull request:

* Implement all requested features in #804 except column reordering and an overview for software
* The data generation script now only assigns a grant ID in 80% of the time

How to test:

* `docker-compose down --volumes && docker-compose build --parallel && docker-compose up --scale data-generation=1`  
* Login as an admin and visit http://localhost/user/project-quality
* Check that the columns with `Start date`, `End date`, `Grant ID`, `Related software`, `Related projects` are correct
* Check that numerical values that were `0` now have a red cross


Related to #804

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [X] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
