### PR TITLE
1092 slow backend logs function

### DIFF
--- a/database/118-backend-logs-views.sql
+++ b/database/118-backend-logs-views.sql
@@ -1,6 +1,6 @@
+-- SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
--- SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -8,27 +8,25 @@ CREATE FUNCTION slug_from_log_reference(
 	table_name VARCHAR,
 	reference_id UUID
 )
-RETURNS TABLE (
-	slug VARCHAR
-)
+RETURNS VARCHAR
 LANGUAGE sql STABLE AS
 $$
 SELECT CASE
 	WHEN table_name = 'repository_url' THEN (
 		SELECT
-			CONCAT('/software/', slug, '/edit/information') as slug
+			CONCAT('/software/', slug, '/edit/information')
 		FROM
 			software WHERE id = reference_id
 	)
 	WHEN table_name = 'package_manager' THEN (
 		SELECT
-			CONCAT('/software/', slug, '/edit/package-managers') as slug
+			CONCAT('/software/', slug, '/edit/package-managers')
 		FROM
 			software
 		WHERE id = (SELECT software FROM package_manager WHERE id = reference_id))
 	WHEN table_name = 'mention' AND reference_id IS NOT NULL THEN (
 		SELECT
-			CONCAT('/api/v1/mention?id=eq.', reference_id) as slug
+			CONCAT('/api/v1/mention?id=eq.', reference_id)
 	)
 	END
 $$;

--- a/frontend/components/admin/logs/apiLogs.ts
+++ b/frontend/components/admin/logs/apiLogs.ts
@@ -26,20 +26,23 @@ export async function getLogs({page, rows, token, searchFor, orderBy}: ApiParams
     const url = `${getBaseUrl()}/rpc/backend_log_view?${query}`
 
     // make request
+    const headers: any = {
+      ...createJsonHeaders(token)
+    }
+    if (page === 0) {
+      // request record count to be returned
+      // note: it's returned in the header
+      headers['Prefer'] = 'count=exact'
+    }
     const resp = await fetch(url,{
       method: 'GET',
-      headers: {
-        ...createJsonHeaders(token),
-        // request record count to be returned
-        // note: it's returned in the header
-        'Prefer': 'count=exact'
-      },
+      headers: headers
     })
 
     if ([200,206].includes(resp.status)) {
       const logs: BackendLog[] = await resp.json()
       return {
-        count: extractCountFromHeader(resp.headers) ?? 0,
+        count: extractCountFromHeader(resp.headers),
         logs
       }
     }

--- a/frontend/components/admin/logs/useLogs.tsx
+++ b/frontend/components/admin/logs/useLogs.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -55,7 +56,9 @@ export default function useLogs({orderBy}:useContributorsProps) {
 
     if (abort === false) {
       setLogs(logs)
-      setCount(count)
+      if (count) {
+        setCount(count)
+      }
       setLoading(false)
     }
 

--- a/frontend/utils/extractCountFromHeader.ts
+++ b/frontend/utils/extractCountFromHeader.ts
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2021 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +16,7 @@ export function extractCountFromHeader(headers:Headers){
       const splitted = stats.split('/')
       if (splitted.length > 0){
         const count = parseInt(splitted[1])
-        return count
+        return isNaN(count) ? null : count
       }
       return null
     }


### PR DESCRIPTION
## Faster backend log browsing

Changes proposed in this pull request:

* Change the return type of `slug_from_log_reference()` to be a `VARCHAR` instead of a `TABLE`, to allow for inlining
* Change the frontend to only request the amount of results on the first page of the logs

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Run the following query to create 30000 fake log entries:

```sql
DO
$$
BEGIN
	FOR i IN 1..30000 LOOP
		INSERT INTO backend_log(service_name, table_name) VALUES ('scraper', 'table');
	END LOOP;
END;
$$
```

* Log in as admin and browse through te backend logs. It should be fast after the first page. When filtering, the count should be updated.

Closes #1092

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
