### PR TITLE
Software and project overview by person based on ORCID

### DIFF
--- a/database/104-person-views.sql
+++ b/database/104-person-views.sql
@@ -1,4 +1,6 @@
+-- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 -- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+-- SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 dv4all
 --
 -- SPDX-License-Identifier: Apache-2.0
@@ -92,4 +94,3 @@ FROM
 INNER JOIN
 	project ON team_member.project = project.id
 $$;
-

--- a/frontend/auth/index.tsx
+++ b/frontend/auth/index.tsx
@@ -250,7 +250,7 @@ export function removeRsdTokenNode(res: OutgoingMessage) {
   }
 }
 
-export function getUserFromToken(token: string | null) {
+export function getUserFromToken(token?: string | null) {
   if (token) {
     const result = verifyJwt(token)
     if (result === 'valid') {

--- a/frontend/components/AppHeader/isActiveMenuItem.tsx
+++ b/frontend/components/AppHeader/isActiveMenuItem.tsx
@@ -13,7 +13,10 @@ type IsActiveMenuItemProps = {
 export default function isActiveMenuItem({item, activePath}:IsActiveMenuItemProps) {
 
   if (activePath && item.match) {
-    return activePath.includes(item.match)
+    // console.log('activePath...', activePath)
+    // console.log('match...', item.match)
+    // using startsWith to be activate root of the tree
+    return activePath.startsWith(item.match)
   }
 
   return false

--- a/frontend/components/admin/keywords/apiKeywords.tsx
+++ b/frontend/components/admin/keywords/apiKeywords.tsx
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -84,9 +86,6 @@ export async function patchKeyword({id, value, token}: { id: string, value: stri
       method: 'PATCH',
       headers: {
         ...createJsonHeaders(token),
-        // request record count to be returned
-        // note: it's returned in the header
-        'Prefer': 'count=exact'
       },
       body: JSON.stringify({
         value

--- a/frontend/components/admin/logs/apiLogs.ts
+++ b/frontend/components/admin/logs/apiLogs.ts
@@ -63,10 +63,7 @@ export async function deleteLogById({id,token}:{id:string, token:string}){
     const resp = await fetch(url,{
       method: 'DELETE',
       headers: {
-        ...createJsonHeaders(token),
-        // request record count to be returned
-        // note: it's returned in the header
-        // 'Prefer': 'count=exact'
+        ...createJsonHeaders(token)
       },
     })
 

--- a/frontend/components/layout/OrcidLink.tsx
+++ b/frontend/components/layout/OrcidLink.tsx
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import LogoOrcid from '~/assets/logos/logo-orcid.svg'
+
+export default function OrcidLink({orcid}:{orcid?:string|null}) {
+  // if no orcid do not show
+  if (!orcid) return null
+  // construct url
+  const url =`https://orcid.org/${orcid}`
+  // show orcid link
+  return (
+    <a href={url} target="_blank" rel="noreferrer"
+      style={{whiteSpace:'nowrap'}}
+    >
+      <LogoOrcid className="inline max-w-[1.125rem] mr-1" />
+      <span className="text-sm align-bottom">{orcid}</span>
+    </a>
+  )
+}

--- a/frontend/components/organisation/software/useOrganisationSoftware.tsx
+++ b/frontend/components/organisation/software/useOrganisationSoftware.tsx
@@ -52,7 +52,7 @@ export default function useOrganisationSoftware() {
           if (orderInfo) orderBy=`${order}.${orderInfo.direction},slug.asc`
         }
 
-        const projects: State = await getSoftwareForOrganisation({
+        const software: State = await getSoftwareForOrganisation({
           organisation:id,
           searchFor: search ?? undefined,
           keywords: decodeJsonParam(keywords_json,null),
@@ -68,7 +68,7 @@ export default function useOrganisationSoftware() {
         // abort
         if (abort) return
         // set state
-        setState(projects)
+        setState(software)
         // set loding done
         setLoading(false)
       }

--- a/frontend/components/people/PeopleSearchPanel.tsx
+++ b/frontend/components/people/PeopleSearchPanel.tsx
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import SearchInput from '~/components/search/SearchInput'
+import SelectRows from '~/components/software/overview/search/SelectRows'
+import ViewToggleGroup, {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
+
+type PeopleSearchPanelProps={
+  placeholder: string
+  layout: ProjectLayoutType
+  rows: number
+  search: string | null
+  onSetView: (view:ProjectLayoutType)=>void
+  handleQueryChange: (key:string, value: string|string[])=>void
+}
+
+export default function PeopleSearchPanel({
+  placeholder,layout,rows,search,
+  onSetView,handleQueryChange
+}:PeopleSearchPanelProps) {
+  return (
+    <div className="flex border rounded-md shadow-sm bg-base-100 p-2">
+      <SearchInput
+        placeholder={placeholder}
+        onSearch={(search: string) => handleQueryChange('search', search)}
+        defaultValue={search ?? ''}
+      />
+      <ViewToggleGroup
+        layout={layout}
+        onSetView={onSetView}
+      />
+      <SelectRows
+        rows={rows}
+        handleQueryChange={handleQueryChange}
+      />
+    </div>
+  )
+}

--- a/frontend/components/people/apiProfile.ts
+++ b/frontend/components/people/apiProfile.ts
@@ -1,0 +1,146 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import {ProjectListItem} from '~/types/Project'
+import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
+import {RsdContributor} from '~/components/admin/rsd-contributors/useContributors'
+import {extractCountFromHeader} from '~/utils/extractCountFromHeader'
+
+type PersonProfilesProps={
+  orcid: string
+  token?: string
+}
+
+export async function getPersonProfiles({orcid, token}: PersonProfilesProps) {
+  try {
+    if (!orcid) return null
+    // filter on orcid, order by image first
+    const query = `orcid=eq.${orcid}&order=avatar_id.nullslast`
+
+    // complete url
+    const url = `${getBaseUrl()}/rpc/person_mentions?${query}`
+
+    // make request
+    const resp = await fetch(url,{
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+      },
+    })
+
+    if ([200,206].includes(resp.status)) {
+      const profiles: RsdContributor[] = await resp.json()
+      return profiles
+    }
+    logger(`getPersonProfiles: ${resp.status}: ${resp.statusText}`,'warn')
+    return null
+  } catch (e: any) {
+    logger(`getPersonProfiles: ${e.message}`,'error')
+    return null
+  }
+}
+
+type ProfileRpcQuery = {
+  orcid: string
+  rows: number
+  page: number
+  search?: string,
+  token?: string
+}
+
+export async function getProfileSoftware({orcid,rows=12,page=0,search,token}:ProfileRpcQuery) {
+  try {
+    if (!orcid) return null
+    const offset = page * rows
+    // filter on orcid, order by mention count first
+    let query = `orcid=cs.%7B${orcid}%7D&order=mention_cnt.desc,contributor_cnt.desc,id&limit=${rows}&offset=${offset}`
+    // include search
+    if (search){
+      const encodedSearch = encodeURIComponent(search)
+      query+=`&or=(brand_name.ilike.*${encodedSearch}*,short_statement.ilike.*${encodedSearch}*,keywords_text.ilike.*${encodedSearch}*)`
+    }
+    // complete url
+    const url = `${getBaseUrl()}/rpc/software_by_orcid?${query}`
+    // console.log("getProfileSoftware...url...", url)
+    // make request
+    const resp = await fetch(url,{
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+        // request record count to be returned
+        // note: it's returned in the header
+        'Prefer': 'count=exact'
+      },
+    })
+
+    if ([200,206].includes(resp.status)) {
+      const software: SoftwareOverviewItemProps[] = await resp.json()
+      return {
+        software_cnt: extractCountFromHeader(resp.headers) ?? 0,
+        software
+      }
+    }
+    logger(`getProfileSoftware: ${resp.status}: ${resp.statusText}`,'warn')
+    return {
+      software_cnt:0,
+      software:[]
+    }
+  } catch (e: any) {
+    logger(`getProfileSoftware: ${e.message}`,'error')
+    return {
+      software_cnt:0,
+      software:[]
+    }
+  }
+}
+
+export async function getProfileProjects({orcid,rows=12,page=0,search,token}:ProfileRpcQuery) {
+  try {
+    if (!orcid) return null
+    const offset = page * rows
+    // filter on orcid, order by impact_cnt first
+    let query = `orcid=cs.%7B${orcid}%7D&order=impact_cnt.desc,output_cnt.desc,id&limit=${rows}&offset=${offset}`
+    // include search
+    if (search){
+      const encodedSearch = encodeURIComponent(search)
+      query+=`&or=(title.ilike.*${encodedSearch}*,subtitle.ilike.*${encodedSearch}*,keywords_text.ilike.*${encodedSearch}*)`
+    }
+    // complete url
+    const url = `${getBaseUrl()}/rpc/project_by_orcid?${query}`
+    // console.log('getProfileProjects...url...', url)
+    // console.log('getProfileProjects...search...', search)
+    // make request
+    const resp = await fetch(url,{
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+        // request record count to be returned
+        // note: it's returned in the header
+        'Prefer': 'count=exact'
+      },
+    })
+
+    if ([200,206].includes(resp.status)) {
+      const projects: ProjectListItem[] = await resp.json()
+      return {
+        project_cnt: extractCountFromHeader(resp.headers) ?? 0,
+        projects
+      }
+    }
+    logger(`getProfileProjects: ${resp.status}: ${resp.statusText}`,'warn')
+    return {
+      project_cnt: 0,
+      projects:[]
+    }
+  } catch (e: any) {
+    logger(`getProfileProjects: ${e.message}`,'error')
+    return {
+      project_cnt: 0,
+      projects:[]
+    }
+  }
+}

--- a/frontend/components/people/context/PeopleContext.tsx
+++ b/frontend/components/people/context/PeopleContext.tsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {createContext, useContext} from 'react'
+import {ProjectListItem} from '~/types/Project'
+import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
+
+type PeopleContextProps={
+  software_cnt: number,
+  software: SoftwareOverviewItemProps[],
+  project_cnt: number,
+  projects: ProjectListItem[]
+}
+
+// create context
+const PeopleContext = createContext<PeopleContextProps|null>(null)
+
+// profile context provider
+export function PeopleContextProvider(props:any){
+  return <PeopleContext.Provider
+    {...props}
+  />
+}
+
+// profile context hook
+export function usePeopleContext(){
+  const props = useContext(PeopleContext)
+  if (props===null){
+    throw Error('usePeopleContext requires PeopleContextProvider at parent')
+  }
+  return props
+}
+
+export default PeopleContext

--- a/frontend/components/people/metadata/index.tsx
+++ b/frontend/components/people/metadata/index.tsx
@@ -1,0 +1,104 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Avatar from '@mui/material/Avatar'
+import EmailIcon from '@mui/icons-material/Email'
+
+import {getImageUrl} from '~/utils/editImage'
+import {getDisplayInitials, getDisplayName} from '~/utils/getDisplayName'
+import {RsdContributor} from '~/components/admin/rsd-contributors/useContributors'
+import BaseSurfaceRounded from '~/components/layout/BaseSurfaceRounded'
+import OrcidLink from '~/components/layout/OrcidLink'
+
+function aggregateProfiles(profiles:RsdContributor[]|null){
+  const name:string[]=[],affiliation:string[]=[],role:string[]=[],email:string[]=[]
+  let logo:string|null=null, orcid:string|null=null, initials:string|null=null
+
+  // const name:string =
+  profiles?.forEach(item=>{
+    // name
+    const displayName = getDisplayName(item)
+    if (displayName && name.includes(displayName)===false) {
+      name.push(displayName)
+    }
+    if (initials===null) initials = getDisplayInitials(item)
+    // orcid
+    if (item.orcid && orcid===null) orcid=item.orcid
+    // logo
+    if (logo===null && item?.avatar_id) logo = item.avatar_id
+    // affiliation
+    if (item.affiliation && affiliation.includes(item.affiliation.trim())===false) affiliation.push(item.affiliation.trim())
+    // roles
+    if (item.role && role.includes(item.role.trim())===false) role.push(item.role.trim())
+    // emails
+    if (item.email_address && email.includes(item.email_address)===false) email.push(item.email_address)
+  })
+
+  return {
+    name,
+    initials,
+    logo,
+    affiliation,
+    role,
+    email,
+    orcid
+  }
+}
+
+export default function PeopleMetadata({profiles}:{profiles:RsdContributor[]|null}) {
+  const {name, logo, initials, role, affiliation, email, orcid} = aggregateProfiles(profiles)
+  return (
+    <section className="grid md:grid-cols-[1fr,3fr] xl:grid-cols-[1fr,5fr] gap-4 mt-8">
+      <BaseSurfaceRounded className="flex justify-center p-4 overflow-hidden relative">
+        <Avatar
+          alt={name[0] ?? ''}
+          src={getImageUrl(logo ?? null) ?? ''}
+          sx={{
+            width: '10rem',
+            height: '10rem',
+            fontSize: '3.25rem'
+          }}
+        >
+          {initials}
+        </Avatar>
+      </BaseSurfaceRounded>
+      <BaseSurfaceRounded className="grid lg:grid-cols-[3fr,1fr] lg:gap-8 xl:grid-cols-[4fr,1fr] p-4">
+        <div>
+          <h1
+            title={name[0]}
+            className="text-xl font-medium line-clamp-1">
+            {name}
+          </h1>
+          <p className="py-2">
+            <OrcidLink orcid={orcid} />
+          </p>
+          {
+            role?.length > 0 ?
+              <p className="text-base-700 line-clamp-3 break-words py-1">
+                <span className="text-base-content-disabled">Role(s)</span><br/>
+                {role.join('; ')}
+              </p>
+              : null
+          }
+          {
+            affiliation?.length > 0 ?
+              <p className="text-base-700 line-clamp-3 break-words py-1">
+                <span className="text-base-content-disabled">Affiliation(s)</span><br/>
+                {affiliation.join('; ')}
+              </p>
+              : null
+          }
+        </div>
+        <div className="flex flex-col gap-4">
+          {email.map(item=>{
+            return (
+              <div key={item} className="flex gap-2"><EmailIcon /> {item}</div>
+            )
+          })}
+        </div>
+      </BaseSurfaceRounded>
+    </section>
+  )
+}

--- a/frontend/components/people/projects/PeopleProjectOverview.tsx
+++ b/frontend/components/people/projects/PeopleProjectOverview.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+
+import {ProjectListItem} from '~/types/Project'
+import NoContent from '~/components/layout/NoContent'
+import ProjectCardContent from '~/components/projects/overview/cards/ProjectCardContent'
+import ProjectListItemContent from '~/components/projects/overview/list/ProjectListItemContent'
+import ProjectOverviewList from '~/components/projects/overview/list/ProjectOverviewList'
+import {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
+import SoftwareOverviewGrid from '~/components/software/overview/cards/SoftwareOverviewGrid'
+import OverviewListItem from '~/components/software/overview/list/OverviewListItem'
+
+type PeopleProjectOverviewProps = {
+  layout: ProjectLayoutType
+  projects: ProjectListItem[]
+}
+
+export default function PeopleProjectOverview({layout,projects}:PeopleProjectOverviewProps) {
+
+  if (!projects || projects.length === 0) {
+    return <NoContent />
+  }
+
+  if (layout === 'list') {
+    return (
+      <ProjectOverviewList>
+        {projects.map(item => {
+          return (
+            <Link
+              data-testid="project-list-item"
+              key={item.id}
+              href={`/projects/${item.slug}`}
+              className='flex-1 hover:text-inherit'
+              title={item.title}
+            >
+              <OverviewListItem className='pr-4'>
+                <ProjectListItemContent key={item.id} {...item} />
+              </OverviewListItem>
+            </Link>
+          )
+        })}
+      </ProjectOverviewList>
+    )
+  }
+
+  // GRID as default
+  return (
+    <SoftwareOverviewGrid fullWidth={true}>
+      {projects.map((item) => {
+        return (
+          <Link
+            key={item.id}
+            data-testid="project-grid-card"
+            href={`/projects/${item.slug}`}
+            className="h-full hover:text-inherit"
+          >
+            <ProjectCardContent
+              visibleKeywords={3}
+              {...item}
+            />
+          </Link>
+        )
+      })}
+    </SoftwareOverviewGrid>
+  )
+
+}

--- a/frontend/components/people/projects/PeopleSearchProjects.tsx
+++ b/frontend/components/people/projects/PeopleSearchProjects.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
+import useQueryChange from '~/components/organisation/projects/useQueryChange'
+import useProjectParams from '~/components/organisation/projects/useProjectParams'
+import PeopleSearchPanel from '~/components/people/PeopleSearchPanel'
+
+type PeopleSearchSoftware = {
+  count: number
+  layout: ProjectLayoutType
+  setView: (view:ProjectLayoutType)=>void
+}
+
+
+export default function PeopleSearchProjects({
+  count, layout, setView
+}: PeopleSearchSoftware) {
+  const {search,page,rows} = useProjectParams()
+  const {handleQueryChange} = useQueryChange()
+
+  const placeholder = 'Find project'
+
+  // console.group('PeopleSearchSoftware')
+  // console.log('page...', page)
+  // console.log('rows...', rows)
+  // console.log('search...', search)
+  // console.groupEnd()
+
+  return (
+    <section data-testid="search-section">
+      <PeopleSearchPanel
+        placeholder={placeholder}
+        layout={layout}
+        rows={rows}
+        search={search}
+        onSetView={setView}
+        handleQueryChange={handleQueryChange}
+      />
+      <div className="flex justify-between items-center px-1 py-2">
+        <div className="text-sm opacity-70">
+          Page {page ?? 1} of {count} results
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/people/projects/index.tsx
+++ b/frontend/components/people/projects/index.tsx
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+import Pagination from '@mui/material/Pagination'
+
+import {setDocumentCookie} from '~/utils/userSettings'
+import {useUserSettings} from '~/components/organisation/context/UserSettingsContext'
+import {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
+import useProjectParams from '~/components/organisation/projects/useProjectParams'
+import useQueryChange from '~/components/organisation/projects/useQueryChange'
+import {usePeopleContext} from '~/components/people/context/PeopleContext'
+import ProfileSearchProjects from './PeopleSearchProjects'
+import ProfileProjectOverview from './PeopleProjectOverview'
+
+export default function ProfileProjects() {
+  const {rsd_page_layout} = useUserSettings()
+  const {project_cnt,projects} = usePeopleContext()
+  const {page,rows} = useProjectParams()
+  const {handleQueryChange} = useQueryChange()
+  // if masonry we change to grid
+  const initView = rsd_page_layout === 'masonry' ? 'grid' : rsd_page_layout
+  const [view, setView] = useState<ProjectLayoutType>(initView ?? 'grid')
+  const numPages = Math.ceil(project_cnt / rows)
+
+  function setLayout(view: ProjectLayoutType) {
+    // update local view
+    setView(view)
+    // save to cookie
+    setDocumentCookie(view,'rsd_page_layout')
+  }
+
+  return (
+    <div className="flex-1">
+      <ProfileSearchProjects
+        count={project_cnt}
+        layout={view}
+        setView={setLayout}
+      />
+      {/* project overview/content */}
+      <ProfileProjectOverview
+        layout={view}
+        projects={projects}
+      />
+      {/* Pagination */}
+      {numPages > 1 &&
+        <div className="flex flex-wrap justify-center mt-8">
+          <Pagination
+            count={numPages}
+            page={page}
+            onChange={(_, page) => {
+              handleQueryChange('page',page.toString())
+            }}
+          />
+        </div>
+      }
+    </div>
+  )
+}

--- a/frontend/components/people/settings/index.tsx
+++ b/frontend/components/people/settings/index.tsx
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export default function PeopleSettings() {
+  return (
+    <h1>People settings</h1>
+  )
+}

--- a/frontend/components/people/software/PeopleSearchSoftware.tsx
+++ b/frontend/components/people/software/PeopleSearchSoftware.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
+import useQueryChange from '~/components/organisation/projects/useQueryChange'
+import useSoftwareParams from '~/components/organisation/software/filters/useSoftwareParams'
+import PeopleSearchPanel from '~/components/people/PeopleSearchPanel'
+
+type PeopleSearchSoftware = {
+  count: number
+  layout: ProjectLayoutType
+  setView: (view:ProjectLayoutType)=>void
+}
+
+
+export default function PeopleSearchSoftware({
+  count, layout, setView
+}: PeopleSearchSoftware) {
+  const {search,page,rows} = useSoftwareParams()
+  const {handleQueryChange} = useQueryChange()
+
+  const placeholder = 'Find software'
+
+  // console.group('PeopleSearchSoftware')
+  // console.log('page...', page)
+  // console.log('rows...', rows)
+  // console.log('search...', search)
+  // console.groupEnd()
+
+  return (
+    <section data-testid="search-section">
+      <PeopleSearchPanel
+        placeholder={placeholder}
+        layout={layout}
+        rows={rows}
+        search={search}
+        onSetView={setView}
+        handleQueryChange={handleQueryChange}
+      />
+      <div className="flex justify-between items-center px-1 py-2">
+        <div className="text-sm opacity-70">
+          Page {page ?? 1} of {count} results
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/people/software/PeopleSoftwareOverview.tsx
+++ b/frontend/components/people/software/PeopleSoftwareOverview.tsx
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+import NoContent from '~/components/layout/NoContent'
+import {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
+import SoftwareGridCard from '~/components/software/overview/cards/SoftwareGridCard'
+import SoftwareOverviewGrid from '~/components/software/overview/cards/SoftwareOverviewGrid'
+import OverviewListItem from '~/components/software/overview/list/OverviewListItem'
+import SoftwareListItemContent from '~/components/software/overview/list/SoftwareListItemContent'
+import SoftwareOverviewList from '~/components/software/overview/list/SoftwareOverviewList'
+import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
+
+type PeopleSoftwareOverviewProps = {
+  layout: ProjectLayoutType
+  software: SoftwareOverviewItemProps[]
+}
+
+export default function PeopleSoftwareOverview({layout,software}:PeopleSoftwareOverviewProps) {
+
+  if (!software || software.length === 0) {
+    return <NoContent />
+  }
+
+  if (layout === 'list') {
+    return (
+      <SoftwareOverviewList>
+        {software.map(item => {
+          return (
+            <Link
+              data-testid="software-list-item"
+              key={item.id}
+              href={`/software/${item.slug}`}
+              className='flex-1 hover:text-inherit'
+              title={item.brand_name}
+            >
+              <OverviewListItem className='pr-4'>
+                <SoftwareListItemContent key={item.id} {...item} />
+              </OverviewListItem>
+            </Link>
+          )
+        })}
+      </SoftwareOverviewList>
+    )
+  }
+
+  // GRID as default
+  return (
+    <SoftwareOverviewGrid fullWidth={true}>
+      {software.map((item) => {
+        return <SoftwareGridCard key={item.id} {...item}/>
+      })}
+    </SoftwareOverviewGrid>
+  )
+
+}

--- a/frontend/components/people/software/index.tsx
+++ b/frontend/components/people/software/index.tsx
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+import Pagination from '@mui/material/Pagination'
+
+import {setDocumentCookie} from '~/utils/userSettings'
+import {useUserSettings} from '~/components/organisation/context/UserSettingsContext'
+import {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
+import useSoftwareParams from '~/components/organisation/software/filters/useSoftwareParams'
+import useQueryChange from '~/components/organisation/projects/useQueryChange'
+import {usePeopleContext} from '../context/PeopleContext'
+import PeopleSoftwareOverview from './PeopleSoftwareOverview'
+import PeopleSearchSoftware from './PeopleSearchSoftware'
+
+export default function PeopleSoftware() {
+  const {rsd_page_layout} = useUserSettings()
+  const {software_cnt,software} = usePeopleContext()
+  const {page,rows} = useSoftwareParams()
+  const {handleQueryChange} = useQueryChange()
+  // if masonry we change to grid
+  const initView = rsd_page_layout === 'masonry' ? 'grid' : rsd_page_layout
+  const [view, setView] = useState<ProjectLayoutType>(initView ?? 'grid')
+  const numPages = Math.ceil(software_cnt / rows)
+
+  // console.group('PeopleSoftware')
+  // console.log('page...', page)
+  // console.log('rows...', rows)
+  // console.log('software_cnt...', software_cnt)
+  // console.log('software...', software)
+  // console.log('view...', view)
+  // console.log('rsd_page_layout...', rsd_page_layout)
+  // console.groupEnd()
+
+  function setLayout(view: ProjectLayoutType) {
+    // update local view
+    setView(view)
+    // save to cookie
+    setDocumentCookie(view,'rsd_page_layout')
+  }
+
+  return (
+    <div className="flex-1">
+      <PeopleSearchSoftware
+        count={software_cnt}
+        layout={view}
+        setView={setLayout}
+      />
+      {/* software overview/content */}
+      <PeopleSoftwareOverview
+        layout={view}
+        software={software}
+      />
+      {/* Pagination */}
+      {numPages > 1 &&
+        <div className="flex flex-wrap justify-center mt-8">
+          <Pagination
+            count={numPages}
+            page={page}
+            onChange={(_, page) => {
+              handleQueryChange('page',page.toString())
+            }}
+          />
+        </div>
+      }
+    </div>
+  )
+}

--- a/frontend/components/people/tabs/PeopleTabContent.tsx
+++ b/frontend/components/people/tabs/PeopleTabContent.tsx
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import dynamic from 'next/dynamic'
+
+import logger from '~/utils/logger'
+import {PeopleTabKey} from './PeopleTabItems'
+import ContentLoader from '~/components/layout/ContentLoader'
+import PeopleSoftware from '../software'
+const PeopleProjects = dynamic(()=> import ('../projects'),{
+  loading: ()=><ContentLoader />
+})
+const PeopleSettings = dynamic(()=> import ('../settings'),{
+  loading: ()=><ContentLoader />
+})
+
+export default function PeopleTabContent({tab_id}:{tab_id:PeopleTabKey}) {
+  // const select_tab = useSelectedTab(tab_id)
+  // tab router
+  switch (tab_id) {
+    case 'projects':
+      return <PeopleProjects />
+    case 'settings':
+      return <PeopleSettings />
+    case 'software':
+      return <PeopleSoftware />
+    default:
+      logger(`Unknown tab_id ${tab_id}...returning default software tab`,'warn')
+      return <PeopleSoftware />
+  }
+}

--- a/frontend/components/people/tabs/PeopleTabItems.tsx
+++ b/frontend/components/people/tabs/PeopleTabItems.tsx
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import TerminalIcon from '@mui/icons-material/Terminal'
+import ListAltIcon from '@mui/icons-material/ListAlt'
+import SettingsIcon from '@mui/icons-material/Settings'
+
+import {OrganisationTabItemProps} from '~/components/organisation/tabs/OrganisationTabItems'
+
+export type PeopleTabKey = 'software' | 'projects' | 'settings'
+
+export type PeopleTabProps = {
+  [key in PeopleTabKey]: OrganisationTabItemProps
+}
+
+export const profileTabItems:PeopleTabProps = {
+  software: {
+    id:'software',
+    label:({software_cnt})=>`Software (${software_cnt ?? 0})`,
+    icon: <TerminalIcon />,
+    isVisible: (props) => true,
+  },
+  projects:{
+    id:'projects',
+    label: ({project_cnt})=>`Projects (${project_cnt ?? 0})`,
+    icon: <ListAltIcon />,
+    isVisible: (props) => true,
+  },
+  settings:{
+    id:'settings',
+    label:()=>'Settings',
+    icon: <SettingsIcon />,
+    // we do not show this option if not a maintainer
+    isVisible: ({isMaintainer}) => isMaintainer
+  }
+}

--- a/frontend/components/people/tabs/index.tsx
+++ b/frontend/components/people/tabs/index.tsx
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useRouter} from 'next/router'
+import Tabs from '@mui/material/Tabs'
+import Tab from '@mui/material/Tab'
+
+import {usePeopleContext} from '../context/PeopleContext'
+import {PeopleTabKey, profileTabItems} from './PeopleTabItems'
+
+
+type ProfileTabsProps={
+  tab_id: PeopleTabKey,
+  isMaintainer: boolean
+}
+
+// extract tab items (object keys)
+const tabItems = Object.keys(profileTabItems) as PeopleTabKey[]
+
+export default function ProfileTabs({tab_id, isMaintainer}:ProfileTabsProps) {
+  const router = useRouter()
+  const {software_cnt,project_cnt} = usePeopleContext()
+  return (
+    <Tabs
+      variant="scrollable"
+      allowScrollButtonsMobile
+      value={tab_id}
+      onChange={(_, value) => {
+        // change tab
+        const query:any={
+          orcid: router.query['orcid'],
+          tab: value,
+        }
+        // push tab change
+        router.push({query},undefined,{scroll:false})
+      }}
+      aria-label="profile tabs"
+    >
+      {tabItems.map(key => {
+        const item = profileTabItems[key]
+        if (item.isVisible({isMaintainer})===true){
+          return <Tab
+            icon={item.icon}
+            key={key}
+            label={item.label({
+              software_cnt,
+              project_cnt
+            })}
+            value={key}
+          />
+        }
+      })}
+    </Tabs>
+  )
+}

--- a/frontend/components/software/ContributorsList.tsx
+++ b/frontend/components/software/ContributorsList.tsx
@@ -7,16 +7,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useState} from 'react'
-
-import {Person} from '../../types/Contributor'
-import ContributorAvatar from './ContributorAvatar'
-import {getDisplayName, getDisplayInitials} from '../../utils/getDisplayName'
-import PersonalInfo from './PersonalInfo'
-import {getImageUrl} from '~/utils/editImage'
 import Button from '@mui/material/Button'
+import LaunchIcon from '@mui/icons-material/Launch'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+
+import {getImageUrl} from '~/utils/editImage'
+import {getDisplayName, getDisplayInitials} from '~/utils/getDisplayName'
+import {Person} from '~/types/Contributor'
+import PersonalInfo from './PersonalInfo'
 import useContributorList from './useContributorList'
+import ContributorAvatar from './ContributorAvatar'
 
 type GetMoreIconButtonProps={
   showAll: boolean
@@ -66,7 +67,7 @@ function ShowButton({showAll,showLess,onShowAll,onShowLess}:GetMoreIconButtonPro
   return null
 }
 
-export default function ContributorsList({contributors}: { contributors: Person[] }) {
+export default function ContributorsList({contributors,section='software'}: { contributors: Person[],section:'software'|'projects'}) {
   // show top 12 items
   const [limit,setLimit] = useState(12)
   const {persons,hasMore} = useContributorList({
@@ -97,8 +98,14 @@ export default function ContributorsList({contributors}: { contributors: Person[
                   displayInitials={getDisplayInitials(item)}
                 />
                 <div className='flex-1'>
-                  <div className="text-xl font-medium ">
-                    {displayName}
+                  <div className="text-xl font-medium">
+                    {item.orcid ?
+                      <a href={`/people/${item.orcid}/${section}`} className="flex gap-2 items-center">
+                        {displayName} <LaunchIcon/>
+                      </a>
+                      :
+                      <span>{displayName}</span>
+                    }
                   </div>
                   <PersonalInfo {...item} />
                 </div>

--- a/frontend/components/software/ContributorsSection.tsx
+++ b/frontend/components/software/ContributorsSection.tsx
@@ -37,6 +37,11 @@ export default function ContributorsSection({contributors, title='Contributors'}
   if (typeof contributors == 'undefined' || contributors?.length===0) return null
   // clasify
   const {contact, contributorList} = clasifyContributors(contributors)
+  // determine section for the profile link
+  let section:'software'|'projects' = 'software'
+  if (title==='Team'){
+    section = 'projects'
+  }
   return (
     <section className="bg-base-200">
       <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
@@ -50,7 +55,7 @@ export default function ContributorsSection({contributors, title='Contributors'}
             <ContactPersonCard person={contact} />
           </div>
           <div className="2xl:flex-[3]">
-            <ContributorsList contributors={contributorList} />
+            <ContributorsList contributors={contributorList} section={section}/>
           </div>
         </section>
       </PageContainer>

--- a/frontend/components/software/PersonalInfo.tsx
+++ b/frontend/components/software/PersonalInfo.tsx
@@ -1,11 +1,12 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import LogoOrcid from '~/assets/logos/logo-orcid.svg'
+import OrcidLink from '../layout/OrcidLink'
 
 type PersonalInfoProps = {
   role?: string | null
@@ -20,14 +21,7 @@ export default function PersonalInfo({role, affiliation, orcid}:PersonalInfoProp
     <div>
       {role && <div>{role}</div>}
       {affiliation && <div>{affiliation}</div>}
-      {orcid && <div>
-        <a href={'https://orcid.org/' + orcid} target="_blank" rel="noreferrer"
-          style={{whiteSpace:'nowrap'}}
-        >
-          <LogoOrcid className="inline max-w-[1.125rem] mr-1" />
-          <span className="text-sm align-bottom">{orcid}</span>
-        </a>
-      </div>}
+      {orcid && <div><OrcidLink orcid={orcid} /></div>}
     </div>
   )
 }

--- a/frontend/components/software/overview/cards/SoftwareOverviewGrid.tsx
+++ b/frontend/components/software/overview/cards/SoftwareOverviewGrid.tsx
@@ -8,11 +8,20 @@
 
 import {JSX} from 'react'
 
-export default function SoftwareOverviewGrid({children}: { children: JSX.Element | JSX.Element[] }) {
+export default function SoftwareOverviewGrid({children,fullWidth=false}: {
+  children: JSX.Element | JSX.Element[], fullWidth?:boolean }) {
+  // default
+  let md=1,lg=2,xl=3
+  // update number of items
+  if (fullWidth===true){
+    md=2
+    lg=3
+    xl=4
+  }
   return (
     <section
       data-testid="software-overview-grid"
-      className="mt-4 grid gap-8 lg:grid-cols-2 xl:grid-cols-3 auto-rows-[28rem]"
+      className={`mt-4 grid gap-8 md:grid-cols-${md} lg:grid-cols-${lg} xl:grid-cols-${xl} auto-rows-[28rem]`}
     >
       {children}
     </section>

--- a/frontend/pages/people/[orcid]/[tab].tsx
+++ b/frontend/pages/people/[orcid]/[tab].tsx
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next'
+import {RsdUser, getUserFromToken} from '~/auth'
+import {app} from '~/config/app'
+import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
+import {ProjectListItem} from '~/types/Project'
+import {getUserSettings} from '~/utils/userSettings'
+import PageMeta from '~/components/seo/PageMeta'
+import CanonicalUrl from '~/components/seo/CanonicalUrl'
+import BackgroundAndLayout from '~/components/layout/BackgroundAndLayout'
+import BaseSurfaceRounded from '~/components/layout/BaseSurfaceRounded'
+import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
+import {RsdContributor} from '~/components/admin/rsd-contributors/useContributors'
+import {UserSettingsProvider} from '~/components/organisation/context/UserSettingsContext'
+import {getPersonProfiles, getProfileProjects, getProfileSoftware} from '~/components/people/apiProfile'
+import ProfileMetadata from '~/components/people/metadata'
+import ProfileTabs from '~/components/people/tabs'
+import ProfileTabContent from '~/components/people/tabs/PeopleTabContent'
+import {PeopleContextProvider} from '~/components/people/context/PeopleContext'
+
+type SoftwareByOrcidProps={
+  orcid: string
+  rsd_page_layout: LayoutType,
+  rsd_page_rows: number,
+  tab: 'software' | 'projects' | 'settings'
+  profiles: RsdContributor[],
+  software_cnt: number,
+  software: SoftwareOverviewItemProps[],
+  project_cnt: number,
+  projects: ProjectListItem[]
+}
+
+export default function SoftwareByOrcid({
+  orcid,rsd_page_rows,rsd_page_layout,
+  tab,profiles,software_cnt,
+  software, project_cnt, projects
+}:SoftwareByOrcidProps) {
+
+  // console.group('SoftwareByOrcid')
+  // console.log('orcid...', orcid)
+  // console.log('rsd_page_rows....', rsd_page_rows)
+  // console.log('rsd_page_layout....', rsd_page_layout)
+  // console.log('tab....', tab)
+  // console.log('profiles....', profiles)
+  // console.log('software....', software)
+  // console.log('software_cnt....', software_cnt)
+  // console.log('projects....', projects)
+  // console.log('project_cnt....', project_cnt)
+  // console.groupEnd()
+
+  return (
+    <>
+      {/* Page Head meta tags */}
+      <PageMeta
+        title={`${orcid} | ${app.title}`}
+        description="Software overview by orcid"
+      />
+      <CanonicalUrl />
+      <BackgroundAndLayout>
+        <UserSettingsProvider
+          settings={{
+            rsd_page_layout,
+            rsd_page_rows
+          }}
+        >
+          <PeopleContextProvider value={{
+            software_cnt,
+            software,
+            project_cnt,
+            projects
+          }}>
+            {/* PROFILE METADATA */}
+            <ProfileMetadata profiles={profiles} />
+            {/* TABS */}
+            <BaseSurfaceRounded
+              className="my-4 p-2"
+              type="section"
+            >
+              <ProfileTabs tab_id={tab} isMaintainer={false} />
+            </BaseSurfaceRounded>
+            {/* TAB CONTENT */}
+            <section className="flex md:min-h-[60rem] mb-12">
+              <ProfileTabContent tab_id={tab} />
+            </section>
+          </PeopleContextProvider>
+        </UserSettingsProvider>
+      </BackgroundAndLayout>
+    </>
+  )
+}
+
+
+// fetching data server side
+// see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  try{
+    const {params, req, query} = context
+    // check if orcid provided
+    if (!params?.orcid){
+      return {
+        notFound: true,
+      }
+    }
+    // find person by orcid
+    const token = req?.cookies['rsd_token']
+    const orcid = params?.orcid as string
+    const profiles = await getPersonProfiles({orcid,token})
+    // 404 if profiles not found
+    if (profiles === null || profiles.length === 0){
+      return {
+        notFound: true,
+      }
+    }
+    // extract user settings from cookie
+    const {rsd_page_layout, rsd_page_rows} = getUserSettings(req)
+    // for rows we use query param or user settings definition
+    const rows = parseInt(query['rows'] as string ?? rsd_page_rows)
+    // get page for pagination
+    let page = parseInt(query['page'] as string ?? 0)
+    // api works with 0 page index
+    if (page>0) page = page-1
+    // tab & search
+    const tab = params?.tab ?? 'software'
+    const search = query?.search as string
+    let softwareSearch, projectSearch
+    if (tab==='software' && search) {
+      softwareSearch=search
+    }else if (tab==='projects' && search){
+      projectSearch=search
+    }
+    // get both software and projects
+    const [software, project] = await Promise.all([
+      getProfileSoftware({orcid,rows,page,search:softwareSearch,token}),
+      getProfileProjects({orcid,rows,page,search:projectSearch,token})
+    ])
+    // return data
+    return {
+      props:{
+        rsd_page_layout,
+        rsd_page_rows,
+        orcid,
+        tab,
+        profiles,
+        ...software,
+        ...project
+      }
+    }
+  }catch(e){
+    return {
+      notFound: true,
+    }
+  }
+}


### PR DESCRIPTION
# People overview

Closes #879

Changes proposed in this pull request:
* If the contributor have ORCID we enable link to "people" page 
* The visitors can view all software and projects of "ORCID" person by clicking on the name
* The info about role, affiliation and email of all entries is grouped and listed on the page

How to test:
* `make start` to build app
* navigate to software page, select one software item and go to contributors section. Click on the contributor name. It should take you to a page showing software collection of this subject (based on ORCID). 
* find a person without ORCID (or create one). The link should not be placed on this person name (because we can only filter by ORCID)
* navigate to a project and perform the similar operation with team members
* NOTE! test data is not best suited for this. It is better to restore backup of real data and test it locally.

## Link to specific person contributions
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/e5d3ba3e-c394-40fc-bcf2-37493e0360ce)

## Contributor page
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/c1cfd2cd-9f12-47db-b886-c89236d717c6)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
