### PR TITLE
fix: data generation now makes an about page

### DIFF
--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -466,8 +466,8 @@ async function generateOrganisations(amount=500) {
 function generateMetaPages() {
 	const result = [];
 
-	const titles = ['Terms of Service', 'Privacy Statement'];
-	const slugs = ['terms-of-service', 'privacy-statement'];
+	const titles = ['About', 'Terms of Service', 'Privacy Statement'];
+	const slugs = ['about', 'terms-of-service', 'privacy-statement'];
 	for (let index = 0; index < titles.length; index++) {
 		result.push({
 			title: titles[index],


### PR DESCRIPTION
# Data generation now makes an about page

Changes proposed in this pull request:

* Data generation now makes an about page

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* http://localhost/page/about should exist


Closes #863

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
