### PR TITLE
fix: broken icon for other package managers

### DIFF
--- a/frontend/components/charts/d3LineChart/drawLineChart.tsx
+++ b/frontend/components/charts/d3LineChart/drawLineChart.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,8 +22,9 @@ type LineChartConfig = {
 }
 
 const margin = {
-  left: 5, right: 5,
-  top: 0, bottom: 20
+  // minimal margins to host first/last year label 'overflow'
+  left: 12, right: 12,
+  top: 4, bottom: 16
 }
 
 function findMax(data:LineData[]) {

--- a/frontend/components/software/AboutPackageManagers.tsx
+++ b/frontend/components/software/AboutPackageManagers.tsx
@@ -1,35 +1,47 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {PackageManager, packageManagerSettings} from './edit/package-managers/apiPackageManager'
 import WidgetsIcon from '@mui/icons-material/Widgets'
+import LogoAvatar from '~/components/layout/LogoAvatar'
+import {PackageManager, packageManagerSettings} from './edit/package-managers/apiPackageManager'
 
 type AboutPackageManagersProps={
   packages: PackageManager[]
 }
 
 function PackageManager({item}:{item:PackageManager}){
-  // get package manager info
-  const info = packageManagerSettings[item.package_manager ?? 'other']
-  return (
-    <div
-      title={info.name}
-      className="flex items-center p-1 h-[4rem] w-[4rem] hover:bg-base-200"
-    >
+  // get package manager only when url provided
+  if (item.url){
+    const info = packageManagerSettings[item.package_manager ?? 'other']
+    const link = new URL(item.url)
+    return (
       <a href={item.url} target="_blank">
-        <img src={info.icon ?? ''} alt={`Logo ${info.name}`} />
+        <LogoAvatar
+          name={link.hostname}
+          src={info.icon ?? undefined}
+          sx={{
+            height: '4rem',
+            width: '4rem',
+            fontSize: '1.5rem',
+            borderRadius: '0.25rem',
+            '& img': {
+              // fit icon into area
+              objectFit: 'scale-down'
+            }
+          }}
+        />
       </a>
-    </div>
-  )
+    )
+  }
+  return null
 }
 
 
 export default function AboutPackageManagers({packages}:AboutPackageManagersProps) {
-
   if (packages?.length > 0){
     return (
       <>

--- a/frontend/components/software/edit/package-managers/PackageManagerItem.tsx
+++ b/frontend/components/software/edit/package-managers/PackageManagerItem.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,7 +23,7 @@ type PackageManagerItemProps = {
 export default function PackageManagerItem({pos, item, onDelete, onEdit}: PackageManagerItemProps) {
   // get package manager info
   const info = packageManagerSettings[item.package_manager ?? 'other']
-
+  const url = new URL(item.url)
   return (
     <SortableListItem
       key={item.id}
@@ -48,7 +49,7 @@ export default function PackageManagerItem({pos, item, onDelete, onEdit}: Packag
             }
           }}
         >
-          {info.name.slice(0,3)}
+          {url?.hostname?.slice(0,3)}
         </Avatar>
       </ListItemAvatar>
       <ListItemText

--- a/frontend/components/software/edit/package-managers/apiPackageManager.ts
+++ b/frontend/components/software/edit/package-managers/apiPackageManager.ts
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -11,6 +11,13 @@ import {
   createJsonHeaders, extractErrorMessages,
   extractReturnMessage, getBaseUrl
 } from '~/utils/fetchHelpers'
+
+export type PackageManagerSettings={
+  name: string,
+  icon: string|null,
+  hostname: string[],
+  services: string[]
+}
 
 export const packageManagerSettings = {
   anaconda: {
@@ -52,8 +59,8 @@ export const packageManagerSettings = {
   other: {
     name: 'Other',
     icon: null,
-    hostname: ['other'],
-    services: ['other']
+    hostname: [],
+    services: []
   }
 }
 
@@ -224,7 +231,7 @@ export function getPackageManagerTypeFromUrl(url:string) {
     const keys = Object.keys(packageManagerSettings)
 
     const pm_key = keys.find(key => {
-      const manager = packageManagerSettings[key as PackageManagerTypes]
+      const manager = packageManagerSettings[key as PackageManagerTypes] as PackageManagerSettings
       // match hostname
       return manager.hostname.includes(urlObject.hostname)
     })

--- a/frontend/components/software/edit/services/PackageManagerServices.tsx
+++ b/frontend/components/software/edit/services/PackageManagerServices.tsx
@@ -9,8 +9,9 @@ import ContentLoader from '~/components/layout/ContentLoader'
 import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 
-import {packageManagerSettings} from '../package-managers/apiPackageManager'
+import {PackageManagerSettings, packageManagerSettings} from '../package-managers/apiPackageManager'
 import {ServiceInfoListItem} from './ServiceInfoListItem'
+
 
 export default function PackageManagerServices() {
   const {loading,services} = usePackageManagerServices()
@@ -22,13 +23,13 @@ export default function PackageManagerServices() {
       <div>
         {services.map(service=>{
           // For each PM show status of scrapers
-          const svcInfo = packageManagerSettings[service.package_manager]
-          if (svcInfo && svcInfo?.services.length > 0){
+          const svcInfo = packageManagerSettings[service.package_manager] as PackageManagerSettings
+          if (svcInfo && svcInfo.services.length > 0){
             return (
-              <List key={service.package_manager}>
+              <List key={service.url}>
                 {svcInfo?.services.includes('downloads') ?
                   <ServiceInfoListItem
-                    key={`downloads-${service.package_manager}`}
+                    key={`downloads-${service.url}`}
                     title={`${service.package_manager.toLocaleUpperCase()} downloads`}
                     scraped_at={service.download_count_scraped_at}
                     last_error={service.download_count_last_error}
@@ -39,7 +40,7 @@ export default function PackageManagerServices() {
                 }
                 {svcInfo?.services.includes('dependents') ?
                   <ServiceInfoListItem
-                    key={`dependants-${service.package_manager}`}
+                    key={`dependants-${service.url}`}
                     title={`${service.package_manager.toLocaleUpperCase()} dependents`}
                     scraped_at={service.reverse_dependency_count_scraped_at}
                     last_error={service.reverse_dependency_count_last_error}
@@ -59,7 +60,7 @@ export default function PackageManagerServices() {
   return (
     <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
       <AlertTitle sx={{fontWeight:500}}>Not active</AlertTitle>
-      No information about package managers is provided for this software
+      No information about <strong>supported</strong> package managers is provided for this software.
     </Alert>
   )
 }

--- a/frontend/components/software/edit/services/apiSoftwareServices.tsx
+++ b/frontend/components/software/edit/services/apiSoftwareServices.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -98,7 +98,8 @@ export function usePackageManagerServices(){
 
       getPackageManagerServices(software.id,token)
         .then(items=>{
-          if (abort===false) setServices(items)
+          const supported = items.filter(item=>item.package_manager!=='other')
+          if (abort===false) setServices(supported)
         })
         .catch(e=>{
           logger(`usePackageManagerServices failed. ${e.message}`,'error')


### PR DESCRIPTION
# Fix broken icon for other package managers

Closes #1077

Changes proposed in this pull request:
* When link to a software package is provided to the package manager that are not "supported" with the logo we show first 3 letters of the hostname instead of the icon (see image below) 
* Increase margins in the commit line chart to show complete year at the first/last label

How to test:
* `make start` to build and generate test data
* login as rsd_admin, use `RSD_ENVIRONMENT=dev` in .env file to promote first user logged into rsd_admin role
* select first software from the list and go to edit package manager section. Enter unknown package manager links like:
   * https://packages.debian.org/search?keywords=libcdk-java
   * https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle/overview
* confirm that links are shown as squares with first 3 letters of the hostname for examples
* try adding "supported" package managers like CRAN, Maven etc and confirm that these are loaded with proper logos
* for testing commit chart last label you can use CDK repo https://github.com/cdk/cdk

## Example package manager links on software page

![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/d9514708-952d-4a3c-921d-2b7b431f2f82)


## Example commit chart improved last label
- Current
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/4e3a0843-4994-40a5-9746-13a34e7b0935)

- Improved
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/a4d3f1af-2c94-45c1-8025-d3c711d75845)



PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
