### PR TITLE
Fix: missing organisation slug on maintainer invite confirmation page

### DIFF
--- a/frontend/pages/invite/organisation/[id].tsx
+++ b/frontend/pages/invite/organisation/[id].tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -99,9 +99,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     if (resp.organisationInfo?.id) {
       // get organisation path to link to in the message
       const slug = await getRsdPathForOrganisation({
-        uuid: resp.organisationInfo?.id,
-        token,
-        frontend:false
+        uuid: resp.organisationInfo.id,
+        token
       })
 
       if (slug.status === 200) {
@@ -118,7 +117,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       // error from second request
       return {
         props: {
-          error: slug
+          error: slug.message
         }
       }
     }

--- a/frontend/utils/editOrganisation.test.ts
+++ b/frontend/utils/editOrganisation.test.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {mockResolvedValueOnce} from './jest/mockFetch'
+import {getRsdPathForOrganisation} from './editOrganisation'
+
+describe('getRsdPathForOrganisation', () => {
+  it('returns rsd_path in response message', async () => {
+    const mockData = {
+      organisation: 'TEST-ORGANISATION-NAME',
+      rsd_path: 'test_organisation_path',
+      parent_names: 'TEST-PARENT-NAMES'
+    }
+    // mock response
+    mockResolvedValueOnce(mockData)
+    // get organisation path to link to in the message
+    const slug = await getRsdPathForOrganisation({
+      uuid: 'TEST_ORGANISATION_UUID',
+      token: 'TEST_TOKEN'
+    })
+
+    expect(slug.status).toEqual(200)
+    expect(slug.message).toEqual(mockData.rsd_path)
+  })
+
+  it('returns custom error message from api', async () => {
+    const mockError = {
+      status: 400,
+      message: 'This is custom error message from api'
+    }
+    // mock error response
+    mockResolvedValueOnce({
+      message: mockError.message
+    }, {
+      status: mockError.status,
+      statusText: 'Not OK'
+    })
+    // get organisation path to link to in the message
+    const slug = await getRsdPathForOrganisation({
+      uuid: 'TEST_ORGANISATION_UUID',
+      token: 'TEST_TOKEN'
+    })
+
+    expect(slug.status).toEqual(mockError.status)
+    expect(slug.message).toEqual(mockError.message)
+  })
+})
+

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -293,22 +293,22 @@ export async function deleteOrganisation({uuid,logo_id, token}:
   }
 }
 
-export async function getRsdPathForOrganisation({uuid,token,frontend = false}:
-  {uuid: string, token?: string, frontend?: boolean}) {
+export async function getRsdPathForOrganisation({uuid,token}:
+  {uuid: string, token?: string}) {
   try {
     const query = `rpc/organisation_route?id=${uuid}`
-    let url = `${process.env.POSTGREST_URL}/${query}`
-    if (frontend) {
-      url =`/api/v1/${query}`
-    }
+    let url = `${getBaseUrl()}/${query}`
     const resp = await fetch(url, {
       method: 'GET',
       headers: {
-        ...createJsonHeaders(token)
+        ...createJsonHeaders(token),
+        // request single object item
+        'Accept': 'application/vnd.pgrst.object+json'
       }
     })
+
     if (resp.status === 200) {
-      const json: {organisation: string, rsd_path: string} = await resp.json()
+      const json: { organisation: string, rsd_path: string, parent_names:string } = await resp.json()
       return {
         status: 200,
         message: json.rsd_path


### PR DESCRIPTION
# Fix: organisation slug on maintainer invite confirmation page

Closes #859

Changes proposed in this pull request:
*  Provides direct link to organisation page after maintainer is added to list of organisation maintainers    

How to test:
* `make start` to build app
* login as rsd_admin (professor3 if you use same .env file as me) 
* navigate to organisation and create maintainer invite link. Send or copy link to use it and next step.
* Logout from rsd. Paste link in the addressbar. You will receive message that you need to login first.
* Login as professor1 now. 
* You will see confirmation page with the working link to a organisation page
* Click the link and confirm that organisation page is loaded and you are the maintainer.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
