### PR TITLE
feat: configurable software highlights title

### DIFF
--- a/deployment/rsd/data/settings.json
+++ b/deployment/rsd/data/settings.json
@@ -12,7 +12,8 @@
     },
     "login_info_url": "https://research-software-directory.github.io/documentation/getting-access.html",
     "terms_of_service_url": "/page/terms-of-service/",
-    "privacy_statement_url": "/page/privacy-statement/"
+    "privacy_statement_url": "/page/privacy-statement/",
+    "software_highlights_title": "Software Highlights"
   },
   "links": [
     {

--- a/frontend/components/admin/software-highlights/index.tsx
+++ b/frontend/components/admin/software-highlights/index.tsx
@@ -1,6 +1,8 @@
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -10,10 +12,12 @@ import {useSession} from '~/auth'
 import AddSoftwareHighlights from './AddSoftwareHighlights'
 import SortableHighlightsList from './SortableHighlightList'
 import useSoftwareHighlights from './useSoftwareHighlights'
+import useRsdSettings from '~/config/useRsdSettings'
 
 export default function AdminSoftwareHighlightsPage() {
   const {token} = useSession()
   const {highlights, loading, addHighlight, sortHighlights, deleteHighlight} = useSoftwareHighlights(token)
+  const {host} = useRsdSettings()
 
   // console.group('AdminSoftwareHighlight')
   // console.log('highlights...', highlights)
@@ -23,7 +27,7 @@ export default function AdminSoftwareHighlightsPage() {
     <section className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr,2fr] xl:px-0 xl:gap-8">
       <div>
         <h2 className="flex pr-4 pb-4 justify-between">
-          <span>Highlights</span>
+          <span>{host.software_highlights_title}</span>
           <span>{highlights.length}</span>
         </h2>
         <SortableHighlightsList

--- a/frontend/components/software/overview/SoftwareHighlights.tsx
+++ b/frontend/components/software/overview/SoftwareHighlights.tsx
@@ -1,6 +1,8 @@
+// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -9,12 +11,14 @@
 import ContentContainer from '~/components/layout/ContentContainer'
 import {HighlightsCarousel} from './highlights/HighlightsCarousel'
 import {SoftwareHighlight} from '~/components/admin/software-highlights/apiSoftwareHighlights'
+import useRsdSettings from '~/config/useRsdSettings'
 
 export default function SoftwareHighlights({highlights}: { highlights: SoftwareHighlight[] }) {
   // console.group('SoftwareHighlights')
   // console.log('loading...', loading)
   // console.log('highlights...', highlights)
   // console.groupEnd()
+  const {host} = useRsdSettings()
 
   // if there are no hightlights we do not show this section
   if (highlights.length===0) return null
@@ -25,7 +29,7 @@ export default function SoftwareHighlights({highlights}: { highlights: SoftwareH
         <div
           className="text-3xl"
         >
-          Software Highlights
+          {host.software_highlights_title}
         </div>
       </ContentContainer>
       <HighlightsCarousel items={highlights} />

--- a/frontend/config/defaultSettings.json
+++ b/frontend/config/defaultSettings.json
@@ -12,7 +12,8 @@
     },
     "login_info_url": "https://research-software-directory.github.io/documentation/getting-access.html",
     "terms_of_service_url": "/page/terms-of-service/",
-    "privacy_statement_url": "/page/privacy-statement/"
+    "privacy_statement_url": "/page/privacy-statement/",
+    "software_highlights_title":  "Software Highlights"
   },
   "links": [
     {

--- a/frontend/config/getSettingsServerSide.ts
+++ b/frontend/config/getSettingsServerSide.ts
@@ -51,6 +51,12 @@ export async function getSettingsServerSide(req: IncomingMessage | undefined, qu
     getRsdSettings(),
     getAnnouncement()
   ])
+
+  // Set default values that should not be overwritten if they don't exist in settings.host
+  if (!settings.host.software_highlights_title) {
+    settings.host.software_highlights_title = defaultSettings.host.software_highlights_title
+  }
+
   // compose all settings
   const rsdSettings = {
     ...defaultRsdSettings,

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -32,7 +32,8 @@ export type RsdHost = {
   },
   login_info_url?:string,
   terms_of_service_url?: string,
-  privacy_statement_url?: string
+  privacy_statement_url?: string,
+  software_highlights_title?: string
 }
 
 export type CustomLink = {
@@ -62,14 +63,7 @@ export type RsdSettingsAction = {
 
 export type RsdSettingsDispatch = (action: RsdSettingsAction)=>void
 
-export const defaultRsdSettings: RsdSettingsState = {
-  host: {
-    name: 'rsd',
-    email: 'rsd@esciencecenter.nl'
-  },
-  theme: defaultSettings.theme,
-  links:[]
-}
+export const defaultRsdSettings: RsdSettingsState = defaultSettings
 
 export function rsdSettingsReducer(state: RsdSettingsState, action: RsdSettingsAction) {
   // console.group('rsdSettingsReducer')


### PR DESCRIPTION
# Configurable Software Highlights

Fixes #626 

Changes proposed in this pull request:

* make the "Software Highlights" configurable via `settings.json`
* if `software_highlights_title` is not defined in `data/settings.json`, use the value from `frontend/config/defaultSettings.json`

How to test:

* mount the `deployment/rsd` folder in the frontend via `docker-compose.yml`:
  ```yml
    volumes:
      - ./deployment/rsd:/app/public
  ```
* `docker compose build --parallel && docker compose up`
* change the variable `software_highlights_title` in `deployment/rsd/data/settings.json` to something else and verify it is shown on the software page
* remove `software_highlights_title`from `deployment/rsd/data/settings.json` and verify that the title is now "Software Highlights"

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
