### PR TITLE
feat: organisation maintainer can edit about page

### DIFF
--- a/frontend/components/organisation/settings/RsdAdminSection.tsx
+++ b/frontend/components/organisation/settings/RsdAdminSection.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -78,18 +78,8 @@ export default function AdminSection() {
         defaultValue={is_tenant}
         onSave={saveIsTenant}
       />
-      <div className="py-2"></div>
-      <EditSectionTitle
-        title={config.description.title}
-        subtitle={config.description.subtitle}
-      />
-      <AutosaveControlledMarkdown
-        id={id}
-        name="description"
-        maxLength={config.description.validation.maxLength.value}
-        patchFn={patchOrganisationTable}
-      />
-      <div className="py-8"></div>
+      {/* additional spacing for About page */}
+      <div className="py-4"></div>
     </>
   )
 }

--- a/frontend/components/organisation/settings/index.tsx
+++ b/frontend/components/organisation/settings/index.tsx
@@ -15,6 +15,9 @@ import RsdAdminSection from './RsdAdminSection'
 import ProtectedOrganisationPage from '../ProtectedOrganisationPage'
 import AutosaveOrganisationTextField from './AutosaveOrganisationTextField'
 import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
+import AutosaveControlledMarkdown from '~/components/form/AutosaveControlledMarkdown'
+import {patchOrganisationTable} from './updateOrganisationSettings'
+import EditSectionTitle from '~/components/layout/EditSectionTitle'
 
 const formId='organisation-settings-form'
 
@@ -30,7 +33,7 @@ export default function OrganisationSettings({organisation, isMaintainer}:
     watch, register, formState
   } = methods
   // const {isValid, isDirty} = formState
-  const [name,website]=watch(['name','website'])
+  const [id,name,website]=watch(['id','name','website'])
 
   // console.group('OrganisationSettings')
   // console.log('isDirty...', isDirty)
@@ -94,6 +97,17 @@ export default function OrganisationSettings({organisation, isMaintainer}:
         <RsdAdminSection />
         : null
       }
+      {/* About page section */}
+      <EditSectionTitle
+        title={config.description.title}
+        subtitle={config.description.subtitle}
+      />
+      <AutosaveControlledMarkdown
+        id={id}
+        name="description"
+        maxLength={config.description.validation.maxLength.value}
+        patchFn={patchOrganisationTable}
+      />
     </form>
     </FormProvider>
     </ProtectedOrganisationPage>


### PR DESCRIPTION
# Edit organisation about page

Closes #855

Changes proposed in this pull request:
*  The organisation maintainer can edit about page of the organisation. Previously this was only possible for rsd_admin role   

How to test:
* `make start` to rebuild app
* login as rsd_admin (professor3 if you have same settings as I do)
* navigate to settings. You should see about page in settings. 
* navigate to organisation maintainers and create an invite. Copy link and then logout.
* paste link and login as professor1
* navigate to settings. You should see About page section.
* Add some text to About page. 
* Log out and visit organisation as public user. You should see the content of about page.

## Example edit about page

![image](https://user-images.githubusercontent.com/9204081/235456945-cb9daaa5-83ba-45ca-be87-4078558c147f.png)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
