### PR TITLE
Remove PyPI downloads scraper

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MainPackageManager.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MainPackageManager.java
@@ -43,8 +43,8 @@ public class MainPackageManager {
 			};
 			tasks.add(task);
 		}
-		ExecutorService executorService = Executors.newCachedThreadPool();
-		try {
+
+		try (ExecutorService executorService = Executors.newCachedThreadPool()) {
 			List<Future<Void>> completedTasks = executorService.invokeAll(tasks);
 			for (Future<Void> completedTask : completedTasks) {
 				try {
@@ -55,8 +55,6 @@ public class MainPackageManager {
 			}
 		} catch (InterruptedException e) {
 			throw new RuntimeException(e);
-		} finally {
-			executorService.shutdownNow();
 		}
 		System.out.println("Done scraping package manager data");
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
@@ -27,7 +27,7 @@ public class PostgrestConnector {
 	}
 
 	public Collection<BasicPackageManagerData> oldestDownloadCounts(int limit) {
-		String filter = "or=(package_manager.eq.dockerhub,package_manager.eq.pypi)";
+		String filter = "or=(package_manager.eq.dockerhub)";
 		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=id,url,package_manager&order=download_count_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("download_count_scraped_at"));
 		return parseBasicJsonData(data);
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PypiScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PypiScraper.java
@@ -7,14 +7,7 @@ package nl.esciencecenter.rsd.scraper.package_manager;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.time.Duration;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -36,22 +29,7 @@ public class PypiScraper implements PackageManagerScraper {
 
 	@Override
 	public Long downloads() {
-		HttpClient client = HttpClient.newBuilder()
-				.followRedirects(HttpClient.Redirect.NORMAL)
-				.build();
-		HttpRequest request = HttpRequest.newBuilder(URI.create("https://api.pepy.tech/api/v2/projects/" + packageName))
-				.timeout(Duration.ofSeconds(30))
-				.build();
-		try {
-			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
-			if (response.statusCode() == 404) throw new RsdResponseException(response.statusCode(), request.uri(), response.body(), "Not found, is the URL correct?");
-			else if (response.statusCode() != 200) throw new RsdResponseException(response.statusCode(), request.uri(), response.body(), "Unexpected response");
-
-			JsonElement tree = JsonParser.parseString(response.body());
-			return tree.getAsJsonObject().getAsJsonPrimitive("total_downloads").getAsLong();
-		} catch (IOException | InterruptedException e) {
-			throw new RuntimeException(e);
-		}
+		throw new UnsupportedOperationException();
 	}
 
 	@Override


### PR DESCRIPTION
# Remove PyPI downloads scraper

Changes proposed in this pull request:

* Remove PyPI downloads scraper that uses https://api.pepy.tech/, since that API now requires a paid API key.

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Login as admin and create a software page. Add https://pypi.org/project/cffconvert/ as a package manager
* Run the package manager scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.package_manager.MainPackageManager`
* This should create no errors in the console and in the error logs and the reverse dependency count should have been scraped

Note that this will not delete already scraped download counts.

We can look later into replacing this with a different scraper.

Related to #1037

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
