### PR TITLE
fix: Helmholtz AAI handling if only one eduperson_entitlement is returned

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -102,6 +102,11 @@ HELMHOLTZAAI_RESPONSE_MODE=query
 # consumed by: authentication
 # uncomment if you want to allow users from non-Helmholtz centres or social IdPs:
 #HELMHOLTZAAI_ALLOW_EXTERNAL_USERS=true
+# consumed by: authentication
+# set to true to allow users specified in HELMHOLTZAAI_ALLOW_LIST access to the RSD
+# HELMHOLTZAAI_USE_ALLOW_LIST=false
+# consumed by: authentication
+# HELMHOLTZAAI_ALLOW_LIST=
 
 # ORCID
 # consumed by: authentication, frontend/utils/loginHelpers

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
@@ -1,9 +1,10 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -112,6 +113,16 @@ public class Config {
 	public static boolean helmholtzAaiAllowExternalUsers() {
 		return Boolean.parseBoolean(
 			System.getenv("HELMHOLTZAAI_ALLOW_EXTERNAL_USERS")
+		);
+	}
+
+	public static String helmholtzAaiAllowList() {
+		return System.getenv("HELMHOLTZAAI_ALLOW_LIST");
+	}
+
+	public static boolean helmholtzAaiUseAllowList() {
+		return Boolean.parseBoolean(
+			System.getenv("HELMHOLTZAAI_USE_ALLOW_LIST")
 		);
 	}
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,8 +1,8 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
-# SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 # SPDX-FileCopyrightText: 2022 dv4all
 #
@@ -69,6 +69,8 @@ services:
       - HELMHOLTZAAI_REDIRECT
       - HELMHOLTZAAI_WELL_KNOWN_URL
       - HELMHOLTZAAI_SCOPES
+      - HELMHOLTZAAI_USE_ALLOW_LIST
+      - HELMHOLTZAAI_ALLOW_LIST
       - ORCID_CLIENT_ID
       - ORCID_REDIRECT
       - ORCID_WELL_KNOWN_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2021 - 2023 dv4all
-# SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-# SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+# SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
@@ -71,6 +71,8 @@ services:
       - HELMHOLTZAAI_REDIRECT
       - HELMHOLTZAAI_WELL_KNOWN_URL
       - HELMHOLTZAAI_SCOPES
+      - HELMHOLTZAAI_USE_ALLOW_LIST
+      - HELMHOLTZAAI_ALLOW_LIST
       - ORCID_CLIENT_ID
       - ORCID_REDIRECT
       - ORCID_WELL_KNOWN_URL

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
   auth:
     build: ./authentication
     image: rsd/auth:1.2.2
+    ports:
+      - 5005:5005
     expose:
       - 7000
     environment:
@@ -83,6 +85,13 @@ services:
       - backend
     networks:
       - net
+    entrypoint:
+      [
+        "java",
+        "-agentlib:jdwp=transport=dt_socket,address=*:5005,server=y,suspend=n",
+        "-cp", "auth.jar",
+        "nl.esciencecenter.rsd.authentication.Main"
+      ]
 
   frontend:
     build:


### PR DESCRIPTION
# Fix issue in Helmholtz AAI login

Fixes #857 

Changes proposed in this pull request:

* fixes handling of `eduperson_entitlement`
* adds an allow list for Helmholtz AAI via env variable `HELMHOLTZAAI_ALLOW_LIST`
* users in allow list are identified via email address
* enable usage of allow list via `HELMHOLTZAAI_USE_ALLOW_LIST`
* enable external debugging in auth container

How to test:

* enable Helmholtz AAI login provider and in `.env` set
  * `HELMHOLTZAAI_ALLOW_EXTERNAL_USERS=false`
  * `HELMHOLTZAAI_USE_ALLOW_LIST=false`
* `docker compose build --parallel && docker compose up --scale scrapers=0`
* login via Helmholtz AAI using a social IdP (Google, ORCID or GitHub)
* check that auth does not log any errors
* the user will be presented the error message: "You are not allowed to login."
* `docker compose stop`
* in `.env` set `HELMHOLTZAAI_USE_ALLOW_LIST=true`
* `docker compose up --scale scrapers=0`
* login via Helmholtz AAI using a social IdP (Google, ORCID or GitHub)
* the user will be presented the error message: "Your email address (<mail>) is not in the allow list."
* `docker compose stop`
* in `.env` add your mail address to `HELMHOLTZAAI_ALLOW_LIST`
* `docker compose up --scale scrapers=0`
* login via Helmholtz AAI using the same social idp as before
* login successful

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
