### PR TITLE
863 slow org page

### DIFF
--- a/backend-postgrest/Dockerfile
+++ b/backend-postgrest/Dockerfile
@@ -1,6 +1,6 @@
-# SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgrest/postgrest:v10.0.0
+FROM postgrest/postgrest:v11.0.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   backend:
     build: ./backend-postgrest
-    image: rsd/backend-postgrest:1.11.2
+    image: rsd/backend-postgrest:1.12.0
     expose:
       - 3500
     environment:


### PR DESCRIPTION
# Fix slow organisation pages by upgrading PostgREST

Changes proposed in this pull request:

* Upgrade to version [v11.0.1](https://github.com/PostgREST/postgrest/releases/tag/v11.0.1) of PostgREST

How to test:

* Check that the end to end tests still work: `make e2e-tests`
* Check that the backend tests still work, see [here](https://github.com/research-software-directory/RSD-as-a-service/blob/main/backend-postgrest/tests/README.md)
* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Login as an admin, create a maintainer invite for an organisation
* Login as a regular user and accept the invite
* Browsing sections on that page should have normal speed again
* Since this is a major upgrade of PostgREST, check that other functionality still works


Closes #863

PR Checklist:

*   [X] Increase version numbers in `docker-compose.yml`
*   [X] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
