### PR TITLE
fix: support software card without image

### DIFF
--- a/frontend/components/admin/software-highlights/apiSoftwareHighlights.tsx
+++ b/frontend/components/admin/software-highlights/apiSoftwareHighlights.tsx
@@ -10,7 +10,6 @@ import {SoftwareListItem} from '~/types/SoftwareTypes'
 import {extractCountFromHeader} from '~/utils/extractCountFromHeader'
 import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
-import {paginationUrlParams} from '~/utils/postgrestUrl'
 import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
 
 export type SoftwareHighlight = SoftwareListItem & {

--- a/frontend/components/software/overview/SearchInput.tsx
+++ b/frontend/components/software/overview/SearchInput.tsx
@@ -18,7 +18,7 @@ type SearchInputProps = {
 export default function SearchInput({
   placeholder,
   onSearch,
-  delay = 400,
+  delay = 700,
   defaultValue = ''
 }: SearchInputProps) {
   const [state, setState] = useState({

--- a/frontend/components/software/overview/SoftwareCard.tsx
+++ b/frontend/components/software/overview/SoftwareCard.tsx
@@ -21,19 +21,22 @@ export const SoftwareCard = ({item, direction}:SoftwareCardProps) => {
   const isHorizontal = !!direction
 
   return (
-    <Link href={'/software/'+item.slug} key={item.id} className="hover:text-inherit">
+    <Link href={`/software/${item.slug}`} key={item.id} className="hover:text-inherit">
       <div className={`flex-shrink-0 transition bg-white shadow-md hover:shadow-lg rounded-lg hover:cursor-pointer h-full select-none ${isHorizontal ? 'flex flex-col sm:flex-row w-[20rem] sm:w-full' : 'flex-col'}`} >
         {/* Cover image */}
-        <img
-          className={`
-            object-cover
-            ${isHorizontal
-              ? 'w-full rounded-tr-lg rounded-tl-lg   sm:rounded-bl-lg sm:rounded-tl-lg sm:rounded-tr-none sm:w-[20rem] sm:h-[20rem]'
-              : 'w-full rounded-tr-lg rounded-tl-lg'
-            }`}
+        {
+          item.image_id &&
+          <img
+            className={`
+              object-cover
+              ${isHorizontal
+                ? 'w-full rounded-tr-lg rounded-tl-lg   sm:rounded-bl-lg sm:rounded-tl-lg sm:rounded-tr-none sm:w-[20rem] sm:h-[20rem]'
+                : 'w-full rounded-tr-lg rounded-tl-lg'
+              }`}
           src={`${getImageUrl(item.image_id) ?? ''}`}
           alt={`Cover image for ${item.brand_name}`}
           />
+        }
 
         {/* Card content */}
         <div className={`flex flex-col p-4 ${isHorizontal ? 'max-w-[350px]' : ''}`}>


### PR DESCRIPTION
# Software card should support software without image (logo)

Closes #841

Changes proposed in this pull request:
* When image_id is not provided the image section of software card is not used
* Order descending is also fixed in rsd-v2-release branch during rebasing
* Input delay increased from 400 to 700 ms in order to avoid request (and page jump) when "slow" typing :-)
* Removed unused import

How to test:
* `make start` to rebuild app
* login as rsd_admin
* navigate to admin page software-highlights. Edit one of the highlight items and remove image/logo
* visit [highlights page](https://localhost/highlights). The card should be displayed without image section (see example)
* search for that same software in overview. The card should also be displayed without image section (see example)
* validate order is descending when using filter on highlights page

## Example card without image

![image](https://user-images.githubusercontent.com/9204081/232825146-a222fcee-56de-4166-8b00-adb6e2fdb3ee.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
