### PR TITLE
Rename pending project status to upcoming

### DIFF
--- a/database/105-project-views.sql
+++ b/database/105-project-views.sql
@@ -161,7 +161,7 @@ SELECT
 	project.id,
 	CASE
 		WHEN project.date_end < now() THEN 'finished'::VARCHAR
-		WHEN project.date_start > now() THEN 'pending'::VARCHAR
+		WHEN project.date_start > now() THEN 'upcoming'::VARCHAR
 		WHEN project.date_start < now() AND project.date_end > now() THEN 'in_progress'::VARCHAR
 		ELSE 'unknown'::VARCHAR
 	END AS status

--- a/frontend/components/projects/ProjectStatus.test.tsx
+++ b/frontend/components/projects/ProjectStatus.test.tsx
@@ -16,15 +16,15 @@ const mockProps = {
 
 const now = new Date()
 
-it('renders project with Pending status', () => {
+it('renders project with Upcoming status', () => {
   // dates in future
   mockProps.date_start = new Date(now.getTime() + 1000 * 60 * 60).toISOString()
   mockProps.date_end = new Date(now.getTime() + 10000 * 60 * 60).toISOString()
 
   render(<ProjectStatus {...mockProps} />)
 
-  const status = screen.getByText('Pending')
-  expect(status).toBeInTheDocument()
+  screen.getByText('Upcoming')
+
 })
 
 it('renders project with In progress status', () => {
@@ -35,8 +35,7 @@ it('renders project with In progress status', () => {
 
   render(<ProjectStatus {...mockProps} />)
 
-  const status = screen.getByText('In progress')
-  expect(status).toBeInTheDocument()
+  screen.getByText('In progress')
 })
 
 it('renders project with Finished status', () => {
@@ -47,8 +46,7 @@ it('renders project with Finished status', () => {
 
   render(<ProjectStatus {...mockProps} />)
 
-  const status = screen.getByText('Finished')
-  expect(status).toBeInTheDocument()
+  screen.getByText('Finished')
 })
 
 it('renders project progress to 50%', () => {

--- a/frontend/components/projects/overview/filters/ProjectStatusFilter.tsx
+++ b/frontend/components/projects/overview/filters/ProjectStatusFilter.tsx
@@ -24,7 +24,7 @@ type ProjectStatusFilterProps = {
 export const ProjectStatusLabels: {
   [K in ProjectStatusKey]: string
 } = {
-  'pending': 'Pending',
+  'upcoming': 'Upcoming',
   'in_progress': 'In progress',
   'finished': 'Finished',
   'unknown': 'Unknown'

--- a/frontend/types/Project.ts
+++ b/frontend/types/Project.ts
@@ -41,7 +41,7 @@ export type EditProject = Project & {
   keywords: KeywordForProject[]
 }
 
-export type ProjectStatusKey = 'pending' | 'in_progress' | 'finished' | 'unknown'
+export type ProjectStatusKey = 'upcoming' | 'in_progress' | 'finished' | 'unknown'
 export type ProjectListItem = {
   id: string
   slug: string

--- a/frontend/utils/getProjects.ts
+++ b/frontend/utils/getProjects.ts
@@ -150,7 +150,7 @@ export function getProjectStatus({date_start, date_end}:
 
     let statusKey: ProjectStatusKey = 'unknown'
 
-    if (today < start_date) statusKey = 'pending'
+    if (today < start_date) statusKey = 'upcoming'
     if (today > end_date) statusKey = 'finished'
     if (today > start_date && today < end_date) statusKey = 'in_progress'
 


### PR DESCRIPTION
# Rename pending project status to upcoming

Closes #1040

Changes proposed in this pull request:
*   Changed pending project status to upcoming

How to test:
* `make start` to rebuild and generate test data
* navigate to project overview and confirm the project status filter has Upcoming option
* navigate to organisation and select projects tab. confirm the status filter has Upcoming option
* select filter and confirm it works

## Example project status filter options
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/1d574d0b-5b70-4af3-b703-4567b943a7c8)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
