### PR TITLE
fix: add a request timeout on all HTTP requests

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
@@ -20,6 +20,7 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.util.Base64;
 import java.util.Date;
 
@@ -50,6 +51,7 @@ public class Utils {
 	public static String get(String uri, String... headers) {
 		HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
 				.GET()
+				.timeout(Duration.ofSeconds(30))
 				.uri(URI.create(uri));
 		if (headers != null && headers.length > 0 && headers.length % 2 == 0) {
 			httpRequestBuilder.headers(headers);
@@ -71,6 +73,7 @@ public class Utils {
 	public static HttpResponse<String> getAsHttpResponse(String uri, String... headers) {
 		HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
 				.GET()
+				.timeout(Duration.ofSeconds(30))
 				.uri(URI.create(uri));
 		if (headers != null && headers.length > 0 && headers.length % 2 == 0) {
 			httpRequestBuilder.headers(headers);
@@ -97,6 +100,7 @@ public class Utils {
 		HttpRequest request = HttpRequest.newBuilder()
 				.GET()
 				.uri(URI.create(uri))
+				.timeout(Duration.ofSeconds(30))
 				.header("Authorization", "Bearer " + jwtString)
 				.build();
 		HttpClient client = HttpClient.newHttpClient();
@@ -125,6 +129,7 @@ public class Utils {
 	public static String post(String uri, String body, String... extraHeaders) {
 		HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
 				.POST(HttpRequest.BodyPublishers.ofString(body))
+				.timeout(Duration.ofSeconds(30))
 				.uri(URI.create(uri));
 		if (extraHeaders != null && extraHeaders.length > 0 && extraHeaders.length % 2 == 0) {
 			httpRequestBuilder.headers(extraHeaders);
@@ -156,6 +161,7 @@ public class Utils {
 		HttpRequest request = HttpRequest.newBuilder()
 				.POST(HttpRequest.BodyPublishers.ofString(json))
 				.uri(URI.create(uri))
+				.timeout(Duration.ofSeconds(30))
 				.header("Content-Type", "application/json")
 				.header("Authorization", "Bearer " + jwtString)
 				.headers(extraHeaders)
@@ -178,6 +184,7 @@ public class Utils {
 		HttpRequest request = HttpRequest.newBuilder()
 				.method("PATCH", HttpRequest.BodyPublishers.ofString(json))
 				.uri(URI.create(uri))
+				.timeout(Duration.ofSeconds(30))
 				.header("Content-Type", "application/json")
 				.header("Authorization", "Bearer " + jwtString)
 				.build();

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitlabScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitlabScraper.java
@@ -20,6 +20,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.time.ZonedDateTime;
 
 public class GitlabScraper implements GitScraper {
@@ -83,6 +84,7 @@ public class GitlabScraper implements GitScraper {
 			HttpRequest request = HttpRequest.newBuilder().GET()
 					.uri(URI.create(apiUri + "/projects/" + Utils.urlEncode(projectPath)
 							+ "/repository/commits?per_page=100&order=default&page=" + page))
+					.timeout(Duration.ofSeconds(30))
 					.build();
 			HttpClient client =
 					HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/DockerHubScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/DockerHubScraper.java
@@ -44,7 +44,7 @@ public class DockerHubScraper implements PackageManagerScraper {
 				.followRedirects(HttpClient.Redirect.NORMAL)
 				.build();
 		HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-				.timeout(Duration.ofSeconds(10))
+				.timeout(Duration.ofSeconds(30))
 				.build();
 		String json;
 		try {

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PackageManagerScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PackageManagerScraper.java
@@ -31,7 +31,7 @@ public interface PackageManagerScraper {
 				.followRedirects(HttpClient.Redirect.NORMAL)
 				.build();
 		HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-				.timeout(Duration.ofSeconds(10))
+				.timeout(Duration.ofSeconds(30))
 				.build();
 		try {
 			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PypiScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PypiScraper.java
@@ -40,7 +40,7 @@ public class PypiScraper implements PackageManagerScraper {
 				.followRedirects(HttpClient.Redirect.NORMAL)
 				.build();
 		HttpRequest request = HttpRequest.newBuilder(URI.create("https://api.pepy.tech/api/v2/projects/" + packageName))
-				.timeout(Duration.ofSeconds(5))
+				.timeout(Duration.ofSeconds(30))
 				.build();
 		try {
 			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());


### PR DESCRIPTION
# Scrapers request timeouts

Changes proposed in this pull request:

* All HTTP requests of the scrapers now have a timeout, which is triggered when the headers of the request have not been received by that time.

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Check that the scrapers still work
* Check in the code that I didn't forget to add a timeout somewhere


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
