### PR TITLE
875: show research unit name on software/project pages

### DIFF
--- a/frontend/components/software/ParticipatingOrganisation.tsx
+++ b/frontend/components/software/ParticipatingOrganisation.tsx
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -26,9 +26,11 @@ export default function OrganisationItem({rsd_path, name, website, logo_url}: Pa
     return (
       <Link href={url}
         title={name}
-        className="flex items-center" rel="noreferrer"
+        className="flex flex-col items-center" rel="noreferrer"
         passHref>
         {renderLogo()}
+        {/* show name only for research units */}
+        {rsd_path.includes('/',2)===true ? name : null}
       </Link>
     )
   }

--- a/frontend/components/software/edit/organisations/FindOrganisationItem.tsx
+++ b/frontend/components/software/edit/organisations/FindOrganisationItem.tsx
@@ -27,11 +27,13 @@ export default function FindOrganisationItem({...org}:FindOrganisationItemProps)
       data-testid="organisation-list-item"
       // information used by e2e tests
       data-source={org.source}
+      className="flex-1"
+      title={org.parent_names}
     >
       <div>
         {org.name}
       </div>
-      <div className="text-sm text-base-content-secondary">
+      <div className="text-sm text-base-content-disabled">
         {
           path &&
           <div>{path}</div>


### PR DESCRIPTION
# Show research unit name on software and project page

Closes #875 

Changes proposed in this pull request:
*   Show research unit name below logo on the software and project page   

How to test:
* `make start` to rebuild app
* login as rsd_admin in order to be able to change existing data
* navigate to organisation and add few research units
* select one of its software and add research units
* view the software page and confirm unit name is shown next to logo as in picture above

## Example

![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/461e77a8-c8b6-443c-a248-91d2ae861e16)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
