### PR TITLE
fix: show 404 page for non-existing organisation/research unit

### DIFF
--- a/frontend/components/organisation/apiOrganisations.ts
+++ b/frontend/components/organisation/apiOrganisations.ts
@@ -85,8 +85,9 @@ export async function getOrganisationBySlug({slug, token}:
         token
       })
     ])
-    // if no uuid return
-    if (typeof uuid == 'undefined') return undefined
+    // if no uuid return undefined
+    // console.log('getOrganisationBySlug...uuid...', uuid)
+    if (typeof uuid === 'undefined' || uuid === null) return undefined
     // is this user maintainer of this organisation
     const isMaintainer = maintainerOf.includes(uuid)
     const [organisation, description] = await Promise.all([
@@ -110,26 +111,31 @@ export async function getOrganisationBySlug({slug, token}:
 }
 
 export async function getOrganisationIdForSlug({slug, token, frontend=false}:
-  { slug: string[], token: string, frontend?:boolean }) {
-  const path = slug.join('/')
-  let url = `${process.env.POSTGREST_URL}/rpc/slug_to_organisation`
-  if (frontend) {
-    url = '/api/v1/rpc/slug_to_organisation'
-  }
+  { slug: string[], token: string, frontend?: boolean }) {
+  try {
+    const path = slug.join('/')
+    let url = `${process.env.POSTGREST_URL}/rpc/slug_to_organisation`
+    if (frontend) {
+      url = '/api/v1/rpc/slug_to_organisation'
+    }
 
-  let resp = await fetch(url, {
-    method: 'POST',
-    headers: {
-      ...createJsonHeaders(token),
-    },
-    body: JSON.stringify({
-      'full_slug': path
+    let resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token),
+      },
+      body: JSON.stringify({
+        'full_slug': path
+      })
     })
-  })
-  // cannot find organisation by slug
-  if (resp.status !== 200) return undefined
-  const uuid:string = await resp.json()
-  return uuid
+    // cannot find organisation by slug
+    if (resp.status !== 200) return undefined
+    const uuid:string = await resp.json()
+    return uuid
+  } catch (e:any) {
+    logger(`getOrganisationIdForSlug: ${e?.message}`, 'error')
+    return undefined
+  }
 }
 
 

--- a/frontend/pages/organisations/[...slug].tsx
+++ b/frontend/pages/organisations/[...slug].tsx
@@ -112,6 +112,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       slug: params?.slug as string[] ?? [],
       token: req?.cookies['rsd_token'] ?? ''
     })
+    // console.log('organisation...', organisation)
     if (typeof organisation == 'undefined'){
       // returning notFound triggers 404 page
       return {


### PR DESCRIPTION
# Show 404 page for non-existing organisation

Closes #922

Changes proposed in this pull request:
*  When organisation does not exist (based on url/slug) show 404 page. Page not found message.    

How to test:
* `make start` to build app and create test data
* navigation to organisations page
* select and organisation, the page shoud load
* modify url to point to non-existing organisation slug/url
* simple 404 page will be shown (as with other pages when page does not exist)

![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/36b1edc3-4201-416d-b491-7be303f59a8e)


PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
