### PR TITLE
fix: mixed contributors list when switching between software items using global search

### DIFF
--- a/frontend/components/software/useContributorList.tsx
+++ b/frontend/components/software/useContributorList.tsx
@@ -3,36 +3,31 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useEffect, useState} from 'react'
 import {Profile} from '~/types/Contributor'
 
 type UseContributorListProps={
   items: Profile[]
-  limit: number
+  limit: number,
 }
 
 export default function useContributorList({items,limit=12}:UseContributorListProps){
-  const [persons, setPersons] = useState<Profile[]>([])
+  let persons:Profile[] = []
 
-  useEffect(()=>{
-    let abort = false
+  if (limit >= items.length && persons.length < items.length){
+    persons = [
+      ...items
+    ]
+  }
 
-    if (limit >= items.length && persons.length < items.length){
-      // exit if hook is closed
-      if (abort) return
-      // show all items
-      setPersons(items)
-    }
+  if (limit < items.length && persons.length !== limit){
+    persons = items.slice(0,limit)
+  }
 
-    if (limit < items.length && persons.length !== limit){
-      // exit if hook is closed
-      if (abort) return
-      // show only limited list
-      setPersons(items.slice(0,limit))
-    }
-
-    return ()=>{abort=true}
-  },[items,limit,persons])
+  // console.group('useContributorList')
+  // console.log('items...', items)
+  // console.log('persons...', persons)
+  // console.log('limit...', limit)
+  // console.groupEnd()
 
   return {
     persons,


### PR DESCRIPTION
# Fix contributor list

Closes #1063

Changes proposed in this pull request:
*  Fixed the list of contributors when changing the software pages using global search
How to test:
* `make start` to build solution and generate test data
* note the title of two software items, one with a larger number of contributors and one with 1 or 2 contributors.
* visit first the software

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
