### PR TITLE
Don't allow user to set updated_at columns for account

### DIFF
--- a/backend-tests/README.md
+++ b/backend-tests/README.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
@@ -13,20 +13,29 @@ This folder contains backend tests for the RSD. It is intended to mainly:
 - load test the backend/database (no tests yet)
 
 ## Tech stack
+
 This module is written in Java as a Maven project.
 To help with testing REST endpoints, we make use of [REST Assured](https://rest-assured.io/), which has its documentation [here](https://github.com/rest-assured/rest-assured/wiki/Usage).
 As a testing framework we use [JUnit 5](https://junit.org/junit5/).
 
 ## Principles
+
 Tests should be written taking the following principles in account:
 - each test should be runnable independently of other tests
 - each test should be repeatable, without e.g. having to clean up the database first
 
+## Writing tests
+
+Each class containing tests should be annotated with `@ExtendWith({SetupAllTests.class})`. This refers to a class containing a global setup method, which runs once to check the connection to the database and to initialise global parameters.
+
 ## Running
+
 ### From the command line
+
 This section assumes that you are in the root directory of the project.
 
 The easiest way to run the tests is with `make`. Make sure no other RSD containers are running.
+
 ```shell
 make run-backend-tests
 ```

--- a/backend-tests/pom.xml
+++ b/backend-tests/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 
 SPDX-License-Identifier: Apache-2.0
 -->
@@ -28,14 +28,14 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.6.0</version>
+				<version>3.6.1</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.5</version>
 			</plugin>
 
 			<!--
@@ -43,21 +43,21 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.surefire</groupId>
 				<artifactId>surefire-junit-platform</artifactId>
-				<version>3.1.0</version>
+				<version>3.2.5</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter-engine -->
 			<plugin>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-engine</artifactId>
-				<version>5.9.3</version>
+				<version>5.10.1</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher -->
 			<plugin>
 				<groupId>org.junit.platform</groupId>
 				<artifactId>junit-platform-launcher</artifactId>
-				<version>1.9.3</version>
+				<version>1.10.1</version>
 			</plugin>
 		</plugins>
 	</build>
@@ -83,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>rest-assured</artifactId>
-			<version>5.3.2</version>
+			<version>5.4.0</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -91,7 +91,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.9.3</version>
+			<version>5.10.1</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
@@ -26,7 +26,7 @@ import java.util.List;
 public class AuthenticationIntegrationTest {
 
 	@Test
-	void givenAdmin_whenCreatingAccount_thenSuccess() {
+	void whenCreatingUserAccount_thenSuccess() {
 		User.create(false);
 	}
 
@@ -50,7 +50,7 @@ public class AuthenticationIntegrationTest {
 	void givenUserWhoAgreedOnTerms_whenCreatingAndEditingSoftware_thenSuccess() {
 		User user = User.create(false);
 
-		RestAssured.given().log().all()
+		RestAssured.given()
 				.header(user.authHeader)
 				.contentType(ContentType.JSON)
 				.body("{\"agree_terms\": true, \"notice_privacy_statement\": true}")
@@ -81,7 +81,8 @@ public class AuthenticationIntegrationTest {
 				.then()
 				.statusCode(200)
 				.extract()
-				.path("[0].get_started_url");
+				.jsonPath()
+				.getString("[0].get_started_url");
 		Assertions.assertEquals(getStartedUrl, patchedGetStartedUrl);
 	}
 
@@ -313,7 +314,8 @@ public class AuthenticationIntegrationTest {
 				.then()
 				.statusCode(201)
 				.extract()
-				.path("[0].id");
+				.jsonPath()
+				.getString("[0].id");
 	}
 
 	String createUniqueCategory(String name, String short_name, String parentId) {

--- a/backend-tests/src/test/java/nl/esciencecenter/SetupAllTests.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/SetupAllTests.java
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Date;
+
+public class SetupAllTests implements BeforeAllCallback {
+
+	@Override
+	public void beforeAll(ExtensionContext extensionContext) throws Exception {
+		checkBackendAvailable();
+		setupRestAssured();
+	}
+
+	public static Header adminAuthHeader;
+
+	public static void checkBackendAvailable() throws InterruptedException {
+		URI backendUri = URI.create(System.getenv("POSTGREST_URL"));
+		HttpClient client = HttpClient.newHttpClient();
+		HttpRequest request = HttpRequest.newBuilder(backendUri).build();
+		int maxTries = 30;
+		for (int i = 1; i <= maxTries; i++) {
+			try {
+				client.send(request, HttpResponse.BodyHandlers.discarding());
+				System.out.println("Attempt %d/%d to connect to the backend on %s succeeded, continuing with the tests"
+						.formatted(i, maxTries, backendUri));
+				return;
+			} catch (IOException e) {
+				System.out.println("Attempt %d/%d to connect to the backend on %s failed, trying again in 1 second"
+						.formatted(i, maxTries, backendUri));
+				Thread.sleep(1000);
+			}
+		}
+		throw new RuntimeException("Unable to make connection to the backend with URI: " + backendUri);
+	}
+
+	public static void setupRestAssured() {
+		String backendUri = System.getenv("POSTGREST_URL");
+		RestAssured.baseURI = backendUri;
+		RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+
+		String secret = System.getenv("PGRST_JWT_SECRET");
+		Algorithm signingAlgorithm = Algorithm.HMAC256(secret);
+
+		String adminToken = JWT.create()
+				.withClaim("iss", "rsd_test")
+				.withClaim("role", "rsd_admin")
+				.withExpiresAt(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // expires in one hour
+				.sign(signingAlgorithm);
+		adminAuthHeader = new Header("Authorization", "bearer " + adminToken);
+
+		User.adminAuthHeader = adminAuthHeader;
+	}
+}

--- a/backend-tests/src/test/java/nl/esciencecenter/User.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/User.java
@@ -1,14 +1,18 @@
-package nl.esciencecenter;
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
 
-import java.util.Date;
+package nl.esciencecenter;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.google.gson.JsonObject;
-
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
+
+import java.util.Date;
 
 public class User {
 	String accountId;

--- a/backend-tests/src/test/java/nl/esciencecenter/User.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/User.java
@@ -23,8 +23,7 @@ public class User {
 
 	static User create(boolean hasAgreedTerms) {
 		if (adminAuthHeader == null) {
-			// throw new Exception("User.adminAuthHeader is not initialized.");
-			System.out.println("ERROR: User.adminAuthHeader is not initialized.");
+			throw new RuntimeException("User.adminAuthHeader is not initialized.");
 		}
 
 		String accountId = RestAssured.given()

--- a/backend-tests/src/test/java/nl/esciencecenter/UserIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/UserIntegrationTest.java
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.path.json.JsonPath;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+@ExtendWith({SetupAllTests.class})
+public class UserIntegrationTest {
+
+	@Test
+	void givenUser_whenUpdatingUpdatedAtFieldsForAccount_thenChangesIgnored() {
+		User user = User.create();
+		String accountId = user.accountId;
+
+
+		JsonPath body = RestAssured.given()
+				.header(user.authHeader)
+				.when()
+				.get("account?select=agree_terms_updated_at,notice_privacy_statement_updated_at&id=eq.%s".formatted(accountId))
+				.then()
+				.statusCode(200)
+				.extract()
+				.jsonPath();
+
+		ZonedDateTime agree_terms_updated_at_database_old = ZonedDateTime.parse(body.getString("[0].agree_terms_updated_at"));
+		ZonedDateTime notice_privacy_statement_updated_at_database_old = ZonedDateTime.parse(body.getString("[0].notice_privacy_statement_updated_at"));
+
+		ZonedDateTime agree_terms_updated_at_future = ZonedDateTime.now().plusDays(10);
+		ZonedDateTime notice_privacy_statement_updated_at_future = ZonedDateTime.now().plusMonths(10);
+
+		String patchBody = "{\"agree_terms_updated_at\": \"%s\", \"notice_privacy_statement_updated_at\": \"%s\"}"
+				.formatted(agree_terms_updated_at_future.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME), notice_privacy_statement_updated_at_future.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+
+		RestAssured.given()
+				.header(user.authHeader)
+				.contentType(ContentType.JSON)
+				.body(patchBody)
+				.when()
+				.patch("account?id=eq.%s".formatted(accountId))
+				.then()
+				.statusCode(204);
+
+		JsonPath bodyNew = RestAssured.given()
+				.header(user.authHeader)
+				.when()
+				.get("account?select=agree_terms_updated_at,notice_privacy_statement_updated_at&id=eq.%s".formatted(accountId))
+				.then()
+				.statusCode(200)
+				.extract()
+				.jsonPath();
+
+		ZonedDateTime agree_terms_updated_at_database_new = ZonedDateTime.parse(bodyNew.getString("[0].agree_terms_updated_at"));
+		ZonedDateTime notice_privacy_statement_updated_at_database_new = ZonedDateTime.parse(bodyNew.getString("[0].notice_privacy_statement_updated_at"));
+
+		Assertions.assertEquals(agree_terms_updated_at_database_old, agree_terms_updated_at_database_new);
+		Assertions.assertNotEquals(agree_terms_updated_at_database_old, agree_terms_updated_at_future);
+		Assertions.assertEquals(notice_privacy_statement_updated_at_database_old, notice_privacy_statement_updated_at_database_new);
+		Assertions.assertNotEquals(notice_privacy_statement_updated_at_database_new, notice_privacy_statement_updated_at_future);
+	}
+}

--- a/database/011-create-account-table.sql
+++ b/database/011-create-account-table.sql
@@ -1,5 +1,5 @@
--- SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 - 2023 dv4all
 -- SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
@@ -43,9 +43,13 @@ BEGIN
 	NEW.updated_at = LOCALTIMESTAMP;
 	IF NEW.agree_terms != OLD.agree_terms THEN
 		NEW.agree_terms_updated_at = NEW.updated_at;
+	ELSE
+		NEW.agree_terms_updated_at = OLD.agree_terms_updated_at;
 	END IF;
 	IF NEW.notice_privacy_statement != OLD.notice_privacy_statement THEN
 		NEW.notice_privacy_statement_updated_at = NEW.updated_at;
+	ELSE
+		NEW.notice_privacy_statement_updated_at = OLD.notice_privacy_statement_updated_at;
 	END IF;
 	return NEW;
 END


### PR DESCRIPTION
## Don't allow user to set updated_at columns for account

Changes proposed in this pull request:

* Silently reset the `agree_terms_updated_at` and `notice_privacy_statement_updated_at` columns when a user changes this in the `account` table.
* Add a test for this and refactor some older tests
* Update dependencies of the backend tests
* Add a line to the docs explaining to add the setup class

How to test:

* Inspect the test to see if it does what it is supposed to
* Build and run the tests: `make run-backend-tests`

I'm not entirely sure if silently overwriting is better than generating an error. If someone has a good argument for the latter, I might change it.

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [x] Tests
