### PR TITLE
876: New layout add organisation list

### DIFF
--- a/database/012-create-organisation-table.sql
+++ b/database/012-create-organisation-table.sql
@@ -1,8 +1,8 @@
+-- SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
--- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+-- SPDX-FileCopyrightText: 2022 - 2023 dv4all
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
--- SPDX-FileCopyrightText: 2022 dv4all
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -157,5 +157,5 @@ WITH RECURSIVE search_tree(slug, name, organisation_id, parent, reverse_depth) A
 		FROM organisation o, search_tree st
 		WHERE o.id = st.parent
 )
-SELECT organisation_route.id, STRING_AGG(slug, '/' ORDER BY reverse_depth DESC), STRING_AGG(name, ' -> ' ORDER BY reverse_depth DESC) FROM search_tree;
+SELECT organisation_route.id, STRING_AGG(slug, '/' ORDER BY reverse_depth DESC), STRING_AGG(name, ' > ' ORDER BY reverse_depth DESC) FROM search_tree;
 $$;

--- a/e2e/helpers/citations.ts
+++ b/e2e/helpers/citations.ts
@@ -10,7 +10,7 @@ import {expect} from '@playwright/test'
 import fs from 'fs/promises'
 
 export async function addCitation(page, input: string, waitForResponse: string) {
-  await page.pause()
+  // await page.pause()
   // clear previous input - if clear btn is visible
   const clearBtn = await page.getByRole('button', {
     name: 'Clear'

--- a/e2e/helpers/utils.ts
+++ b/e2e/helpers/utils.ts
@@ -148,7 +148,9 @@ export async function addOrganisation(page, organisation: Organisation, apiUrl) 
       hasText:RegExp(organisation.name,'i')
     })
     .first()
-  const source = await option.getByTestId('organisation-list-item-source').textContent()
+
+  // get source information
+  const source = await option.getByTestId('organisation-list-item').getAttribute('data-source')
 
   if (source === 'RSD') {
     await Promise.all([

--- a/frontend/components/software/edit/organisations/FindOrganisationItem.tsx
+++ b/frontend/components/software/edit/organisations/FindOrganisationItem.tsx
@@ -15,37 +15,35 @@ type FindOrganisationItemProps = {
 
 export default function FindOrganisationItem({...org}:FindOrganisationItemProps) {
 
-  function renderSecondRow() {
-    return (
-      <div className="grid grid-cols-[4fr,3fr] gap-2">
-        <div className="break-all" >{
-          org.website ??
-          <span className="text-base-content-disabled">website url missing</span>
-        }</div>
-        <div className="pl-4 text-right">{
-          org.ror_id ??
-          <span className="text-base-content-disabled">ror_id missing</span>
-        }</div>
-      </div>
-    )
+  // show path only if different from name (multiple levels)
+  let path:string = org.parent_names ?? ''
+  if (org.parent_names?.toLowerCase() === org.name.toLowerCase()) {
+    path = ''
   }
 
   return (
-    <article className="flex-1" title={org.parent_names}>
-      <div className="grid grid-cols-[3fr,1fr] gap-2">
-        <div
-          data-testid="organisation-list-item-label"
-          className="flex items-center">
-          <span className="flex-1">{org.name}</span>
-        </div>
-        <span
-          data-testid="organisation-list-item-source"
-          className="text-right">
-          <strong>{org.source}</strong>
-        </span>
+    <article
+      // information used by e2e tests
+      data-testid="organisation-list-item"
+      // information used by e2e tests
+      data-source={org.source}
+    >
+      <div>
+        {org.name}
       </div>
-      <div className="py-1 text-[0.75rem]">
-        {renderSecondRow()}
+      <div className="text-sm text-base-content-secondary">
+        {
+          path &&
+          <div>{path}</div>
+        }
+        {
+          org.website &&
+          <div>{org.website}</div>
+        }
+        {
+          org.ror_id &&
+          <div>{org.ror_id}</div>
+        }
       </div>
     </article>
   )

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -48,51 +48,6 @@ export async function searchForOrganisation({searchFor, token}:
   }
 }
 
-// export async function fetchRSDOrganisations({searchFor, rorIds, token}:
-//   { searchFor: string, rorIds: string[], token?: string}) {
-//   try {
-//     // select only columns required for SearchOrganisation (avoid quering counts)
-//     const columns = ['id', 'slug', 'parent', 'primary_maintainer', 'name', 'ror_id', 'is_tenant', 'website', 'logo_id', 'description']
-
-//     let query = `select=${columns.join(',')}`
-
-//     if (rorIds.length) {
-//       const rorIdsCommaSeparated = rorIds.join(',')
-//       query += `&or=(name.ilike.*${searchFor}*,website.ilike.*${searchFor}*,ror_id.in.(${rorIdsCommaSeparated}))&limit=20`
-//     } else {
-//       query += `&or=(name.ilike.*${searchFor}*,website.ilike.*${searchFor}*)&limit=20`
-//     }
-
-//     const url = `${getBaseUrl()}/rpc/organisations_overview?${query}`
-
-//     const resp = await fetch(url, {
-//       method: 'GET',
-//       headers: {
-//         ...createJsonHeaders(token),
-//       }
-//     })
-//     if (resp.status === 200) {
-//       const data: Organisation[] = await resp.json()
-//       const options: AutocompleteOption<SearchOrganisation>[] = data.map(item => {
-//         return {
-//           key: item?.ror_id ?? item?.slug ?? item.name,
-//           label: item.name ?? '',
-//           data: {
-//             ...item,
-//             source: 'RSD'
-//           },
-//         }
-//       })
-//       return options
-//     }
-//     logger(`fetchRSDOrganisations ERROR: ${resp?.status} ${resp?.statusText}`, 'error')
-//     return []
-//   } catch (e: any) {
-//     logger(`fetchRSDOrganisations: ${e?.message}`, 'error')
-//     return []
-//   }
-// }
-
 export async function findRSDOrganisation({searchFor, token, rorIds}:
   { searchFor: string, token?: string, rorIds: string[] }){
   try {


### PR DESCRIPTION
# Add organisation list (new layout)

Closes #876 

Changes proposed in this pull request:
* Show organisation path in the find organisation list item
* Remove source RSD/ROR
* Show website if present
* Show ROR id (url) if present   

How to test:
* `make start` to build app and generate data
* login as rsd_admin in order to be able to change items
* select first organisation and create some research units
* select first software and edit organisations. Search for the unit. The find organisation list should be in new layout showing the organisation parents separated by `>` to indicate level

## Example
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/b1780f1e-7258-4062-b9e6-8982aca92570)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
