### PR TITLE
1021 clear releases

### DIFF
--- a/database/010-create-release-table.sql
+++ b/database/010-create-release-table.sql
@@ -18,6 +18,20 @@ CREATE TABLE release_version (
 );
 
 
+CREATE FUNCTION z_delete_old_releases() RETURNS TRIGGER LANGUAGE plpgsql SECURITY DEFINER AS
+$$
+BEGIN
+	IF NEW.concept_doi IS DISTINCT FROM OLD.concept_doi THEN
+		DELETE FROM release_version WHERE release_version.release_id = OLD.id;
+		DELETE FROM release WHERE release.software = OLD.id;
+	END IF;
+	RETURN NEW;
+END
+$$;
+
+CREATE TRIGGER z_delete_old_releases BEFORE UPDATE ON software FOR EACH ROW EXECUTE PROCEDURE z_delete_old_releases();
+
+
 CREATE FUNCTION software_join_release() RETURNS TABLE (
 	software_id UUID,
 	slug VARCHAR,


### PR DESCRIPTION
# Clear releases on concept DOI change

Changes proposed in this pull request:

* When you change or delete the concept DOI from a software page, a database trigger will now delete all associated released of that software.
* Fix the releases scraper so that it can handle multiple software entries having the same concept DOI.

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Login as regular user, create two software pages with the same concept DOI (e.g. `10.5281/zenodo.6379973`).
* Run the releases scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases`
* Both pages should have the releases now
* Delete or edit the concept DOI from one page, the release should now also be gone
* Repeat as admin

Closes #1021

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
