### PR TITLE
feat: show top 12 contributors initially

### DIFF
--- a/frontend/components/software/ContributorsList.tsx
+++ b/frontend/components/software/ContributorsList.tsx
@@ -1,46 +1,120 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
 
 import {Person} from '../../types/Contributor'
 import ContributorAvatar from './ContributorAvatar'
 import {getDisplayName, getDisplayInitials} from '../../utils/getDisplayName'
 import PersonalInfo from './PersonalInfo'
 import {getImageUrl} from '~/utils/editImage'
+import Button from '@mui/material/Button'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import ExpandLessIcon from '@mui/icons-material/ExpandLess'
+import useContributorList from './useContributorList'
+
+type GetMoreIconButtonProps={
+  showAll: boolean
+  showLess: boolean
+  onShowAll: ()=>void
+  onShowLess: ()=>void
+}
+
+function ShowButton({showAll,showLess,onShowAll,onShowLess}:GetMoreIconButtonProps){
+  // console.group('ShowToggleButton')
+  // console.log('showAll...', showAll)
+  // console.log('showLess...',showLess)
+  // console.groupEnd()
+  // show all button
+  if (showAll===true){
+    return (
+      <div className="flex justify-start">
+        <Button
+          title='Show all items'
+          aria-label="Show all items"
+          onClick={onShowAll}
+          size="large"
+          startIcon = {<ExpandMoreIcon />}
+        >
+          Show all
+        </Button>
+      </div>
+    )
+  }
+  // show top X items definied by limit
+  if (showLess===true){
+    return (
+      <div className="flex justify-start">
+        <Button
+          title='Show less items'
+          aria-label="Show less items"
+          onClick={onShowLess}
+          size="large"
+          startIcon = {<ExpandLessIcon />}
+        >
+          Show less
+        </Button>
+      </div>
+    )
+  }
+  // do not render button
+  return null
+}
 
 export default function ContributorsList({contributors}: { contributors: Person[] }) {
+  // show top 12 items
+  const [limit,setLimit] = useState(12)
+  const {persons,hasMore} = useContributorList({
+    items:contributors,
+    limit
+  })
   // do not render component if no data
-  if (contributors?.length === 0) return null
+  if (persons?.length === 0) return null
 
+  // console.group('ContributorsList')
+  // console.log('persons...', persons)
+  // console.log('limit...',limit)
+  // console.log('hasMore...',hasMore)
+  // console.groupEnd()
 
   return (
-    <div className="gap-4 mt-12 md:grid md:grid-cols-2 hd:grid-cols-3 2xl:mt-0">
-      {contributors.map(item => {
-        const displayName = getDisplayName(item)
-        const avatarUrl = getImageUrl(item.avatar_id) ?? ''
-        if (displayName) {
-          return (
-            <div key={displayName} className="flex py-4 pr-4 md:pr-8 2xl:pr-12 2xl:pb-8">
-              <ContributorAvatar
-                avatarUrl={avatarUrl}
-                displayName={displayName}
-                displayInitials={getDisplayInitials(item)}
-              />
-              <div className='flex-1'>
-                <div className="text-xl font-medium ">
-                  {displayName}
+    <>
+      <div className="gap-4 mt-12 md:grid md:grid-cols-2 hd:grid-cols-3 2xl:mt-0">
+        {persons.map(item => {
+          const displayName = getDisplayName(item)
+          const avatarUrl = getImageUrl(item.avatar_id) ?? ''
+          if (displayName) {
+            return (
+              <div key={displayName} className="flex py-4 pr-4 md:pr-8 2xl:pr-12 2xl:pb-8">
+                <ContributorAvatar
+                  avatarUrl={avatarUrl}
+                  displayName={displayName}
+                  displayInitials={getDisplayInitials(item)}
+                />
+                <div className='flex-1'>
+                  <div className="text-xl font-medium ">
+                    {displayName}
+                  </div>
+                  <PersonalInfo {...item} />
                 </div>
-                <PersonalInfo {...item} />
               </div>
-            </div>
-          )
+            )
+          }
+          return null
+        })
         }
-        return null
-      })
-      }
-    </div>
+      </div>
+      <ShowButton
+        showAll={hasMore}
+        showLess={contributors.length === limit}
+        onShowAll={()=>setLimit(contributors.length)}
+        onShowLess={()=>setLimit(12)}
+      />
+    </>
   )
 }

--- a/frontend/components/software/useContributorList.tsx
+++ b/frontend/components/software/useContributorList.tsx
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {Person} from '~/types/Contributor'
+
+type UseContributorListProps={
+  items: Person[]
+  limit: number
+}
+
+export default function useContributorList({items,limit=12}:UseContributorListProps){
+  const [persons, setPersons] = useState<Person[]>([])
+
+  useEffect(()=>{
+    let abort = false
+
+    if (limit >= items.length && persons.length < items.length){
+      // exit if hook is closed
+      if (abort) return
+      // show all items
+      setPersons(items)
+    }
+
+    if (limit < items.length && persons.length !== limit){
+      // exit if hook is closed
+      if (abort) return
+      // show only limited list
+      setPersons(items.slice(0,limit))
+    }
+
+    return ()=>{abort=true}
+  },[items,limit,persons])
+
+  return {
+    persons,
+    hasMore: persons?.length < items?.length
+  }
+}


### PR DESCRIPTION
# Use  button(s) to limit initial contributors list to top 12 items

Based on the feedback from initial approach the feature is changed to:
- if there are less than 12 items, all items are shown
- if there are more than 12 items we initially show first 12 items and the `Show all` button (see image 1). Click on the button will load all items
- when more than 12 items are loaded, `Show less` button is displayed. Click on the button will reduce list to first 12 items

## Show all button
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/bf4727b6-98a1-479c-b28d-f7b33c66411e)

## Show less button
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/65d96d53-b6c0-4eaf-95b2-73e5218002d7)

How to test:
* `make start` to build app
* create new software item. Use this concept DOI 10.5281/zenodo.3401363 on info page
* import contributors
* view software page. Confirm that 12 contributors and the button is shown. Load more by clicking on the button.
* reduce list by clicking on `Show less` button
* visit the software with less than 12 contributors, no buttons should be shown
* note that the position of contributor/team member can be changed in the edit section
* the same feature is available in Team section of project page

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
