### PR TITLE
Add closed_source flag to database

### DIFF
--- a/database/003-create-software-table.sql
+++ b/database/003-create-software-table.sql
@@ -4,6 +4,8 @@
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 -- SPDX-FileCopyrightText: 2022 dv4all
+-- SPDX-FileCopyrightText: 2023 Diego Alonso Alvarez (ICL) <d.alonso-alvarez@imperial.ac.uk>
+-- SPDX-FileCopyrightText: 2023 Imperial College London
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -21,6 +23,7 @@ CREATE TABLE software (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
 	slug VARCHAR(200) UNIQUE NOT NULL CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
 	brand_name VARCHAR(200) NOT NULL,
+	closed_source BOOLEAN DEFAULT FALSE NOT NULL,
 	concept_doi CITEXT CHECK (concept_doi ~ '^10(\.\w+)+/\S+$' AND LENGTH(concept_doi) <= 255),
 	description VARCHAR(10000),
 	description_url VARCHAR(200) CHECK (description_url ~ '^https?://'),


### PR DESCRIPTION
# Pull request Title

As part of the ongoing discussions to contribute to the RSD, here is the first step towards adding explicit support for open/close source software.

Fixes https://github.com/ImperialCollegeLondon/RSD-as-a-service/issues/12

Changes proposed in this pull request:

* In this case, it is a simple flag in the DB to indicate if a piece of software is open source or not. This flag could then be used in the front end (down the line) to require mandatory fields for open/close source or to show/hide certain parts of the page.

How to test:

* (Not testable, yet)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests

## Question:

I understand that there should be a migration in the dB in order to apply these changes. However, it is not clear to me if the instructions you indicate in the [relevant README](https://github.com/research-software-directory/RSD-as-a-service/tree/main/data-migration) should be used or no. Could you advise on how to proceed? I'll proceed based on what you tell me and mar this PR as a ready to review. 