### PR TITLE
fix: add poster as mention type

### DIFF
--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -39,6 +39,7 @@ function generateMentions(amountExtra = 100) {
 		'journalArticle',
 		'magazineArticle',
 		'newspaperArticle',
+		'poster',
 		'presentation',
 		'report',
 		'thesis',

--- a/database/009-create-mention-table.sql
+++ b/database/009-create-mention-table.sql
@@ -17,6 +17,7 @@ CREATE TYPE mention_type AS ENUM (
 	'journalArticle',
 	'magazineArticle',
 	'newspaperArticle',
+	'poster',
 	'presentation',
 	'report',
 	'thesis',

--- a/frontend/components/mention/config.ts
+++ b/frontend/components/mention/config.ts
@@ -235,6 +235,12 @@ export const mentionType = {
     singular: 'Newspaper article',
     manual: true
   },
+  poster: {
+    key: 'poster',
+    plural: 'Posters',
+    singular: 'Poster',
+    manual: true
+  },
   presentation: {
     key: 'presentation',
     plural: 'Presentations',

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -355,6 +355,7 @@ function rsdTypeFromResourceType(resourceType: string) {
       return 'newspaperArticle'
     case 'audiovisual':
     case 'poster':
+      return 'poster'
     case 'presentation':
       return 'presentation'
     case 'report series':

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -100,7 +100,7 @@ public class DataciteMentionRepository implements MentionRepository {
 		dataciteTextTypeMap.put("Conference paper", MentionType.conferencePaper);
 		dataciteTextTypeMap.put("Dissertation", MentionType.thesis);
 		dataciteTextTypeMap.put("Journal article", MentionType.journalArticle);
-		dataciteTextTypeMap.put("Poster", MentionType.presentation);
+		dataciteTextTypeMap.put("Poster", MentionType.poster);
 		dataciteTextTypeMap.put("Presentation", MentionType.presentation);
 		dataciteTextTypeMap.put("Report", MentionType.report);
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionType.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionType.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,6 +17,7 @@ public enum MentionType {
 	journalArticle,
 	magazineArticle,
 	newspaperArticle,
+	poster,
 	presentation,
 	report,
 	thesis,


### PR DESCRIPTION
# Add "poster" as mention type

Changes proposed in this pull request:

* Add "poster" as a mention type and adapt the different modules to it, including the data generation script

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker-compose up --scale data-generation=1`
* Visit http://localhost/api/v1/mention?select=mention_type and check that some mentions have type `poster`
* Now we will test the scraper, to make this easy, we will first remove everything:
* `docker compose down --volumes && docker-compose up --scale data-generation=0`
* Create a software page, add a mention with the poster type, e.g. from the DOI `10.5281/zenodo.3939737`
* Also manually add a poster
* Check that both the maintainer view and the public view are correct
* Run the mention scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions`
* Check that the mention with a DOI was scraped and still has the `poster` type: http://localhost/api/v1/mention


Closes #931

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
