### PR TITLE
WIP: custom imperial college homepage starter

### DIFF
--- a/deployment/.gitignore
+++ b/deployment/.gitignore
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 # SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 #
@@ -14,3 +15,4 @@
 
 hmz
 nle
+imperial

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -241,9 +242,9 @@ services:
       - auth
     volumes:
       - ./frontend:/app
-      # - ./deployment/hmz/styles:/app/public/styles
-      # - ./deployment/hmz/data:/app/public/data
-      # - ./deployment/hmz/images:/app/public/images
+      - ./deployment/imperial/styles:/app/public/styles
+      - ./deployment/imperial/data:/app/public/data
+      - ./deployment/imperial/images:/app/public/images
     networks:
       - net
     deploy:

--- a/frontend/components/home/imperial/CounterBox.tsx
+++ b/frontend/components/home/imperial/CounterBox.tsx
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+type CounterBoxProps = {
+  label: string
+  value: string
+}
+
+/**
+ * Custom counter box component example for Imperial College homepage
+ */
+export default function CounterBox({label,value}:CounterBoxProps) {
+  return (
+    <div className="bg-primary text-primary-content p-4 text-center">
+      <div className="text-2xl">{label}</div>
+      <div className="text-4xl">{value}</div>
+    </div>
+  )
+}

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {HomeProps} from 'pages'
+import CounterBox from './CounterBox'
+import {useSession} from '~/auth'
+import useImperialData from './useImperialData'
+import ContentLoader from '~/components/layout/ContentLoader'
+import MainContent from '~/components/layout/MainContent'
+
+export default function MainContentImperialCollege({counts}: HomeProps) {
+  const {token} = useSession()
+  const {loading, organisations} = useImperialData(token)
+
+  return (
+    <MainContent>
+      <h1>Main content placeholder</h1>
+
+      {/* COUNTERS SECTION EXAMPLE */}
+      <div className="max-w-screen-xl mx-auto flex flex-wrap justify-between gap-10 md:gap-16 p-5 md:p-10 ">
+        <CounterBox
+          label="Open-Source Software"
+          value={counts.software_cnt.toString()}
+        />
+      </div>
+
+      {
+      /* ORGANISATION LIST EXAMPLE
+        show spinner when loading===true,
+        otherwise show json organisation data
+        received from useImperialData custom hook (line 10)
+      */}
+      {
+        loading ?
+          <ContentLoader />
+        :
+          <div className="mb-12">
+            <pre>
+              {JSON.stringify(organisations,null,' ')}
+            </pre>
+          </div>
+      }
+
+    </MainContent>
+  )
+}

--- a/frontend/components/home/imperial/index.tsx
+++ b/frontend/components/home/imperial/index.tsx
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {app} from '~/config/app'
+import AppHeader from '~/components/AppHeader'
+import AppFooter from '~/components/AppFooter'
+import PageMeta from '~/components/seo/PageMeta'
+import CanonicalUrl from '~/components/seo/CanonicalUrl'
+import {HomeProps} from 'pages/index'
+
+// Custom Imperial College content component
+import MainContentImperialCollege from './MainContentImperialCollege'
+
+// Meta tags title and description
+const pageTitle = `Home | ${app.title}`
+const pageDesc = 'The Research Software Directory is designed to show the impact research software has on research and society. We stimulate the reuse of research software and encourage proper citation of research software to ensure researchers and RSEs get credit for their work.'
+
+/**
+ * Main entry point (component) of the custom ImperialCollege homepage example
+ */
+export default function ImperialCollegeHome({counts}: HomeProps) {
+  return (
+    <>
+      {/* Page Head meta tags */}
+      <PageMeta
+        title={pageTitle}
+        description={pageDesc}
+      />
+      {/* Canonical url meta tag */}
+      <CanonicalUrl />
+
+      {/* CONTENT */}
+      <section className="flex-1 flex flex-col bg-secondary text-secondary-content">
+        {/* shared header component */}
+        <AppHeader />
+        {/* custom content component */}
+        <MainContentImperialCollege counts={counts} />
+        {/* shared footer component */}
+        <AppFooter/>
+      </section>
+    </>
+  )
+}

--- a/frontend/components/home/imperial/useImperialData.tsx
+++ b/frontend/components/home/imperial/useImperialData.tsx
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {OrganisationForOverview} from '~/types/Organisation'
+import {createJsonHeaders} from '~/utils/fetchHelpers'
+import logger from '~/utils/logger'
+
+/**
+ * Example of actual request to api with error handling and logging
+ * @param param0
+ * @returns
+ */
+async function getOrganisationsList({url, token}: {url: string, token?: string}) {
+  try {
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+      },
+    })
+
+    if ([200, 206].includes(resp.status)) {
+      const json = await resp.json()
+      return {
+        data: json
+      }
+    }
+    // otherwise request failed
+    logger(`getOrganisationsList failed: ${resp.status} ${resp.statusText}`, 'warn')
+    // we log and return zero
+    return {
+      data: []
+    }
+  } catch (e: any) {
+    logger(`getOrganisationsList: ${e?.message}`, 'error')
+    return {
+      data: []
+    }
+  }
+}
+
+/**
+ * Custom react hook to fetch any additional data
+ * needed for the custom Imperial College homepage
+ */
+export default function useImperialData(token: string) {
+  const [organisations, setOrganisations] = useState<OrganisationForOverview[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let abort = false
+    // async function to collect data
+    async function getData() {
+      setLoading(true)
+      // construct api url with all params
+      const url = '/api/v1/rpc/organisations_overview?parent=is.null&limit=1'
+      // pass it to async api call function
+      const {data} = await getOrganisationsList({url, token})
+      // if for any reason the hook is
+      if (abort) return
+      // set new data, this triggers rerenders on change
+      setOrganisations(data)
+      // set loading flag to finish
+      setLoading(false)
+    }
+    // call async function
+    getData()
+    // hook clean up
+    return () => { abort = true }
+  }, [token])
+
+  return {
+    organisations,
+    loading
+  }
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,19 +1,21 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {app} from '~/config/app'
 import {getHomepageCounts} from '~/components/home/getHomepageCounts'
 import HelmholtzHome from '~/components/home/helmholtz'
+import ImperialCollegeHome from '~/components/home/imperial'
 import RsdHome,{RsdHomeProps} from '~/components/home/rsd'
 import PageMeta from '~/components/seo/PageMeta'
-import CanonicalUrl, {useCanonicalUrl} from '~/components/seo/CanonicalUrl'
+import CanonicalUrl from '~/components/seo/CanonicalUrl'
 import useRsdSettings from '~/config/useRsdSettings'
 
-type HomeProps = {
+export type HomeProps = {
   counts: RsdHomeProps
 }
 
@@ -23,10 +25,31 @@ const pageDesc = 'The Research Software Directory is designed to show the impact
 export default function Home({counts}: HomeProps) {
   const {host} = useRsdSettings()
 
-  // console.log('host...', host)
-  if (host && host.name.toLowerCase() === 'helmholtz') {
-    return <HelmholtzHome />
+  console.log('host...', host)
+
+  if (host && host.name) {
+    switch (host.name.toLocaleLowerCase()) {
+      case 'helmholtz':
+        return <HelmholtzHome />
+      case 'imperial':
+        return <ImperialCollegeHome counts={counts} />
+      default:
+        // RSD default homepage
+        return (
+          <>
+            {/* Page Head meta tags */}
+            <PageMeta
+              title={pageTitle}
+              description={pageDesc}
+            />
+            {/* canonical url meta tag */}
+            <CanonicalUrl/>
+            <RsdHome {...counts} />
+          </>
+        )
+    }
   }
+  // RSD default home page
   return (
     <>
       {/* Page Head meta tags */}

--- a/frontend/public/data/settings.json.license
+++ b/frontend/public/data/settings.json.license
@@ -1,4 +1,6 @@
 SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2022 - 2023 dv4all
+SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
# Custom Imperial College homepage starter

This is the starter/example/template of custom homepage for Imperial College London. @dalonsoa Maybe you can use this PR/branch as a starter?

## Used frontend technologies (knowledge required/use documentation):
- [React/Next.js](https://nextjs.org/docs)
- [Material-UI](https://mui.com/material-ui/react-autocomplete/)
- [Tailwind CSS](https://tailwindcss.com/docs/background-color)

## Basic setup

To add a custom landing page for imperial we use the following two-stage approach:

1. There is a `frontend/components/home/imperial` folder located in this repo that contains the components needed for the Imperial landing page. An simple template is provided (see below for more details) which can be extended. 

2. There is a separate `deployment/imperial` folder (in the .gitignore of this repo) which contains data items like `settings.json`, `index.css`, fonts, etc.  As there can only be one copy of these files, the different implementations (default, helmholtz, imperial) have different value and will clash. We therefore mount this folder separately in the
`docker-compose.yml` (example provided in the PR). This allows each instance of the RSD to use its own styles. An example of the content of this folder is provided in [imperial.zip](https://github.com/research-software-directory/RSD-as-a-service/files/12001493/imperial.zip).  See below for more details. 

## Changes proposed in this pull request:
* Added support for `imperial` host name in the homepage route (/frontend/pages/index.tsx)
* Added ignore rule to ignore `/deployment/imperial` folder. This is the folder where all custom settings should be saved. The content of this folder is mounted into the frontend image for `docker development` using `make frontend-docker`
* Mounted `deployment/imperial` folders in the docker-compose.yml (as demo how it should be done).
* Added `frontend/components/home/imperial` folder and the starter components.
   *  CounterBox.tsx: simple/basic example of counter component. Further customization needed
   *  index.tsx: main entry point for custom Imperial College Homepage. It has basic meta tags, default app header and footer and custom main content (see next component)
   *  MainContentImperialCollege.tsx: This component is starter where custom content and additional custom imperial components are placed.
   * useImperialData.tsx: is custom React hook that can be used to perform additional api calls that are specific for this custom page

## How to test:
*  download [imperial.zip](https://github.com/research-software-directory/RSD-as-a-service/files/12001493/imperial.zip) file. It contains the custom files that can be used. Unzip the content into deployment folder. After unzipping you should have following structure in the `deployment/imperial` folder:
   * `data`: holds settings.json where you can specify host.name, other contact information and the theme collors. I changed few values: host name, logo, contact email, primary and secondary colors. **Further adjustments of settings.json are needed**.
   * `images`: all images are stored in this folder. **I added imperial-college-logo.svg**. Add all other custom images you will be using.  
   * `styles`: `index.css` is global css file imported in the main template (see frontend/pages/_document.tsx - line 44). Here you can specify additional global custom styles and the custom fonts. The attached file currently defines RSD custom fonts. **The file should be updated to custom Imperial College fonts and RSD fonts removed if you do not want to use them**.
     
* `make frontend-docker` to run development in docker and have the custom settings and styles mounted. The homepage should look like image below
* The frontend is on http://localhost:3000/
* Note! You will need to reload the page manually after changing the values in `/deployment/imperial/data/settings.json`. 
For example by changing `host.name` from `imperial` to `rsd` will load default rsd home page content, or when using `helmholtz` you should see custom Helmholtz page.

```json
{
  "host": {
    "name": "imperial",
    "email": "rsd@imperial-college.com",
    "emailHeaders": [],
    "logo_url": "/images/imperial-college-logo.svg",
    "website": "https://www.imperial.ac.uk/",
    "feedback": {
      "enabled": true,
      "url": "rsd@esciencecenter.nl",
      "issues_page_url": "https://github.com/research-software-directory/RSD-as-a-service/issues"
    },
    "login_info_url":"https://research-software-directory.github.io/documentation/getting-access.html",
    "terms_of_service_url": "/page/terms-of-service/",
    "privacy_statement_url": "/page/privacy-statement/"
  },
 ... other settings
}
```


## Current state of custom homepage for Imprial College London
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/8372efe3-06b7-4279-bb4c-95e8e92fab0a)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests

