### PR TITLE
fix: better data generation to create profiles

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -217,7 +217,7 @@ services:
   #----------------------------------------------
   data-generation:
     build: ./data-generation
-    image: rsd/generation:1.3.1
+    image: rsd/generation:1.3.2
     environment:
       # it needs to be here to use values from .env file
       - PGRST_JWT_SECRET


### PR DESCRIPTION
## Better data generation for profiles

Changes proposed in this pull request:

* Within a single run, use a fixed pool of randomly generated ORCIDs to use for contributors and team members.
* Generate fake login credentials for those ORCIDs.
* With 80% chance, accounts will agree to display their public profiles.

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Check various software and project pages and visit various profiles.


PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
