### PR TITLE
1078 clear package manager scraper errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -109,7 +109,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:2.5.1
+    image: rsd/frontend:2.5.2
     environment:
       # it uses values from .env file
       - POSTGREST_URL
@@ -155,7 +155,7 @@ services:
 
   scrapers:
     build: ./scrapers
-    image: rsd/scrapers:1.5.1
+    image: rsd/scrapers:1.5.2
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/admin/logs/apiLogs.ts
+++ b/frontend/components/admin/logs/apiLogs.ts
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +17,7 @@ export async function getLogs({page, rows, token, searchFor, orderBy}: ApiParams
   try {
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
-      query+=`&or=(service_name.ilike.*${searchFor}*,table_name.ilike.*${searchFor}*,message.ilike.*${searchFor}*,stack_trace.ilike.*${searchFor}*)`
+      query+=`&or=(service_name.ilike.*${searchFor}*,table_name.ilike.*${searchFor}*,message.ilike.*${searchFor}*,stack_trace.ilike.*${searchFor}*,slug.ilike.*${searchFor}*)`
     }
     if (orderBy) {
       query+=`&order=${orderBy.column}.${orderBy.direction}`

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,7 +28,9 @@ public class PostgrestConnector {
 
 	public Collection<BasicPackageManagerData> oldestDownloadCounts(int limit) {
 		String filter = "or=(package_manager.eq.dockerhub)";
-		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=id,url,package_manager&order=download_count_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("download_count_scraped_at"));
+		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=id,url,package_manager&order=download_count_scraped_at.asc.nullsfirst&limit=" + limit
+				+ "&" + Utils.atLeastOneHourAgoFilter("download_count_scraped_at")
+		);
 		return parseBasicJsonData(data);
 	}
 
@@ -39,12 +41,12 @@ public class PostgrestConnector {
 	}
 
 	public void saveDownloadCount(UUID id, Long count, ZonedDateTime scrapedAt) {
-		String json = "{\"download_count\": %s, \"download_count_scraped_at\": \"%s\"}".formatted(count, scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		String json = "{\"download_count\": %s, \"download_count_scraped_at\": \"%s\", \"download_count_last_error\": null}".formatted(count, scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
 		Utils.patchAsAdmin(backendUrl + "?id=eq." + id, json);
 	}
 
 	public void saveReverseDependencyCount(UUID id, Integer count, ZonedDateTime scrapedAt) {
-		String json = "{\"reverse_dependency_count\": %s, \"reverse_dependency_count_scraped_at\": \"%s\"}".formatted(count, scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		String json = "{\"reverse_dependency_count\": %s, \"reverse_dependency_count_scraped_at\": \"%s\", \"reverse_dependency_count_last_error\": null}".formatted(count, scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
 		Utils.patchAsAdmin(backendUrl + "?id=eq." + id, json);
 	}
 


### PR DESCRIPTION
## Clear package manager scraper errors on success

Changes proposed in this pull request:

* When scraping a package manager is succesful, clear the old error message
* When searching error logs, also search in the slug

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Create a software page with a package manager pointing to e.g. https://pypi.org/project/ESMValTool/
* Run the package manager scraper (`docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.package_manager.MainPackageManager`), this should work without errors in the logs or in the "Background services" tab
* Manually set an error: `UPDATE package_manager SET reverse_dependency_count_last_error = 'Test error';`
* Check for the error on the "Background services" tab
* Clear the `scraped_at` field so you don't have to wait an hour before scraping again: `UPDATE package_manager SET reverse_dependency_count_scraped_at = NULL;`
* Run the scraper again, the error should disappear from the tab.
* Create another package manager scraper with a non-existing link, like https://pypi.org/project/idonotexist/
* Run the scraper again, there should be an error in the logs.
* Filter the error logs on the slug of the software page, it should still be there

Closes #1078

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
