### PR TITLE
955 improve performance

### DIFF
--- a/database/002-create-image-table.sql
+++ b/database/002-create-image-table.sql
@@ -1,7 +1,8 @@
+-- SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 dv4all
+-- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -41,6 +42,7 @@ CREATE TRIGGER sanitise_update_image BEFORE UPDATE ON image FOR EACH ROW EXECUTE
 
 -- ----------------------------------------
 -- RPC to get image by id => sha-1 of data
+-- cache incrased to 1 year based on lighthouse audit
 -- ----------------------------------------
 
 CREATE FUNCTION get_image(uid VARCHAR(40)) RETURNS BYTEA STABLE LANGUAGE plpgsql AS
@@ -52,7 +54,7 @@ BEGIN
 	SELECT format(
 		'[{"Content-Type": "%s"},'
 		'{"Content-Disposition": "inline; filename=\"%s\""},'
-		'{"Cache-Control": "max-age=259200"}]',
+		'{"Cache-Control": "max-age=31536001"}]',
 		mime_type,
 		uid)
 	FROM image WHERE id = uid INTO headers;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -108,7 +108,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:2.0.0
+    image: rsd/frontend:2.0.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2021 - 2022 dv4all
+# SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +12,7 @@
 # ----------------------------------------
 # 1. Install dependencies only when needed
 # ----------------------------------------
-FROM node:18.5-buster-slim AS deps
+FROM node:20.5-slim AS deps
 
 WORKDIR /app
 
@@ -45,7 +47,7 @@ RUN yarn build
 # ----------------------------------------
 # 3. Production image (standalone mode)
 # ----------------------------------------
-FROM node:18.5-buster-slim AS runner
+FROM node:20.5-slim AS runner
 
 # optional install updates
 # RUN apt-get upgrade -y

--- a/frontend/auth/api/useLoginProviders.tsx
+++ b/frontend/auth/api/useLoginProviders.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -7,19 +9,38 @@ import {useEffect, useState} from 'react'
 
 import {Provider} from 'pages/api/fe/auth'
 
+// save info after initial call
+let loginProviders:Provider[] = []
+
 export default function useLoginProviders() {
   const [providers, setProviders] = useState<Provider[]>([])
+
+  // console.group('useLoginProviders')
+  // console.log('providers...', providers)
+  // console.log('loginProviders...', loginProviders)
+  // console.groupEnd()
 
   useEffect(() => {
     let abort = false
 
     async function getProviders() {
-      const url = '/api/fe/auth'
-      const resp = await fetch(url)
-      if (resp.status === 200 && abort === false) {
-        const providers: Provider[] = await resp.json()
-        if (abort) return
-        setProviders(providers)
+      if (loginProviders.length === 0){
+        const url = '/api/fe/auth'
+        const resp = await fetch(url)
+        if (resp.status === 200 && abort === false) {
+          const providers: Provider[] = await resp.json()
+          if (abort) return
+          setProviders(providers)
+          // api response is the same once the app is started
+          // because the info eventually comes from .env file
+          // to avoid additional api calls we save api response
+          // into the loginProviders variable and reuse it
+          loginProviders = [
+            ...providers
+          ]
+        }
+      }else if (abort===false){
+        setProviders(loginProviders)
       }
     }
     if (abort === false) {

--- a/frontend/components/AppHeader/index.tsx
+++ b/frontend/components/AppHeader/index.tsx
@@ -64,8 +64,20 @@ export default function AppHeader() {
         className="flex-1 flex flex-col px-4 xl:flex-row items-start lg:container lg:mx-auto">
         <div className="w-full flex-1 flex items-center justify-between">
           <Link href="/" passHref className="hover:text-inherit" aria-label="Link to home page">
-            <LogoApp className="hidden 2xl:block"/>
-            <LogoAppSmall className="block 2xl:hidden"/>
+            <LogoApp
+              className="hidden 2xl:block"
+              loading='eager'
+              // lighthouse audit requires explicit width and height
+              width="100%"
+              height="1.5rem"
+            />
+            <LogoAppSmall
+              className="2xl:hidden"
+              loading='eager'
+              // lighthouse audit requires explicit width and height
+              width="100%"
+              height="1.5rem"
+            />
           </Link>
 
           <GlobalSearchAutocomplete className="hidden xl:block ml-12 mr-6"/>

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -55,6 +55,9 @@ export default function ImageWithPlaceholder({
       title={placeholder ?? alt}
       role="img"
       src={src}
+      // lighthouse audit requires explicit width and height
+      height="100%"
+      width="100%"
       style={{
         objectFit: bgSize,
         objectPosition: bgPosition

--- a/frontend/components/layout/LogoAvatar.tsx
+++ b/frontend/components/layout/LogoAvatar.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,13 +21,14 @@ export default function LogoAvatar({name,src,sx,...props}:LogoAvatarProps) {
       alt={name}
       src={src}
       sx={{
+        // lighthouse audit requires explicit width and height
         width: '100%',
         height: '100%',
         fontSize: '3rem',
         '& img': {
-          height: 'auto',
+          // height: 'auto',
           maxHeight: '100%',
-          width: 'auto',
+          // width: 'auto',
           maxWidth: '100%'
         },
         ...sx

--- a/frontend/components/login/LoginButton.tsx
+++ b/frontend/components/login/LoginButton.tsx
@@ -18,10 +18,8 @@ import useLoginProviders from '~/auth/api/useLoginProviders'
 import {getUserMenuItems} from '~/config/userMenuItems'
 import UserMenu from '~/components/layout/UserMenu'
 import LoginDialog from './LoginDialog'
-import useRsdSettings from '~/config/useRsdSettings'
 
 export default function LoginButton() {
-  const {host} = useRsdSettings()
   const providers = useLoginProviders()
   const {session} = useAuth()
   const status = session?.status || 'loading'

--- a/frontend/components/projects/edit/impact/EditProjectImpactIndex.test.tsx
+++ b/frontend/components/projects/edit/impact/EditProjectImpactIndex.test.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
@@ -21,7 +22,7 @@ import projectState from '../__mocks__/editProjectState'
 
 const mockGetImpactForProject = jest.fn((props) => Promise.resolve(mockImpactForProject))
 jest.mock('~/utils/getProjects', () => ({
-  getImpactForProject: jest.fn((props)=>mockGetImpactForProject(props))
+  getMentionsForProject: jest.fn((props)=>mockGetImpactForProject(props))
 }))
 
 const mockGetMentionByDoiFromRsd = jest.fn((props) => Promise.resolve([] as any))

--- a/frontend/components/projects/edit/impact/ImportProjectImpact.tsx
+++ b/frontend/components/projects/edit/impact/ImportProjectImpact.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
@@ -10,7 +11,7 @@ import ImportMentions from '~/components/mention/ImportMentions/index'
 import ImportMentionsInfoPanel from '~/components/mention/ImportMentions/ImportMentionsInfoPanel'
 import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
 import useProjectContext from '~/components/projects/edit/useProjectContext'
-import {getImpactForProject} from '~/utils/getProjects'
+import {getMentionsForProject} from '~/utils/getProjects'
 import {cfgImpact as config} from './config'
 
 export default function ImportProjectImpact() {
@@ -20,7 +21,7 @@ export default function ImportProjectImpact() {
 
   async function reloadImpact() {
     setLoading(true)
-    const data = await getImpactForProject({project: project.id, token: token, frontend: true})
+    const data = await getMentionsForProject({project: project.id,table:'impact_for_project',token: token})
     setMentions(data)
     setLoading(false)
   }

--- a/frontend/components/projects/edit/impact/useImpactForProject.tsx
+++ b/frontend/components/projects/edit/impact/useImpactForProject.tsx
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useEffect, useState} from 'react'
-import {getImpactForProject} from '~/utils/getProjects'
+import {getMentionsForProject} from '~/utils/getProjects'
 
 import {sortOnNumProp} from '~/utils/sortFn'
 import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
@@ -24,11 +26,10 @@ export default function useImpactForProject({project, token}: ImpactForProjectPr
     let abort = false
     async function getImpactFromApi() {
       setLoading(true)
-      // TODO! this request is made two times, investigate
-      const mentionsForProject = await getImpactForProject({
+      const mentionsForProject = await getMentionsForProject({
         project,
-        token,
-        frontend: true
+        table:'impact_for_project',
+        token
       })
       if (mentionsForProject && abort === false) {
         const mentions:MentionItemProps[] = mentionsForProject.sort((a, b) => {

--- a/frontend/components/projects/edit/output/EditProjectOutputIndex.test.tsx
+++ b/frontend/components/projects/edit/output/EditProjectOutputIndex.test.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -22,7 +23,7 @@ import outputForProject from './__mocks__/outputForProject.json'
 // MOCK getOutputForProject
 const mockGetOutputForProject = jest.fn((props) => Promise.resolve(outputForProject))
 jest.mock('~/utils/getProjects', () => ({
-  getOutputForProject: jest.fn((props)=>mockGetOutputForProject(props))
+  getMentionsForProject: jest.fn((props)=>mockGetOutputForProject(props))
 }))
 // MOCK getMentionByDoiFromRsd
 const mockGetMentionByDoiFromRsd = jest.fn((props) => Promise.resolve([] as any))

--- a/frontend/components/projects/edit/output/ImportProjectOutput.tsx
+++ b/frontend/components/projects/edit/output/ImportProjectOutput.tsx
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useSession} from '~/auth'
-import {getOutputForProject} from '~/utils/getProjects'
+import {getMentionsForProject} from '~/utils/getProjects'
 import ImportMentions from '~/components/mention/ImportMentions/index'
 import ImportMentionsInfoPanel from '~/components/mention/ImportMentions/ImportMentionsInfoPanel'
 import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
@@ -21,7 +21,7 @@ export default function ImportProjectOutput() {
 
   async function reloadOutput() {
     setLoading(true)
-    const data = await getOutputForProject({project: project.id, token: token, frontend: true})
+    const data = await getMentionsForProject({project: project.id,table:'output_for_project',token: token})
     setMentions(data)
     setLoading(false)
   }

--- a/frontend/components/projects/edit/output/useOutputForProject.tsx
+++ b/frontend/components/projects/edit/output/useOutputForProject.tsx
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useEffect, useState} from 'react'
 import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
 import {MentionItemProps} from '~/types/Mention'
-import {getOutputForProject} from '~/utils/getProjects'
+import {getMentionsForProject} from '~/utils/getProjects'
 import {sortOnNumProp} from '~/utils/sortFn'
 
 type OutputForProjectProps = {
@@ -22,10 +24,10 @@ export default function useOutputForProject({project, token}: OutputForProjectPr
     let abort = false
     async function getImpact() {
       setLoading(true)
-      const mentions = await getOutputForProject({
+      const mentions = await getMentionsForProject({
         project,
-        token,
-        frontend: true
+        table:'output_for_project',
+        token
       })
       const output:MentionItemProps[] = mentions.sort((a, b) => {
         // sort mentions on publication year, newest at the top
@@ -41,12 +43,7 @@ export default function useOutputForProject({project, token}: OutputForProjectPr
     if (project && token && project!==loadedProject) {
       getImpact()
     }
-    // else {
-    //   console.group('skip request useOutputForProject')
-    //   console.log('project...', project)
-    //   console.log('loadedProject...', loadedProject)
-    //   console.groupEnd()
-    // }
+
     return () => { abort = true }
     // we skip setMentions and setLoading methods in the deps to avoid loop
     // TODO! try wrapping methods of useEditMentionReducer in useCallback?

--- a/frontend/components/projects/overview/list/ListImageWithGradientPlaceholder.tsx
+++ b/frontend/components/projects/overview/list/ListImageWithGradientPlaceholder.tsx
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import useValidateImageSrc from '~/utils/useValidateImageSrc'
+
+export default function ListImageWithGradientPlaceholder({imgSrc,alt}:{imgSrc:string|null, alt:string|null}) {
+  const validImg = useValidateImageSrc(imgSrc)
+
+  // console.group('ListItemImageWithGradientPlaceholder')
+  // console.log('imgSrc...', imgSrc)
+  // console.log('validImg...', validImg)
+  // console.groupEnd()
+
+  if (validImg === false || imgSrc === null){
+    // return gradient square as placeholder
+    return (
+      <div
+        className="w-12 self-stretch bg-gradient-to-br from-base-300 from-0% via-base-100 via-50% to-base-100"
+      />
+    )
+  }
+
+  return (
+    <img
+      src={`${imgSrc ?? ''}`}
+      alt={alt ?? 'Image'}
+      className="w-12 max-h-[3.5rem] text-base-content-disabled p-2 object-contain object-center"
+      // lighthouse audit requires explicit width and height
+      height="2.5rem"
+      width="100%"
+    />
+  )
+}

--- a/frontend/components/projects/overview/list/ProjectListItemContent.tsx
+++ b/frontend/components/projects/overview/list/ProjectListItemContent.tsx
@@ -7,8 +7,8 @@
 
 import {JSX} from 'react'
 import {getImageUrl} from '~/utils/editImage'
-import useValidateImageSrc from '~/utils/useValidateImageSrc'
 import ProjectMetrics from '../cards/ProjectMetrics'
+import ListImageWithGradientPlaceholder from './ListImageWithGradientPlaceholder'
 
 type ProjectListItemProps = {
   title: string
@@ -19,23 +19,14 @@ type ProjectListItemProps = {
   statusBanner?: JSX.Element
 }
 
-
 export default function ProjectListItemContent(item: ProjectListItemProps) {
   const imgSrc = getImageUrl(item.image_id ?? null)
-  const validImg = useValidateImageSrc(imgSrc)
   return (
     <>
-      {validImg ?
-        <img
-          src={`${imgSrc ?? ''}`}
-          alt={`Cover image for ${item.title}`}
-          className="w-12 max-h-[3.5rem] text-base-content-disabled p-2 object-contain object-center"
-        />
-        :
-        <div
-          className="w-12 bg-gradient-to-br from-base-300 from-0% via-base-100 via-50% to-base-100"
-        />
-      }
+      <ListImageWithGradientPlaceholder
+        imgSrc={imgSrc}
+        alt = {`Cover image for ${item.title}`}
+      />
       <div className="flex flex-col md:flex-row gap-3 flex-1 py-2">
         <div className="flex-1">
           <div className='line-clamp-2 md:line-clamp-1 break-words font-medium'>

--- a/frontend/components/software/edit/mentions/ImportSoftwareMentions.tsx
+++ b/frontend/components/software/edit/mentions/ImportSoftwareMentions.tsx
@@ -1,3 +1,4 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
@@ -20,7 +21,7 @@ export default function ImportSoftwareMentions() {
 
   async function reloadMentions() {
     setLoading(true)
-    const data = await getMentionsForSoftware({software: software.id, token: token, frontend: true})
+    const data = await getMentionsForSoftware({software: software.id, token: token})
     setMentions(data)
     setLoading(false)
   }

--- a/frontend/components/software/edit/mentions/useMentionForSoftware.tsx
+++ b/frontend/components/software/edit/mentions/useMentionForSoftware.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,13 +22,12 @@ export default function useMentionForSoftware({software, token}: MentionForSoftw
 
   useEffect(() => {
     let abort = false
-    async function getImpactFromApi() {
+    async function getMentionsFromApi() {
       setLoading(true)
       // TODO! this request is made two times, investigate
       const mentionsForSoftware = await getMentionsForSoftware({
         software,
-        token,
-        frontend: true
+        token
       })
       if (mentionsForSoftware && abort === false) {
         // debugger
@@ -37,7 +38,7 @@ export default function useMentionForSoftware({software, token}: MentionForSoftw
     }
     if (software && token &&
       software !== loadedSoftware) {
-      getImpactFromApi()
+      getMentionsFromApi()
     }
 
     return () => { abort = true }

--- a/frontend/components/software/overview/cards/SoftwareMasonryCard.tsx
+++ b/frontend/components/software/overview/cards/SoftwareMasonryCard.tsx
@@ -34,12 +34,16 @@ export default function SoftwareMasonryCard({item}:SoftwareCardProps){
       className="hover:text-inherit">
       <div className="flex-shrink-0 transition bg-base-100 shadow-md hover:shadow-lg rounded-lg hover:cursor-pointer h-full select-none flex-col">
         {/* Cover image, show only if valid image link */}
-        {
-          validImg &&
+        { validImg === false ? null
+          :
           <img
             className="object-cover w-full rounded-tr-lg rounded-tl-lg"
             src={`${imgSrc ?? ''}`}
             alt={`Cover image for ${item.brand_name}`}
+            loading='eager'
+            // lighthouse audit requires explicit with and height
+            height="100%"
+            width="100%"
           />
         }
         {/* Card content */}

--- a/frontend/components/software/overview/highlights/HighlightsCard.tsx
+++ b/frontend/components/software/overview/highlights/HighlightsCard.tsx
@@ -13,6 +13,7 @@ import CardTitleSubtitle from '~/components/cards/CardTitleSubtitle'
 import ProgrammingLanguageList from '~/components/software/overview/cards/ProgrammingLanguageList'
 import SoftwareMetrics from '~/components/software/overview/cards/SoftwareMetrics'
 import useValidateImageSrc from '~/utils/useValidateImageSrc'
+import {useState} from 'react'
 
 type HighlightsCardProps = {
   id:string
@@ -37,6 +38,11 @@ export default function HighlightsCard(item: HighlightsCardProps) {
   const visibleNumberOfKeywords: number = 3
   const visibleNumberOfProgLang: number = 3
 
+  // console.group('HighlightsCard')
+  // console.log('imgSrc...', imgSrc)
+  // console.log('validImg...', validImg)
+  // console.groupEnd()
+
   return (
     <Link
       data-testid="highlights-card"
@@ -44,18 +50,23 @@ export default function HighlightsCard(item: HighlightsCardProps) {
       href={`/software/${item.slug}`}
       className="hover:text-inherit">
       <div className="flex-shrink-0 transition bg-base-100 shadow-md hover:shadow-lg rounded-lg hover:cursor-pointer h-full select-none flex flex-col sm:flex-row sm:w-full" >
-        {/* Cover image, show only if valid image link */}
-        {
-          validImg &&
+        {/*
+          Cover image, show only if valid image link! To avoid the layout shift we
+          flip the logic to hide the image only when the image link is not valid.
+        */}
+        { validImg === false ? null
+          :
           <img
             className="object-contain object-left w-full rounded-tr-lg rounded-tl-lg sm:rounded-bl-lg sm:rounded-tl-lg sm:rounded-tr-none sm:h-[20rem]"
             src={`${imgSrc ?? ''}`}
             alt={`Cover image for ${item.brand_name}`}
-            style={{maxWidth:'20rem'}}
+            style={{maxWidth:'22rem'}}
+            loading='eager'
           />
         }
+
         {/* Card content */}
-        <div className="flex flex-col p-4 max-w-[20rem] lg:max-w-[22rem]">
+        <div className="flex flex-col p-4 max-w-[20rem] lg:max-w-[22rem] lg:h-[20rem]">
           <CardTitleSubtitle
             title={item.brand_name}
             subtitle={item.short_statement}

--- a/frontend/components/software/overview/highlights/HighlightsCard.tsx
+++ b/frontend/components/software/overview/highlights/HighlightsCard.tsx
@@ -13,7 +13,6 @@ import CardTitleSubtitle from '~/components/cards/CardTitleSubtitle'
 import ProgrammingLanguageList from '~/components/software/overview/cards/ProgrammingLanguageList'
 import SoftwareMetrics from '~/components/software/overview/cards/SoftwareMetrics'
 import useValidateImageSrc from '~/utils/useValidateImageSrc'
-import {useState} from 'react'
 
 type HighlightsCardProps = {
   id:string
@@ -61,7 +60,12 @@ export default function HighlightsCard(item: HighlightsCardProps) {
             src={`${imgSrc ?? ''}`}
             alt={`Cover image for ${item.brand_name}`}
             style={{maxWidth:'22rem'}}
+            // lighthouse audit requires explicit width and height
+            height="100%"
+            width="100%"
             loading='eager'
+            // this is correct markup but supported yet
+            // fetchPriority="high"
           />
         }
 

--- a/frontend/components/software/overview/highlights/HighlightsCarousel.tsx
+++ b/frontend/components/software/overview/highlights/HighlightsCarousel.tsx
@@ -16,11 +16,15 @@ export const HighlightsCarousel = ({items=[]}: {items:SoftwareHighlight[]}) => {
   // card size + margin
   const cardMovement: number = 680
   const divRef =useRef<HTMLDivElement>(null)
-  const [distance, setDistance] = useState(0)
-
+  const [distance, setDistance] = useState<number>()
   // Keep track of the current scroll position of the carousel.
   const [scrollPosition, setScrollPosition] = useState(0)
   const carousel = useRef<HTMLDivElement>(null)
+
+  // console.group('HighlightsCarousel')
+  // console.log('distance...',distance)
+  // console.log('scrollPosition...', scrollPosition)
+  // console.groupEnd()
 
   useEffect(() => {
     const calculateDistance = () => {
@@ -53,16 +57,24 @@ export const HighlightsCarousel = ({items=[]}: {items:SoftwareHighlight[]}) => {
     setScrollPosition(event.target.scrollLeft)
   }
 
+  if (typeof distance === 'undefined'){
+    // return only empty reference div if distance is not calculated and keep highlight space
+    return <div ref={divRef} className="container mx-auto invisible sm:h-[22rem]" />
+  }
+
   return (
     <>
-      <div ref={divRef} className="container mx-auto invisible"> </div>
       {/* Reference Div to center align card */}
+      <div ref={divRef} className="lg:container mx-auto invisible" />
       <div
         data-testid="highlights-carousel"
-        className="group relative w-full overflow-x-visible" >
-        {scrollPosition > 0 && <LeftButton handlePrevClick={handlePrevClick} /> }
-        <RightButton handleNextClick={handleNextClick} />
-
+        className="group relative w-full overflow-x-visible sm:h-[22rem]"
+      >
+        {/* Left button */}
+        {scrollPosition > 0 ?
+          <LeftButton handlePrevClick={handlePrevClick} />
+          : null
+        }
         {/* Carousel */}
         <div
           ref={carousel}
@@ -72,13 +84,15 @@ export const HighlightsCarousel = ({items=[]}: {items:SoftwareHighlight[]}) => {
           style={{scrollbarWidth:'none',left:-scrollPosition, paddingLeft: distance +'px'}}>
           {/* render software card in the row direction */}
           {items.map(highlight => (
-            <div key={highlight.id}
+            <div
+              key={highlight.id}
               className="snap-center flex-shrink-0 hover:scale-[101%] transition duration-500">
               <HighlightsCard {...highlight}/>
             </div>
-          ))
-          }
+          ))}
         </div>
+        {/* Right button */}
+        <RightButton handleNextClick={handleNextClick} />
       </div>
     </>
   )

--- a/frontend/components/software/overview/list/SoftwareListItemContent.tsx
+++ b/frontend/components/software/overview/list/SoftwareListItemContent.tsx
@@ -5,7 +5,7 @@
 
 import {JSX} from 'react'
 import {getImageUrl} from '~/utils/editImage'
-import useValidateImageSrc from '~/utils/useValidateImageSrc'
+import ListImageWithGradientPlaceholder from '~/components/projects/overview/list/ListImageWithGradientPlaceholder'
 import SoftwareMetrics from '../cards/SoftwareMetrics'
 
 type SoftwareOverviewListItemProps = {
@@ -27,20 +27,13 @@ type SoftwareOverviewListItemProps = {
 
 export default function SoftwareListItemContent(item:SoftwareOverviewListItemProps) {
   const imgSrc = getImageUrl(item.image_id ?? null)
-  const validImg = useValidateImageSrc(imgSrc)
+
   return (
     <>
-      {validImg ?
-        <img
-          src={`${imgSrc ?? ''}`}
-          alt={`Cover image for ${item.brand_name}`}
-          className="w-12 max-h-[3.5rem] text-base-content-disabled p-2 object-contain object-center"
-        />
-        :
-        <div
-          className="w-12 self-stretch bg-gradient-to-br from-base-300 from-0% via-base-100 via-50% to-base-100"
-        />
-      }
+      <ListImageWithGradientPlaceholder
+        imgSrc={imgSrc}
+        alt = {`Cover image for ${item.brand_name}`}
+      />
       <div className="flex flex-col md:flex-row gap-3 flex-1 py-2">
         <div className="flex-1">
           <div className='line-clamp-2 md:line-clamp-1 break-words font-medium'>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -79,7 +79,6 @@ interface SoftwareIndexData extends ScriptProps{
 }
 
 export default function SoftwareIndexPage(props:SoftwareIndexData) {
-  const [resolvedUrl, setResolvedUrl] = useState('')
   const [author, setAuthor] = useState('')
   // extract data from props
   const {
@@ -91,11 +90,6 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
   } = props
 
   useEffect(() => {
-    if (typeof location != 'undefined') {
-      setResolvedUrl(location.href)
-    }
-  }, [])
-  useEffect(() => {
     const contact = contributors.filter(item => item.is_contact_person)
     if (contact.length > 0) {
       const name = getDisplayName(contact[0])
@@ -106,7 +100,7 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
   if (!software?.brand_name){
     return <NoContent />
   }
-  // console.log('SoftwareIndexPage...releases...', releases)
+  // console.log('SoftwareIndexPage...mentions...', mentions)
   return (
     <>
       {/* Page Head meta tags */}
@@ -218,32 +212,6 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       }
     }
     // fetch all info about software in parallel based on software.id
-    const fetchData = [
-      // software versions info
-      getReleasesForSoftware(software.id,token),
-      // keywords
-      getKeywordsForSoftware(software.id,false,token),
-      // licenseInfo
-      getLicenseForSoftware(software.id, false, token),
-      // repositoryInfo: url, languages and commits
-      getRepostoryInfoForSoftware(software.id, token),
-      // softwareMentionCounts
-      getContributorMentionCount(software.id,token),
-      // mentions
-      getMentionsForSoftware({software: software.id, frontend: false, token}),
-      // testimonials
-      getTestimonialsForSoftware({software:software.id,frontend: false,token}),
-      // contributors
-      getContributorsForSoftware({software:software.id,token}),
-      // relatedTools
-      getRelatedSoftwareForSoftware({software: software.id, frontend: false, token}),
-      // relatedProjects
-      getRelatedProjectsForSoftware({software: software.id, token, frontend: false}),
-      // check if maintainer
-      isMaintainerOfSoftware({slug, account:userInfo?.account, token, frontend: false}),
-      // get organisations
-      getParticipatingOrganisations({software:software.id,frontend:false,token})
-    ]
     const [
       releases,
       keywords,
@@ -257,8 +225,32 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       relatedProjects,
       isMaintainer,
       organisations
-    ] = await Promise.all(fetchData)
-
+    ] = await Promise.all([
+      // software versions info
+      getReleasesForSoftware(software.id,token),
+      // keywords
+      getKeywordsForSoftware(software.id,false,token),
+      // licenseInfo
+      getLicenseForSoftware(software.id, false, token),
+      // repositoryInfo: url, languages and commits
+      getRepostoryInfoForSoftware(software.id, token),
+      // softwareMentionCounts
+      getContributorMentionCount(software.id,token),
+      // mentions
+      getMentionsForSoftware({software:software.id,token}),
+      // testimonials
+      getTestimonialsForSoftware({software:software.id,frontend: false,token}),
+      // contributors
+      getContributorsForSoftware({software:software.id,token}),
+      // relatedTools
+      getRelatedSoftwareForSoftware({software: software.id, frontend: false, token}),
+      // relatedProjects
+      getRelatedProjectsForSoftware({software: software.id, token, frontend: false}),
+      // check if maintainer
+      isMaintainerOfSoftware({slug, account:userInfo?.account, token, frontend: false}),
+      // get organisations
+      getParticipatingOrganisations({software:software.id,frontend:false,token})
+    ])
     // pass data to page component as props
     return {
       props: {


### PR DESCRIPTION
# Improve RSD v2 performance

Closes #955

Changes proposed in this pull request:
* loading mentions on the software and project page api is changed to more performant api requests. (reduced from ~300ms to ~50ms)
* auth endpoint response is improved to cache the list of login providers on initial load instead of reading it on each request (reduced from ~500ms to ~10ms after initial request).
* fix cumulative layout shift on software overview page when highlights section is used
* bump the node version to v20 in the fe image. Node v20 is going to be LTS version from October 2023, so we should switch from v18 to v20 asap. Advice to FE developers, use [nvm](https://github.com/nvm-sh/nvm) to manage multiple node versions on your machine. 
* apply fixes advised by Lighthouse audit: increase image cache to 1yr and provide width and height for images

How to test:
* The improvement cannot be tested without comparing it to performance of the previous version.
* `make start` to rebuild app
* Navigate between home, software, organisation and project pages. The loading of the pages should be improved.
* After merging this PR I will set this version on `dev server` and perform load testing. Then we can compare the results with the load test results of the previous version. The expectation is that performance should be improved by these changes. I will post the results of load test in rsd-v2-release PR.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
