### PR TITLE
fix: update broken documentation link

### DIFF
--- a/frontend/components/admin/organisations/OrganisationItem.test.tsx
+++ b/frontend/components/admin/organisations/OrganisationItem.test.tsx
@@ -97,7 +97,7 @@ it('can EDIT organisation with software or projects', () => {
   mockOrganisationItem.software_cnt = 1
   mockOrganisationItem.project_cnt = 0
 
-  const editLink=`http://localhost/organisations/${mockOrganisationItem.rsd_path}?page=settings`
+  const editLink=`http://localhost/organisations/${mockOrganisationItem.rsd_path}?tab=settings`
 
   render(
     <OrganisationItem

--- a/frontend/components/admin/organisations/OrganisationItem.tsx
+++ b/frontend/components/admin/organisations/OrganisationItem.tsx
@@ -36,7 +36,7 @@ export default function OrganisationItem({item, onDelete}: OrganisationItemProps
             edge="end"
             aria-label="edit"
             sx={{marginRight: '1rem'}}
-            href={`/organisations/${item.rsd_path}?page=settings`}
+            href={`/organisations/${item.rsd_path}?tab=settings`}
           >
             <EditIcon />
           </IconButton>

--- a/frontend/components/home/rsd/OrganisationSignUpDialog.tsx
+++ b/frontend/components/home/rsd/OrganisationSignUpDialog.tsx
@@ -96,7 +96,7 @@ export default function OrganisationSignUpDialog({
             {title}
           </div>
           <div className="text-sm text-[#B7B7B7] pb-4">
-            You can find more information about registering your organisation in our <u><a href="https://research-software-directory.github.io/documentation/register-organization.html" target="_blank" rel="noreferrer">documentation</a></u>.
+            You can find more information about registering your organisation in our <u><a href="https://research-software-directory.github.io/documentation/register-organisation.html" target="_blank" rel="noreferrer">documentation</a></u>.
           </div>
           {/* INPUTS */}
           <input type="text"


### PR DESCRIPTION
# Update broken documentation link and edit organisation link (rsd-admin)

Closes #1014

Changes proposed in this pull request:
* The link to documentation to register organisation is updated to https://research-software-directory.github.io/documentation/register-organisation.html
* Edit organisation link from admin page updated to open settings tab

How to test:
* `make start` to build app
* visit home page, click on register organisation button. Try documentation link, it should open the page in new tab
* login as rsd-admin, navigate to admin section, the organisations page. Use edit button and confirm that opens organisation page on the settings tab

## Documentation link

![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/f70058b8-60bf-4a74-90e6-b1362f2af33b)

## Admin organisations edit link
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/db613359-e442-412d-b2c0-58884b861285)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
