### PR TITLE
feat: upgrade to postgres 15

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgres:14.2
+FROM postgres:15.3
 RUN chmod a+rwx /docker-entrypoint-initdb.d
 COPY --chown=postgres:postgres *.sh /docker-entrypoint-initdb.d/
 COPY --chown=postgres:postgres *.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:2.0.2
+    image: rsd/database:2.1.0
     ports:
     # enable connection from outside (development mode)
      - "5432:5432"


### PR DESCRIPTION
# Major upgrade to Postgres 15

Changes proposed in this pull request:

* Upgrade from Postgres 14.2 to 15.3

How to test:

* We will first create some data on 14.2:
* `git switch main && docker compose down --volumes && docker compose build --parallel && docker-compose up --scale data-generation=1`
* Login as a regular user, make a software and project page
* Make a backup (if you changed your `.env`, substitute the correct values):
* `docker compose exec database pg_dump --format=tar --file=rsd-backup.tar --username=rsd --dbname=rsd-db`
* Copy over the backup to your local file system:
* `docker compose cp database:rsd-backup.tar rsd-backup.tar`
* Now we will delete the old database and switch to the new version:
* `docker compose down --volumes && git switch 943-postgres-15 && docker compose build --parallel && docker-compose up --scale data-generation=0`
* Copy over the backup to the database container:
* `docker compose cp rsd-backup.tar database:rsd-backup.tar`
* Restore the backup:
* `docker compose exec database pg_restore --username=rsd --dbname=rsd-db --clean rsd-backup.tar`
* Login with the same account, check that you're still a maintainer of the pages you created and that everything works as expected


The upgrade strategy for production, if you use our images, is similar. Because the database container, when there is no database yet, will recreate the database structure, restoring a data only backup is sufficient. These are the steps to take:

* stop the NGINX and scrapers containers
* create a backup and copy it to the file system
* delete the database volume
* download the new images
* start the database container (or at least don't start the NGINX and scrapers containers)
* restore the backup
* start the other containers


Closes #943

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
