### PR TITLE
Fix helper text for Git platform

### DIFF
--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -5,6 +5,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -404,8 +405,8 @@ export const relatedSoftwareInformation = {
 function verifyGithubUrl(repoUrl: string) {
   if ((repoUrl.startsWith('https://github.com/') || repoUrl.startsWith('http://github.com/'))
     && !repoUrl.match('^https?://github\\.com/([^\\s/]+)/([^\\s/]+)/?$')) {
-    return <div style={{color: 'orange'}}>This does not seem to be the root of a single GitHub repository, are you
-      sure?</div>
+    return <span className="text-warning">This does not seem to be the root of a single GitHub repository, are you
+      sure?</span>
   }
 
   return 'Link to source code repository'

--- a/frontend/components/software/edit/information/AutosaveRepositoryPlatform.tsx
+++ b/frontend/components/software/edit/information/AutosaveRepositoryPlatform.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +18,7 @@ import {softwareInformation as config} from '../editSoftwareConfig'
 type AutosaveRepositoryPlatformProps = {
   value: CodePlatform | null
   disabled: boolean
-  helperText: string
+  helperText: string | JSX.Element
   onChange: (selected:string)=>void
 }
 

--- a/frontend/components/software/edit/information/AutosaveRepositoryUrl.tsx
+++ b/frontend/components/software/edit/information/AutosaveRepositoryUrl.tsx
@@ -69,7 +69,7 @@ export default function AutosaveRepositoryUrl() {
   const [platform, setPlatform] = useState<{
     id: CodePlatform | null
     disabled: boolean
-    helperText: string
+    helperText: string | JSX.Element
   }>({
     id: repository_platform,
     disabled: repository_platform === null,
@@ -112,7 +112,7 @@ export default function AutosaveRepositoryUrl() {
             setPlatform({
               id: platform.id,
               disabled: false,
-              helperText: suggestion === platform.id ? 'Suggested' : 'Are you sure?'
+              helperText: suggestion === platform.id ? 'Suggested' : <span className="text-warning">Are you sure?</span>
             })
           }
         )

--- a/frontend/components/software/edit/information/AutosaveRepositoryUrl.tsx
+++ b/frontend/components/software/edit/information/AutosaveRepositoryUrl.tsx
@@ -73,7 +73,7 @@ export default function AutosaveRepositoryUrl() {
   }>({
     id: repository_platform,
     disabled: repository_platform === null,
-    helperText: 'Suggestion'
+    helperText: ''
   })
   const [suggestedPlatform, setSuggestedPlatform] = useState<CodePlatform>()
 
@@ -101,7 +101,18 @@ export default function AutosaveRepositoryUrl() {
             setPlatform({
               id: suggestion,
               disabled: false,
-              helperText: 'Suggestion'
+              helperText: 'Suggested'
+            })
+          }
+        )
+      } else {
+        suggestPlatform(repository_url).then(
+          (suggestion) => {
+            setSuggestedPlatform(suggestion)
+            setPlatform({
+              id: platform.id,
+              disabled: false,
+              helperText: suggestion === platform.id ? 'Suggested' : 'Are you sure?'
             })
           }
         )
@@ -143,7 +154,7 @@ export default function AutosaveRepositoryUrl() {
       data.url = value
     } else if (name === 'repository_platform') {
       // compare to suggested platform
-      let helperText = 'Selected'
+      let helperText: string
       if (suggestedPlatform === value) {
         helperText = 'Suggested'
       } else {
@@ -163,7 +174,7 @@ export default function AutosaveRepositoryUrl() {
       // console.group('saveRepositoryInfo')
       // console.log('DELETE...', id)
       // console.groupEnd()
-      // DELETE entry when url is clered
+      // DELETE entry when url is cleared
       resp = await deleteFromRepositoryTable({software: id, token})
       // remove platform value
       setPlatform({


### PR DESCRIPTION
# Fix helper text for Git platform

Changes proposed in this pull request:

* Always show the correct helper text when updating the repository URL or the Git platform.

How to test :

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Test out the use cases in #999 and try out other variations as well.

Closes #999

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
