### PR TITLE
chore: remove links in login options

### DIFF
--- a/frontend/components/login/LoginButton.tsx
+++ b/frontend/components/login/LoginButton.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -35,14 +36,7 @@ export default function LoginButton() {
   }
 
   if (status === 'authenticated') {
-    // when user is authenticated
-    let hasOrcid = false
-    providers.forEach(provider => {
-      if ( provider.name === 'ORCID' ) {
-        hasOrcid = true
-      }
-    })
-    const menuItems = getUserMenuItems(session.user?.role, hasOrcid)
+    const menuItems = getUserMenuItems(session.user?.role)
     // we show user menu with the avatar and user specific options
     return (
       <>

--- a/frontend/config/userMenuItems.tsx
+++ b/frontend/config/userMenuItems.tsx
@@ -2,8 +2,9 @@
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,15 +12,13 @@ import TerminalIcon from '@mui/icons-material/Terminal'
 import ListAltIcon from '@mui/icons-material/ListAlt'
 import BusinessIcon from '@mui/icons-material/Business'
 import ManageAccountsIcon from '@mui/icons-material/ManageAccounts'
-import PlaylistAddCheckIcon from '@mui/icons-material/PlaylistAddCheck'
 import SettingsIcon from '@mui/icons-material/Settings'
 import Logout from '@mui/icons-material/Logout'
 
 import {MenuItemType} from './menuItems'
 
 export function getUserMenuItems(
-    role: 'rsd_admin' | 'rsd_user'='rsd_user',
-    orcidEnabled: boolean=false,
+    role: 'rsd_admin' | 'rsd_user'='rsd_user'
   ) {
 
   const userMenuItems: MenuItemType[] = [

--- a/frontend/pages/api/fe/auth/orcid.ts
+++ b/frontend/pages/api/fe/auth/orcid.ts
@@ -1,9 +1,10 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -60,8 +61,8 @@ export async function orcidInfo() {
       name: 'ORCID',
       redirectUrl,
       html: `
-        Sign in with ORCID is supported <strong>only for persons invited by the RSD administrators</strong>.
-        <strong><a href="mailto:rsd@esciencecenter.nl?subject=${encodeURIComponent('Login with ORCID')}" target="_blank">Contact us</a></strong> if you wish to login with your ORCID.
+        Sign in with ORCID is supported <strong>only for persons approved by the RSD administrators</strong>.
+        Contact us on rsd@esciencecenter.nl if you wish to login with your ORCID.
       `
     }
   }

--- a/frontend/pages/api/fe/auth/surfconext.ts
+++ b/frontend/pages/api/fe/auth/surfconext.ts
@@ -1,9 +1,10 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -59,10 +60,8 @@ export async function surfconextInfo() {
     return {
       name: 'SURFconext',
       redirectUrl,
-      html: `<p>Sign in with SURFconext is for <strong>Dutch Institutions who enabled the 
-      RSD service</strong> in the <a href="https://dashboard.surfconext.nl/apps/9514/oidc10_rp/about" target = "_new">
-      SURFconext IdP dashboard</a>.
-      </p>`
+      html: `Sign in with SURFconext is for <strong>Dutch Institutions</strong> who enabled the
+      RSD service in the SURFconext IdP dashboard.`
     }
   }
   return null


### PR DESCRIPTION
# Remove links in 

Closes #889

Changes proposed in this pull request:
*  Removing additional links in the login options. The approach is confusing because it opens additional links instead of opening login screen    

How to test:
* `make start` to build app an create test data
* from the homepage try to login. You will be presented with number of options. If you have same .env value as me, it would be 4 options (see screenshot)
* confirm that are no additional links in the login options
* note! The only additional link is to documentation, at the bottom of the modal

## Login options (without additional links)

![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/43435bdb-96ef-45fe-b7c5-b6027af6ef23)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
