### PR TITLE
Replace postman tests

### DIFF
--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2022 - 2023 dv4all
 # SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2023 dv4all
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -35,11 +35,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: "newman tests with docker compose"
-        working-directory: backend-postgrest/tests
+      - name: "backend tests with docker compose"
+        working-directory: backend-tests
         run: |
           docker compose up \
-            --abort-on-container-exit \
             --exit-code-from postgrest-tests
 
   scrapers-tests:

--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -8,25 +8,27 @@
 name: backend tests
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
     paths:
       - "backend-postgrest/**"
       - "database/**"
+      - "backend-tests/**"
   pull_request:
     paths:
       - "backend-postgrest/**"
       - "database/**"
+      - "backend-tests/**"
 
 jobs:
   api-tests:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: "newman tests with docker compose"
-        working-directory: backend-postgrest/tests
+      - name: "backend tests with docker compose"
+        working-directory: backend-tests
         run: |
           docker compose up \
-            --abort-on-container-exit \
             --exit-code-from postgrest-tests

--- a/Makefile
+++ b/Makefile
@@ -86,3 +86,9 @@ e2e-tests:
 	docker compose --file e2e/docker-compose.yml up
 	docker compose down
 	docker compose --file e2e/docker-compose.yml down --volumes
+
+run-backend-tests:
+	docker compose --file backend-tests/docker-compose.yml down --volumes
+	docker compose --file backend-tests/docker-compose.yml build --parallel
+	docker compose --file backend-tests/docker-compose.yml up --exit-code-from postgrest-tests
+	docker compose --file backend-tests/docker-compose.yml down --volumes

--- a/backend-postgrest/tests/README.md
+++ b/backend-postgrest/tests/README.md
@@ -7,6 +7,10 @@ SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 SPDX-License-Identifier: CC-BY-4.0
 -->
 
+# Deprecated
+This folder is deprecated in favor of using the tests in the folder `backend-tests`.
+This folder is kept here to see which old tests were used, but might be deleted in the future.
+
 # Research Software Directory (RSD) - PostgREST tests
 
 This service can automatically be build and started with `docker compose`. It does not work in conjunction with the `data-migration` service. It also assumes that the database is empty at the start.

--- a/backend-tests/.gitignore
+++ b/backend-tests/.gitignore
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+#
+# SPDX-License-Identifier: Apache-2.0
+
+target/
+!.mvn/wrapper/maven-wrapper.jar
+!**/src/main/**/target/
+!**/src/test/**/target/
+
+### IntelliJ IDEA ###
+.idea/modules.xml
+.idea/jarRepositories.xml
+.idea/compiler.xml
+.idea/libraries/
+*.iws
+*.iml
+*.ipr
+
+### Eclipse ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+build/
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### VS Code ###
+.vscode/
+
+### Mac OS ###
+.DS_Store

--- a/backend-tests/Dockerfile
+++ b/backend-tests/Dockerfile
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+#
+# SPDX-License-Identifier: Apache-2.0
+
+FROM maven:3.8.7-openjdk-18
+WORKDIR /usr/mymaven
+RUN mkdir src
+COPY pom.xml .
+RUN mvn dependency:go-offline
+COPY ./src ./src
+CMD mvn test --offline

--- a/backend-tests/README.md
+++ b/backend-tests/README.md
@@ -1,0 +1,51 @@
+<!--
+SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+# Backend tests
+
+This folder contains backend tests for the RSD. It is intended to mainly: 
+- test the correctness of row level security rules
+- test the correctness of remote procedure calls (no tests yet)
+- load test the backend/database (no tests yet)
+
+## Tech stack
+This module is written in Java as a Maven project.
+To help with testing REST endpoints, we make use of [REST Assured](https://rest-assured.io/), which has its documentation [here](https://github.com/rest-assured/rest-assured/wiki/Usage).
+As a testing framework we use [JUnit 5](https://junit.org/junit5/).
+
+## Principles
+Tests should be written taking the following principles in account:
+- each test should be runnable independently of other tests
+- each test should be repeatable, without e.g. having to clean up the database first
+
+## Running
+### From the command line
+This section assumes that you are in the root directory of the project.
+
+The easiest way to run the tests is with `make`. Make sure no other RSD containers are running.
+```shell
+make run-backend-tests
+```
+
+You can also run the tests directly with `docker compose`.
+```shell
+docker compose --file backend-tests/docker-compose.yml down --volumes && \
+docker compose --file backend-tests/docker-compose.yml build --parallel && \
+docker compose --file backend-tests/docker-compose.yml up
+```
+This leaves the containers running, so you can inspect the database if necessary. To clean up run
+```shell
+docker compose --file backend-tests/docker-compose.yml down --volumes
+```
+
+### From an IDE
+If you use an IDE that supports [JUnit](https://junit.org/junit5/), you can run each test manually against a running RSD instance (that you started with e.g. `make start`).
+Make sure to have set the following environment variables:
+- `POSTGREST_URL`
+- `PGRST_JWT_SECRET`
+
+Check your `.env` file for the values, but you should **EXPLICITELY** add the port number to `POSTGREST_URL` (which is most likely `80`).

--- a/backend-tests/docker-compose.yml
+++ b/backend-tests/docker-compose.yml
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+# SPDX-FileCopyrightText: 2022 dv4all
+#
+# SPDX-License-Identifier: Apache-2.0
+
+version: "3.0"
+
+services:
+  database:
+    container_name: database-test
+    build: ../database
+    image: rsd/database-test:1.0.0
+    ports:
+      # enable connection from outside
+      - "5432:5432"
+    environment:
+      - POSTGRES_DB=rsd-db
+      - POSTGRES_USER=rsd
+      - POSTGRES_PASSWORD=securepassword
+      - POSTGRES_AUTHENTICATOR_PASSWORD=simplepassword
+    volumes:
+      # persist data in named docker volume
+      # to remove use: docker compose down --volumes
+      # to inspect use: docker volume ls
+      - pgdb-test:/var/lib/postgresql/data/
+    networks:
+      - net-test
+
+  backend:
+    container_name: backend-postgrest-test
+    build: ../backend-postgrest
+    image: rsd/backend-postgrest-test:1.0.0
+    ports:
+      # enable connection from outside
+      - "3500:3500"
+    environment:
+      - PGRST_DB_URI=postgres://rsd_authenticator:simplepassword@database:5432/rsd-db
+      - PGRST_DB_ANON_ROLE=rsd_web_anon
+      - PGRST_DB_SCHEMA=public
+      - PGRST_SERVER_PORT=3500
+      - PGRST_JWT_SECRET=normally_this_is_a_secret_string_that_none_knows_BUT_this_is_just_a_test
+    depends_on:
+      - "database"
+    networks:
+      - net-test
+
+  postgrest-tests:
+    container_name: postgrest-tests
+    build:
+      context: .
+      # dockerfile to use for build
+      dockerfile: ./Dockerfile
+    image: rsd/postgrest-tests:1.0.0
+    environment:
+      - PGRST_JWT_SECRET=normally_this_is_a_secret_string_that_none_knows_BUT_this_is_just_a_test
+      - POSTGREST_URL=http://backend:3500
+    depends_on:
+      - "database"
+      - "backend"
+    networks:
+      - net-test
+
+# define name for docker network
+# it should have name: rsd-as-a-service_net-test
+networks:
+  net-test:
+
+# named volumes can be managed easier using docker compose
+# volume should have name rsd-as-a-service_pgdb
+volumes:
+  pgdb-test:

--- a/backend-tests/pom.xml
+++ b/backend-tests/pom.xml
@@ -22,6 +22,45 @@ SPDX-License-Identifier: Apache-2.0
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
+    <build>
+        <plugins>
+            <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.0</version>
+            </plugin>
+
+            <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+
+            <!-- https://mvnrepository.com/artifact/org.apache.maven.surefire/surefire-junit-platform -->
+            <plugin>
+                <groupId>org.apache.maven.surefire</groupId>
+                <artifactId>surefire-junit-platform</artifactId>
+                <version>3.1.0</version>
+            </plugin>
+
+            <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
+            <plugin>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>5.9.3</version>
+            </plugin>
+
+            <!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher -->
+            <plugin>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-launcher</artifactId>
+                <version>1.9.3</version>
+            </plugin>
+        </plugins>
+    </build>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
         <dependency>

--- a/backend-tests/pom.xml
+++ b/backend-tests/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>nl.research-software</groupId>
+    <artifactId>backend-tests</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>4.4.0</version>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->
+        <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <version>5.3.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
@@ -1,0 +1,229 @@
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Date;
+import java.util.List;
+import java.util.UUID;
+
+public class AuthenticationIntegrationTest {
+
+	static final long ONE_HOUR_IN_MILLISECONDS = 3600_000L; // 60 * 60 * 1000
+	static String adminToken;
+
+	static String userJwt(String account) {
+		String secret = System.getenv("PGRST_JWT_SECRET");
+		Algorithm signingAlgorithm = Algorithm.HMAC256(secret);
+
+		return JWT.create()
+				.withClaim("account", account)
+				.withClaim("iss", "rsd_test")
+				.withClaim("role", "rsd_user")
+				.withExpiresAt(new Date(System.currentTimeMillis() + ONE_HOUR_IN_MILLISECONDS))
+				.sign(signingAlgorithm);
+	}
+
+	static String createUser() {
+		return RestAssured.given()
+				.header(new Header("Authorization", "bearer " + adminToken))
+				.header(new Header("Prefer", "return=representation"))
+				.when()
+				.post("account")
+				.then()
+				.statusCode(201)
+				.contentType(ContentType.JSON)
+				.extract()
+				.path("[0].id");
+	}
+
+	@BeforeAll
+	static void setupRestAssured() {
+		RestAssured.port = 80;
+		RestAssured.baseURI = "http://localhost";
+		RestAssured.basePath = "api/v1";
+		RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+		String secret = System.getenv("PGRST_JWT_SECRET");
+		Algorithm signingAlgorithm = Algorithm.HMAC256(secret);
+
+		adminToken = JWT.create()
+				.withClaim("iss", "rsd_test")
+				.withClaim("role", "rsd_admin")
+				.withExpiresAt(new Date(System.currentTimeMillis() + ONE_HOUR_IN_MILLISECONDS))
+				.sign(signingAlgorithm);
+	}
+
+	@Test
+	void givenAdmin_whenCreatingAccount_thenSuccess() {
+		createUser();
+	}
+
+	@Test
+	void givenUserWithoutAgreeingOnTerms_whenCreatingSoftware_thenNotAllowed() {
+		String accountId = createUser();
+
+		String userToken = userJwt(accountId);
+
+		String expectedMessage = "You need to agree to our Terms of Service and the Privacy Statement before proceeding. Please open your user profile settings to agree.";
+		RestAssured.given()
+				.header(new Header("Authorization", "bearer " + userToken))
+				.contentType(ContentType.JSON)
+				.body("{\"slug\": \"test-slug-user\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}")
+				.when()
+				.post("software")
+				.then()
+				.statusCode(400)
+				.body(CoreMatchers.containsString(expectedMessage));
+	}
+
+	@Test
+	void givenUserWhoAgreedOnTerms_whenCreatingAndEditingSoftware_thenSuccess() {
+		String accountId = createUser();
+
+		String userToken = userJwt(accountId);
+
+		RestAssured.given()
+				.header(new Header("Authorization", "bearer " + userToken))
+				.contentType(ContentType.JSON)
+				.body("{\"agree_terms\": true, \"notice_privacy_statement\": true}")
+				.when()
+				.patch("account?id=eq." + accountId)
+				.then()
+				.statusCode(204);
+
+		String slug = UUID.randomUUID().toString();
+		RestAssured.given()
+				.header(new Header("Authorization", "bearer " + userToken))
+				.contentType(ContentType.JSON)
+				.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}".formatted(slug))
+				.when()
+				.post("software")
+				.then()
+				.statusCode(201);
+
+		String getStartedUrl = "https://www.example.com";
+		String patchedGetStartedUrl = RestAssured.given()
+				.header(new Header("Authorization", "bearer " + userToken))
+				.header(new Header("Prefer", "return=representation"))
+				.contentType(ContentType.JSON)
+				.body("{\"get_started_url\": \"%s\"}".formatted(getStartedUrl))
+				.when()
+				.patch("software?select=get_started_url&slug=eq." + slug)
+				.then()
+				.statusCode(200)
+				.extract()
+				.path("[0].get_started_url");
+		Assertions.assertEquals(getStartedUrl, patchedGetStartedUrl);
+	}
+
+	@Test
+	void givenUserWhoAgreedOnTerms_whenEditingSoftwareNotMaintainer_thenNowAllowed() {
+		String slug = UUID.randomUUID().toString();
+		RestAssured.given()
+				.header(new Header("Authorization", "bearer " + adminToken))
+				.contentType(ContentType.JSON)
+				.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}".formatted(slug))
+				.when()
+				.post("software")
+				.then()
+				.statusCode(201);
+
+		String accountId = createUser();
+
+		String userToken = userJwt(accountId);
+
+		RestAssured.given()
+				.header(new Header("Authorization", "bearer " + userToken))
+				.contentType(ContentType.JSON)
+				.body("{\"agree_terms\": true, \"notice_privacy_statement\": true}")
+				.when()
+				.patch("account?id=eq." + accountId)
+				.then()
+				.statusCode(204);
+
+
+		String getStartedUrl = "https://www.example.com";
+		List response = RestAssured.given()
+				.header(new Header("Authorization", "bearer " + userToken))
+				.header(new Header("Prefer", "return=representation"))
+				.contentType(ContentType.JSON)
+				.body("{\"get_started_url\": \"%s\"}".formatted(getStartedUrl))
+				.when()
+				.patch("software?select=get_started_url&slug=eq." + slug)
+				.then()
+				.statusCode(200)
+				.extract()
+				.body()
+				.as(List.class);
+		Assertions.assertTrue(response.isEmpty());
+	}
+
+	@Test
+	void givenUnauthenticatedUser_whenViewingTables_thenSuccess() {
+		RestAssured
+				.when()
+				.get("software")
+				.then()
+				.statusCode(200);
+
+		RestAssured
+				.when()
+				.get("project")
+				.then()
+				.statusCode(200);
+	}
+
+	@Test
+	void givenUnauthenticatedUser_whenViewingUnpublishedSoftware_thenNothingReturned() {
+		String slug = UUID.randomUUID().toString();
+		RestAssured.given()
+				.header(new Header("Authorization", "bearer " + adminToken))
+				.contentType(ContentType.JSON)
+				.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": false, \"short_statement\": \"Test software for testing\"}".formatted(slug))
+				.when()
+				.post("software")
+				.then()
+				.statusCode(201);
+
+		List response = RestAssured.when()
+				.get("software?slug=eq."  + slug)
+				.then()
+				.statusCode(200)
+				.extract()
+				.body()
+				.as(List.class);
+		Assertions.assertTrue(response.isEmpty());
+	}
+
+	@Test
+	void givenUnauthenticatedUser_whenEditingAnyTable_thenNotAllowed() {
+		RestAssured.given()
+				.contentType(ContentType.JSON)
+				.body("{\"short_statement\": \"invalid statement\"}")
+				.when()
+				.patch("software")
+				.then()
+				.statusCode(401);
+
+		RestAssured.given()
+				.contentType(ContentType.JSON)
+				.body("{\"subtitle\": \"invalid subtitle\"}")
+				.when()
+				.patch("project")
+				.then()
+				.statusCode(401);
+	}
+}


### PR DESCRIPTION
# Replace Postman tests

Changes proposed in this pull request:

* Postman tests are replaced by full code tests written in Java as a Maven project
* Main libraries are [REST Assured](https://rest-assured.io/) and [JUnit 5](https://junit.org/junit5/)
* Not all tests were migrated
* Add deprecation note on the old README but keep the folder so the old tests can still be found

How to test:

* Read the new `README.md` and check if the instructions are clear enough for you to be able to run the new tests 😉
* Check if any essential tests are missing


Closes #813

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [x] Tests
