### PR TITLE
933 show different into about project period based on project state

### DIFF
--- a/database/105-project-views.sql
+++ b/database/105-project-views.sql
@@ -303,7 +303,8 @@ CREATE FUNCTION project_overview() RETURNS TABLE (
 	research_domain_text TEXT,
 	participating_organisations VARCHAR[],
 	impact_cnt INTEGER,
-	output_cnt INTEGER
+	output_cnt INTEGER,
+	project_state VARCHAR(20)
 ) LANGUAGE sql STABLE AS
 $$
 SELECT
@@ -323,7 +324,13 @@ SELECT
 	research_domain_filter_for_project.research_domain_text,
 	project_participating_organisations.organisations AS participating_organisations,
 	COALESCE(count_project_impact.impact_cnt, 0) AS impact_cnt,
-	COALESCE(count_project_output.output_cnt, 0) AS output_cnt
+	COALESCE(count_project_output.output_cnt, 0) AS output_cnt,
+	CASE
+			WHEN project.date_end < now() THEN 'Finished'::VARCHAR
+			WHEN project.date_start > now() AND project.date_end > now() THEN 'Pending'::VARCHAR
+			WHEN project.date_start < now() AND project.date_end > now() THEN 'In progress'::VARCHAR
+			ELSE 'Waiting to start'::VARCHAR
+	END AS project_state
 FROM
 	project
 LEFT JOIN
@@ -358,7 +365,8 @@ CREATE FUNCTION project_search(search VARCHAR) RETURNS TABLE (
 	research_domain_text TEXT,
 	participating_organisations VARCHAR[],
 	impact_cnt INTEGER,
-	output_cnt INTEGER
+	output_cnt INTEGER,
+	project_state VARCHAR(20)
 ) LANGUAGE sql STABLE AS
 $$
 SELECT
@@ -378,7 +386,13 @@ SELECT
 	research_domain_filter_for_project.research_domain_text,
 	project_participating_organisations.organisations AS participating_organisations,
 	COALESCE(count_project_impact.impact_cnt, 0),
-	COALESCE(count_project_output.output_cnt, 0)
+	COALESCE(count_project_output.output_cnt, 0),
+	CASE
+			WHEN project.date_end < now() THEN 'Finished'::VARCHAR
+			WHEN project.date_start > now() AND project.date_end > now() THEN 'Pending'::VARCHAR
+			WHEN project.date_start < now() AND project.date_end > now() THEN 'In progress'::VARCHAR
+			ELSE 'Waiting to start'::VARCHAR
+	END AS project_state
 FROM
 	project
 LEFT JOIN

--- a/database/112-organisation-views.sql
+++ b/database/112-organisation-views.sql
@@ -22,7 +22,8 @@ CREATE FUNCTION projects_by_organisation(organisation_id UUID) RETURNS TABLE (
 	research_domain VARCHAR[],
 	participating_organisations VARCHAR[],
 	impact_cnt INTEGER,
-	output_cnt INTEGER
+	output_cnt INTEGER,
+	project_state VARCHAR(20)
 ) LANGUAGE sql STABLE AS
 $$
 SELECT DISTINCT ON (project.id)
@@ -42,7 +43,13 @@ SELECT DISTINCT ON (project.id)
 	research_domain_filter_for_project.research_domain,
 	project_participating_organisations.organisations AS participating_organisations,
 	COALESCE(count_project_impact.impact_cnt, 0) AS impact_cnt,
-	COALESCE(count_project_output.output_cnt, 0) AS output_cnt
+	COALESCE(count_project_output.output_cnt, 0) AS output_cnt,
+	CASE
+			WHEN project.date_end < now() THEN 'Finished'::VARCHAR
+			WHEN project.date_start > now() AND project.date_end > now() THEN 'Pending'::VARCHAR
+			WHEN project.date_start < now() AND project.date_end > now() THEN 'In progress'::VARCHAR
+			ELSE 'Waiting to start'::VARCHAR
+	END AS project_state
 FROM
 	project
 LEFT JOIN
@@ -86,7 +93,8 @@ CREATE FUNCTION projects_by_organisation_search(
 	research_domain VARCHAR[],
 	participating_organisations VARCHAR[],
 	impact_cnt INTEGER,
-	output_cnt INTEGER
+	output_cnt INTEGER,
+	project_state VARCHAR(20)
 ) LANGUAGE sql STABLE AS
 $$
 SELECT DISTINCT ON (project.id)
@@ -106,7 +114,13 @@ SELECT DISTINCT ON (project.id)
 	research_domain_filter_for_project.research_domain,
 	project_participating_organisations.organisations AS participating_organisations,
 	COALESCE(count_project_impact.impact_cnt, 0) AS impact_cnt,
-	COALESCE(count_project_output.output_cnt, 0) AS output_cnt
+	COALESCE(count_project_output.output_cnt, 0) AS output_cnt,
+	CASE
+			WHEN project.date_end < now() THEN 'Finished'::VARCHAR
+			WHEN project.date_start > now() AND project.date_end > now() THEN 'Pending'::VARCHAR
+			WHEN project.date_start < now() AND project.date_end > now() THEN 'In progress'::VARCHAR
+			ELSE 'Waiting to start'::VARCHAR
+	END AS project_state
 FROM
 	project
 LEFT JOIN

--- a/frontend/components/projects/overview/cards/ProjectCardContent.tsx
+++ b/frontend/components/projects/overview/cards/ProjectCardContent.tsx
@@ -6,6 +6,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {ProjectState} from '~/types/Project'
 import {getImageUrl} from '~/utils/editImage'
 import KeywordList from '~/components/cards/KeywordList'
 import CardTitleSubtitle from '~/components/cards/CardTitleSubtitle'
@@ -33,6 +34,7 @@ type ProjectCardProps = {
   impact_cnt: number | null
   output_cnt: number | null
   visibleKeywords?: number
+  project_state: ProjectState
 }
 
 export default function ProjectCardContent(item:ProjectCardProps){
@@ -72,6 +74,7 @@ export default function ProjectCardContent(item:ProjectCardProps){
             <ProjectPeriod
               date_start={item.date_start}
               date_end={item.date_end}
+              project_state={item.project_state}
             />
           </div>
           {/* Metrics */}

--- a/frontend/components/projects/overview/cards/ProjectPeriod.tsx
+++ b/frontend/components/projects/overview/cards/ProjectPeriod.tsx
@@ -5,14 +5,31 @@
 
 import PeriodProgressBar from '~/components/charts/progress/PeriodProgressBar'
 import ProjectDuration from './ProjectDuration'
+import {ProjectState} from '~/types/Project'
 
 type ProjectPeriodProps = {
   date_start: string | null
   date_end: string | null
+  project_state: ProjectState
 }
 
-export default function ProjectPeriod({date_start,date_end}:ProjectPeriodProps) {
-  if (!date_start || !date_end) return null
+export default function ProjectPeriod({date_start, date_end, project_state}: ProjectPeriodProps) {
+  // if one of dates is missing we only show project_state
+  if (!date_start || !date_end) {
+    return (
+      <div className="text-sm text-base-content-secondary">{project_state}</div>
+    )
+  }
+  // when project is finished we only show dates
+  if (project_state === 'Finished') {
+    return (
+      <ProjectDuration
+        date_start={date_start}
+        date_end={date_end}
+      />
+    )
+  }
+  // show both dates and progressbar
   return (
     <>
       <ProjectDuration

--- a/frontend/types/Organisation.ts
+++ b/frontend/types/Organisation.ts
@@ -6,6 +6,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {ProjectState} from './Project'
+
 // based on ENUMS defined in 012-inter-relation-tables.sql
 export type Status = 'rejected_by_origin' | 'rejected_by_relation' | 'approved'
 export type OrganisationRole = 'participating' | 'funding' | 'hosting'
@@ -171,7 +173,8 @@ export type ProjectOfOrganisation = {
   keywords: string[] | null
   research_domain: string[] | null
   impact_cnt: number | null
-  output_cnt: number | null
+  output_cnt: number | null,
+  project_state: ProjectState
 }
 
 export type OrganisationList = {

--- a/frontend/types/Project.ts
+++ b/frontend/types/Project.ts
@@ -41,7 +41,7 @@ export type EditProject = Project & {
   keywords: KeywordForProject[]
 }
 
-export type CurrentState = 'Starting' | 'Running' | 'Finished'
+export type ProjectState = 'Waiting to start' | 'Pending' | 'In progress' | 'Finished'
 export type ProjectListItem = {
   id: string
   slug: string
@@ -58,6 +58,7 @@ export type ProjectListItem = {
   participating_organisations?: string[]
   impact_cnt: number | null
   output_cnt: number | null
+  project_state: ProjectState
 }
 
 // object returned from api
@@ -109,6 +110,7 @@ export type SearchProject = {
   image_id: string | null
 }
 
+export type CurrentState = 'Starting' | 'Running' | 'Finished'
 export type RelatedProject = SearchProject & {
   current_state: CurrentState
   date_start: string | null


### PR DESCRIPTION
# Project state and the period presentation improvements

Closes #933 

Changes proposed in this pull request:
*  Based on project period we deduct project status. We classify project status into following categories: 
     - `Finished`: when project end date is in the past (< now())
     - `In progress`: when project start date is in the past and end date in the future
     - `Pending`: when project start date and end date are in the future
     - `Waiting to start`:  in all other cases (missing just start date or missing start date and end date and any other situations - it is final ELSE clause)

NOTE! The same project status values should be applied to status filter proposed in #934. 

How to test:
* `make start` to build solution and generate random data
* navigate to project overview and confirm that:
   - Finished projects show only dates / period
   - In progress and pending projects show dates and the progress bar
   - Projects with missing start date or end date have message 'Waiting to start' 
* navigate to project overview of an organisation and confirm the same approach on project card

## Example project overview cards

![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/793dd6e7-8f96-497f-9954-881039a0c963)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
