### PR TITLE
fix: use docker compose extend to override frontend service settings …

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
+# SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 #
@@ -49,9 +49,9 @@ clean:
 stop:
 	docker compose down
 
-frontend-docker: frontend/.env.local
-	docker compose build frontend-dev
-	docker compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
+frontend-dev: frontend/.env.local
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml build frontend
+	docker compose -f docker-compose.yml -f docker-compose.dev.yml up --scale scrapers=0
 
 data:
 	docker compose up --scale data-generation=1 --scale scrapers=0

--- a/README.md
+++ b/README.md
@@ -86,8 +86,6 @@ make dev
 make down
 ```
 
-More information about building and data migration can be found in [Getting started](https://research-software-directory.github.io/RSD-as-a-service/getting-started.html) documentation.
-
 ## License
 
 The content of this repository is licensed under several licenses. We follow the [REUSE specification](https://reuse.software/) to indicate which license applies to the files specifically. Here are some general hints:

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ SPDX-FileCopyrightText: 2021 - 2022 dv4all
 SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
 SPDX-FileCopyrightText: 2021 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
-SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
@@ -70,9 +70,9 @@ You can run frontend in development mode as docker a service (called frontend-de
 
 ```
 # Run frontend development using docker at http://localhost:3000
-make frontend-docker
+make frontend-dev
 # OR use docker compose directly
-docker compose up --scale frontend=0 --scale scrapers=0 --scale frontend-dev=1
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up 
 ```
 
 It is possible to directly run the frontend too (without using a docker container). You must then have NodeJS installed, preferably v18.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+#
+# SPDX-License-Identifier: Apache-2.0
+
+services:
+ frontend:
+  build:
+    context: ./frontend
+    # dockerfile to use for build
+    dockerfile: Dockerfile.dev
+    args:
+      - DUID
+      - DGID
+  ports:
+    - "3000:3000"
+    - "9229:9229"
+  volumes:
+    - ./frontend:/app
+    # Replace the follwoing directory with the custom deployment directory
+    # - ./deployment/rsd:/app/public

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@
 # SPDX-FileCopyrightText: 2021 - 2023 dv4all
 # SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
-# SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-# SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+# SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
@@ -229,52 +229,7 @@ services:
       - net
     deploy:
       replicas: 0
-
-  frontend-dev:
-    build:
-      context: ./frontend
-      # dockerfile to use for build
-      dockerfile: Dockerfile.dev
-      args:
-        - DUID
-        - DGID
-    # update version number to correspond to frontend/package.json
-    image: rsd/frontend-dev:2.5.1
-    ports:
-      - "3000:3000"
-      - "9229:9229"
-    environment:
-      # it uses values from .env file
-      - POSTGREST_URL
-      - PGRST_JWT_SECRET
-      - RSD_AUTH_URL
-      - RSD_AUTH_PROVIDERS
-      - MATOMO_URL
-      - MATOMO_ID
-      - SURFCONEXT_CLIENT_ID
-      - SURFCONEXT_REDIRECT
-      - SURFCONEXT_WELL_KNOWN_URL
-      - SURFCONEXT_SCOPES
-      - SURFCONEXT_RESPONSE_MODE
-      - HELMHOLTZAAI_CLIENT_ID
-      - HELMHOLTZAAI_REDIRECT
-      - HELMHOLTZAAI_WELL_KNOWN_URL
-      - HELMHOLTZAAI_SCOPES
-      - HELMHOLTZAAI_RESPONSE_MODE
-    depends_on:
-      - database
-      - backend
-      - auth
-    volumes:
-      - ./frontend:/app
-      # - ./deployment/hmz/styles:/app/public/styles
-      # - ./deployment/hmz/data:/app/public/data
-      # - ./deployment/hmz/images:/app/public/images
-    networks:
-      - net
-    deploy:
-      replicas: 0
-
+ 
 # define name for docker network
 # it should have name: rsd-as-a-service_net
 networks:

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,8 +1,8 @@
 <!--
 SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2021 - 2023 dv4all
-SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2023 Netherlands eScience Center
@@ -31,10 +31,23 @@ Based on the features in the legacy application and the current requirements we 
 
 **Use this if you are using a custom theme and mount files from the `/deployment` directory**
 
+First, add the folders that contain the custom configuration to the `docker-compose.dev.yml`:
+
+```yml
+services:
+ frontend:
+#   .....
+  volumes:
+    - ./frontend:/app
+    # Replace the follwoing directory with the custom deployment directory
+    - ./deployment/rsd:/app/public
+
+```
+
 You can start the frontend in dev mode inside Docker using the `Makefile`. The command will make sure that the created Docker container uses a user with the same user id and group id as your local account. This ensures that you will be the owner of all files that are written via mounted volumes to your drive (mainly everything in the `frontend/.next` and `frontend/node_modules` folders).
 
 ```bash
-make frontend-docker
+make frontend-dev
 ```
 
 Alternatively you can run
@@ -43,8 +56,8 @@ Alternatively you can run
 # Export your user and group ids to the variables so Docker will correctly build the frontend-dev container. This is required only if you build the container
 export DUID=$(id -u)
 export DGID=$(id -g)
-docker compose build frontend-dev
-docker compose up --scale frontend=0 --scale frontend-dev=1 --scale scrapers=0
+docker compose -f docker-compose.yml -f docker-compose.dev.yml build frontend
+docker compose -f docker-compose.yml -f docker-compose.dev.yml up
 ```
 
 ### Environment variables


### PR DESCRIPTION
## Fix undiscoverable frontend container in dev mode

Fixes #1082

Changes proposed in this pull request:

* use docker compose [extend](https://docs.docker.com/compose/multiple-compose-files/extends/#example-use-case) to override settings of the `frontend` service using a second compose file.
* rename `make` command from `frontend-docker` to `frontend-dev`

How to test:

* `make frontend-dev` and verify that the frontend runs in dev mode inside docker

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
