### PR TITLE
lighthouse: add arial labels to admin buttons.

### DIFF
--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -144,6 +144,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
         </div>
         <input className="px-2 pl-8 py-2 bg-transparent rounded-sm border border-base-600 focus:outline-0 w-full focus:bg-base-100 focus:text-base-900 duration-200"
           data-testid="global-search"
+          name="global-search"
           placeholder="Search or jump to..."
           autoComplete="off"
           value={inputValue}

--- a/frontend/components/menu/IconBtnMenuOnAction.tsx
+++ b/frontend/components/menu/IconBtnMenuOnAction.tsx
@@ -64,6 +64,7 @@ export default function IconBtnMenuOnAction({
             <MenuItem
               data-testid="icon-menu-option"
               key={item.label}
+              aria-label={item.label}
               onClick={() => handleAction(item.action)}>
               {item.icon ? <span className="mr-2">{item.icon}</span> : null}
               {item.label}
@@ -80,6 +81,7 @@ export default function IconBtnMenuOnAction({
       <IconButton
         size="large"
         data-testid="icon-menu-button"
+        aria-label='Menu'
         aria-controls="more-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : 'false'}

--- a/frontend/components/organisation/metadata/OrganisationLogoMenu.tsx
+++ b/frontend/components/organisation/metadata/OrganisationLogoMenu.tsx
@@ -71,6 +71,7 @@ export default function OrganisationLogoMenu({logo, onAddLogo, onRemoveLogo}: Ad
       <IconButton
         size="large"
         data-testid="icon-menu-button"
+        aria-label="Logo options"
         aria-controls="more-menu"
         aria-haspopup="true"
         aria-expanded={open ? 'true' : 'false'}


### PR DESCRIPTION
# Lightouse improvement suggestions for organisation page

Closes #976

Changes proposed in this pull request:
*  Add aria labels to admin buttons on organisation page

How to test:
*  `make start` to build complete solution
*  login as rsd-admin role. If you use same .env as mine you can login as `professor3`
*  navigate to organisation page as admin
*  run Lighthouse audit on the page. The score should be improved and there will be no messages about buttons missing accessible name (see image bellow).
* Note! the score will probably not be that high on your local machine because ssl + http2  is not enabled at localhost.

## Audit improvement

![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/c77bd68a-86cd-4c60-8120-fbdf28b2d0a5)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
