### PR TITLE
1039 author size

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,11 @@
 # example env file
 # copy to .env and /frontend/.env.local
 
+################ WARNING ################
+# Using special characters in the values (e.g. in passwords or secrets) might corrupt some processes.
+# If you experience any problems, remove the special characters from the values or place them in quotes (' or ").
+################ WARNING ################
+
 # .env.local is consumed by frontent (Next)
 # see https://nextjs.org/docs/basic-features/environment-variables
 

--- a/database/009-create-mention-table.sql
+++ b/database/009-create-mention-table.sql
@@ -33,7 +33,7 @@ CREATE TABLE mention (
 	doi_registration_date TIMESTAMPTZ,
 	url VARCHAR(500) CHECK (url ~ '^https?://'),
 	title VARCHAR(500) NOT NULL,
-	authors VARCHAR(15000),
+	authors VARCHAR(50000),
 	publisher VARCHAR(255),
 	publication_year SMALLINT,
 	journal VARCHAR(500),

--- a/database/118-backend-logs-views.sql
+++ b/database/118-backend-logs-views.sql
@@ -16,16 +16,20 @@ $$
 SELECT CASE
 	WHEN table_name = 'repository_url' THEN (
 		SELECT
-			CONCAT('/software/',slug,'/edit/information') as slug
+			CONCAT('/software/', slug, '/edit/information') as slug
 		FROM
 			software WHERE id = reference_id
 	)
 	WHEN table_name = 'package_manager' THEN (
 		SELECT
-			CONCAT('/software/',slug,'/edit/package-managers') as slug
+			CONCAT('/software/', slug, '/edit/package-managers') as slug
 		FROM
 			software
 		WHERE id = (SELECT software FROM package_manager WHERE id = reference_id))
+	WHEN table_name = 'mention' AND reference_id IS NOT NULL THEN (
+		SELECT
+			CONCAT('/api/v1/mention?id=eq.', reference_id) as slug
+	)
 	END
 $$;
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
@@ -235,12 +235,14 @@ public class Utils {
 		postAsAdmin(Config.backendBaseUrl() + "/backend_log", logData.toString());
 	}
 
-	public static void saveErrorMessageInDatabase(String message, String tableName, String columnName, String primaryKey, String primaryKeyName, ZonedDateTime scrapedAt, String scapedAtName) {
+	public static void saveErrorMessageInDatabase(String message, String tableName, String columnName, String primaryKey, String primaryKeyName, ZonedDateTime scrapedAt, String scrapedAtName) {
 		JsonObject body = new JsonObject();
-		body.addProperty(columnName, message);
+		if (columnName != null) {
+			body.addProperty(columnName, message);
+		}
 
-		if (scrapedAt != null && scapedAtName != null) {
-			body.addProperty(scapedAtName, scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		if (scrapedAt != null && scrapedAtName != null) {
+			body.addProperty(scrapedAtName, scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
 		}
 
 		String uri = createPatchUri(Config.backendBaseUrl(), tableName, primaryKey, primaryKeyName);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
@@ -99,7 +99,7 @@ public class CrossrefMention implements Mention {
 		} catch (RuntimeException e) {
 			//			year not found, we leave it at null, nothing to do
 		}
-		if (workJson.getAsJsonArray("container-title").size() > 0) {
+		if (!workJson.getAsJsonArray("container-title").isEmpty()) {
 			JsonArray journalTitles = workJson.getAsJsonArray("container-title");
 			result.journal = journalTitles.get(0).getAsString();
 			for (int i = 1; i < journalTitles.size(); i++) {

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -202,7 +202,9 @@ public class DataciteMentionRepository implements MentionRepository {
 
 	@Override
 	public Collection<MentionRecord> mentionData(Collection<String> dois) {
-		if (dois.isEmpty()) return Collections.EMPTY_LIST;
+		if (dois.isEmpty()) {
+			return Collections.emptyList();
+		}
 
 		JsonObject body = new JsonObject();
 		body.addProperty("query", QUERY_UNFORMATTED.formatted(joinCollection(dois)));


### PR DESCRIPTION
# Mention improvements

Changes proposed in this pull request:

* The max size of the `authors` column in the `mention` table has been increased from `15000` to `50000`, in order to facilitate e.g. [10.1038/s41586-022-04893-w](https://doi.org/10.1038/s41586-022-04893-w).
* The mention scraper now saves error messages in the database and will try to update the `scraped_at` field for failed mentions.
* Add a warning to `.env.example` about special characters.

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Login as admin and create a software page. Add `10.1038/s41586-022-04893-w` as a mention and add a few others.
* Run the mention scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions`
* This should create no errors in the console and in the error logs.
* To create errors, we will decrease the size of `authors` again: `UPDATE mention SET authors = NULL; ALTER TABLE mention ALTER COLUMN authors SET DATA TYPE VARCHAR(15000);`
* Run the mention scraper again.
* You should see an error in the error logs, but when you visit http://localhost/api/v1/mention?select=doi,scraped_at,authors all the `scraped_at` fields should have been updated. The authors for all mentions except the faulty one should not be `null`.
* The error in the logs should contain a link to the mention in the API.

Close #1039

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
