### PR TITLE
932 & 935 Software overview page improvements

### DIFF
--- a/frontend/components/layout/ContentContainer.tsx
+++ b/frontend/components/layout/ContentContainer.tsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+type ContentContainerProps = {
+  element?: 'section' | 'article' | 'main' | 'div'
+  className?: string
+  children: JSX.Element | JSX.Element[]
+}
+
+export default function ContentContainer(props: ContentContainerProps) {
+  // basic container alignment - for lg + breakpoints
+  const classes = `px-4 lg:container lg:mx-auto ${props.className ?? ''}`
+
+  switch (props?.element) {
+    case 'section':
+      return (
+        <section className={classes}>
+          {props.children}
+        </section>
+      )
+    case 'article':
+      return (
+        <article className={classes}>
+          {props.children}
+        </article>
+      )
+    case 'main':
+      return (
+        <main className={classes}>
+          {props.children}
+        </main>
+      )
+    default:
+      return (
+        <div className={classes}>
+          {props.children}
+        </div>
+      )
+  }
+}

--- a/frontend/components/software/overview/SoftwareHighlights.tsx
+++ b/frontend/components/software/overview/SoftwareHighlights.tsx
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import ContentContainer from '~/components/layout/ContentContainer'
 import {HighlightsCarousel} from './highlights/HighlightsCarousel'
 import {SoftwareHighlight} from '~/components/admin/software-highlights/apiSoftwareHighlights'
 
@@ -20,6 +21,13 @@ export default function SoftwareHighlights({highlights}: { highlights: SoftwareH
 
   return (
     <div className="mt-8">
+      <ContentContainer>
+        <div
+          className="text-3xl"
+        >
+          Software Highlights
+        </div>
+      </ContentContainer>
       <HighlightsCarousel items={highlights} />
     </div>
   )

--- a/frontend/components/software/overview/cards/SoftwareMasonryCard.tsx
+++ b/frontend/components/software/overview/cards/SoftwareMasonryCard.tsx
@@ -63,11 +63,13 @@ export default function SoftwareMasonryCard({item}:SoftwareCardProps){
               visibleNumberOfProgLang={visibleNumberOfProgLang}
             />
             {/* Metrics */}
-            <SoftwareMetrics
-              contributor_cnt={item.contributor_cnt}
-              mention_cnt={item.mention_cnt}
-              downloads={item.downloads}
-            />
+            <div className="flex gap-4">
+              <SoftwareMetrics
+                contributor_cnt={item.contributor_cnt}
+                mention_cnt={item.mention_cnt}
+                downloads={item.downloads}
+              />
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Software overview page improvements

Closes #932 
Closes #935 

Changes proposed in this pull request:
* Improved alignment of stats of masonry card (bottom right) - see image
* Added "Software Highlights" - see image

How to test:
* `make start` to build and generate test data
* visit software overview page, select masonry layout (if not selected)
* Confirm alignment of stats at the bottom right of the card
* If highlights are defined, confirm that Software Hightlights has title. Then login as rsd_admin and remove all highlights. The highlights section including the title should not be shown
* If highlights are not defined, eg. highlights section is not visible: Login as rsd_admin and define highlights in the admin section first. Then confirm section including the title is visible

## Example

![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/9a2b001a-1584-4ea9-8aee-9b689d412436)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
