### PR TITLE
feat: add a hint to upload organisation logos

### DIFF
--- a/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
+++ b/frontend/components/software/edit/organisations/EditOrganisationModal.tsx
@@ -1,7 +1,7 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -25,6 +25,7 @@ import {organisationInformation as config} from '../editSoftwareConfig'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
 import {deleteImage, getImageUrl} from '~/utils/editImage'
 import {handleFileUpload} from '~/utils/handleFileUpload'
+import {Alert, AlertTitle} from '@mui/material'
 
 type EditOrganisationModalProps = {
   open: boolean,
@@ -242,6 +243,12 @@ export default function EditOrganisationModal({open, onCancel, onSubmit, organis
               />
             </div>
           </section>
+          <Alert
+          severity="info"
+        >
+          <AlertTitle>Do you have a logo?</AlertTitle>
+          You are the first to reference this organisation and can add a logo now. After clicking on &quot;Save&quot;, logos can only by added by organisation maintainers.
+        </Alert>
         </DialogContent>
         <DialogActions sx={{
           padding: '1rem 1.5rem',


### PR DESCRIPTION
# Info to users that they can upload organisation logo

When users in the Helmholtz RSD add new organisations, they usually add them without uploading logos. We would like to add a hint so that they are aware that they have the chance to add a logo once while adding the organsiation.

Changes proposed in this pull request:

* Adds a hint to `EditOrganisationModal` so that users understand that they can upload a logo now, but not later

![image](https://user-images.githubusercontent.com/14222414/236801121-8191cff3-30a0-4b16-a2b7-d47a3f5bb073.png)


How to test:

* `docker compose build && docker compose up --scale scrapers=0`
* reference a new organisation in a software entry

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
