### PR TITLE
782 version dois

### DIFF
--- a/frontend/components/mention/__mocks__/mentions.json
+++ b/frontend/components/mention/__mocks__/mentions.json
@@ -45,7 +45,7 @@
     "id": "4a9d0565-c25e-4538-bfb4-9a3248db83d9",
     "doi": "10.1017/9781009085809",
     "url": "https://doi.org/10.1017/9781009085809",
-    "title": "Sexyback",
+    "title": "Back",
     "authors": null,
     "publisher": "Romaguera Group",
     "publication_year": 2011,

--- a/frontend/components/mention/__mocks__/mentions.json.license
+++ b/frontend/components/mention/__mocks__/mentions.json.license
@@ -1,4 +1,6 @@
 SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 SPDX-FileCopyrightText: 2022 dv4all
+SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 
 SPDX-License-Identifier: Apache-2.0

--- a/frontend/components/software/edit/information/ValidateConceptDoi.test.tsx
+++ b/frontend/components/software/edit/information/ValidateConceptDoi.test.tsx
@@ -1,4 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -59,12 +61,23 @@ it('shows valid concept DOI message', async() => {
   // mock response for valid Concept DOI
   mockGetSoftwareVersionInfoForDoi.mockResolvedValueOnce({
     status: 200,
-    data: {
-      software: {
-        versionOfCount: 0
+    'data': {
+      'software': {
+        'relatedIdentifiers': [
+          {
+            'relationType': 'IsSupplementTo',
+            'relatedIdentifierType': 'URL',
+            'relatedIdentifier': 'https://github.com/UtrechtUniversity/animal-sounds/tree/v0.0.1-alpha'
+          },
+          {
+            'relationType': 'HasVersion',
+            'relatedIdentifierType': 'DOI',
+            'relatedIdentifier': '10.5281/zenodo.7137567'
+          }
+        ]
       }
     }
-  })
+})
   // render
   render(
     <MuiSnackbarProvider>
@@ -84,18 +97,24 @@ it('shows valid concept DOI message', async() => {
 it('shows version DOI message and suggest concept DOI', async() => {
   // provide DOI
   mockProps.doi = '10.1017/9781009085809'
-  const conceptDOI = '10.1017/9781009085801'
+  const conceptDOI = '10.5281/zenodo.7137566'
   // mock response for valid Concept DOI
   mockGetSoftwareVersionInfoForDoi.mockResolvedValueOnce({
     status: 200,
-    data: {
-      software: {
-        versionOfCount: 1,
-        versionOf: {
-          nodes: [
-            {doi:conceptDOI}
-          ]
-        }
+    'data': {
+      'software': {
+        'relatedIdentifiers': [
+          {
+            'relationType': 'IsSupplementTo',
+            'relatedIdentifierType': 'URL',
+            'relatedIdentifier': 'https://github.com/UtrechtUniversity/animal-sounds/tree/v0.0.1-alpha'
+          },
+          {
+            'relationType': 'IsVersionOf',
+            'relatedIdentifierType': 'DOI',
+            'relatedIdentifier': '10.5281/zenodo.7137566'
+          }
+        ]
       }
     }
   })

--- a/frontend/components/software/edit/information/ValidateConceptDoi.tsx
+++ b/frontend/components/software/edit/information/ValidateConceptDoi.tsx
@@ -19,6 +19,14 @@ type ValidateConceptDoiProps = {
   onUpdate:(doi:string)=>void
 }
 
+type DataciteWorkType = {
+  relatedIdentifiers: {
+    relationType: string,
+    relatedIdentifierType: string,
+    relatedIdentifier: string,
+  }[]
+}
+
 export default function ValidateConceptDoi({doi, onUpdate}: ValidateConceptDoiProps) {
   const {showErrorMessage,showSuccessMessage, showWarningMessage} = useSnackbar()
   const [loading, setLoading] = useState(false)
@@ -41,7 +49,7 @@ export default function ValidateConceptDoi({doi, onUpdate}: ValidateConceptDoiPr
     setLoading(false)
   }
 
-  function extractConceptDoiOrNull(dataciteWork: any) {
+  function extractConceptDoiOrNull(dataciteWork: DataciteWorkType) {
     for (const relatedIdentifier of dataciteWork.relatedIdentifiers) {
       if(relatedIdentifier.relationType === 'IsVersionOf' && relatedIdentifier.relatedIdentifierType === 'DOI' && relatedIdentifier.relatedIdentifier) return relatedIdentifier.relatedIdentifier
     }

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -91,13 +91,10 @@ function graphQLDoisQuery(dois: string[]) {
 function gqlConceptDoiQuery(doi: string) {
   const gql =`{
     software(id:"${doi}"){
-      doi,
-      versionCount,
-      versionOfCount,
-      versionOf{
-        nodes{
-          doi
-        }
+      relatedIdentifiers {
+        relationType
+        relatedIdentifierType
+        relatedIdentifier
       }
     }
   }`

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -30,7 +30,7 @@ public class DataciteMentionRepository implements MentionRepository {
 
 	private static final String QUERY_UNFORMATTED = """
 			query {
-			  works(ids: [%s]) {
+			  works(ids: [%s], first: 10000) {
 			    nodes {
 			      doi
 			      types {


### PR DESCRIPTION
# Improved version/concept DOI detection

Changes proposed in this pull request:

* The frontend uses `relatedIdentifiers` instead of `versionOfCount` to detect if an entered DOI is a concept or version DOI
* The scraper uses the same to scrape the versions

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`  
* Login and create software pages with the following concept DOIs (they should also be validated properly):
	* 10.5281/zenodo.7137566
	* 10.5281/zenodo.5751860
	* 10.5281/zenodo.1404735
* Let the scraper run (`docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases`)
* Check that the first two have one version, and that the third has 14 versions (especially `1.3.0` and `1.4.0`)
* Try to validate the following version DOIs, you should get a warning that they are not concept DOIs:
	* 10.5281/zenodo.7137567
	* 10.5281/zenodo.5751861


Closes #782

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [X] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
