### PR TITLE
Update backend dependencies

### DIFF
--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -45,10 +45,14 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
       - name: "Maven JUnit tests"
         working-directory: scrapers
         run: |
-          JAVA_HOME=$JAVA_HOME_17_X64 mvn test
+          mvn test
 
   e2e-chrome:
     # wait fe test to finish first
@@ -56,55 +60,55 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18.5
-        cache: 'npm'
-        cache-dependency-path: e2e/package-lock.json
-    - name: get playwright version
-      id: playwright-version
-      working-directory: e2e
-      run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
-    - name: cache playwright binaries
-      uses: actions/cache@v3
-      id: playwright-cache
-      with:
-        path: |
-          ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-    - name: install dependencies
-      working-directory: e2e
-      run: npm ci
-    - name: install browsers
-      working-directory: e2e
-      run: npx playwright install chromium chrome --with-deps
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-    - name: build rsd
-      working-directory: .
-      run: |
-        cp e2e/.env.e2e .env
-        docker compose build --parallel database backend auth frontend nginx
-    - name: start rsd
-      working-directory: .
-      run: |
-        docker compose up --detach database backend auth frontend nginx swagger
-        sleep 5
-    - name: run e2e tests in chrome
-      working-directory: e2e
-      run: npm run e2e:chrome:action
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: e2e/playwright-report/
-        retention-days: 30
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: browser state and .env file
-        path: |
-          e2e/state/
-          .env
-        retention-days: 30
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.5
+          cache: 'npm'
+          cache-dependency-path: e2e/package-lock.json
+      - name: get playwright version
+        id: playwright-version
+        working-directory: e2e
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+      - name: install dependencies
+        working-directory: e2e
+        run: npm ci
+      - name: install browsers
+        working-directory: e2e
+        run: npx playwright install chromium chrome --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - name: build rsd
+        working-directory: .
+        run: |
+          cp e2e/.env.e2e .env
+          docker compose build --parallel database backend auth frontend nginx
+      - name: start rsd
+        working-directory: .
+        run: |
+          docker compose up --detach database backend auth frontend nginx swagger
+          sleep 5
+      - name: run e2e tests in chrome
+        working-directory: e2e
+        run: npm run e2e:chrome:action
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 30
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: browser state and .env file
+          path: |
+            e2e/state/
+            .env
+          retention-days: 30
 

--- a/.github/workflows/authentication_tests.yml
+++ b/.github/workflows/authentication_tests.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
@@ -40,10 +44,10 @@ jobs:
       - name: "Maven JUnit tests and JaCoCo test report"
         working-directory: authentication
         run: |
-          JAVA_HOME=$JAVA_HOME_17_X64 mvn verify
+          mvn verify
       - name: SonarCloud Scan authentication
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         working-directory: authentication
-        run: JAVA_HOME=$JAVA_HOME_17_X64 mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=nl.research-software:authentication -Pcoverage
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=nl.research-software:authentication -Pcoverage

--- a/.github/workflows/scrapers_tests.yml
+++ b/.github/workflows/scrapers_tests.yml
@@ -25,6 +25,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '21'
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
@@ -40,10 +44,10 @@ jobs:
       - name: "Maven JUnit tests and JaCoCo test report"
         working-directory: scrapers
         run: |
-          JAVA_HOME=$JAVA_HOME_17_X64 mvn verify
+          mvn verify
       - name: SonarCloud Scan scrapers
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         working-directory: scrapers
-        run: JAVA_HOME=$JAVA_HOME_17_X64 mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=nl.research-software:scrapers -Pcoverage
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=nl.research-software:scrapers -Pcoverage

--- a/authentication/Dockerfile
+++ b/authentication/Dockerfile
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.8.6-openjdk-18 AS builder
+FROM maven:3.9.5-eclipse-temurin-21 AS builder
 WORKDIR /usr/mymaven
 RUN mkdir src
 COPY pom.xml .
@@ -15,7 +15,7 @@ RUN mvn dependency:go-offline
 COPY ./src ./src
 RUN mvn package --offline
 
-FROM openjdk:18.0.1.1-jdk-slim-bullseye
+FROM eclipse-temurin:21-jre-jammy
 WORKDIR /usr/myjava
 COPY --from=builder /usr/mymaven/target/*-jar-with-dependencies.jar auth.jar
 CMD java -cp auth.jar nl.esciencecenter.rsd.authentication.Main

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -20,8 +20,8 @@ SPDX-License-Identifier: Apache-2.0
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<sonar.organization>research-software-directory</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>
@@ -98,28 +98,28 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>io.javalin</groupId>
 			<artifactId>javalin</artifactId>
-			<version>5.1.1</version>
+			<version>5.6.3</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>2.0.3</version>
+			<version>2.0.9</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
-			<version>4.2.0</version>
+			<version>4.4.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.9.1</version>
+			<version>2.10.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk -->
@@ -157,9 +157,25 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-inline</artifactId>
-			<version>4.6.1</version>
+			<version>5.2.0</version>
 			<scope>test</scope>
 		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy -->
+		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy</artifactId>
+			<version>1.14.9</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy-agent -->
+		<dependency>
+			<groupId>net.bytebuddy</groupId>
+			<artifactId>byte-buddy-agent</artifactId>
+			<version>1.14.9</version>
+			<scope>test</scope>
+		</dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/backend-postgrest/Dockerfile
+++ b/backend-postgrest/Dockerfile
@@ -3,4 +3,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgrest/postgrest:v11.0.1
+FROM postgrest/postgrest:v11.2.1

--- a/backend-tests/Dockerfile
+++ b/backend-tests/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.8.7-openjdk-18
+FROM maven:3.9.5-eclipse-temurin-21
 WORKDIR /usr/mymaven
 RUN mkdir src
 COPY pom.xml .

--- a/backend-tests/pom.xml
+++ b/backend-tests/pom.xml
@@ -8,92 +8,92 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<modelVersion>4.0.0</modelVersion>
 
-    <groupId>nl.research-software</groupId>
-    <artifactId>backend-tests</artifactId>
-    <version>1.0-SNAPSHOT</version>
+	<groupId>nl.research-software</groupId>
+	<artifactId>backend-tests</artifactId>
+	<version>1.0-SNAPSHOT</version>
 
-    <properties>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    </properties>
+	<properties>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 
-    <build>
-        <plugins>
-            <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.6.0</version>
-            </plugin>
+	<build>
+		<plugins>
+			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-dependency-plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-dependency-plugin</artifactId>
+				<version>3.6.0</version>
+			</plugin>
 
-            <!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.1.0</version>
-            </plugin>
+			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>3.1.0</version>
+			</plugin>
 
-            <!--
-            https://mvnrepository.com/artifact/org.apache.maven.surefire/surefire-junit-platform -->
-            <plugin>
-                <groupId>org.apache.maven.surefire</groupId>
-                <artifactId>surefire-junit-platform</artifactId>
-                <version>3.1.0</version>
-            </plugin>
+			<!--
+			https://mvnrepository.com/artifact/org.apache.maven.surefire/surefire-junit-platform -->
+			<plugin>
+				<groupId>org.apache.maven.surefire</groupId>
+				<artifactId>surefire-junit-platform</artifactId>
+				<version>3.1.0</version>
+			</plugin>
 
-            <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
-            <plugin>
-                <groupId>org.junit.jupiter</groupId>
-                <artifactId>junit-jupiter-engine</artifactId>
-                <version>5.9.3</version>
-            </plugin>
+			<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
+			<plugin>
+				<groupId>org.junit.jupiter</groupId>
+				<artifactId>junit-jupiter-engine</artifactId>
+				<version>5.9.3</version>
+			</plugin>
 
-            <!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher -->
-            <plugin>
-                <groupId>org.junit.platform</groupId>
-                <artifactId>junit-platform-launcher</artifactId>
-                <version>1.9.3</version>
-            </plugin>
-        </plugins>
-    </build>
+			<!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher -->
+			<plugin>
+				<groupId>org.junit.platform</groupId>
+				<artifactId>junit-platform-launcher</artifactId>
+				<version>1.9.3</version>
+			</plugin>
+		</plugins>
+	</build>
 
-    <dependencies>
+	<dependencies>
 
-        <!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
-        <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
-            <version>2.10.1</version>
-            <scope>test</scope>
-        </dependency>
+		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
+		<dependency>
+			<groupId>com.google.code.gson</groupId>
+			<artifactId>gson</artifactId>
+			<version>2.10.1</version>
+			<scope>test</scope>
+		</dependency>
 
-        <!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
-        <dependency>
-            <groupId>com.auth0</groupId>
-            <artifactId>java-jwt</artifactId>
-            <version>4.4.0</version>
-        </dependency>
+		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
+		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+			<version>4.4.0</version>
+		</dependency>
 
-        <!-- https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->
-        <dependency>
-            <groupId>io.rest-assured</groupId>
-            <artifactId>rest-assured</artifactId>
-            <version>5.3.0</version>
-            <scope>test</scope>
-        </dependency>
+		<!-- https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->
+		<dependency>
+			<groupId>io.rest-assured</groupId>
+			<artifactId>rest-assured</artifactId>
+			<version>5.3.2</version>
+			<scope>test</scope>
+		</dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.9.3</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-api -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<version>5.9.3</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 </project>

--- a/data-generation/Dockerfile
+++ b/data-generation/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:18.14.0-bullseye-slim
+FROM node:21.0.0-bullseye-slim
 WORKDIR /usr/app
 COPY ./package.json /usr/app
 RUN npm install

--- a/data-migration/pom.xml
+++ b/data-migration/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2021 - 2022 Netherlands eScience Center
+SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
 
 SPDX-License-Identifier: Apache-2.0
 -->
@@ -43,7 +43,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.9.0</version>
+			<version>2.10.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgres:15.3
+FROM postgres:15.4
 RUN chmod a+rwx /docker-entrypoint-initdb.d
 COPY --chown=postgres:postgres *.sh /docker-entrypoint-initdb.d/
 COPY --chown=postgres:postgres *.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,10 +16,10 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:2.1.0
+    image: rsd/database:2.1.1
     ports:
-    # enable connection from outside (development mode)
-     - "5432:5432"
+      # enable connection from outside (development mode)
+      - "5432:5432"
     environment:
       # it uses values from .env file
       - POSTGRES_DB
@@ -36,7 +36,7 @@ services:
 
   backend:
     build: ./backend-postgrest
-    image: rsd/backend-postgrest:1.12.0
+    image: rsd/backend-postgrest:1.12.1
     expose:
       - 3500
     environment:
@@ -53,7 +53,7 @@ services:
 
   auth:
     build: ./authentication
-    image: rsd/auth:1.2.2
+    image: rsd/auth:1.2.3
     ports:
       - 5005:5005
     expose:
@@ -153,7 +153,7 @@ services:
 
   scrapers:
     build: ./scrapers
-    image: rsd/scrapers:1.5.0
+    image: rsd/scrapers:1.5.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL
@@ -185,7 +185,7 @@ services:
   nginx:
     build:
       context: ./nginx
-    image: rsd/nginx:1.1.2
+    image: rsd/nginx:1.1.3
     ports:
       - "80:80"
       - "443:443"
@@ -206,7 +206,7 @@ services:
   #----------------------------------------------
   data-generation:
     build: ./data-generation
-    image: rsd/generation:1.3.0
+    image: rsd/generation:1.3.1
     environment:
       # it needs to be here to use values from .env file
       - PGRST_JWT_SECRET

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,8 +1,8 @@
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM nginx:1.21.6
+FROM nginx:1.25.2
 RUN apt-get update && apt-get install --yes certbot python3-certbot-nginx
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/scrapers/Dockerfile
+++ b/scrapers/Dockerfile
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.8.6-openjdk-18 AS builder
+FROM maven:3.9.5-eclipse-temurin-21 AS builder
 WORKDIR /usr/mymaven
 RUN mkdir ./src
 COPY pom.xml .
@@ -13,15 +13,10 @@ RUN mvn dependency:go-offline
 COPY ./src ./src
 RUN mvn package --offline
 
-FROM openjdk:18.0.1.1-jdk-slim-bullseye
+FROM eclipse-temurin:21-jre-jammy
 WORKDIR /usr/myjava
-RUN apt-get update && apt-get --yes install cron python pip nano
-COPY --from=builder /usr/mymaven/src/main/resources/requirements.txt requirements.txt
-RUN pip install --requirement requirements.txt
+RUN apt-get update && apt-get --yes install cron nano
 COPY jobs.cron /etc/cron.d/jobs.cron
 RUN crontab /etc/cron.d/jobs.cron
 COPY --from=builder /usr/mymaven/target/*-jar-with-dependencies.jar scrapers.jar
-COPY --from=builder /usr/mymaven/src/main/resources/releases.py releases.py
-COPY --from=builder /usr/mymaven/src/main/resources/zotero.py zotero.py
-COPY --from=builder /usr/mymaven/src/main/resources/oaipmh.py oaipmh.py
 CMD printenv > /etc/environment && cron -f

--- a/scrapers/jobs.cron
+++ b/scrapers/jobs.cron
@@ -2,12 +2,11 @@
 #
 # SPDX-License-Identifier: CC-BY-4.0
 #
-*/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-*/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.package_manager.MainPackageManager > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-2-59/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainBasicData > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-4-59/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-1-59/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-3-59/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-5-59/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainContributors > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-5-59/6 * * * * /usr/local/openjdk-18/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
-0 1 * * * /usr/bin/python3 -u /usr/myjava/oaipmh.py > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+*/6 * * * * /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+*/6 * * * * /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.package_manager.MainPackageManager > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+2-59/6 * * * * /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainBasicData > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+4-59/6 * * * * /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+1-59/6 * * * * /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+3-59/6 * * * * /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+5-59/6 * * * * /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainContributors > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1
+5-59/6 * * * * /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations > /proc/$(cat /var/run/crond.pid)/fd/1 2>&1

--- a/scrapers/pom.xml
+++ b/scrapers/pom.xml
@@ -11,7 +11,8 @@ SPDX-License-Identifier: Apache-2.0
 -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>nl.research-software</groupId>
@@ -20,8 +21,8 @@ SPDX-License-Identifier: Apache-2.0
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>17</maven.compiler.source>
-		<maven.compiler.target>17</maven.compiler.target>
+		<maven.compiler.source>21</maven.compiler.source>
+		<maven.compiler.target>21</maven.compiler.target>
 		<sonar.organization>research-software-directory</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>
@@ -109,14 +110,14 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>com.auth0</groupId>
 			<artifactId>java-jwt</artifactId>
-			<version>4.2.0</version>
+			<version>4.4.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.google.code.gson/gson -->
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.9.1</version>
+			<version>2.10.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->


### PR DESCRIPTION
# Update backend dependencies

Changes proposed in this pull request:

* Update various backend dependencies as described in #1020
* Disable the old Python OAI-PMH scraper (the table will be deleted in a different branch)

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Browse the website, see if everything works
* Login as a regular user, create some pages, see if everything works
* Login as admin, create some pages, check out the admin pages, see if everything works

Closes #1020

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
