### PR TITLE
fix: show error message when spaces in email of contributor and team

### DIFF
--- a/frontend/components/projects/edit/team/EditTeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/EditTeamMemberModal.tsx
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -47,7 +49,7 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
   const {showWarningMessage,showErrorMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
   const [removeAvatar, setRemoveAvatar] = useState<null|string>(null)
-  const {handleSubmit, watch, formState, reset, control, register, setValue} = useForm<TeamMember>({
+  const {handleSubmit, watch, formState, reset, control, register, setValue,trigger} = useForm<TeamMember>({
     mode: 'onChange',
     defaultValues: {
       ...member
@@ -63,11 +65,14 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
   // console.log('isValid...', isValid)
   // console.groupEnd()
 
-  useEffect(() => {
-    if (member) {
-      reset(member)
+  useEffect(()=>{
+    if (trigger){
+      setTimeout(()=>{
+        // trigger initial validation after default data is loaded
+        trigger()
+      },1)
     }
-  }, [member,reset])
+  },[trigger])
 
   function handleCancel() {
     // reset form
@@ -281,9 +286,10 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
             <ControlledTextField
               control={control}
               options={{
+                // do not use type: 'email' because it automatically ignores leading/trailing spaces,
+                // and then the regex email validation does not detect these properly
                 name: 'email_address',
                 label: config.email_address.label,
-                type: 'email',
                 useNull: true,
                 defaultValue: member?.email_address,
                 helperTextMessage: config.email_address.help,

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -2,11 +2,13 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEvent, useState} from 'react'
+import {ChangeEvent, useEffect, useState} from 'react'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -46,7 +48,7 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
   const {showWarningMessage,showErrorMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
   const [removeAvatar, setRemoveAvatar] = useState<null|string>(null)
-  const {handleSubmit, watch, formState, reset, control, register, setValue} = useForm<Contributor>({
+  const {handleSubmit, watch, formState, reset, control, register, setValue,trigger} = useForm<Contributor>({
     mode: 'onChange',
     defaultValues: {
       ...contributor
@@ -60,7 +62,17 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
   // console.group('EditContributorModal')
   // console.log('isDirty...', isDirty)
   // console.log('isValid...', isValid)
+  // console.log('errors...', errors)
   // console.groupEnd()
+
+  useEffect(()=>{
+    if (trigger){
+      setTimeout(()=>{
+        // trigger initial validation after default data is loaded
+        trigger()
+      },1)
+    }
+  },[trigger])
 
   function handleCancel() {
     // reset form
@@ -274,9 +286,10 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
             <ControlledTextField
               control={control}
               options={{
+                // do not use type: 'email' because it automatically ignores leading/trailing spaces,
+                // and then the regex email validation does not detect these properly
                 name: 'email_address',
                 label: config.email_address.label,
-                type: 'email',
                 useNull: true,
                 defaultValue: contributor?.email_address,
                 helperTextMessage: config.email_address.help,


### PR DESCRIPTION
# Show error message on leading/trailing spaces

Closes #1022

Changes proposed in this pull request:
*  Add leading/trailing spaces error detection to email in contributor and team member modals 

How to test:
* `make start` to build app and create data
* login as rsd-admin and open software to edit
* navigate to contributors and try to create email with leading/trailing spaces. Confirm correct error message is
* open project page for edit. Navigate to team members. Add team member and try adding some spaces into email. Confirm error messages are correct

## Example invalid email error
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/8c96e8c4-cfe1-4c9c-9da4-d2d7b157a5dd)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
