### PR TITLE
fix: redirect to ordered software overview on login

### DIFF
--- a/frontend/auth/locationCookie.test.ts
+++ b/frontend/auth/locationCookie.test.ts
@@ -50,7 +50,7 @@ it('ignores these paths', () => {
 it('when root write cookie to redirect to software', () => {
   // should ignore this path
   window.location.pathname = '/'
-  const expectedCookie = 'rsd_pathname=http://localhost/software;path=/auth;SameSite=None;Secure'
+  const expectedCookie = 'rsd_pathname=http://localhost/software?order=mention_cnt;path=/auth;SameSite=None;Secure'
   document.cookie = ''
   // call function
   saveLocationCookie()

--- a/frontend/auth/locationCookie.ts
+++ b/frontend/auth/locationCookie.ts
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +22,7 @@ export function saveLocationCookie() {
       break
     case '/':
       // root is send to /software
-      document.cookie = `rsd_pathname=${location.href}software;path=/auth;SameSite=None;Secure`
+      document.cookie = `rsd_pathname=${location.href}software?order=mention_cnt;path=/auth;SameSite=None;Secure`
       break
     default:
       // write simple browser cookie


### PR DESCRIPTION
# Redirect to ordered software page when login from homepage

Closes #1005

Changes proposed in this pull request:
* Save redirect link to include order on mentions on the software overview page   
* Update the test

How to test:
* `make start` to build and generate test data
* navigate to homepage
* use sign in to login
* your should be redirected to software page and order should be applied (mentions)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
