### PR TITLE
chore: exclude test and mock files from sonar code analyses

### DIFF
--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -1,3 +1,4 @@
+# SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 # SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 #
@@ -16,6 +17,12 @@ sonar.organization=research-software-directory
 
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
+
+# Exclude specific folders without "real" code and the test files from code analyses
+sonar.exclusions=./utils/jest/**, **/__tests__/**, **/__mocks__/**, **/*.test.{js,jsx,ts,tsx}
+
+# Include all test files in the test analyses
+sonar.test.inclusions=**/*.test.{js,jsx,ts,tsx}
 
 # Test coverage report, see https://docs.sonarcloud.io/enriching/test-coverage/javascript-typescript-test-coverage/
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info


### PR DESCRIPTION
# Exclude folders and files from Sonar analyses

Changes proposed in this pull request:
* Do not analyse test, mocks and assets folders
* Define all test files   

How to test:
* De sonar analyses should now exclude large number of irrelevant files from it's analyses.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
