### PR TITLE
fix: prevent blurry logo image in the organisation card

### DIFF
--- a/frontend/components/organisation/overview/card/OrganisationCard.tsx
+++ b/frontend/components/organisation/overview/card/OrganisationCard.tsx
@@ -45,7 +45,7 @@ export default function OrganisationCard({organisation}: { organisation: Organis
               alt={`Logo for ${organisation.name}`}
               type="gradient"
               className={`w-full text-base-content-disabled ${organisation.logo_id ? 'p-4':''}`}
-              bgSize={'contain'}
+              bgSize={'scale-down'}
             />
           </CardImageFrame>
           <CardContentFrame>


### PR DESCRIPTION
# Organisation card logo/image  scaling

Changes proposed in this pull request:
*   Prevent enlarging of organisation images/logo's with very small dimensions. See examples from [live RSD on dev](https://research-software.dev/organisations?page=4&rows=12)
* The similar scaling is applied to software card logo's previously. The look of "larger" images in the card remains unchanged.

How to test:
* `make start` to build
* login as rsd admin
* navigate to organisations overview. the logos should look nice.
* change the organisation logo to a very small image. The logo in the card should be sharp but small, not large and blurry (see example).

## Example scaling change
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/e0893042-a016-4210-a4f6-b325e5c16902)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
