### PR TITLE
fix: warn when project end date is before start date

### DIFF
--- a/frontend/components/form/AutosaveControlledTextField.tsx
+++ b/frontend/components/form/AutosaveControlledTextField.tsx
@@ -1,27 +1,29 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useController} from 'react-hook-form'
 import ControlledTextField, {ControlledTextFieldOptions} from '~/components/form/ControlledTextField'
 
-export type OnSaveProps = {
-  name: string,
+export type OnSaveProps<T> = {
+  name: keyof T,
   value: string
 }
 
-export type AutosaveControlledTextField = {
+export type AutosaveControlledTextField<T> = {
   control: any
-  options: ControlledTextFieldOptions
+  options: ControlledTextFieldOptions<T>
   rules?: any
-  onSaveField: ({name,value}: OnSaveProps) => void
+  onSaveField: ({name,value}: OnSaveProps<T>) => void
 }
 
-export default function AutosaveControlledTextField({control,options,rules,onSaveField}:AutosaveControlledTextField) {
+export default function AutosaveControlledTextField<T>({control,options,rules,onSaveField}:AutosaveControlledTextField<T>) {
   const {field:{value},fieldState:{isDirty,error}} = useController({
     control,
-    name: options.name
+    name: options.name.toString()
   })
 
   // add onBlur fn to muiProps

--- a/frontend/components/form/ControlledTextField.tsx
+++ b/frontend/components/form/ControlledTextField.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,8 +11,8 @@ import {Controller} from 'react-hook-form'
 import TextField, {TextFieldProps} from '@mui/material/TextField'
 import HelperTextWithCounter from './HelperTextWithCounter'
 
-export type ControlledTextFieldOptions = {
-  name: string,
+export type ControlledTextFieldOptions<T> = {
+  name: keyof T,
   autofocus?:boolean
   autoComplete?: string
   multiline?: boolean
@@ -29,13 +30,13 @@ export type ControlledTextFieldOptions = {
   muiProps?: TextFieldProps
 }
 
-export type ControlledTextFieldProps = {
-  options: ControlledTextFieldOptions,
+export type ControlledTextFieldProps<T> = {
+  options: ControlledTextFieldOptions<T>,
   control: any,
   rules?: any
 }
 
-export default function ControlledTextField({options, control, rules}:ControlledTextFieldProps) {
+export default function ControlledTextField<T>({options, control, rules}:ControlledTextFieldProps<T>) {
   const inputRef = useRef<HTMLInputElement | null>(null)
 
   useEffect(() => {
@@ -48,20 +49,22 @@ export default function ControlledTextField({options, control, rules}:Controlled
 
   return (
     <Controller
-      name={options.name}
+      name={options.name.toString()}
       defaultValue={options?.defaultValue}
       rules={rules}
       control={control}
       render={({field,fieldState}) => {
         const {onChange,value} = field
         const {error} = fieldState
-          // console.group(`ControlledTextField...${options.name}`)
-          // console.log('error...',error)
-          // console.log('value...', value)
-          // console.groupEnd()
+        // if (error) {
+        //   console.group(`ControlledTextField...${options.name.toString()}`)
+        //   console.log('error...',error)
+        //   console.log('value...', value)
+        //   console.groupEnd()
+        // }
         return (
           <TextField
-            id={options.name ?? `input-${Math.floor(Math.random()*10000)}`}
+            id={options.name.toString() ?? `input-${Math.floor(Math.random()*10000)}`}
             inputRef={inputRef}
             disabled={options?.disabled ?? false}
             autoComplete={options?.autoComplete ?? 'off'}

--- a/frontend/components/organisation/settings/AutosaveOrganisationTextField.tsx
+++ b/frontend/components/organisation/settings/AutosaveOrganisationTextField.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,10 +11,11 @@ import AutosaveControlledTextField, {OnSaveProps} from '~/components/form/Autosa
 import {ControlledTextFieldOptions} from '~/components/form/ControlledTextField'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {patchOrganisationTable} from './updateOrganisationSettings'
+import {OrganisationForOverview} from '~/types/Organisation'
 
 export type AutosaveProjectInfoProps = {
   organisation_id: string
-  options: ControlledTextFieldOptions
+  options: ControlledTextFieldOptions<OrganisationForOverview>
   rules?: any
 }
 
@@ -21,7 +24,7 @@ export default function AutosaveOrganisationTextField({organisation_id,options,r
   const {showErrorMessage} = useSnackbar()
   const {control, resetField} = useFormContext()
 
-  async function saveSoftwareInfo({name, value}: OnSaveProps) {
+  async function saveSoftwareInfo({name, value}: OnSaveProps<OrganisationForOverview>) {
     // patch project table
     const resp = await patchOrganisationTable({
       id: organisation_id,

--- a/frontend/components/projects/edit/information/AutosaveProjectPeriod.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectPeriod.tsx
@@ -1,36 +1,93 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useEffect} from 'react'
+import {useCallback, useEffect} from 'react'
 import {useFormContext} from 'react-hook-form'
 
+import {useSession} from '~/auth'
 import {EditProject} from '~/types/Project'
-import AutosaveProjectTextField from './AutosaveProjectTextField'
+import useSnackbar from '~/components/snackbar/useSnackbar'
 import {projectInformation as config} from './config'
+import AutosaveControlledTextField, {OnSaveProps} from '~/components/form/AutosaveControlledTextField'
+import {patchProjectTable} from './patchProjectInfo'
 
 export default function AutosaveProjectPeriod({date_start, date_end}:
   { date_start: string | null, date_end: string | null }) {
-  const {setError, watch} = useFormContext<EditProject>()
+  const {token} = useSession()
+  const {showErrorMessage} = useSnackbar()
+  const {control, watch, setError, clearErrors, resetField} = useFormContext<EditProject>()
   const [id, start, end] = watch(['id', 'date_start', 'date_end'])
 
-  // end_date validation
-  // useEffect(() => {
-  //   if (start && end) {
-  //     const start_date = new Date(start)
-  //     const end_date = new Date(end)
-  //     if (start_date >= end_date) {
-  //       debugger
-  //       setError('date_end', {type:'required',message:'Less then start date'})
-  //     }
-  //   }
-  // },[start,end,setError])
+  const validateDateRange = useCallback(() => {
+    if (start && end) {
+      const start_date = new Date(start)
+      const end_date = new Date(end)
+      // console.group('validateDateRange')
+      // console.log('start_date...', start_date)
+      // console.log('end_date...', end_date)
+      // console.log('start...', start)
+      // console.log('end...', end)
+      // console.groupEnd()
+
+      if (start_date > end_date) {
+        // we need to wait for event loop to complete before setting new error
+        setTimeout(() => {
+          setError('date_start', {type: 'validate', message: 'Start date should be before end date'})
+          setError('date_end', {type:'validate',message:'End date should be after start date'})
+        }, 1)
+      } else {
+        // console.log('clearErrors')
+        clearErrors(['date_start','date_end'])
+      }
+    }
+  }, [start, end, clearErrors, setError])
+
+  // date validation
+  useEffect(() => {
+    if (start && end) {
+      validateDateRange()
+    }
+  }, [start, end, validateDateRange])
+
+  async function saveProjectPeriod({name, value}: OnSaveProps<EditProject>) {
+    // console.group('saveProjectPeriod')
+    // console.log('name...', name)
+    // console.log('value...', value)
+    // console.log('start...', start)
+    // console.log('end...', end)
+    // console.groupEnd()
+    // patch project table, both values at the same time
+    const resp = await patchProjectTable({
+      id,
+      data: {
+        'date_start': start,
+        'date_end': end
+      },
+      token
+    })
+
+    if (resp?.status !== 200) {
+      showErrorMessage(`Failed to save ${name}. ${resp?.message}`)
+    } else {
+      // rest changed field after save to remove dirty/touched flags
+      resetField('date_start', {
+        defaultValue: start
+      })
+      resetField('date_end', {
+        defaultValue: end
+      })
+    }
+  }
 
   return (
     <div className="flex">
-      <AutosaveProjectTextField
-        project_id={id}
+      <AutosaveControlledTextField
+        control={control}
+        onSaveField={saveProjectPeriod}
         options={{
           name: 'date_start',
           label: '',
@@ -48,8 +105,9 @@ export default function AutosaveProjectPeriod({date_start, date_end}:
         }}
       />
       <div className="px-5"></div>
-      <AutosaveProjectTextField
-        project_id={id}
+      <AutosaveControlledTextField
+        control={control}
+        onSaveField={saveProjectPeriod}
         options={{
           name: 'date_end',
           label: '',

--- a/frontend/components/projects/edit/information/AutosaveProjectTextField.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectTextField.tsx
@@ -1,10 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useFormContext} from 'react-hook-form'
+
 import {useSession} from '~/auth'
+import {EditProject} from '~/types/Project'
 import AutosaveControlledTextField, {OnSaveProps} from '~/components/form/AutosaveControlledTextField'
 import {ControlledTextFieldOptions} from '~/components/form/ControlledTextField'
 import useSnackbar from '~/components/snackbar/useSnackbar'
@@ -13,7 +17,7 @@ import {patchProjectTable} from './patchProjectInfo'
 
 export type AutosaveProjectInfoProps = {
   project_id: string
-  options: ControlledTextFieldOptions
+  options: ControlledTextFieldOptions<EditProject>
   rules?: any
 }
 
@@ -23,7 +27,7 @@ export default function AutosaveProjectTextField({project_id,options,rules}:Auto
   const {setProjectTitle, setProjectSlug} = useProjectContext()
   const {control, resetField} = useFormContext()
 
-  async function saveProjectInfo({name, value}: OnSaveProps) {
+  async function saveProjectInfo({name, value}: OnSaveProps<EditProject>) {
     // patch project table
     const resp = await patchProjectTable({
       id: project_id,
@@ -40,10 +44,10 @@ export default function AutosaveProjectTextField({project_id,options,rules}:Auto
     // console.groupEnd()
 
     if (resp?.status !== 200) {
-      showErrorMessage(`Failed to save ${options.name}. ${resp?.message}`)
+      showErrorMessage(`Failed to save ${options.name.toString()}. ${resp?.message}`)
     } else {
       // debugger
-      resetField(options.name, {
+      resetField(options.name.toString(), {
         defaultValue:value
       })
       // update shared state

--- a/frontend/components/software/edit/information/AutosaveRemoteMarkdown.tsx
+++ b/frontend/components/software/edit/information/AutosaveRemoteMarkdown.tsx
@@ -2,24 +2,28 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useState,useEffect} from 'react'
 import {useWatch,useFormState} from 'react-hook-form'
+
+import {EditSoftwareItem} from '~/types/SoftwareTypes'
+import {getRemoteMarkdown} from '~/utils/getSoftware'
+import {useDebounceValid} from '~/utils/useDebounce'
 import ReactMarkdownWithSettings from '~/components/layout/ReactMarkdownWithSettings'
 import PageErrorMessage from '~/components/layout/PageErrorMessage'
-import {getRemoteMarkdown} from '~/utils/getSoftware'
 import ContentLoader from '~/components/layout/ContentLoader'
-import {useDebounceValid} from '~/utils/useDebounce'
 import AutosaveControlledTextField, {OnSaveProps} from '~/components/form/AutosaveControlledTextField'
 import {ControlledTextFieldOptions} from '~/components/form/ControlledTextField'
 
 type AutosaveRemoteMarkdownProps = {
   control: any,
   rules: any,
-  options: ControlledTextFieldOptions,
-  onSaveField: ({name,value}: OnSaveProps) => void
+  options: ControlledTextFieldOptions<EditSoftwareItem>,
+  onSaveField: ({name,value}: OnSaveProps<EditSoftwareItem>) => void
 }
 
 export default function AutosaveRemoteMarkdown({control,rules,options,onSaveField}: AutosaveRemoteMarkdownProps) {

--- a/frontend/components/software/edit/information/AutosaveRepositoryUrl.tsx
+++ b/frontend/components/software/edit/information/AutosaveRepositoryUrl.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -77,7 +78,7 @@ export default function AutosaveRepositoryUrl() {
   const [suggestedPlatform, setSuggestedPlatform] = useState<CodePlatform>()
 
   const options = {
-    name: 'repository_url',
+    name: 'repository_url' as keyof EditSoftwareItem,
     label: config.repository_url.label,
     useNull: true,
     defaultValue: repository_url,
@@ -115,7 +116,7 @@ export default function AutosaveRepositoryUrl() {
     }
   },[urlError,repository_url,platform.id])
 
-  async function saveRepositoryInfo({name, value}: OnSaveProps) {
+  async function saveRepositoryInfo({name, value}: OnSaveProps<EditSoftwareItem>) {
     // complete record for upsert
     const data:RepositoryUrl = {
       software: id,

--- a/frontend/components/software/edit/information/AutosaveSoftwareTextField.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareTextField.tsx
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -6,6 +8,7 @@
 import {useRouter} from 'next/router'
 import {useFormContext} from 'react-hook-form'
 import {useSession} from '~/auth'
+import {EditSoftwareItem} from '~/types/SoftwareTypes'
 import AutosaveControlledTextField, {OnSaveProps} from '~/components/form/AutosaveControlledTextField'
 import {ControlledTextFieldOptions} from '~/components/form/ControlledTextField'
 import useSnackbar from '~/components/snackbar/useSnackbar'
@@ -14,7 +17,7 @@ import {patchSoftwareTable} from './patchSoftwareTable'
 
 export type AutosaveProjectInfoProps = {
   software_id: string
-  options: ControlledTextFieldOptions
+  options: ControlledTextFieldOptions<EditSoftwareItem>
   rules?: any
 }
 
@@ -25,7 +28,7 @@ export default function AutosaveSoftwareTextField({software_id,options,rules}:Au
   const {setSoftwareTitle, setSoftwareSlug, setConceptDoi} = useSoftwareContext()
   const {control, resetField} = useFormContext()
 
-  async function saveSoftwareInfo({name, value}: OnSaveProps) {
+  async function saveSoftwareInfo({name, value}: OnSaveProps<EditSoftwareItem>) {
     // patch project table
     const resp = await patchSoftwareTable({
       id: software_id,


### PR DESCRIPTION
# Warn when project end date is before start date

Closes #897

Changes proposed in this pull request:
* Show warning under start and end date input when end date is before start date
* Save both values at the same time when input is valid (on lost focus)

How to test:
* `make start` to build app create test data
* login as rsd_admin to be able to manipulate existing project
* select first project from overview and edit project period
* select end date which is before start date. The error should appear (see image)
* correct end date and error should be removed
* select start date to be after end date. The error on end date should appear

## Example end date error/notification
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/c8e532b2-a3ec-4d61-a6ec-303fa189c0ac)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
