### PR TITLE
Cleanup scrapers

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Config.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Config.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -9,12 +9,13 @@
 
 package nl.esciencecenter.rsd.scraper;
 
-import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** 
- * Helper class to retrieve various environment variables.  
+import java.util.Optional;
+
+/**
+ * Helper class to retrieve various environment variables.
  */
 public class Config {
 
@@ -24,123 +25,121 @@ public class Config {
 
 	/**
 	 * Retrieves the value of the environment variable with the given name. Variable is not allowed to unset, and an Error
-	 * will be thrown if this is the case. 
-	 * 
-	 * @param name the name of the variable. 
+	 * will be thrown if this is the case.
+	 *
+	 * @param name the name of the variable.
 	 * @return the value of the variable.
 	 */
-	private static final String getMandatoryEnv(String name) {
-		
-		if (name == null || name.isBlank()) { 
-			LOGGER.error("Attemping to retrieve mandatory environment variable without a name!");			
-			throw new Error("Attemping to retrieve mandatory environment variable without a name!");
+	private static String getMandatoryEnv(String name) {
+
+		if (name == null || name.isBlank()) {
+			LOGGER.error("Attempting to retrieve mandatory environment variable without a name!");
+			throw new Error("Attempting to retrieve mandatory environment variable without a name!");
 		}
 
-		String value = null;
-		
-		try { 
-			value = System.getenv(name);			
-		} catch (Exception e) {			
+		String value;
+
+		try {
+			value = System.getenv(name);
+		} catch (Exception e) {
 			LOGGER.error("Failed to retrieve environment variable: {}", name, e);
-			return null;
-			// throw new Error("Failed to retrieve environment variable: " + name, e);
+			throw new Error("Failed to retrieve environment variable: " + name, e);
 		}
-		
-		if (value == null || value.isBlank()) { 
+
+		if (value == null || value.isBlank()) {
 			LOGGER.error("Blank environment variable: {}", name);
-			return value;
-			//throw new Error("Failed to retrieve environment variable: " + name);
+			throw new Error("Failed to retrieve environment variable: " + name);
 		}
-		
+
 		return value;
 	}
-	
+
 	/**
-	 * Retrieves the value of the environment variable with the given name. Allows the variable to be unset.  
-	 * 
-	 * @param name the name of the variable. 
+	 * Retrieves the value of the environment variable with the given name. Allows the variable to be unset.
+	 *
+	 * @param name the name of the variable.
 	 * @return the value of the variable if set, or empty Optional otherwise.
 	 */
-	private static final Optional<String> getOptionalEnv(String name) {
+	private static Optional<String> getOptionalEnv(String name) {
 
-		if (name == null || name.isBlank()) { 
-			LOGGER.warn("Attemping to retrieve environment variable without a name!");			
+		if (name == null || name.isBlank()) {
+			LOGGER.warn("Attempting to retrieve environment variable without a name!");
 			return Optional.empty();
 		}
 
-		try { 
-			String value = System.getenv(name);			
+		try {
+			String value = System.getenv(name);
 			return (value == null || value.isBlank()) ? Optional.empty() : Optional.of(value.strip());
-		} catch (Exception e) {			
+		} catch (Exception e) {
 			LOGGER.warn("Failed to retrieve environment variable: {}", name, e);
 			return Optional.empty();
 		}
 	}
 
 	/**
-	 * Retrieves the integer value of the environment variable with the given name. When the variable is unset, empty 
+	 * Retrieves the integer value of the environment variable with the given name. When the variable is unset, empty
 	 * or contains an invalid value, the default value is returned.
-	 * 
-	 * @param name the name of the variable.
-	 * @param defaultValue the default value to return if the enviroment variable is unset, empty, or does not contain an integer.
-	 * @return
+	 *
+	 * @param name         the name of the variable.
+	 * @param defaultValue the default value to return if the environment variable is unset, empty, or does not contain an integer.
+	 * @return the value from the environment of the default value if no value could be obtained
 	 */
-	private static final int getIntEnv(String name, int defaultValue) { 
-		
-		if (name == null || name.isBlank()) { 
-			LOGGER.warn("Attemping to retrieve environment variable without a name!");			
+	private static int getIntEnv(String name, int defaultValue) {
+
+		if (name == null || name.isBlank()) {
+			LOGGER.warn("Attempting to retrieve environment variable without a name!");
 			return defaultValue;
 		}
 
-		try { 
+		try {
 			return Integer.parseInt(System.getenv(name));
 		} catch (Exception e) {
-			LOGGER.warn("Failed to retrieve environment variable: {}", name, e);			
+			LOGGER.warn("Failed to retrieve environment variable: {}", name, e);
 		}
 
-		return defaultValue;		
+		return defaultValue;
 	}
 
 	/**
-	 * Get the JWT expiration time (in milliseconds). 
-	 * 
-	 * @return the the JWT expiration time. 
-	 */	
-	
+	 * Get the JWT expiration time (in milliseconds).
+	 *
+	 * @return the JWT expiration time.
+	 */
+
 	public static long jwtExpirationTime() {
 		return TEN_MINUTES_IN_MILLISECONDS;
 	}
 
 	/**
-	 * Get Postgrest JWT secret. 
-	 * 
-	 * @return the Postgrest JWT secret. 
-	 */	
+	 * Get Postgrest JWT secret.
+	 *
+	 * @return the Postgrest JWT secret.
+	 */
 	public static String jwtSigningSecret() {
 		return getMandatoryEnv("PGRST_JWT_SECRET");
 	}
 
 	/**
-	 * Get base URL to connect to the backend. 
-	 * 
-	 * @return the Get base URL to connect to the backend. 
-	 */	
+	 * Get base URL to connect to the backend.
+	 *
+	 * @return the Get base URL to connect to the backend.
+	 */
 	public static String backendBaseUrl() {
 		return getMandatoryEnv("POSTGREST_URL");
 	}
 
 	/**
-	 * The maximum requests rate for Github.
-	 * 
+	 * The maximum requests rate for GitHub.
+	 *
 	 * @return the maximum request rate (default 6).
 	 */
 	public static int maxRequestsGithub() {
 		return getIntEnv("MAX_REQUESTS_GITHUB", 6);
 	}
-	
+
 	/**
 	 * The maximum requests rate for GitLab.
-	 * 
+	 *
 	 * @return the maximum request rate (default 6).
 	 */
 	public static int maxRequestsGitLab() {
@@ -148,46 +147,46 @@ public class Config {
 	}
 
 	/**
-	 * Get the maximum number of mentions to scrape in one run of the MentionScraper. 
-	 * 
-	 * @return the maximum number of mentions to scrape (default 6).  
+	 * Get the maximum number of mentions to scrape in one run of the MentionScraper.
+	 *
+	 * @return the maximum number of mentions to scrape (default 6).
 	 */
 	public static int maxRequestsDoi() {
 		return getIntEnv("MAX_REQUESTS_DOI", 6);
 	}
 
 	/**
-	 * Get the maximum number of citation sources to scrape in one run of the CitationScraper. 
-	 * 
-	 * @return the maximum number of citation sources to scrape (default 5).  
+	 * Get the maximum number of citation sources to scrape in one run of the CitationScraper.
+	 *
+	 * @return the maximum number of citation sources to scrape (default 5).
 	 */
 	public static int maxCitationSourcesToScrape() {
 		return getIntEnv("MAX_REQUESTS_OPENALEX", 5);
 	}
 
 	/**
-	 * Get the email contact address for crossref. 
-	 * 
-	 * @return the Get the email contact address for crossref (default unset). 
-	 */	
+	 * Get the email contact address for crossref.
+	 *
+	 * @return the Get the email contact address for crossref (default unset).
+	 */
 	public static Optional<String> crossrefContactEmail() {
 		return getOptionalEnv("CROSSREF_CONTACT_EMAIL");
 	}
 
 	/**
-	 * Get the API credentials for github. 
-	 * 
-	 * @return the API credentials for github (default unset). 
-	 */	
+	 * Get the API credentials for GitHub.
+	 *
+	 * @return the API credentials for GitHub (default unset).
+	 */
 	public static Optional<String> apiCredentialsGithub() {
-		return Optional.ofNullable(System.getenv("API_CREDENTIALS_GITHUB"));
+		return getOptionalEnv("API_CREDENTIALS_GITHUB");
 	}
 
 	/**
-	 * Get the IO key for libraries.io. 
-	 * 
-	 * @return the IO key for libraries.io (default unset). 
-	 */	
+	 * Get the IO key for libraries.io.
+	 *
+	 * @return the IO key for libraries.io (default unset).
+	 */
 	public static Optional<String> librariesIoKey() {
 		return getOptionalEnv("LIBRARIES_IO_ACCESS_TOKEN");
 	}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/UtilsIT.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/UtilsIT.java
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class UtilsIT {
+
+	private final String gitHubApiUrl = "https://api.github.com";
+	private final String gitHubRepository = "research-software-directory/RSD-as-a-service";
+	private final String gitHubUri = gitHubApiUrl + "/repos/" + gitHubRepository;
+	private final String dbUrl = Config.backendBaseUrl();
+
+	@Disabled
+	@Test
+	void getWithoutToken() {
+		final String jsonResponse = Assertions.assertDoesNotThrow(() -> Utils.get(gitHubUri));
+		Assertions.assertTrue(jsonResponse.startsWith("{"));
+	}
+
+	@Disabled
+	@Test
+	void getWrongUri() {
+		final String wrongUri = gitHubApiUrl + "/repos/research-software-directory/wrongRepo";
+		Exception thrown = Assertions.assertThrows(
+				Exception.class, () -> Utils.get(wrongUri)
+		);
+		Assertions.assertTrue(thrown.getMessage().startsWith("Error fetching data"));
+	}
+
+	@Disabled
+	@Test
+	void getAsAdmin() {
+		String table = "repository_url";
+		String value = Utils.getAsAdmin(dbUrl + "/" + table);
+		Assertions.assertTrue(value.startsWith("[{\"software\":"));
+	}
+}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/UtilsTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/UtilsTest.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -8,56 +8,25 @@
 package nl.esciencecenter.rsd.scraper;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 public class UtilsTest {
-	private final String gitHubApiUrl = "https://api.github.com";
-	private final String gitHubRepository = "research-software-directory/RSD-as-a-service";
-	private final String gitHubUri = gitHubApiUrl + "/repos/" + gitHubRepository;
-
-	private final String dbUrl = Config.backendBaseUrl();
 
 	@Test
-	void urlencode() {
+	void urlEncode() {
 		Assertions.assertEquals("one%2Ftwo", Utils.urlEncode("one/two"));
 	}
 
 	@Test
 	void testCreatePatchUri() {
-		String baseuri = "http://localhost/api/v1";
+		String baseUri = "http://localhost/api/v1";
 		String tableName = "table_name";
 		String primaryKey = "d8718d90-a3df-4714-864d-40786223e462";
 		String primaryKeyName = "id";
 
 		String expectedUri = "http://localhost/api/v1/table_name?id=eq.d8718d90-a3df-4714-864d-40786223e462";
-		String actualUri = Utils.createPatchUri(baseuri, tableName, primaryKey, primaryKeyName);
+		String actualUri = Utils.createPatchUri(baseUri, tableName, primaryKey, primaryKeyName);
 
 		Assertions.assertEquals(expectedUri, actualUri);
-	}
-
-	@Disabled
-	@Test
-	void getWithoutToken() {
-		final String jsonResponse = Assertions.assertDoesNotThrow(() -> Utils.get(gitHubUri));
-		Assertions.assertTrue(jsonResponse.startsWith("{"));
-	}
-
-	@Disabled
-	@Test
-	void getWrongUri() {
-		final String wrongUri = gitHubApiUrl + "/repos/research-software-directory/wrongRepo";
-		Exception thrown = Assertions.assertThrows(
-				Exception.class, () -> Utils.get(wrongUri)
-		);
-		Assertions.assertTrue(thrown.getMessage().startsWith("Error fetching data"));
-	}
-
-	@Disabled
-	@Test
-	void getAsAdmin() {
-		String table = "repository_url";
-		String value = Utils.getAsAdmin(dbUrl + "/" + table);
-		Assertions.assertTrue(value.startsWith("[{\"software\":"));
 	}
 }

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScaperIT.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScaperIT.java
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper.git;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+public class GithubScaperIT {
+
+	private final String githubUrlPrefix = "https://github.com/";
+	private final String repo = "research-software-directory/RSD-as-a-service";
+	private final String repoEmpty = "cmeessen/empty";
+	private final String repoNonEx = "research-software-directory/does-not-exist";
+
+	private final GithubScraper githubScraper = GithubScraper.create(githubUrlPrefix + repo).get();
+	private final GithubScraper githubScraperEmpty = GithubScraper.create(githubUrlPrefix + repoEmpty).get();
+	private final GithubScraper githubScraperNonEx = GithubScraper.create(githubUrlPrefix + repoNonEx).get();
+
+	@Disabled
+	@Test
+	void languages() {
+		final String languages = Assertions.assertDoesNotThrow(() -> githubScraper.languages());
+		Assertions.assertTrue(languages.startsWith("{"));
+		Assertions.assertTrue(languages.endsWith("}"));
+		Assertions.assertTrue(languages.contains("Java"));
+	}
+
+	@Disabled
+	@Test
+	void license() {
+		String license = Assertions.assertDoesNotThrow(() -> githubScraper.basicData().license);
+		Assertions.assertEquals("Apache-2.0", license);
+	}
+
+	@Disabled
+	@Test
+	void contributions() {
+		final CommitsPerWeek contributions = Assertions.assertDoesNotThrow(githubScraper::contributions);
+		// Assertions.assertTrue(contributions.startsWith("[{\"total"));
+	}
+
+	@Disabled
+	@Test
+	void contributionsEmpty() {
+		final CommitsPerWeek contributionsEmpty = Assertions.assertDoesNotThrow(githubScraperEmpty::contributions);
+		// Assertions.assertTrue("[]", contributionsEmpty);
+	}
+
+	@Disabled
+	@Test
+	void contributionsNonEx() {
+		final CommitsPerWeek contributionsNonEx = Assertions.assertDoesNotThrow(githubScraperNonEx::contributions);
+		// Assertions.assertNull(contributionsNonEx);
+	}
+}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperTest.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -8,7 +8,6 @@
 package nl.esciencecenter.rsd.scraper.git;
 
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -20,47 +19,6 @@ public class GithubScraperTest {
 	private final String repo = "research-software-directory/RSD-as-a-service";
 	private final String repoEmpty = "cmeessen/empty";
 	private final String repoNonEx = "research-software-directory/does-not-exist";
-
-	private final GithubScraper githubScraper = GithubScraper.create(githubUrlPrefix + repo).get();
-	private final GithubScraper githubScraperEmpty = GithubScraper.create(githubUrlPrefix + repoEmpty).get();
-	private final GithubScraper githubScraperNonEx = GithubScraper.create(githubUrlPrefix + repoNonEx).get();
-
-	@Disabled
-	@Test
-	void languages() {
-		final String languages = Assertions.assertDoesNotThrow(() -> githubScraper.languages());
-		Assertions.assertTrue(languages.startsWith("{"));
-		Assertions.assertTrue(languages.endsWith("}"));
-		Assertions.assertTrue(languages.contains("Java"));
-	}
-
-	@Disabled
-	@Test
-	void license() {
-		String license = Assertions.assertDoesNotThrow(() -> githubScraper.basicData().license);
-		Assertions.assertEquals("Apache-2.0", license);
-	}
-
-	@Disabled
-	@Test
-	void contributions() {
-		final CommitsPerWeek contributions = Assertions.assertDoesNotThrow(githubScraper::contributions);
-		// Assertions.assertTrue(contributions.startsWith("[{\"total"));
-	}
-
-	@Disabled
-	@Test
-	void contributionsEmpty() {
-		final CommitsPerWeek contributionsEmpty = Assertions.assertDoesNotThrow(githubScraperEmpty::contributions);
-		// Assertions.assertTrue("[]", contributionsEmpty);
-	}
-
-	@Disabled
-	@Test
-	void contributionsNonEx() {
-		final CommitsPerWeek contributionsNonEx = Assertions.assertDoesNotThrow(githubScraperNonEx::contributions);
-		// Assertions.assertNull(contributionsNonEx);
-	}
 
 	@Test
 	void givenListWithLastPageHeader_whenParsing_thenCorrectPageReturned() {

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GitlabScraperIT.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GitlabScraperIT.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 
-public class GitlabScraperTest {
+public class GitlabScraperIT {
 	private final String baseApiUrl = "https://git.gfz-potsdam.de/api";
 	private final String repo = "swc-bb/swc-templates/swc-l/python";
 	private final GitlabScraper scraper = new GitlabScraper(baseApiUrl, repo);


### PR DESCRIPTION
## Scraper cleanup

Changes proposed in this pull request:

* Move (unused) tests that are actually integration tests to dedicated classes
* Cleanup the Config class (typos, unused code, etc.)
* Wrap forgotten HttpClient in try-with-resources

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Wait for some scrapers to run

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
