### PR TITLE
Add pagination for software and projects on organisation page

### DIFF
--- a/frontend/components/organisation/projects/index.tsx
+++ b/frontend/components/organisation/projects/index.tsx
@@ -9,10 +9,12 @@ import {OrganisationComponentsProps} from '../OrganisationNavItems'
 import SearchAndPagination from '../SearchAndPagination'
 import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
 import OrganisationProjectCards from './OrganisationProjectsCards'
+import Pagination from '@mui/material/Pagination'
 
 export default function OrganisationProjects({organisation, isMaintainer}:OrganisationComponentsProps) {
   const {itemHeight, minWidth, maxWidth} = useAdvicedDimensions()
-  const {searchFor,page,rows,setCount} = usePaginationWithSearch(`Find project in ${organisation.name}`)
+  const {searchFor,page,rows,count,setCount,setPage} = usePaginationWithSearch(`Find project in ${organisation.name}`)
+  const pageCount = Math.ceil(count/rows)
 
   return (
     <>
@@ -35,6 +37,17 @@ export default function OrganisationProjects({organisation, isMaintainer}:Organi
           isMaintainer={isMaintainer}
         />
       </FlexibleGridSection>
+      <div className="flex flex-wrap justify-center">
+        {pageCount > 1 &&
+          <Pagination
+            size="large"
+            shape="rounded"
+            count={pageCount}
+            page={page + 1}
+            onChange={(e:any,page:number)=>setPage(page-1)}
+          />
+        }
+      </div>
     </>
   )
 }

--- a/frontend/components/organisation/software/OrganisationSoftwareCards.tsx
+++ b/frontend/components/organisation/software/OrganisationSoftwareCards.tsx
@@ -18,7 +18,7 @@ type OrganisationSoftwareGridProps = {
   page:number
   rows:number
   isMaintainer: boolean
-  setCount:(count:number)=>void
+  setCount: (count: number) => void
 }
 
 export default function OrganisationSoftwareCards(props: OrganisationSoftwareGridProps) {

--- a/frontend/components/organisation/software/index.tsx
+++ b/frontend/components/organisation/software/index.tsx
@@ -11,10 +11,11 @@ import {OrganisationComponentsProps} from '../OrganisationNavItems'
 import SearchAndPagination from '../SearchAndPagination'
 import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
 import OrganisationSoftwareCards from './OrganisationSoftwareCards'
+import Pagination from '@mui/material/Pagination'
 
 export default function OrganisationSoftware({organisation, isMaintainer}: OrganisationComponentsProps) {
   const {itemHeight, minWidth, maxWidth} = useAdvicedDimensions('software')
-  const {searchFor,page,rows,setCount} = usePaginationWithSearch(`Find software in ${organisation.name}`)
+  const {searchFor,page,rows,count,setCount,setPage} = usePaginationWithSearch(`Find software in ${organisation.name}`)
 
   return (
     <>
@@ -37,6 +38,15 @@ export default function OrganisationSoftware({organisation, isMaintainer}: Organ
           isMaintainer={isMaintainer}
         />
       </FlexibleGridSection>
+      <div className="flex flex-wrap justify-center">
+        <Pagination
+          size="large"
+          shape="rounded"
+          count={Math.ceil(count/rows)}
+          page={page + 1}
+          onChange={(e:any,page:number)=>setPage(page-1)}
+        />
+      </div>
     </>
   )
 }

--- a/frontend/pages/organisations/index.tsx
+++ b/frontend/pages/organisations/index.tsx
@@ -117,7 +117,7 @@ export default function OrganisationsIndexPage({
         organisations={organisations}
       />
 
-      <div className="flex flex-wrap justify-center mb-5">
+      <div className="flex flex-wrap justify-center mb-8">
         <Pagination
           count={Math.ceil(count/rows)}
           page={page + 1}

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -153,7 +153,7 @@ export default function ProjectsIndexPage(
         className="gap-[0.125rem] p-[0.125rem] pt-4 pb-12"
       />
 
-      <div className="flex flex-wrap justify-center mb-5">
+      <div className="flex flex-wrap justify-center mb-8">
         <Pagination
           count={Math.ceil(count/rows)}
           page={page + 1}

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -161,7 +161,7 @@ export default function SoftwareIndexPage(
         software={software}
       />
 
-      <div className="flex flex-wrap justify-center mb-5">
+      <div className="flex flex-wrap justify-center mb-8">
         <Pagination
           count={Math.ceil(count/rows)}
           page={page + 1}

--- a/frontend/utils/usePaginationWithSearch.tsx
+++ b/frontend/utils/usePaginationWithSearch.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -61,6 +61,13 @@ export default function usePaginationWithSearch(placeholder:string) {
     }
   }
 
+  function setPage(page: number) {
+    setPagination({
+      ...pagination,
+      page
+    })
+  }
+
   return {
     searchFor: search,
     // when navigating between sections we need to reset page to 0
@@ -69,7 +76,8 @@ export default function usePaginationWithSearch(placeholder:string) {
     rows: pagination.rows,
     count: pagination.count,
     setSearchInput,
-    setPagination,
-    setCount
+    // setPagination,
+    setCount,
+    setPage
   }
 }


### PR DESCRIPTION
# Add pagination

Closes #829

Changes proposed in this pull request:
* Adding pagination at the bottom of software and project pages on organisation page.
* Use same bottom margin on software, projects and organisation overview pages    

How to test:
* `make start` to build app
* navigate to organisation overview
* select one of organisations and confirm that:
    - software page has pagination at the bottom of the page
    - projects page has pagination at the bottom of the page

## Example software page
![image](https://user-images.githubusercontent.com/9204081/233137997-9d1ca536-8e17-44e2-af15-67de56096364.png)

## Example project page
![image](https://user-images.githubusercontent.com/9204081/233138218-7a91d9e9-dbda-49d8-87f1-756d00cb2c25.png)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
