### PR TITLE
feat: show package managers on software page

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:2.0.2
+    image: rsd/frontend:2.5.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/software/AboutPackageManagers.tsx
+++ b/frontend/components/software/AboutPackageManagers.tsx
@@ -1,0 +1,50 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {PackageManager, packageManagerSettings} from './edit/package-managers/apiPackageManager'
+import WidgetsIcon from '@mui/icons-material/Widgets'
+
+type AboutPackageManagersProps={
+  packages: PackageManager[]
+}
+
+function PackageManager({item}:{item:PackageManager}){
+  // get package manager info
+  const info = packageManagerSettings[item.package_manager ?? 'other']
+  return (
+    <div
+      title={info.name}
+      className="flex items-center p-1 h-[4rem] w-[4rem] hover:bg-base-200"
+    >
+      <a href={item.url} target="_blank">
+        <img src={info.icon ?? ''} alt={`Logo ${info.name}`} />
+      </a>
+    </div>
+  )
+}
+
+
+export default function AboutPackageManagers({packages}:AboutPackageManagersProps) {
+
+  if (packages?.length > 0){
+    return (
+      <>
+        <div className="pt-8 pb-2">
+          <span className="font-bold text-primary">
+            <WidgetsIcon />
+          </span>
+          <span className="text-primary pl-2">Packages</span>
+        </div>
+        <div className="flex gap-4 flex-wrap">
+          {packages.map(item=><PackageManager key={item.id} item={item} />)}
+        </div>
+      </>
+    )
+  }
+  // do not show section if no package managers
+  return null
+}

--- a/frontend/components/software/AboutSection.tsx
+++ b/frontend/components/software/AboutSection.tsx
@@ -2,19 +2,26 @@
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {License, ProgramingLanguages, CodePlatform, KeywordForSoftware, CategoriesForSoftware} from '../../types/SoftwareTypes'
-import PageContainer from '../layout/PageContainer'
+import {
+  License, ProgramingLanguages,
+  CodePlatform, KeywordForSoftware,
+  CategoriesForSoftware} from '~/types/SoftwareTypes'
+import {CategoriesWithHeadlines} from '~/components/category/CategoriesWithHeadlines'
+import PageContainer from '~/components/layout/PageContainer'
+import {PackageManager} from './edit/package-managers/apiPackageManager'
 import AboutStatement from './AboutStatement'
 import SoftwareKeywords from './SoftwareKeywords'
 import AboutLanguages from './AboutLanguages'
 import AboutLicense from './AboutLicense'
 import AboutSourceCode from './AboutSourceCode'
 import SoftwareLogo from './SoftwareLogo'
-import {CategoriesWithHeadlines} from '../category/CategoriesWithHeadlines'
+import AboutPackageManagers from './AboutPackageManagers'
 
 type AboutSectionType = {
   brand_name: string
@@ -27,14 +34,14 @@ type AboutSectionType = {
   platform: CodePlatform
   languages: ProgramingLanguages
   image_id: string | null
+  packages: PackageManager[]
 }
-
 
 export default function AboutSection(props:AboutSectionType) {
   const {
     brand_name = '', description = '', keywords, categories, licenses,
     repository, languages, platform, description_type = 'markdown',
-    image_id
+    image_id, packages
   } = props
   if (brand_name==='') return null
 
@@ -69,6 +76,7 @@ export default function AboutSection(props:AboutSectionType) {
           repository={repository ?? null}
           platform={platform}
         />
+        <AboutPackageManagers packages={packages} />
       </div>
     </PageContainer>
   )

--- a/frontend/components/software/edit/package-managers/apiPackageManager.ts
+++ b/frontend/components/software/edit/package-managers/apiPackageManager.ts
@@ -78,7 +78,7 @@ export type PackageManager = NewPackageManager & {
   reverse_dependency_count_scraped_at: string | null
 }
 
-export async function getPackageManagers({software, token}: { software: string, token: string }) {
+export async function getPackageManagers({software, token}: { software: string, token?: string }) {
   try {
     const query = `software=eq.${software}&order=position.asc,package_manager.asc`
     const url = `${getBaseUrl()}/package_manager?${query}`

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "2.0.1",
+  "version": "2.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -63,6 +63,7 @@ import NoContent from '~/components/layout/NoContent'
 import {getReferencePapersForSoftware} from '~/components/software/edit/reference-papers/apiReferencePapers'
 import DarkThemeSection from '~/components/layout/DarkThemeSection'
 import MentionsSection from '~/components/mention/MentionsSection'
+import {PackageManager, getPackageManagers} from '~/components/software/edit/package-managers/apiPackageManager'
 
 interface SoftwareIndexData extends ScriptProps{
   slug: string
@@ -80,6 +81,7 @@ interface SoftwareIndexData extends ScriptProps{
   relatedProjects: RelatedProject[]
   isMaintainer: boolean,
   organisations: ParticipatingOrganisationProps[],
+  packages: PackageManager[]
 }
 
 export default function SoftwareIndexPage(props:SoftwareIndexData) {
@@ -90,7 +92,7 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
     licenseInfo, repositoryInfo,
     mentions, testimonials, contributors,
     relatedSoftware, relatedProjects, isMaintainer,
-    slug, organisations, referencePapers
+    slug, organisations, referencePapers, packages
   } = props
 
   useEffect(() => {
@@ -104,7 +106,7 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
   if (!software?.brand_name){
     return <NoContent />
   }
-  // console.log('SoftwareIndexPage...referencePapers...', referencePapers)
+  // console.log('SoftwareIndexPage...packages...', packages)
   return (
     <>
       {/* Page Head meta tags */}
@@ -162,6 +164,7 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
         repository={repositoryInfo?.url}
         platform={repositoryInfo?.code_platform}
         image_id={software.image_id}
+        packages={packages}
       />
       {/* Participating organisations */}
       <OrganisationsSection
@@ -241,7 +244,8 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       relatedProjects,
       isMaintainer,
       organisations,
-      referencePapers
+      referencePapers,
+      packages
     ] = await Promise.all([
       // software versions info
       getReleasesForSoftware(software.id,token),
@@ -269,6 +273,8 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       getParticipatingOrganisations({software:software.id,frontend:false,token}),
       // reference papers
       getReferencePapersForSoftware({software:software.id,token}),
+      // package managers
+      getPackageManagers({software:software.id,token})
     ])
     // pass data to page component as props
     return {
@@ -287,7 +293,8 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
         relatedProjects,
         isMaintainer: isMaintainer ? isMaintainer : userInfo?.role==='rsd_admin',
         organisations,
-        slug
+        slug,
+        packages
       }
     }
   }catch(e:any){


### PR DESCRIPTION
# Show packages on the software page

Closes #1053 

Changes proposed in this pull request:
*  The software packages are shown on the software page.    

How to test:
* `make start` to build app and generate test data
* thanks to last update, if you have `RSD_ENVIRONMENT=dev` in your .env file the first login user will become rsd_admin automatically in dev mode. Then you can edit existing software items, otherwise create new software item
* navigate to package mangers section and add few entries. You can use entries from old issue #791 
* confirm that packages section is shown on the software page and that the link points to proper software item
* note that data generation will also create some random package entries

## Example software packages
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/101756ca-6034-4bd8-90b0-be687ea3f8f6)

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
