### PR TITLE
Status report of background services for software

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -6,7 +6,7 @@
   // Formating with ESLint:
   "eslint.format.enable": true,
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true,
+    "source.fixAll.eslint": "explicit"
   },
   "[javascript][javascriptreact][typescript][typescriptreact]": {
     "editor.tabSize": 2,

--- a/frontend/components/software/edit/editSoftwarePages.tsx
+++ b/frontend/components/software/edit/editSoftwarePages.tsx
@@ -19,14 +19,7 @@ import ContentLoader from '~/components/layout/ContentLoader'
 import HomeRepairServiceIcon from '@mui/icons-material/HomeRepairService'
 import PendingActionsIcon from '@mui/icons-material/PendingActions'
 import PostAddIcon from '@mui/icons-material/PostAdd'
-
-// import SoftwareInformation from './information'
-// import SoftwareContributors from './contributors'
-// import SoftwareOgranisations from './organisations'
-// import SoftwareMentions from './mentions'
-// import SoftwareTestimonials from './testimonials'
-// import RelatedTopics from './related'
-// import SoftwareMaintainers from './maintainers'
+import MiscellaneousServicesIcon from '@mui/icons-material/MiscellaneousServices'
 
 // use dynamic imports instead
 const SoftwareContributors = dynamic(() => import('./contributors'),{
@@ -57,6 +50,9 @@ const RelatedProjects = dynamic(() => import('./related-projects'),{
   loading: ()=><ContentLoader />
 })
 const SoftwareTestimonials = dynamic(() => import('./testimonials'),{
+  loading: ()=><ContentLoader />
+})
+const SoftwareServices = dynamic(() => import('./services'),{
   loading: ()=><ContentLoader />
 })
 
@@ -129,5 +125,11 @@ export const editSoftwarePage:EditSoftwarePageProps[] = [{
   icon: <PersonAddIcon />,
   render: () => <SoftwareMaintainers />,
   status: 'Optional information'
+},{
+  id: 'services',
+  label: 'Background services',
+  icon: <MiscellaneousServicesIcon />,
+  render: () => <SoftwareServices />,
+  status: 'Status reports'
 }
 ]

--- a/frontend/components/software/edit/package-managers/apiPackageManager.ts
+++ b/frontend/components/software/edit/package-managers/apiPackageManager.ts
@@ -16,37 +16,44 @@ export const packageManagerSettings = {
   anaconda: {
     name: 'Anaconda',
     icon: '/images/anaconda-logo-96.svg',
-    hostname: ['anaconda.org']
+    hostname: ['anaconda.org'],
+    services: ['dependents']
   },
   cran: {
     name: 'CRAN',
     icon: '/images/cran-r-logo.svg',
-    hostname: ['cran.r-project.org']
+    hostname: ['cran.r-project.org'],
+    services: ['dependents']
   },
   dockerhub: {
     name: 'Dockerhub',
     icon: '/images/dockerhub-logo.webp',
-    hostname: ['hub.docker.com']
+    hostname: ['hub.docker.com'],
+    services: ['downloads']
   },
   maven: {
     name: 'Maven',
     icon: '/images/apache-maven-logo.svg',
-    hostname: ['mvnrepository.com']
+    hostname: ['mvnrepository.com'],
+    services: ['dependents']
   },
   npm: {
     name: 'NPM',
     icon: '/images/npm-logo-64.png',
-    hostname: ['www.npmjs.com','npmjs.com']
+    hostname: ['www.npmjs.com','npmjs.com'],
+    services: ['dependents']
   },
   pypi: {
     name: 'PyPi',
     icon: '/images/pypi-logo.svg',
-    hostname: ['pypi.org']
+    hostname: ['pypi.org'],
+    services: ['dependents']
   },
   other: {
     name: 'Other',
     icon: null,
-    hostname: ['other']
+    hostname: ['other'],
+    services: ['other']
   }
 }
 

--- a/frontend/components/software/edit/services/PackageManagerServices.tsx
+++ b/frontend/components/software/edit/services/PackageManagerServices.tsx
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import List from '@mui/material/List'
+import {usePackageManagerServices} from './apiSoftwareServices'
+import ContentLoader from '~/components/layout/ContentLoader'
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
+
+import {packageManagerSettings} from '../package-managers/apiPackageManager'
+import {ServiceInfoListItem} from './ServiceInfoListItem'
+
+export default function PackageManagerServices() {
+  const {loading,services} = usePackageManagerServices()
+
+  if (loading) return <ContentLoader />
+
+  if (services?.length > 0){
+    return (
+      <div>
+        {services.map(service=>{
+          // For each PM show status of scrapers
+          const svcInfo = packageManagerSettings[service.package_manager]
+          if (svcInfo && svcInfo?.services.length > 0){
+            return (
+              <List key={service.package_manager}>
+                {svcInfo?.services.includes('downloads') ?
+                  <ServiceInfoListItem
+                    key={`downloads-${service.package_manager}`}
+                    title={`${service.package_manager.toLocaleUpperCase()} downloads`}
+                    scraped_at={service.download_count_scraped_at}
+                    last_error={service.download_count_last_error}
+                    url={service.url}
+                  />
+                  : null
+                }
+                {svcInfo?.services.includes('dependents') ?
+                  <ServiceInfoListItem
+                    key={`dependants-${service.package_manager}`}
+                    title={`${service.package_manager.toLocaleUpperCase()} dependents`}
+                    scraped_at={service.reverse_dependency_count_scraped_at}
+                    last_error={service.reverse_dependency_count_last_error}
+                    url={service.url}
+                  />
+                  : null
+                }
+              </List>
+            )
+          }
+        })}
+      </div>
+    )
+  }
+
+  return (
+    <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
+      <AlertTitle sx={{fontWeight:500}}>Not active</AlertTitle>
+      There is no info about running package manager services. <br/>
+      High likely the package managers are not defined for this software.
+    </Alert>
+  )
+}

--- a/frontend/components/software/edit/services/PackageManagerServices.tsx
+++ b/frontend/components/software/edit/services/PackageManagerServices.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -33,6 +33,7 @@ export default function PackageManagerServices() {
                     scraped_at={service.download_count_scraped_at}
                     last_error={service.download_count_last_error}
                     url={service.url}
+                    platform={null}
                   />
                   : null
                 }
@@ -43,6 +44,7 @@ export default function PackageManagerServices() {
                     scraped_at={service.reverse_dependency_count_scraped_at}
                     last_error={service.reverse_dependency_count_last_error}
                     url={service.url}
+                    platform={null}
                   />
                   : null
                 }
@@ -57,8 +59,7 @@ export default function PackageManagerServices() {
   return (
     <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
       <AlertTitle sx={{fontWeight:500}}>Not active</AlertTitle>
-      There is no info about running package manager services. <br/>
-      High likely the package managers are not defined for this software.
+      No information about package managers is provided for this software
     </Alert>
   )
 }

--- a/frontend/components/software/edit/services/ServiceInfoAlert.tsx
+++ b/frontend/components/software/edit/services/ServiceInfoAlert.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Alert from '@mui/material/Alert'
+import AlertTitle from '@mui/material/AlertTitle'
+import useRsdSettings from '~/config/useRsdSettings'
+
+export default function ServiceInfoAlert() {
+  const {host} = useRsdSettings()
+
+  return (
+    <Alert severity="info"
+      sx={{
+        marginTop: '0.5rem'
+      }}
+    >
+      <AlertTitle sx={{fontWeight:500}}>Background services</AlertTitle>
+      <p>
+        This section shows all background services executed by RSD to collect
+        the additional information about your software.
+      </p>
+      <p className="py-2">
+        For each service you see when the information is extracted for the last time. If there were errors during the extraction process we try to construct a human readable message from received error.
+      </p>
+      <p className="py-2 font-medium">
+        Please contact us at <a href={`mailto:${host.email}`} target="_blank">{host.email}</a> in case you need our assistance in solving any of the errors.
+      </p>
+    </Alert>
+  )
+}

--- a/frontend/components/software/edit/services/ServiceInfoAlert.tsx
+++ b/frontend/components/software/edit/services/ServiceInfoAlert.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,11 +18,15 @@ export default function ServiceInfoAlert() {
     >
       <AlertTitle sx={{fontWeight:500}}>Background services</AlertTitle>
       <p>
-        This section shows all background services executed by RSD to collect
-        the additional information about your software.
+        The RSD collects additional information about your software using the links you
+        have provided. For example, the software repository URL is used to collect
+        information about the commit history and programming languages, and a
+        package manager URL can be used to retrieve download numbers.
       </p>
       <p className="py-2">
-        For each service you see when the information is extracted for the last time. If there were errors during the extraction process we try to construct a human readable message from received error.
+        This section provides feedback if the RSD could succesfully retrieve
+        this information or if it has encountered an error. These may be caused by
+        missing or incorrect URL.
       </p>
       <p className="py-2 font-medium">
         Please contact us at <a href={`mailto:${host.email}`} target="_blank">{host.email}</a> in case you need our assistance in solving any of the errors.

--- a/frontend/components/software/edit/services/ServiceInfoListItem.tsx
+++ b/frontend/components/software/edit/services/ServiceInfoListItem.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,20 +12,23 @@ import ListItemText from '@mui/material/ListItemText'
 import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
 import ScheduleIcon from '@mui/icons-material/Schedule'
 import DoDisturbOnIcon from '@mui/icons-material/DoDisturbOn'
+import {CodePlatform} from '~/types/SoftwareTypes'
 
 type ServiceInfoListItemProps={
   title:string
   scraped_at: string|null
   last_error: string|null
   url: string|null
+  platform: CodePlatform|null
 }
 
-export function ServiceInfoListItem({title,scraped_at,last_error,url}:ServiceInfoListItemProps){
-  let status:'error'|'success'|'not_active'|'scheduled' = 'not_active'
+export function ServiceInfoListItem({title,scraped_at,last_error,url,platform}:ServiceInfoListItemProps){
+  let status:'error'|'success'|'not_active'|'scheduled'|'not_supported' = 'not_active'
 
   // set service status
   if (scraped_at) status='success'
   if (url && !scraped_at) status='scheduled'
+  if (url && (platform==='bitbucket' || platform==='other')) status='not_supported'
   if (last_error) status='error'
 
   // define icon color
@@ -52,10 +55,15 @@ export function ServiceInfoListItem({title,scraped_at,last_error,url}:ServiceInf
         <span className="text-success">{`Last run at ${lastRun.toLocaleString()}`}</span>
       )
     }
+    // we have url
     if (url){
-      // we have url
+      if (status==='not_supported'){
+        return (
+          <span>Platform not supported (yet).</span>
+        )
+      }
       return (
-        <span>Scheduled but not yet executed. Check the status again after 30 minutes.</span>
+        <span>Scheduled, check again after 30 minutes.</span>
       )
     }
     // no URL

--- a/frontend/components/software/edit/services/ServiceInfoListItem.tsx
+++ b/frontend/components/software/edit/services/ServiceInfoListItem.tsx
@@ -1,0 +1,91 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Avatar from '@mui/material/Avatar'
+import ListItem from '@mui/material/ListItem'
+import ListItemAvatar from '@mui/material/ListItemAvatar'
+import ErrorIcon from '@mui/icons-material/Error'
+import CheckCircleIcon from '@mui/icons-material/CheckCircle'
+import ListItemText from '@mui/material/ListItemText'
+import HelpOutlineIcon from '@mui/icons-material/HelpOutline'
+import ScheduleIcon from '@mui/icons-material/Schedule'
+import DoDisturbOnIcon from '@mui/icons-material/DoDisturbOn'
+
+type ServiceInfoListItemProps={
+  title:string
+  scraped_at: string|null
+  last_error: string|null
+  url: string|null
+}
+
+export function ServiceInfoListItem({title,scraped_at,last_error,url}:ServiceInfoListItemProps){
+  let status:'error'|'success'|'not_active'|'scheduled' = 'not_active'
+
+  // set service status
+  if (scraped_at) status='success'
+  if (url && !scraped_at) status='scheduled'
+  if (last_error) status='error'
+
+  // define icon color
+  let color:string=''
+  if (status==='error') color='error.main'
+  if (status==='success') color='success.main'
+  if (status==='not_active') color='warning.main'
+
+  function getStatusIcon(){
+    if (status === 'error') return <ErrorIcon sx={{width:'2.5rem',height:'2.5rem'}} />
+    if (status === 'success') return <CheckCircleIcon sx={{width:'2.5rem',height:'2.5rem'}} />
+    if (status === 'scheduled') return <ScheduleIcon sx={{width:'2.5rem',height:'2.5rem'}} />
+    if (status === 'not_active') return <DoDisturbOnIcon sx={{width:'2.5rem',height:'2.5rem'}} />
+    return <HelpOutlineIcon sx={{width:'2.5rem',height:'2.5rem'}} />
+  }
+
+  function getStatusMsg(){
+    if (last_error) return (
+      <span className="text-error">{last_error}</span>
+    )
+    if (scraped_at) {
+      const lastRun = new Date(scraped_at)
+      return (
+        <span className="text-success">{`Last run at ${lastRun.toLocaleString()}`}</span>
+      )
+    }
+    if (url){
+      // we have url
+      return (
+        <span>Scheduled but not yet executed. Check the status again after 30 minutes.</span>
+      )
+    }
+    // no URL
+    return (
+      <span className="text-warning">Not active. Provide repository URL to activate the service.</span>
+    )
+  }
+
+  return (
+    <ListItem
+      data-testid="software-service-item"
+    >
+      <ListItemAvatar>
+        <Avatar
+          alt={status}
+          sx={{
+            width: '2.5rem',
+            height: '2.5rem',
+            marginRight: '1rem',
+            backgroundColor: color ? color : null
+          }}
+        >
+          {getStatusIcon()}
+        </Avatar>
+      </ListItemAvatar>
+
+      <ListItemText
+        primary={title}
+        secondary={getStatusMsg()}
+      />
+    </ListItem>
+  )
+}

--- a/frontend/components/software/edit/services/SoftwareRepoServices.tsx
+++ b/frontend/components/software/edit/services/SoftwareRepoServices.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +24,8 @@ export default function SoftwareRepoServices() {
           desc: service.desc,
           scraped_at: services ? services[service.props.scraped_at] : null,
           last_error: services ? services[service.props.last_error] : null,
-          url: services ? services[service.props.url] : null
+          url: services ? services[service.props.url] : null,
+          platform: services ? services['code_platform'] : null
         }
         return (
           <ServiceInfoListItem key={service.name} {...props} />

--- a/frontend/components/software/edit/services/SoftwareRepoServices.tsx
+++ b/frontend/components/software/edit/services/SoftwareRepoServices.tsx
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import List from '@mui/material/List'
+import {useSoftwareServices} from './apiSoftwareServices'
+import ContentLoader from '~/components/layout/ContentLoader'
+
+import {repoServiceList} from './config'
+import {ServiceInfoListItem} from './ServiceInfoListItem'
+
+
+export default function SoftwareRepoServices() {
+  const {loading,services} = useSoftwareServices()
+
+  if (loading) return <ContentLoader />
+
+  return (
+    <List>
+      {repoServiceList.map(service=>{
+        const props = {
+          title: service.name,
+          desc: service.desc,
+          scraped_at: services ? services[service.props.scraped_at] : null,
+          last_error: services ? services[service.props.last_error] : null,
+          url: services ? services[service.props.url] : null
+        }
+        return (
+          <ServiceInfoListItem key={service.name} {...props} />
+        )
+      })}
+    </List>
+  )
+
+}

--- a/frontend/components/software/edit/services/apiSoftwareServices.tsx
+++ b/frontend/components/software/edit/services/apiSoftwareServices.tsx
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {useSession} from '~/auth'
+import logger from '~/utils/logger'
+import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import {CodePlatform} from '~/types/SoftwareTypes'
+import {PackageManagerTypes} from '../package-managers/apiPackageManager'
+import useSoftwareContext from '../useSoftwareContext'
+
+export type SoftwareServices = {
+  software:string,
+	url:string,
+  code_platform: CodePlatform,
+	basic_data_scraped_at: string|null,
+	basic_data_last_error: string|null,
+	languages_scraped_at: string|null,
+	languages_last_error: string|null,
+	commit_history_scraped_at: string|null,
+	commit_history_last_error: string|null
+}
+
+export type PackageManagerService = {
+  software:string
+  url: string,
+  package_manager: PackageManagerTypes,
+	download_count_scraped_at: string|null,
+	download_count_last_error: string|null,
+	reverse_dependency_count_scraped_at: string|null,
+	reverse_dependency_count_last_error: string|null
+}
+
+async function getSoftwareServices(id:string,token:string){
+  try{
+    const select='select=software,url,code_platform,basic_data_scraped_at,basic_data_last_error,languages_scraped_at,languages_last_error,commit_history_scraped_at,commit_history_last_error'
+    const query = `${select}&software=eq.${id}`
+    const url = `${getBaseUrl()}/repository_url?${query}`
+
+    // make request
+    const resp = await fetch(url,{
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+      },
+    })
+
+    if (resp.status === 200) {
+      const json:SoftwareServices[] = await resp.json()
+      return json[0]
+    }
+    logger(`getSoftwareServices...${resp.status} ${resp.statusText}`,'warn')
+  }catch(e:any){
+    logger(`getSoftwareServices failed. ${e.message}`,'error')
+  }
+}
+
+async function getPackageManagerServices(id:string,token:string){
+  try{
+    const select='select=software,url,package_manager,download_count_scraped_at,download_count_last_error,reverse_dependency_count_scraped_at,reverse_dependency_count_last_error'
+    const query = `${select}&software=eq.${id}&order=position`
+    const url = `${getBaseUrl()}/package_manager?${query}`
+
+    // make request
+    const resp = await fetch(url,{
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+      },
+    })
+
+    if (resp.status === 200) {
+      const json:PackageManagerService[] = await resp.json()
+      return json
+    }
+    logger(`getPackageManagerServices...${resp.status} ${resp.statusText}`,'warn')
+    return []
+  }catch(e:any){
+    logger(`getPackageManagerServices failed. ${e.message}`,'error')
+    return []
+  }
+}
+
+export function usePackageManagerServices(){
+  const {token} = useSession()
+  const {software} = useSoftwareContext()
+  const [services,setServices] = useState<PackageManagerService[]>([])
+  const [loading, setLoading] = useState(true)
+
+
+  useEffect(()=>{
+    let abort=false
+
+    if (token && software.id){
+      setLoading(true)
+
+      getPackageManagerServices(software.id,token)
+        .then(items=>{
+          if (abort===false) setServices(items)
+        })
+        .catch(e=>{
+          logger(`usePackageManagerServices failed. ${e.message}`,'error')
+          if (abort===false) setServices([])
+        })
+        .finally(()=>{
+          if (abort===false) setLoading(false)
+        })
+    }
+
+    return ()=>{abort=true}
+  },[token,software.id])
+
+
+  return {
+    loading,
+    services
+  }
+}
+
+
+export function useSoftwareServices(){
+  const {token} = useSession()
+  const {software} = useSoftwareContext()
+  const [services,setServices] = useState<SoftwareServices>()
+  const [loading, setLoading] = useState(true)
+
+
+  useEffect(()=>{
+    let abort=false
+
+    if (token && software.id){
+      setLoading(true)
+
+      getSoftwareServices(software.id,token)
+        .then(item=>{
+          if (abort===false) setServices(item)
+        })
+        .catch(e=>{
+          logger(`useSoftwareServices failed. ${e.message}`,'error')
+          if (abort===false) setServices(undefined)
+        })
+        .finally(()=>{
+          if (abort===false) setLoading(false)
+        })
+    }
+
+    return ()=>{abort=true}
+  },[token,software.id])
+
+
+  return {
+    loading,
+    services
+  }
+}

--- a/frontend/components/software/edit/services/config.ts
+++ b/frontend/components/software/edit/services/config.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +16,7 @@ type ServiceListProps={
 }
 
 export const repoServiceList:ServiceListProps[]=[{
-  name: 'Commit hisitory',
+  name: 'Commit history',
   desc: 'Information is extracted from the repository api (github/gitlab)',
   props:{scraped_at:'commit_history_scraped_at',last_error:'commit_history_last_error',url:'url'}
 },{
@@ -24,7 +24,19 @@ export const repoServiceList:ServiceListProps[]=[{
   desc: 'Information is extracted from the repository api (github/gitlab)',
   props:{scraped_at:'languages_scraped_at',last_error:'languages_last_error',url:'url'}
 },{
-  name: 'Repository stats',
+  name: 'Repository statistics',
   desc: 'Information is extracted from the repository api (github/gitlab)',
   props:{scraped_at:'basic_data_scraped_at',last_error:'basic_data_last_error',url:'url'}
 }]
+
+
+export const config = {
+  repository:{
+    title: 'Software repository',
+    subtitle: 'Additional information extracted using the source code repository URL'
+  },
+  package_managers:{
+    title: 'Package managers',
+    subtitle: 'Additional information extracted using package manager URL'
+  }
+}

--- a/frontend/components/software/edit/services/config.ts
+++ b/frontend/components/software/edit/services/config.ts
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoftwareServices} from './apiSoftwareServices'
+
+type ServiceListProps={
+  name: string,
+  desc: string,
+  props:{
+    scraped_at: keyof SoftwareServices,
+    last_error: keyof SoftwareServices,
+    url: keyof SoftwareServices
+  }
+}
+
+export const repoServiceList:ServiceListProps[]=[{
+  name: 'Commit hisitory',
+  desc: 'Information is extracted from the repository api (github/gitlab)',
+  props:{scraped_at:'commit_history_scraped_at',last_error:'commit_history_last_error',url:'url'}
+},{
+  name: 'Programming languages',
+  desc: 'Information is extracted from the repository api (github/gitlab)',
+  props:{scraped_at:'languages_scraped_at',last_error:'languages_last_error',url:'url'}
+},{
+  name: 'Repository stats',
+  desc: 'Information is extracted from the repository api (github/gitlab)',
+  props:{scraped_at:'basic_data_scraped_at',last_error:'basic_data_last_error',url:'url'}
+}]

--- a/frontend/components/software/edit/services/index.tsx
+++ b/frontend/components/software/edit/services/index.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import EditSection from '~/components/layout/EditSection'
+import ServiceInfoAlert from './ServiceInfoAlert'
+import SoftwareRepoServices from './SoftwareRepoServices'
+import EditSectionTitle from '~/components/layout/EditSectionTitle'
+import PackageManagerServices from './PackageManagerServices'
+
+export default function SoftwareServices() {
+
+  return (
+    <EditSection className="xl:grid xl:grid-cols-[3fr,2fr] xl:px-0 xl:gap-[3rem]">
+      <div className="pt-4 pb-8">
+        <EditSectionTitle
+          title="Software repository"
+          subtitle="Information is extracted from the repository using public api"
+        />
+        <SoftwareRepoServices />
+        <div className="py-2"></div>
+        <EditSectionTitle
+          title="Package managers"
+          subtitle="Information is extracted from package manager definitions using public api"
+        />
+        <PackageManagerServices />
+      </div>
+      <div className="pt-4 pb-8">
+        <ServiceInfoAlert />
+      </div>
+    </EditSection>
+  )
+}

--- a/frontend/components/software/edit/services/index.tsx
+++ b/frontend/components/software/edit/services/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,6 +8,7 @@ import ServiceInfoAlert from './ServiceInfoAlert'
 import SoftwareRepoServices from './SoftwareRepoServices'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import PackageManagerServices from './PackageManagerServices'
+import {config} from './config'
 
 export default function SoftwareServices() {
 
@@ -15,14 +16,14 @@ export default function SoftwareServices() {
     <EditSection className="xl:grid xl:grid-cols-[3fr,2fr] xl:px-0 xl:gap-[3rem]">
       <div className="pt-4 pb-8">
         <EditSectionTitle
-          title="Software repository"
-          subtitle="Information is extracted from the repository using public api"
+          title={config.repository.title}
+          subtitle={config.repository.subtitle}
         />
         <SoftwareRepoServices />
         <div className="py-2"></div>
         <EditSectionTitle
-          title="Package managers"
-          subtitle="Information is extracted from package manager definitions using public api"
+          title={config.package_managers.title}
+          subtitle={config.package_managers.subtitle}
         />
         <PackageManagerServices />
       </div>

--- a/frontend/pages/software/[slug]/edit/[page].tsx
+++ b/frontend/pages/software/[slug]/edit/[page].tsx
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -55,7 +57,7 @@ export default function SoftwareEditPages({pageIndex,software}:SoftwareEditPageP
         <UserAgrementModal />
         <EditSoftwareProvider state={state}>
           <EditSoftwareStickyHeader />
-          <section className="md:flex gap-[3rem]">
+          <section className="md:flex gap-[3rem] mb-8">
             <EditSoftwareNav slug={software.slug} pageId={page.id} />
             {/* Here we load main component of each step */}
             {renderPageComponent()}


### PR DESCRIPTION
# Status report of background services

**To test background services you will need to have properly defined service items in the .env file. Some might require secret to enable service to scrape information using "less restricted" quota.**

Changes proposed in this pull request:
* The software maintainer can view status of the background services running for the software item
* The statuses reported are: 
    *  `scheduled`: if the url is provided and last_error or last_run value is not present
    * `not_active`: if the repository url or package manager url value is not present
    * `error`: if the last_error value is present
    * `success`: if the last_run value is present and the last_error value is NOT present. We show date/time of the last successful run
* Short description about the background services is added in the right panel of the page

How to test:
* `make start` to build app and generate test data
* login as user, if you use dev environment variable first user will become admin.
* navigate to first software item in the overview and go to edit software page.
* initially you should see background report with scheduled status for all items as in the image 1
* start the scrapers services by restarting app: `docker compose down && docker compose up`
* navigate to second software item. Remove repository URL and all package managers. The background service reports should like ones in the image 2
* login as rsd_amin (if not already), navigate to error logs page of administration section. From there use link to open the software page with an service error. Confirm that error is shown in the background services too (image 3)
* from the software overview page select the item that has programming languages in the card. Navigate to edit section and confirm that, at least, programming languages service was runned successfully (image 4)
* read the background services info on the right side of the page. If not clear please provide suggested changes to the explanation

## Background services (scheduled - initial state)
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/f675697b-ec6b-41ac-a475-f572f86140ea)

## Background services (not active state)
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/7fb5dfd9-29db-4e1e-b071-53e3203aca6a)

## Background services (error state)
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/ae55724f-3421-458a-aebb-6b4ccc26f0f2)

## Background services (multiple package managers)
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/3a2a182b-af35-4ee7-b562-88957b8cbcf8)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
