### PR TITLE
Cs responsive form

### DIFF
--- a/frontend/components/software/add/AddSoftwareCard.tsx
+++ b/frontend/components/software/add/AddSoftwareCard.tsx
@@ -10,6 +10,8 @@ import {useEffect, useState} from 'react'
 import {useRouter} from 'next/router'
 import Button from '@mui/material/Button'
 import Alert from '@mui/material/Alert'
+import FormControlLabel from '@mui/material/FormControlLabel'
+import Switch from '@mui/material/Switch'
 import CircularProgress from '@mui/material/CircularProgress'
 
 import {useForm} from 'react-hook-form'
@@ -35,6 +37,7 @@ type AddSoftwareForm = {
   slug: string,
   brand_name: string,
   short_statement: string|null,
+  closed_source: boolean
 }
 
 let lastValidatedSlug = ''
@@ -52,7 +55,7 @@ export default function AddSoftwareCard() {
   })
   const {errors, isValid} = formState
   // watch for data change in the form
-  const [slug,brand_name,short_statement] = watch(['slug', 'brand_name', 'short_statement'])
+  const [slug,brand_name,short_statement,closed_source] = watch(['slug', 'brand_name', 'short_statement', 'closed_source'])
   // take the last slugValue
   const bouncedSlug = useDebounce(slugValue, 700)
 
@@ -142,6 +145,7 @@ export default function AddSoftwareCard() {
         brand_name: data.brand_name,
         slug: data.slug,
         short_statement: data.short_statement,
+        closed_source: data.closed_source,
         is_published: false,
         description: null,
         description_type: 'markdown',
@@ -251,6 +255,13 @@ export default function AddSoftwareCard() {
               helperText: errors?.slug?.message ?? config.slug.help
             }}
             register={register('slug',config.slug.validation)}
+          />
+          <div className="py-4"></div>
+          <FormControlLabel
+            control={
+              <Switch {...register('closed_source')} />
+            }
+            label="Closed Source"
           />
         </section>
         <section className='flex justify-end'>

--- a/frontend/components/software/add/addConfig.ts
+++ b/frontend/components/software/add/addConfig.ts
@@ -39,6 +39,10 @@ export const addConfig = {
         message: 'Restricted input violiation. Use letters, numbers and dashes "-" only between other input.'
       }
     }
+  },
+  closed_source: {
+    label: 'Closed source',
+    validation: {}
   }
 }
 

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -124,6 +124,9 @@ export const softwareInformation = {
   is_published: {
     label: 'Published',
   },
+  closed_source: {
+    label: 'Closed Source'
+  },
   keywords: {
     title: 'Keywords',
     subtitle: 'Find, add or import using concept DOI.',

--- a/frontend/components/software/edit/information/SoftwareInformationForm.tsx
+++ b/frontend/components/software/edit/information/SoftwareInformationForm.tsx
@@ -45,6 +45,18 @@ export default function SoftwareInformationForm({editSoftware}: SoftwareInformat
   // console.log('formData...', formData)
   // console.groupEnd()
 
+  let repoURL, citationField
+  repoURL = citationField = <></>
+
+  if (formData.closed_source){
+    repoURL = <></>
+    citationField = <></>
+  }
+  else {
+    repoURL = <AutosaveRepositoryUrl />
+    citationField = <AutosaveConceptDoi />
+  }
+
   return (
     <FormProvider {...methods}>
       <form
@@ -134,7 +146,7 @@ export default function SoftwareInformationForm({editSoftware}: SoftwareInformat
               rules={config.get_started_url.validation}
             />
             <div className="py-2"></div>
-            <AutosaveRepositoryUrl />
+            {repoURL}
             <div className="py-2"></div>
             <AutosaveSoftwareMarkdown />
             {/* add white space at the bottom */}
@@ -143,7 +155,7 @@ export default function SoftwareInformationForm({editSoftware}: SoftwareInformat
           <div className="py-4 min-w-[21rem] xl:my-0">
             <AutosaveSoftwarePageStatus />
             <div className="py-4"></div>
-            <AutosaveConceptDoi />
+            {citationField}
             <div className="py-4"></div>
             <AutosaveSoftwareLogo />
             <div className="py-4"></div>

--- a/frontend/components/software/edit/information/SoftwareInformationForm.tsx
+++ b/frontend/components/software/edit/information/SoftwareInformationForm.tsx
@@ -18,6 +18,7 @@ import AutosaveRepositoryUrl from './AutosaveRepositoryUrl'
 import AutosaveSoftwareLicenses from './AutosaveSoftwareLicenses'
 import AutosaveSoftwareMarkdown from './AutosaveSoftwareMarkdown'
 import AutosaveSoftwareLogo from './AutosaveSoftwareLogo'
+import AutosaveSoftwareSwitch from './AutosaveSoftwareSwitch'
 
 type SoftwareInformationFormProviderProps = {
   editSoftware: EditSoftwareItem
@@ -110,6 +111,12 @@ export default function SoftwareInformationForm({editSoftware}: SoftwareInformat
               rules={config.short_statement.validation}
             />
             <div className="py-2"></div>
+            <AutosaveSoftwareSwitch
+              software_id={formData.id}
+              name='closed_source'
+              label={config.closed_source.label}
+              defaultValue={editSoftware.closed_source}
+            />
             <EditSectionTitle
               title='Software URLs'
               subtitle='Where can users find information to start?'

--- a/frontend/types/SoftwareTypes.ts
+++ b/frontend/types/SoftwareTypes.ts
@@ -50,6 +50,7 @@ export type NewSoftwareItem = {
   description_url: string | null,
   description_type: 'markdown'|'link',
   get_started_url: string | null,
+  closed_source: boolean,
   is_published: boolean,
   short_statement: string | null,
   image_id: string | null,
@@ -98,6 +99,7 @@ export const SoftwarePropsToSave = [
   'description_url',
   'get_started_url',
   'image_id',
+  'closed_source',
   'is_published',
   'short_statement'
 ]


### PR DESCRIPTION
Following on from #925 (which added a database flag for closed source software packages) we've been exploring the UI changes that would work with this to actually allow users to submit a closed source package. This PR is presented in draft form to provide a starting point for discussions on the UI changes. The implementation and the appearance of the UI elements is preliminary.

Changes proposed in this pull request:
- Adds a switch UI element to AddSoftwareCard to indicate the whether a package is closed source.
- Adds a switch UI element to SoftwareInformationForm to update whether a package is closed source.
- Updates the contents of SoftwareInformationForm responsively based on the new switch to hide the repoURL and citationField UI elements and to change the subtitle of the Keywords input.
- Updates the licenses recorded in the database for a piece of software such that when the closed source toggle is active a single entry with the value of "Proprietary" is added and when the closed source toggle is inactive licenses may be added as usual.

Feedback is sought regarding the suitability of the proposed UI and license behaviour changes.