### PR TITLE
fix: search only for top level organisation in global search

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1300,6 +1300,9 @@ BEGIN RETURN QUERY
 		) AS search_text
 	FROM
 		organisation
+	WHERE
+	-- ONLY TOP LEVEL ORGANISATIONS
+		organisation.parent IS NULL
 ;
 END
 $$;


### PR DESCRIPTION
# Show only top level organisations in global search

Closes #898

Changes proposed in this pull request:
*  Global search shows only top level organisations not children (research units)    

How to test:
* `make start` to build app and generate test data
* login as rsd_admin in order to manipulate organisations
* select first organisation from the overview and add 1 or 2 research units
* try to find these units using global search. These should not be found.
* try top level organisation. It should be found. Open the page and confirm that organisation has research unit with the name used during search

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
