### PR TITLE
fix: add null check before calling TreeSet#contains(java.lang.Object)

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainCitations.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainCitations.java
@@ -29,7 +29,9 @@ public class MainCitations {
 
 			for (CitationData citationData : referencePapersToScrape) {
 				Collection<MentionRecord> citingMentions = openAlexCitations.citations(citationData.doi, email, citationData.id);
-				citingMentions.removeIf(mention -> citationData.knownDois.contains(mention.doi));
+				// we don't update mentions that have a DOI in the database with OpenAlex data, as they can already be
+				// scraped through Crossref of DataCite
+				citingMentions.removeIf(mention -> mention.doi != null && citationData.knownDois.contains(mention.doi));
 				localMentionRepository.save(citingMentions);
 
 				Collection<UUID> citingMentionIds = new ArrayList<>();


### PR DESCRIPTION
# Fix citation scraper

Changes proposed in this pull request:

* Add a null check to prevent a `NullPointerException` from being thrown

How to test :

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Login as admin and create a software page
* Add a reference paper with DOI `10.1016/j.future.2018.08.004`
* Wait or run the citations scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations`
* In the database run `UPDATE mention SET citations_scraped_at = NULL;` so that the scraper will do its work again without having to wait an hour
* Run the scraper again
* Check the error logs, no logs should have been generated

Closes #1023

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
