### PR TITLE
ci: run separate eslint check before unit tests and build test

### DIFF
--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
+# SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -30,6 +32,9 @@ jobs:
       - name: "install dependencies"
         working-directory: frontend
         run: yarn install --frozen-lockfile
+      - name: "run eslint check"
+        working-directory: frontend
+        run: yarn lint
       - name: "run unit test"
         working-directory: frontend
         run: yarn test:coverage


### PR DESCRIPTION
# Add linter check to CI before running unit and build test

Changes proposed in this pull request:
* Adding linter check to CI to run on PR when fe code changed

How to test:
*  After merging into main the linter check for frontend will run on each PR

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
