### PR TITLE
Vscode settings update

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,18 +3,11 @@
   "eslint.workingDirectories": [
     "./frontend",
   ],
-  // FORMAT ON SAVE for VSC
-  // based on this acticle https://www.aleksandrhovhannisyan.com/blog/format-code-on-save-vs-code-eslint/
-  // define files to validate, can have more options
-  // but in this project we use typescript and react
-  "eslint.validate": [
-    "javascript",
-    "javascriptreact",
-    "typescript",
-    "typescriptreact",
-  ],
   // it tells VScode to use eslint plugin
   // Note! you might also need to disable Prettier or VSCode defaults
+  // like eslint and format on save for other file types
+  // "editor.formatOnSave": false,
+  // "editor.formatOnType": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true,
   },
@@ -31,21 +24,28 @@
     "editor.useTabStops": true,
     "editor.insertSpaces": false,
   },
-  "java.configuration.updateBuildConfiguration": "automatic",
-  "java.test.config": {
-    "envFile": "${workspaceFolder}/.env",
-  },
   "[typescript]": {
+    "editor.formatOnSave": true,
+    "editor.formatOnType": false,
+    "editor.detectIndentation": true,
     "editor.tabSize": 2,
     "editor.insertSpaces": true,
-    "editor.detectIndentation": false
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint",
   },
   "[typescriptreact]": {
     "editor.formatOnSave": true,
+    "editor.formatOnType": false,
+    "editor.detectIndentation": true,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "[javascript]": {
     "editor.formatOnSave": true,
+    "editor.formatOnType": false,
+    "editor.detectIndentation": true,
+    "editor.tabSize": 2,
+    "editor.insertSpaces": true,
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
 }


### PR DESCRIPTION
# Update vscode settings for eslint (autofix on save)

Changes proposed in this pull request:
* removed old/obsolete settings for eslint and java
* improved eslint formatting for typescript, react and javascript files specifically:
    * enabled `formatOnSave` and defined to use eslint plugin
    * disabled `formatOnType` as it applies some vscode formatting that colides with eslint rules we use
    * enabled `detectIndentation` in hope that this will fix your problems when creating new files (but I am not sure this works)
    * `tabSize` and `insertSpaces`: defined tab to use 2 spaces

How to test:
* Open this PR branch in your VSCode editor.
* Create new tsx file `TestComponent.tsx`. The file should use 2 spaces for tabs. Then write few lines of code as in the example
```typescript
export default function TestingComponent() {
  const varX = 23;
  const varY = "Should be single quotes";
  const list = [ "one",  "two",  "three", "lot of spaces between items" ]

  return (
    <div>
      <h1>Testing</h1>
      {list.map(item=>{
        return (
          <div>{item}</div>
        )
      })}
    </div>
  )
}
```
You should see number of eslint warnings and one error as in this image
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/a97a6a55-f440-463e-8e69-466130f42297)

**What happens next is very `strange`. If you use `Ctrl+S` to save changes, the linting warnings will not be fixed?!? But if you enter one empty line between variables and the return statement and then use `Ctrl+S`, the linting warnings will be automatically fixed and the file is saved. It seems that adding new line randomly somewhere in the file triggers automatic fix on save?!? Note that error cannot be fixed automatically, but the error info will point to you that you need to add key to loop elements.** Let me know if you have any ideas why the fix on save works like this :-) and if there are some other improvements we can make.
### After fix on save is applied
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/e4ec14f0-86ad-47ef-800a-6c5022b8fbf5)

## Alternative
To fix all liniting warnings automatically or check all files you can always issue npm command from the frontend directory. Just ensure all dependencies are installed using `yarn install`.

```bash
yarn lint --fix
```

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
