### PR TITLE
More cran urls

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/CranScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/CranScraper.java
@@ -14,18 +14,28 @@ import java.util.regex.Pattern;
 
 public class CranScraper implements PackageManagerScraper {
 
-	private final String packageName;
-	private static final Pattern urlPattern = Pattern.compile("https://cran\\.r-project\\.org/web/packages/([^/]+)(/index\\.html/?)?");
+	final String packageName;
+	private static final Pattern urlPattern1 = Pattern.compile("https://cran\\.r-project\\.org/web/packages/([^/\\s]+)/?(index\\.html/?)?", Pattern.CASE_INSENSITIVE);
+	private static final Pattern urlPattern2 = Pattern.compile("https://cran\\.r-project\\.org/package=([^/\\s]+)/?", Pattern.CASE_INSENSITIVE);
 
 	public CranScraper(String url) {
 		Objects.requireNonNull(url);
-		Matcher urlMatcher = urlPattern.matcher(url);
-		if (!urlMatcher.matches()) {
-			throw new RuntimeException("Invalid CRAN URL: " + url);
+
+		Matcher urlMatcher1 = urlPattern1.matcher(url);
+		if (urlMatcher1.matches()) {
+			packageName = urlMatcher1.group(1);
+			return;
 		}
 
-		packageName = urlMatcher.group(1);
+		Matcher urlMatcher2 = urlPattern2.matcher(url);
+		if (urlMatcher2.matches()) {
+			packageName = urlMatcher2.group(1);
+			return;
+		}
+
+		throw new RuntimeException("Invalid CRAN URL: " + url);
 	}
+
 	@Override
 	public Long downloads() {
 		throw new UnsupportedOperationException();

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/CranScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/CranScraperTest.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper.package_manager;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class CranScraperTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"https://CRAN.R-project.org/package=TIMP,TIMP",
+			"https://CRAN.R-project.org/package=TIMP/,TIMP",
+			"https://cran.r-project.org/package=splithalfr,splithalfr",
+			"https://cran.r-project.org/web/packages/GGIR,GGIR",
+			"https://cran.r-project.org/web/packages/GGIR/,GGIR",
+			"https://cran.r-project.org/web/packages/GGIR/index.html,GGIR",
+			"https://cran.r-project.org/web/packages/GGIR/index.html/,GGIR"
+	})
+	void givenValidCranUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNamesCorrect(String url, String expectedPackageName) {
+		CranScraper cranScraper = Assertions.assertDoesNotThrow(() -> new CranScraper(url));
+		Assertions.assertEquals(expectedPackageName, cranScraper.packageName);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"https://cran.r-project.org/web/packages/",
+			"https://cran.r-project.org/web/packages/GG IR",
+			"https://cran.r-project.org/web/packages/GGIR ",
+			"https://cran.r-project.org/web/packages/GGIR /",
+			"https://CRAN.R-project.org/package=",
+			"https://CRAN.R-project.org/package=TIMP ",
+			"https://CRAN.R-project.org/package=TI MP ",
+			"https://CRAN.R-project.org/package=TIMP /",
+			"https://www.example.com",
+			""
+	})
+	void givenInvalidCranUrl_whenCallingConstructor_thenExceptionThrown(String url) {
+		Assertions.assertThrowsExactly(RuntimeException.class, () -> new CranScraper(url));
+	}
+
+	@ParameterizedTest
+	@NullSource
+	void givenNullUrl_whenCallingConstructor_thenExceptionThrown(String url) {
+		Assertions.assertThrowsExactly(NullPointerException.class, () -> new CranScraper(url));
+	}
+}


### PR DESCRIPTION
# Allow more CRAN URLs

Changes proposed in this pull request:

* The CRAN scraper now also allows for URLs in the form of `https://cran.r-project.org/package=packageName`
* The CRAN scraper now treats the URL as case insensitive, so `https://CRAN.R-project.org/package=packageName` will also work


How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Login as admin, create a software page, make it public and add the following package managers: `https://CRAN.R-project.org/package=TIMP` and `https://cran.r-project.org/package=splithalfr`
* Run the package manager scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.package_manager.MainPackageManager`
* Check that there are no errors in the logs
* Check on http://localhost/api/v1/package_manager that reverse dependency data was indeed scraped and stored

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
