### PR TITLE
Imperial Front-Page Keywords

### DIFF
--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -118,7 +118,8 @@ async function generateSofware(amount=500) {
 			get_started_url: faker.internet.url(),
 			image_id: localImageIds[index%localImageIds.length],
 			is_published: !!faker.helpers.maybe(() => true, {probability: 0.8}),
-			short_statement: faker.commerce.productDescription()
+			short_statement: faker.commerce.productDescription(),
+			closed_source: !!faker.helpers.maybe(() => true, {probability: 0.8})
 		});
 	}
 

--- a/database/007-create-keyword.sql
+++ b/database/007-create-keyword.sql
@@ -57,3 +57,48 @@ VALUES
 	('Text analysis & natural language processing'),
 	('Visualization'),
 	('Workflow technologies');
+
+CREATE VIEW
+	project_counts
+AS SELECT
+	keyword.id AS id,
+	count(*) AS count
+FROM
+	keyword_for_project
+INNER JOIN
+	keyword
+ON
+	keyword_for_project.keyword=keyword.id
+GROUP BY
+	keyword.id;
+
+CREATE VIEW
+	software_counts
+AS SELECT
+	keyword.id AS id,
+	count(*) AS count
+FROM
+	keyword_for_software
+INNER JOIN
+	keyword
+ON
+	keyword_for_software.keyword=keyword.id
+GROUP BY
+	keyword.id;
+
+CREATE VIEW
+	combined_counts
+AS SELECT
+	software_counts.id,
+	coalesce(software_counts.count, 0) + coalesce(project_counts.count, 0)
+AS
+	count
+FROM
+	software_counts
+FULL JOIN
+     project_counts
+ON
+	software_counts.id=project_counts.id
+ORDER BY
+	count
+DESC;

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1408,3 +1408,20 @@ ORDER BY
 DESC LIMIT
 	1;
 $$;
+
+CREATE FUNCTION popular_keywords() RETURNS TABLE (
+       value CITEXT
+) LANGUAGE plpgsql VOLATILE AS
+$$
+BEGIN
+	RETURN QUERY
+	SELECT
+		keyword.value
+	FROM
+		keyword
+	INNER JOIN
+		combined_counts
+	ON
+		keyword.id=combined_counts.id;
+END
+$$;

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1136,6 +1136,7 @@ $$;
 -- this rpc returns json object instead of array
 CREATE FUNCTION homepage_counts(
 	OUT software_cnt BIGINT,
+	OUT open_software_cnt BIGINT,
 	OUT project_cnt BIGINT,
 	OUT organisation_cnt BIGINT,
 	OUT contributor_cnt BIGINT,
@@ -1144,6 +1145,7 @@ CREATE FUNCTION homepage_counts(
 $$
 BEGIN
 	SELECT COUNT(id) FROM software INTO software_cnt;
+	SELECT COUNT(id) FROM software WHERE NOT closed_source INTO open_software_cnt;
 	SELECT COUNT(id) FROM project INTO project_cnt;
 	SELECT
 		COUNT(id) AS organisation_cnt

--- a/frontend/components/home/getHomepageCounts.ts
+++ b/frontend/components/home/getHomepageCounts.ts
@@ -29,6 +29,7 @@ export async function getHomepageCounts(frontend?:boolean) {
     logger(`getHomepageCounts ${resp.status} ${resp.statusText}`, 'warn')
     return {
       software_cnt: null,
+      open_software_cnt: null,
       project_cnt: null,
       organisation_cnt: null,
       contributor_cnt: null,
@@ -40,6 +41,7 @@ export async function getHomepageCounts(frontend?:boolean) {
     // we log and return zero
     return {
       software_cnt: null,
+      open_software_cnt: null,
       project_cnt: null,
       organisation_cnt: null,
       contributor_cnt: null,

--- a/frontend/components/home/imperial/CounterBox.tsx
+++ b/frontend/components/home/imperial/CounterBox.tsx
@@ -13,7 +13,7 @@ type CounterBoxProps = {
  */
 export default function CounterBox({label,value}:CounterBoxProps) {
   return (
-    <div className="bg-primary text-primary-content p-4 text-center">
+    <div className="bg-primary text-primary-content p-4 text-center rounded-md">
       <div className="text-2xl">{label}</div>
       <div className="text-4xl">{value}</div>
     </div>

--- a/frontend/components/home/imperial/KeywordBox.tsx
+++ b/frontend/components/home/imperial/KeywordBox.tsx
@@ -1,0 +1,20 @@
+import Link from 'next/link'
+
+import { ssrProjectsUrl } from '~/utils/postgrestUrl'
+
+type KeywordBoxProps = {
+    label: string
+}
+
+export default function KeywordBox({ label }: KeywordBoxProps) {
+    const url = ssrProjectsUrl({ keywords: [label] })
+    return (
+        <div className="bg-secondary text-primary-content p-2 text-center rounded-md">
+            <div className="text-lg">
+                <Link href={url}>
+                    {label}
+                </Link>
+            </div>
+        </div>
+    )
+}

--- a/frontend/components/home/imperial/Keywords.tsx
+++ b/frontend/components/home/imperial/Keywords.tsx
@@ -1,0 +1,17 @@
+import KeywordBox from './KeywordBox'
+
+type KeywordsProps = {
+    keywords: string
+}
+
+export default function Keywords({ keywords }: KeywordsProps) {
+    const keywordArray = JSON.parse(keywords)
+    const keywordButtons = keywordArray.map((keyword, index) => {
+        return <KeywordBox key={index} label={keyword.value} />
+    })
+    return (
+        <div className="max-w-screen-xl mx-auto flex flex-wrap gap-10 md:gap-3 p-5 md:p-10 ">
+            {keywordButtons}
+        </div>
+    )
+}

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -22,7 +22,11 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
       <div className="max-w-screen-xl mx-auto flex flex-wrap justify-between gap-10 md:gap-16 p-5 md:p-10 ">
         <CounterBox
           label="Open-Source Software"
-          value={counts.software_cnt.toString()}
+          value={counts.open_software_cnt.toString()}
+        />
+        <CounterBox
+          label="Closed-Source Software"
+          value={(counts.software_cnt - counts.open_software_cnt).toString()}
         />
       </div>
 

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -15,7 +15,7 @@ import MainContent from '~/components/layout/MainContent'
 
 export default function MainContentImperialCollege({counts}: HomeProps) {
   const {token} = useSession()
-  const {loading, organisations} = useImperialData(token)
+  const {loading, keywords} = useImperialData(token)
 
   return (
     <MainContent>
@@ -63,6 +63,17 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
           value={counts.software_mention_cnt.toString()}
         />
       </div>
+
+      {
+        loading ?
+          <ContentLoader />
+        :
+          <div className="mb-12">
+            <pre>
+              {JSON.stringify(keywords,null,' ')}
+            </pre>
+          </div>
+      }
 
     </MainContent>
   )

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -6,16 +6,21 @@
 import Image from 'next/legacy/image'
 import Link from 'next/link'
 
-import {HomeProps} from 'pages'
+import { HomeProps } from 'pages'
 import CounterBox from './CounterBox'
-import {useSession} from '~/auth'
+import Keywords from './Keywords'
+import { useSession } from '~/auth'
 import useImperialData from './useImperialData'
 import ContentLoader from '~/components/layout/ContentLoader'
 import MainContent from '~/components/layout/MainContent'
 
-export default function MainContentImperialCollege({counts}: HomeProps) {
-  const {token} = useSession()
-  const {loading, keywords} = useImperialData(token)
+export default function MainContentImperialCollege({ counts }: HomeProps) {
+  const { token } = useSession()
+  const { loading, keywords } = useImperialData(token)
+  console.log(keywords)
+  console.log(typeof keywords)
+  console.log(JSON.stringify(keywords, null, ' '))
+  console.log(typeof JSON.stringify(keywords, null, ' '))
 
   return (
     <MainContent>
@@ -67,11 +72,9 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
       {
         loading ?
           <ContentLoader />
-        :
+          :
           <div className="mb-12">
-            <pre>
-              {JSON.stringify(keywords,null,' ')}
-            </pre>
+            <Keywords keywords={JSON.stringify(keywords, null, ' ')} />
           </div>
       }
 

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -17,10 +17,6 @@ import MainContent from '~/components/layout/MainContent'
 export default function MainContentImperialCollege({ counts }: HomeProps) {
   const { token } = useSession()
   const { loading, keywords } = useImperialData(token)
-  console.log(keywords)
-  console.log(typeof keywords)
-  console.log(JSON.stringify(keywords, null, ' '))
-  console.log(typeof JSON.stringify(keywords, null, ' '))
 
   return (
     <MainContent>

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Image from 'next/legacy/image'
+
 import {HomeProps} from 'pages'
 import CounterBox from './CounterBox'
 import {useSession} from '~/auth'
@@ -16,7 +18,27 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
 
   return (
     <MainContent>
-      <h1>Main content placeholder</h1>
+      <div className="w-10/12 mx-auto p-5 md:p-10 grid lg:grid-cols-[1fr,1fr] gap-[2rem]">
+        <div className="flex flex-col justify-left">
+          <Image
+            src="/images/imperial-college-logo.svg"
+            width="361"
+            height="85"
+            layout="fixed"
+            alt="Imperial College London logo"
+            priority
+          />
+
+          <div className="mt-8 ml-4 text-lg max-w-prose">
+            Some catchy and profound phrase about research software written at Imperial.
+          </div>
+        </div>
+      <div className="relative">
+      <div className="text-center">
+      <h1>Other text</h1>
+      </div>
+        </div>
+      </div>
 
       {/* COUNTERS SECTION EXAMPLE */}
       <div className="max-w-screen-xl mx-auto flex flex-wrap justify-between gap-10 md:gap-16 p-5 md:p-10 ">

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -56,23 +56,6 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
         />
       </div>
 
-      {
-      /* ORGANISATION LIST EXAMPLE
-        show spinner when loading===true,
-        otherwise show json organisation data
-        received from useImperialData custom hook (line 10)
-      */}
-      {
-        loading ?
-          <ContentLoader />
-        :
-          <div className="mb-12">
-            <pre>
-              {JSON.stringify(organisations,null,' ')}
-            </pre>
-          </div>
-      }
-
     </MainContent>
   )
 }

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -28,6 +28,10 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
           label="Closed-Source Software"
           value={(counts.software_cnt - counts.open_software_cnt).toString()}
         />
+        <CounterBox
+          label="Software Mentions"
+          value={counts.software_mention_cnt.toString()}
+        />
       </div>
 
       {

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Image from 'next/legacy/image'
+import Link from 'next/link'
 
 import {HomeProps} from 'pages'
 import CounterBox from './CounterBox'
@@ -33,10 +34,17 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
             Some catchy and profound phrase about research software written at Imperial.
           </div>
         </div>
-      <div className="relative">
-      <div className="text-center">
-      <h1>Other text</h1>
-      </div>
+        <div className="relative justify-center">
+          <div className="bg-secondary text-primary-content p-4 text-center max-w-fit mx-auto rounded-full border-4 border-primary">
+            <Link href="/software">
+              <div className="text-4xl">Browse Software</div>
+            </Link>
+          </div>
+          <div className="bg-secondary text-primary-content p-4 text-center max-w-fit mx-auto rounded-full border-4 border-primary mt-8">
+            <Link href="/software/add">
+              <div className="text-4xl">Submit Software</div>
+            </Link>
+          </div>
         </div>
       </div>
 

--- a/frontend/components/home/imperial/index.tsx
+++ b/frontend/components/home/imperial/index.tsx
@@ -32,7 +32,7 @@ export default function ImperialCollegeHome({counts}: HomeProps) {
       <CanonicalUrl />
 
       {/* CONTENT */}
-      <section className="flex-1 flex flex-col bg-secondary text-secondary-content">
+      <section className="flex-1 flex flex-col text-secondary-content  bg-[url('/images/campus_south_ken.jpg')] bg-contain bg-no-repeat bg-center bg-black bg-scroll">
         {/* shared header component */}
         <AppHeader />
         {/* custom content component */}

--- a/frontend/components/home/imperial/useImperialData.tsx
+++ b/frontend/components/home/imperial/useImperialData.tsx
@@ -13,7 +13,7 @@ import logger from '~/utils/logger'
  * @param param0
  * @returns
  */
-async function getOrganisationsList({url, token}: {url: string, token?: string}) {
+async function getKeywordList({url, token}: {url: string, token?: string}) {
   try {
     const resp = await fetch(url, {
       method: 'GET',
@@ -29,17 +29,21 @@ async function getOrganisationsList({url, token}: {url: string, token?: string})
       }
     }
     // otherwise request failed
-    logger(`getOrganisationsList failed: ${resp.status} ${resp.statusText}`, 'warn')
+    logger(`getKeywordList failed: ${resp.status} ${resp.statusText}`, 'warn')
     // we log and return zero
     return {
       data: []
     }
   } catch (e: any) {
-    logger(`getOrganisationsList: ${e?.message}`, 'error')
+    logger(`getKeywordList: ${e?.message}`, 'error')
     return {
       data: []
     }
   }
+}
+
+export type keyword = {
+  value: string
 }
 
 /**
@@ -47,33 +51,31 @@ async function getOrganisationsList({url, token}: {url: string, token?: string})
  * needed for the custom Imperial College homepage
  */
 export default function useImperialData(token: string) {
-  const [organisations, setOrganisations] = useState<OrganisationForOverview[]>([])
+  const [keywords, setKeywords] = useState<keyword[]>([])
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
     let abort = false
-    // async function to collect data
+
     async function getData() {
       setLoading(true)
-      // construct api url with all params
-      const url = '/api/v1/rpc/organisations_overview?parent=is.null&limit=1'
-      // pass it to async api call function
-      const {data} = await getOrganisationsList({url, token})
-      // if for any reason the hook is
+
+      const url = '/api/v1/rpc/popular_keywords'
+      const {data} = await getKeywordList({url, token})
+
       if (abort) return
-      // set new data, this triggers rerenders on change
-      setOrganisations(data)
-      // set loading flag to finish
+
+      setKeywords(data)
       setLoading(false)
     }
-    // call async function
+
     getData()
-    // hook clean up
+
     return () => { abort = true }
   }, [token])
 
   return {
-    organisations,
+    keywords,
     loading
   }
 }

--- a/frontend/components/home/rsd/index.tsx
+++ b/frontend/components/home/rsd/index.tsx
@@ -34,6 +34,7 @@ import 'aos/dist/aos.css'
 
 export type RsdHomeProps = {
   software_cnt: number,
+  open_software_cnt: number,
   project_cnt: number,
   organisation_cnt: number,
   contributor_cnt: number,

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -25,8 +25,6 @@ const pageDesc = 'The Research Software Directory is designed to show the impact
 export default function Home({counts}: HomeProps) {
   const {host} = useRsdSettings()
 
-  console.log('host...', host)
-
   if (host && host.name) {
     switch (host.name.toLocaleLowerCase()) {
       case 'helmholtz':


### PR DESCRIPTION
# Imperial Front-Page Keywords

Added keyword buttons on the front page that link to the search function. Opened in draft in case there are extra repo hygiene steps I've missed out. Closes https://github.com/ImperialCollegeLondon/RSD-as-a-service/issues/17.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
