### PR TITLE
fix: disable Loom to fix unresponsive auth container

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
@@ -14,6 +14,7 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
+import io.javalin.util.ConcurrencyUtil;
 
 import java.util.Base64;
 import java.util.UUID;
@@ -85,6 +86,7 @@ public class Main {
 	}
 
 	public static void main(String[] args) {
+		ConcurrencyUtil.INSTANCE.setUseLoom(false);
 		Javalin app = Javalin.create().start(7000);
 		app.get("/", ctx -> ctx.json("{\"Module\": \"rsd/auth\", \"Status\": \"live\"}"));
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2021 - 2023 dv4all
+# SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
@@ -53,7 +53,7 @@ services:
 
   auth:
     build: ./authentication
-    image: rsd/auth:1.4.0
+    image: rsd/auth:1.4.1
     ports:
       - 5005:5005
     expose:


### PR DESCRIPTION
## Fix unresponsive auth container by disabling Loom

After finding [this issue](https://github.com/javalin/javalin/issues/2011) on the Javalin project's GitHub page and after some discussion on [this pull request](https://github.com/javalin/javalin/pull/2073), it seems that [project Loom](https://www.baeldung.com/openjdk-project-loom), which is enabled in Java 21, is the cause of the bug in #1073. Hopefully, this change fixes it.

@cmeessen or @fembau, can one of you test this?

Changes proposed in this pull request:

* Disable project Loom in the auth container

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Logging in should still work, also after a minute of no connections made to the auth container.

Closes #1072

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
