### PR TITLE
Easily become admin when developing locally

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,6 +60,11 @@ POSTGREST_URL_EXTERNAL=http://localhost/api/v1
 # .env.local: http://localhost/auth, .env: http://auth:7000
 RSD_AUTH_URL=http://auth:7000
 
+# consumed by services: authentication
+# If set to "dev", the first user to log in will become admin.
+# Any other value doesn't activate this feature (and doesn't do anything).
+RSD_ENVIRONMENT=prod
+
 # consumed by services: authentication, frontend (api/fe)
 # provide a list of supported OpenID auth providers
 # the values should be separated by semicolon (;)

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
@@ -29,6 +29,14 @@ public class Config {
 				.orElse(Collections.emptySet());
 	}
 
+	public static boolean isDevEnv() {
+		try {
+			return "dev".equals(System.getenv("RSD_ENVIRONMENT"));
+		} catch (RuntimeException e) {
+			return false;
+		}
+	}
+
 	public static boolean isLocalEnabled() {
 		return rsdAuthProviders().contains("LOCAL");
 	}

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -58,6 +58,7 @@ services:
       - 7000
     environment:
       # it uses values from .env file
+      - RSD_ENVIRONMENT
       - POSTGREST_URL
       - RSD_AUTH_PROVIDERS
       - RSD_AUTH_USER_MAIL_WHITELIST

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,13 +53,14 @@ services:
 
   auth:
     build: ./authentication
-    image: rsd/auth:1.3.0
+    image: rsd/auth:1.4.0
     ports:
       - 5005:5005
     expose:
       - 7000
     environment:
       # it uses values from .env file
+      - RSD_ENVIRONMENT
       - POSTGREST_URL
       - RSD_AUTH_PROVIDERS
       - RSD_AUTH_USER_MAIL_WHITELIST


### PR DESCRIPTION
## Easily become admin when developing locally

Changes proposed in this pull request:

* Add a new environment variable `RSD_ENVIRONMENT` that when set to the value `dev`, allows the first user that logs in to become an admin. With any other value, this env variable does nothing.

**Note:** This is a feature for local development only and is therefore not safe in production. When two people login at the same time, they might both become admin for example.

How to test:

* Add the new env variable to your `.env` and set its value to `dev`.
* `docker compose down --volumes && docker compose build --parallel && docker compose up`
* Log in in any way you like, you should be an admin. Repeatedly logging in and out with this account should not change this. Repeatedly logging in and out with other accounts should *not* make those admin.
* Run `DELETE FROM admin_account;` in the database to delete all existing admins.
* When you now log in with any account, that account should become admin.
* Delete all admins again, change the value of `RSD_ENVIRONMENT` to anything other than `dev` and restart the RSD (or at least the auth service with `docker compose up auth`)
* Logging in should *not* make you admin.

Closes #1062

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
