### PR TITLE
171 add scraper error logs page to admin section

### DIFF
--- a/database/118-backend-logs-views.sql
+++ b/database/118-backend-logs-views.sql
@@ -1,0 +1,51 @@
+-- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+-- SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+CREATE FUNCTION slug_from_log_reference(
+	table_name VARCHAR,
+	reference_id UUID
+)
+RETURNS TABLE (
+	slug VARCHAR
+)
+LANGUAGE sql STABLE AS
+$$
+SELECT CASE
+	WHEN table_name = 'repository_url' THEN (
+		SELECT
+			CONCAT('/software/',slug,'/edit/information') as slug
+		FROM
+			software WHERE id = reference_id
+	)
+	WHEN table_name = 'package_manager' THEN (
+		SELECT
+			CONCAT('/software/',slug,'/edit/package-managers') as slug
+		FROM
+			software
+		WHERE id = (SELECT software FROM package_manager WHERE id = reference_id))
+	END
+$$;
+
+CREATE FUNCTION backend_log_view() RETURNS TABLE (
+	id UUID,
+	service_name VARCHAR,
+	table_name VARCHAR,
+	reference_id UUID,
+	message VARCHAR,
+	stack_trace VARCHAR,
+	other_data JSONB,
+	created_at TIMESTAMPTZ,
+	updated_at TIMESTAMPTZ,
+	slug VARCHAR
+)
+LANGUAGE sql STABLE AS
+$$
+SELECT
+	*,
+	slug_from_log_reference(backend_log.table_name, backend_log.reference_id)
+FROM
+	backend_log
+$$;

--- a/frontend/components/AppHeader/index.tsx
+++ b/frontend/components/AppHeader/index.tsx
@@ -75,7 +75,7 @@ export default function AppHeader() {
               className="2xl:hidden"
               loading='eager'
               // lighthouse audit requires explicit width and height
-              width="100%"
+              width="7rem"
               height="1.5rem"
             />
           </Link>

--- a/frontend/components/admin/AdminNav.tsx
+++ b/frontend/components/admin/AdminNav.tsx
@@ -22,6 +22,7 @@ import DomainAddIcon from '@mui/icons-material/DomainAdd'
 import AccountCircleIcon from '@mui/icons-material/AccountCircle'
 import FluorescentIcon from '@mui/icons-material/Fluorescent'
 import CampaignIcon from '@mui/icons-material/Campaign'
+import BugReportIcon from '@mui/icons-material/BugReport'
 
 export const adminPages = {
   pages:{
@@ -65,6 +66,12 @@ export const adminPages = {
     subtitle: 'Manage keyword entries',
     icon: <SpellcheckIcon />,
     path: '/admin/keywords',
+  },
+  logs:{
+    title: 'Error logs',
+    subtitle: 'From background services',
+    icon: <BugReportIcon />,
+    path: '/admin/logs',
   },
   announcements: {
     title: 'Announcement',

--- a/frontend/components/admin/AdminPageWithNav.tsx
+++ b/frontend/components/admin/AdminPageWithNav.tsx
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/frontend/components/admin/logs/DeleteOldLogsBtn.tsx
+++ b/frontend/components/admin/logs/DeleteOldLogsBtn.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import IconButton from '@mui/material/IconButton'
+import AutoDeleteIcon from '@mui/icons-material/AutoDelete'
+
+type DeleteOldLogs={
+  disabled: boolean
+  onDelete:()=>void
+}
+
+export default function DeleteOldLogsBtn({disabled,onDelete}:DeleteOldLogs) {
+  return (
+    <IconButton
+      title="Delete logs older than 30 days"
+      disabled={disabled}
+      sx={{
+        alignSelf:'center',
+        marginRight:'1rem'
+      }}
+      onClick={onDelete}
+    >
+      <AutoDeleteIcon />
+    </IconButton>
+  )
+}

--- a/frontend/components/admin/logs/ErrorInfoCell.tsx
+++ b/frontend/components/admin/logs/ErrorInfoCell.tsx
@@ -1,0 +1,139 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+import Tooltip from '@mui/material/Tooltip'
+import IconButton from '@mui/material/IconButton'
+import KeyIcon from '@mui/icons-material/Key'
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline'
+import DataObjectIcon from '@mui/icons-material/DataObject'
+import OpenInNewIcon from '@mui/icons-material/OpenInNew'
+import ContentCopyIcon from '@mui/icons-material/ContentCopy'
+import copyToClipboard from '~/utils/copyToClipboard'
+
+type LogMessageCellProps={
+  message: string
+  other_data: string
+  stack_trace: string
+  id: string
+  slug: string | null
+}
+
+export default function ErrorInfoCell({message,stack_trace,other_data,id,slug}:LogMessageCellProps) {
+  const [action, setAction] = useState<string>()
+
+  function toggleButton(value:string){
+    if (action===value){
+      setAction(undefined)
+    } else {
+      setAction(value)
+    }
+  }
+
+  return (
+    <>
+      <div className="pb-2">{message}</div>
+      <div className="flex items-center gap-4 font-bold">
+        {/* Other data  */}
+        <Tooltip
+          title={
+            <>
+              <div className="flex justify-between text-base">
+                Error data
+                <IconButton
+                  size="small"
+                  onClick={()=>{
+                    copyToClipboard(JSON.stringify(other_data,null,2))
+                    toggleButton('other_data')
+                  }}>
+                  <ContentCopyIcon sx={{color:'primary.contrastText'}} />
+                </IconButton>
+              </div>
+              <pre style={{overflow:'auto', paddingBottom:'0.5rem'}}>
+                {JSON.stringify(other_data,null,2)}
+              </pre>
+            </>
+          }
+          open={action === 'other_data'}
+          // onClose={()=>toggleButton('other_data')}
+          arrow
+        >
+          <IconButton
+            onClick={()=>toggleButton('other_data')}>
+            <DataObjectIcon />
+          </IconButton>
+        </Tooltip>
+
+        {/* Stack trace */}
+        <Tooltip
+          title={
+            <>
+              <div className="flex justify-between text-base">
+                Stack trace
+                <IconButton
+                  size="small"
+                  onClick={()=>{
+                    copyToClipboard(stack_trace)
+                    toggleButton('stack_trace')
+                  }}>
+                  <ContentCopyIcon sx={{color:'primary.contrastText'}} />
+                </IconButton>
+              </div>
+              <pre style={{overflow:'auto', paddingBottom:'0.5rem'}}>
+                {stack_trace}
+              </pre>
+            </>
+          }
+          open={action === 'stack_trace'}
+          arrow
+        >
+          <IconButton
+            onClick={()=>toggleButton('stack_trace')}>
+            <ErrorOutlineIcon />
+          </IconButton>
+        </Tooltip>
+
+        {/* Log id  */}
+        <Tooltip
+          title={
+            <>
+              <div className="flex justify-between items-center text-base">
+                Log id
+                <IconButton
+                  size="small"
+                  onClick={()=>{
+                    copyToClipboard(id)
+                    toggleButton('log_id')
+                  }}>
+                  <ContentCopyIcon sx={{color:'primary.contrastText'}} />
+                </IconButton>
+              </div>
+              <pre style={{overflow:'auto', paddingBottom:'0.5rem'}}>
+                {id}
+              </pre>
+            </>
+          }
+          open={action === 'log_id'}
+          arrow
+        >
+          <IconButton
+            onClick={()=>toggleButton('log_id')}>
+            <KeyIcon />
+          </IconButton>
+        </Tooltip>
+        {slug ?
+          <IconButton
+            title="Go to offending page"
+            href={slug}
+            target='_blank'
+          >
+            <OpenInNewIcon />
+          </IconButton>
+          : null
+        }
+      </div>
+    </>
+  )
+}

--- a/frontend/components/admin/logs/LogsTable.tsx
+++ b/frontend/components/admin/logs/LogsTable.tsx
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
+
+import EditableTable, {Column, OrderByProps} from '~/components/table/EditableTable'
+import ContentLoader from '~/components/layout/ContentLoader'
+import {BackendLog} from './useLogs'
+
+type LogTableProps={
+  loading: boolean
+  columns: Column<BackendLog, keyof BackendLog>[],
+  logs: BackendLog[],
+  orderBy: OrderByProps<BackendLog, keyof BackendLog>
+  setOrderBy: (orderBy:OrderByProps<BackendLog, keyof BackendLog>)=>void
+}
+
+export default function LogsTable({loading,columns,logs,orderBy,setOrderBy}:LogTableProps) {
+  // const [orderBy, setOrderBy] = useState<OrderByProps<BackendLog, keyof BackendLog>>(initalOrder)
+  // const {loading, columns, logs} = useLogs({orderBy})
+
+  // console.group('LogsTable')
+  // console.log('loading...', loading)
+  // console.log('columns...', columns)
+  // console.log('logs...', logs)
+  // console.groupEnd()
+
+  const styles = {
+    flex: 1,
+    overflow: 'auto',
+    padding: '0.5rem 0rem',
+    cursor: 'default',
+    minHeight: logs.length > 7 ?'80vh':'50vh'
+  }
+
+  if (logs.length === 0 && loading===false) {
+    return (
+      <section className="flex-1">
+        <Alert severity="info"
+          sx={{
+            marginTop: '0.5rem'
+          }}
+        >
+          <AlertTitle sx={{fontWeight:500}}>No error logs. Nice job!</AlertTitle>
+        </Alert>
+      </section>
+    )
+  }
+
+  function onSortColumn(column:keyof BackendLog) {
+    if (orderBy && orderBy.column === column) {
+      if (orderBy.direction === 'asc') {
+        setOrderBy({
+          column,
+          direction: 'desc'
+        })
+      } else {
+        setOrderBy({
+          column,
+          direction: 'asc'
+        })
+      }
+    } else {
+      setOrderBy({
+        column,
+        direction: 'asc'
+      })
+    }
+  }
+
+  return (
+    <div style={styles} className={`${loading ? 'cursor-wait' : 'cursor-default'}`}>
+      {
+        loading ?
+          <ContentLoader/>
+          :
+          <EditableTable
+            className='w-full mb-8 text-sm'
+            columns={columns}
+            data={logs}
+            onSort={onSortColumn}
+          />
+      }
+    </div>
+  )
+}

--- a/frontend/components/admin/logs/__mocks__/apiLogs.ts
+++ b/frontend/components/admin/logs/__mocks__/apiLogs.ts
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {ApiParams} from '~/utils/postgrestUrl'
+import {BackendLog} from '../useLogs'
+
+export async function getLogs({page, rows, token, searchFor, orderBy}: ApiParams<BackendLog, keyof BackendLog>) {
+  try {
+    return {
+      count: 0,
+      logs: []
+    }
+  } catch (e: any) {
+    return {
+      count: 0,
+      logs: []
+    }
+  }
+}
+
+export async function deleteLogById({id,token}:{id:string, token:string}){
+  try{
+    return {
+      status:200,
+      message: 'OK'
+    }
+  }catch(e:any){
+    return {
+      status: 500,
+      message: 'Server error'
+    }
+  }
+}
+
+/**
+ * Deletes logs older than specified number of days.
+ * Based on created_at value. Default days is 30 and the limit of 1000 records to remove.
+ * @param @object{days?,limit?,token}
+ * @returns
+ */
+export async function deleteLogsOlderThan({days=30,limit=1000,token}:{token:string,days?:number,limit?:number}){
+  return {
+    status: 200,
+    message: 0,
+  }
+}

--- a/frontend/components/admin/logs/apiLogs.ts
+++ b/frontend/components/admin/logs/apiLogs.ts
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {extractCountFromHeader} from '~/utils/extractCountFromHeader'
+import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
+import {ApiParams, paginationUrlParams} from '~/utils/postgrestUrl'
+import {BackendLog} from './useLogs'
+import {getDateFromNow} from '~/utils/dateFn'
+
+export async function getLogs({page, rows, token, searchFor, orderBy}: ApiParams<BackendLog, keyof BackendLog>) {
+  try {
+    let query = paginationUrlParams({rows, page})
+    if (searchFor) {
+      query+=`&or=(service_name.ilike.*${searchFor}*,table_name.ilike.*${searchFor}*,message.ilike.*${searchFor}*,stack_trace.ilike.*${searchFor}*)`
+    }
+    if (orderBy) {
+      query+=`&order=${orderBy.column}.${orderBy.direction}`
+    }
+    // complete url
+    const url = `${getBaseUrl()}/rpc/backend_log_view?${query}`
+
+    // make request
+    const resp = await fetch(url,{
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+        // request record count to be returned
+        // note: it's returned in the header
+        'Prefer': 'count=exact'
+      },
+    })
+
+    if ([200,206].includes(resp.status)) {
+      const logs: BackendLog[] = await resp.json()
+      return {
+        count: extractCountFromHeader(resp.headers) ?? 0,
+        logs
+      }
+    }
+    logger(`getLogs: ${resp.status}: ${resp.statusText}`,'warn')
+    return {
+      count: 0,
+      logs: []
+    }
+  } catch (e: any) {
+    logger(`getLogs: ${e.message}`,'error')
+    return {
+      count: 0,
+      logs: []
+    }
+  }
+}
+
+export async function deleteLogById({id,token}:{id:string, token:string}){
+  const url = `${getBaseUrl()}/backend_log?id=eq.${id}`
+  try{
+    // make request
+    const resp = await fetch(url,{
+      method: 'DELETE',
+      headers: {
+        ...createJsonHeaders(token),
+        // request record count to be returned
+        // note: it's returned in the header
+        // 'Prefer': 'count=exact'
+      },
+    })
+
+    return extractReturnMessage(resp)
+  }catch(e:any){
+    logger(`getLogs: ${e.message}`,'error')
+    return {
+      status: 500,
+      message: e.message
+    }
+  }
+}
+
+/**
+ * Deletes logs older than specified number of days.
+ * Based on created_at value. Default days is 30 and the limit of 1000 records to remove.
+ * @param @object{days?,limit?,token}
+ * @returns
+ */
+export async function deleteLogsOlderThan({days=30,limit=1000,token}:{token:string,days?:number,limit?:number}){
+  // use negative days value
+  const targetDate = getDateFromNow(-days)
+  // convert to iso string to pass in query
+  const isoStrDate = targetDate.toISOString()
+  // delete records where created_at < isoStrDate
+  // use limit to set max of 1000 deleted records
+  const url = `${getBaseUrl()}/backend_log?created_at=lt.${isoStrDate}&select=id`
+  try{
+    // make request
+    const resp = await fetch(url,{
+      method: 'DELETE',
+      headers: {
+        ...createJsonHeaders(token),
+        // request deleted records to be returned AND the record count in the response header
+        'Prefer': 'return=representation,count=exact'
+      },
+    })
+
+    if ([200,204,206].includes(resp.status)){
+      // const ids:string[] = await resp.json()
+      return {
+        status: 200,
+        message: extractCountFromHeader(resp.headers) ?? 0,
+      }
+    }else{
+      return extractReturnMessage(resp)
+    }
+
+  }catch(e:any){
+    logger(`getLogs: ${e.message}`,'error')
+    return {
+      status: 500,
+      message: e.message
+    }
+  }
+}

--- a/frontend/components/admin/logs/config.tsx
+++ b/frontend/components/admin/logs/config.tsx
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {Column} from '~/components/table/EditableTable'
+import {BackendLog} from './useLogs'
+import ErrorInfoCell from './ErrorInfoCell'
+import IconButton from '@mui/material/IconButton'
+import DeleteIcon from '@mui/icons-material/Delete'
+
+export function createColumns(onDelete:(id:string)=>Promise<void>) {
+  const columns: Column<BackendLog, keyof BackendLog>[] = [{
+    key: 'created_at',
+    label: 'Created at',
+    type: 'datetime',
+    sx: {
+      padding: '0.5rem',
+      width: '7rem',
+    },
+  }, {
+    key: 'service_name',
+    label: 'Service',
+    type: 'string',
+  }, {
+    key: 'table_name',
+    label: 'Table',
+    type: 'string'
+  }, {
+    key: 'message',
+    label: 'Error info',
+    type: 'custom',
+    sx: {
+      // needs scrollers
+      overflow: 'auto'
+    },
+    renderFn: (data) => {
+      return (
+        <ErrorInfoCell
+          message={data.message}
+          stack_trace={data.stack_trace}
+          other_data={data.other_data}
+          id={data.id}
+          slug={data.slug}
+        />
+      )
+    }
+  }, {
+    key: 'delete',
+    label: 'Action',
+    type: 'custom',
+    renderFn: (data) => {
+      return (
+        <IconButton
+          title="Delete"
+          edge="end"
+          size="medium"
+          aria-label="delete"
+          onClick={() => {
+            onDelete(data.id)
+          }}
+        >
+          <DeleteIcon />
+        </IconButton>
+      )
+    }
+  }]
+
+  return columns
+}
+

--- a/frontend/components/admin/logs/index.tsx
+++ b/frontend/components/admin/logs/index.tsx
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import Pagination from '~/components/pagination/Pagination'
+import Searchbox from '~/components/search/Searchbox'
+import {Column, OrderByProps} from '~/components/table/EditableTable'
+import LogsTable from './LogsTable'
+import DeleteOldLogsBtn from './DeleteOldLogsBtn'
+import useLogs, {BackendLog} from './useLogs'
+import {createColumns} from './config'
+import IconButton from '@mui/material/IconButton'
+import RefreshIcon from '@mui/icons-material/Refresh'
+
+// inital logs order is on family names
+const initalOrder:OrderByProps<BackendLog, keyof BackendLog> = {
+  column: 'created_at',
+  direction: 'desc'
+}
+
+export default function ScraperErrorLogs() {
+  const [orderBy, setOrderBy] = useState<OrderByProps<BackendLog, keyof BackendLog>>(initalOrder)
+  const [columns, setColumns] = useState<Column<BackendLog, keyof BackendLog>[]>([])
+  const {loading, logs, loadLogs, deleteLog, deleteOldLogs} = useLogs({orderBy})
+
+  // update columns order
+  if (orderBy) {
+    columns.forEach(col => {
+      if (col.key === orderBy.column) {
+        col.order = {
+          active: true,
+          direction: orderBy.direction
+        }
+      } else {
+        col.order = {
+          active: false,
+          direction: 'asc'
+        }
+      }
+    })
+  }
+
+  useEffect(()=>{
+    // here we pass deleteLog method to columns
+    const cols = createColumns(deleteLog)
+    setColumns(cols)
+  // do not include deleteLog to avoid loop
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[deleteLog])
+
+  return (
+    <section className="flex-1 overflow-hidden">
+      <div className="flex-1 flex py-8 md:py-0 flex-col xl:flex-row justify-start xl:items-center">
+        <div className="flex-1 flex justify-start">
+          <DeleteOldLogsBtn
+            onDelete={()=>deleteOldLogs()}
+            disabled={logs.length===0}
+          />
+          <Searchbox />
+        </div>
+        <div className="flex justify-end">
+          <IconButton
+            title="Reload"
+            sx={{
+              alignSelf:'center',
+              marginLeft:[null,null,null,'1rem']
+            }}
+            onClick={loadLogs}
+          >
+            <RefreshIcon />
+          </IconButton>
+          <Pagination />
+        </div>
+      </div>
+      <LogsTable
+        loading={loading}
+        columns={columns}
+        logs={logs}
+        orderBy={orderBy}
+        setOrderBy={setOrderBy}
+      />
+    </section>
+  )
+}

--- a/frontend/components/admin/logs/useLogs.tsx
+++ b/frontend/components/admin/logs/useLogs.tsx
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useCallback, useEffect, useState} from 'react'
+import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
+
+import {useSession} from '~/auth'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {OrderByProps} from '~/components/table/EditableTable'
+import {getLogs,deleteLogById, deleteLogsOlderThan} from './apiLogs'
+
+export type BackendLog = {
+  id: string,
+  service_name: string
+  table_name: string
+  reference_id: string
+  message: string
+  stack_trace: string
+  other_data: string
+  created_at: string,
+  slug: string,
+  delete?: boolean
+}
+
+type useContributorsProps = {
+  orderBy?: OrderByProps<BackendLog, keyof BackendLog>
+}
+
+export default function useLogs({orderBy}:useContributorsProps) {
+  const {token} = useSession()
+  const {showErrorMessage,showSuccessMessage} = useSnackbar()
+  const {searchFor, page, rows, setCount} = usePaginationWithSearch('Find log')
+  const [logs, setLogs] = useState<BackendLog[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadLogs = useCallback(async () => {
+    let abort = false
+    setLoading(true)
+
+    // console.group('loadLogs')
+    // console.log('page...', page)
+    // console.log('rows...', rows)
+    // console.log('orderBy...', orderBy)
+    // console.groupEnd()
+
+    const {logs, count} = await getLogs({
+      token,
+      searchFor,
+      page,
+      rows,
+      orderBy
+    })
+
+    if (abort === false) {
+      setLogs(logs)
+      setCount(count)
+      setLoading(false)
+    }
+
+    return ()=>{abort=true}
+  // do not include setCount in order to avoid loop
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [token, searchFor, page, rows, orderBy])
+
+  /**
+   * Delete log and reload table.
+   */
+  const deleteLog = useCallback(async(id: string)=>{
+    const resp = await deleteLogById({
+      id,
+      token
+    })
+    if (resp.status===200) {
+      // load logs again
+      await loadLogs()
+    } else {
+      showErrorMessage(`Failed to remove log ${id}. ${resp.message}`)
+    }
+  // we exclude showErrorMessage to avoid extra reloads
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[token,loadLogs])
+
+  const deleteOldLogs = useCallback(async(days?:number)=>{
+    const resp = await deleteLogsOlderThan({
+      days,
+      token,
+    })
+    if (resp.status===200) {
+      showSuccessMessage(`Removed ${resp.message} log items`)
+      // load logs again if some records are deleted
+      if (parseInt(resp.message) > 0) loadLogs()
+    } else {
+      showErrorMessage(`Failed to remove old logs. ${resp.message}`)
+    }
+  // we exclude showErrorMessage,showSuccessMessage to avoid extra reloads
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[token,loadLogs])
+
+
+  useEffect(() => {
+    if (token) loadLogs()
+  },[token,loadLogs])
+
+  return {
+    loading,
+    logs,
+    loadLogs,
+    deleteLog,
+    deleteOldLogs
+  }
+}
+

--- a/frontend/components/admin/rsd-contributors/config.tsx
+++ b/frontend/components/admin/rsd-contributors/config.tsx
@@ -126,7 +126,6 @@ export function createColumns(token: string) {
       return (
         <a href={url} target="_blank" rel="noreferrer">
           <LaunchIcon sx={{marginRight:'0.25rem'}} fontSize="small"/>
-          {data.origin === 'contributor' ? 'Software' : 'Project'}
         </a>
       )
     }

--- a/frontend/components/table/EditableTable.tsx
+++ b/frontend/components/table/EditableTable.tsx
@@ -23,7 +23,7 @@ export type OrderProps = {
 export type Column<T,K extends keyof T> = {
   key: K
   label: string
-  type: 'string' | 'date' | 'boolean' | 'custom'
+  type: 'string' | 'date' | 'datetime' | 'boolean' | 'custom'
   align?: 'left'|'right'|'center'|'justify'
   className?: string
   sx?: SxProps<Theme>

--- a/frontend/components/table/TableBody.tsx
+++ b/frontend/components/table/TableBody.tsx
@@ -24,6 +24,9 @@ function formatValue<T, K extends keyof T>(col: Column<T, K>, value: any) {
       case 'date':
         formatedValue = new Date(value).toLocaleDateString()
         return formatedValue
+      case 'datetime':
+        formatedValue = new Date(value).toLocaleString()
+        return formatedValue
       default:
         // formatedValue = value.toString()
         return value

--- a/frontend/components/table/TableHeader.tsx
+++ b/frontend/components/table/TableHeader.tsx
@@ -20,19 +20,23 @@ export default function TableHeader<T, K extends keyof T>({columns, onSort}:
         {columns.map((col, i) => {
           return (
             <MuiTableCell
-              style={{cursor:'pointer'}}
+              style={{cursor: col.type!=='custom' ? 'pointer' : 'default'}}
               key={`col-header-${i}`}
               align={col?.align ?? 'left'}
-              onClick={() => onSort(col.key)}
+              onClick={() => col.type!=='custom' ? onSort(col.key) : null}
               sx={col?.sx}
             >
-              <MuiTableSortLabel
-                active={col.order?.active}
-                direction={col.order?.direction}
-                onClick={() => onSort(col.key)}
-              >
-                {col.label}
-              </MuiTableSortLabel>
+              {col.type!=='custom' ?
+                <MuiTableSortLabel
+                  active={col.order?.active}
+                  direction={col.order?.direction}
+                  onClick={() => onSort(col.key)}
+                >
+                  {col.label}
+                </MuiTableSortLabel>
+                :
+                col.label
+              }
             </MuiTableCell>
           )
         })}

--- a/frontend/pages/admin/logs.tsx
+++ b/frontend/pages/admin/logs.tsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Head from 'next/head'
+import {app} from '../../config/app'
+import {adminPages} from '~/components/admin/AdminNav'
+import DefaultLayout from '~/components/layout/DefaultLayout'
+import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
+import {SearchProvider} from '~/components/search/SearchContext'
+import {PaginationProvider} from '~/components/pagination/PaginationContext'
+import AdminLogs from '~/components/admin/logs'
+
+const pageTitle = `${adminPages['logs'].title} | Admin page | ${app.title}`
+
+const pagination = {
+  count: 0,
+  page: 0,
+  rows: 12,
+  rowsOptions: [12,24,48],
+  labelRowsPerPage:'Per page'
+}
+
+export default function AdminLogsPage() {
+  return (
+    <DefaultLayout>
+      <Head>
+        <title>{pageTitle}</title>
+      </Head>
+      <AdminPageWithNav title={adminPages['logs'].title}>
+        <SearchProvider>
+          <PaginationProvider pagination={pagination}>
+            <AdminLogs />
+          </PaginationProvider>
+        </SearchProvider>
+      </AdminPageWithNav>
+    </DefaultLayout>
+  )
+}

--- a/frontend/styles/rsdMuiTheme.ts
+++ b/frontend/styles/rsdMuiTheme.ts
@@ -280,7 +280,14 @@ function applyThemeConfig({colors, action, typography}: ThemeConfig) {
             backgroundColor: colors['base-600']
           }
         }
-      }
+      },
+      MuiTooltip: {
+        styleOverrides:{
+          tooltip: {
+            maxWidth: '40rem'
+          },
+        }
+      },
     },
   })
 }

--- a/frontend/utils/dateFn.ts
+++ b/frontend/utils/dateFn.ts
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -126,4 +128,16 @@ export function getMonthYearDate(date: string, locale = 'en-us') {
   } catch (e:any) {
     return null
   }
+}
+
+/**
+ * Calculates the date from now for number of days passed.
+ * Pass positive value for dates in the future and negative values for dates in the past.
+ */
+export function getDateFromNow(days:number){
+  const newDate = new Date()
+  // change date
+  newDate.setDate(newDate.getDate() + days)
+  // return changed date
+  return newDate
 }


### PR DESCRIPTION
# Add scraper error log page to admin section

Related to #171 

Changes proposed in this pull request:
* Created error logs page in the admin section
* Page lists all error logs
* Admin can order and search logs
* Admin can refresh table using reload icon
* Admin can remove each item separately
* Admin can remove logs older than 30 days.
* Error info column shows error message, response data (icon {}), stack trace (! icon), reference key and the link to edit software page where error can be fixed. The user can copy response data and stack trace.
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/baae637c-b3d3-4568-bb28-e27627ee0a60)

How to test:
* `make start` to rebuild app
* Let scrapers run for some time. You need to restart with scrapers enabled `docker compose down && docker compose up -d`
* Wait for 15-30 minutes for scrapers to generate some errors.
* Login as admin `professor3` if you have same settings in .env file
* Navigate to admin section and visit error logs page
* Validate listing of error logs. Search for service or error log text.
* Validate removing specific erorr log using delete button
* Try delete button at the top (mouse over says > 30 days). No records should be removed if you just started. Not sure how to test this as created_at is sanitized and cannot be updated via sql query.  You can check network tab in confirm that the `created-at` in the DELETE request `http://localhost/api/v1/backend_log?created_at=lt.2023-08-19T12:46:57.859Z&select=id&limit=1000&order=created_at` is 30 days from now.

## Error logs admin section
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/1d128ce5-8229-4973-a858-adafdb24b389)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
