### PR TITLE
1095 distinguish openid providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,12 @@ RSD_ENVIRONMENT=prod
 # if you add the value "LOCAL", then local accounts are enabled, USE THIS FOR TESTING PURPOSES ONLY
 RSD_AUTH_PROVIDERS=SURFCONEXT;ORCID;AZURE;LOCAL
 
+# consumed by services: authentication, frontend (api/fe)
+# provide a list of supported OpenID auth providers for coupling with the user's RSD account
+# the values should be separated by semicolon (;)
+# Allowed values are: ORCID
+RSD_AUTH_COUPLE_PROVIDERS=ORCID
+
 # Define a semicolon-separated list of user email addresses which are allowed to
 # login to the RSD. If the variable is left empty, or is not defined, all users
 # will be allowed to login.

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,8 +21,8 @@ public class Config {
 		return System.getenv("PGRST_JWT_SECRET");
 	}
 
-	private static Collection<String> rsdAuthProviders() {
-		return Optional.ofNullable(System.getenv("RSD_AUTH_PROVIDERS"))
+	private static Collection<String> rsdAuthCoupleProviders() {
+		return Optional.ofNullable(System.getenv("RSD_AUTH_COUPLE_PROVIDERS"))
 				.map(String::toUpperCase)
 				.map(s -> s.split(";"))
 				.map(Set::of)
@@ -37,25 +37,37 @@ public class Config {
 		}
 	}
 
-	public static boolean isLocalEnabled() {
-		return rsdAuthProviders().contains("LOCAL");
+	private static Collection<String> rsdLoginProviders() {
+		return Optional.ofNullable(System.getenv("RSD_AUTH_PROVIDERS"))
+			.map(String::toUpperCase)
+			.map(s -> s.split(";"))
+			.map(Set::of)
+			.orElse(Collections.emptySet());
 	}
 
-	public static boolean isSurfConextEnabled() {
-		Collection<String> enabledProviders = rsdAuthProviders();
+	public static boolean isLocalLoginEnabled() {
+		return rsdLoginProviders().contains("LOCAL");
+	}
+
+	public static boolean isSurfConextLoginEnabled() {
+		Collection<String> enabledProviders = rsdLoginProviders();
 		return enabledProviders.isEmpty() || enabledProviders.contains("SURFCONEXT");
 	}
 
-	public static boolean isHelmholtzEnabled() {
-		return rsdAuthProviders().contains("HELMHOLTZAAI");
+	public static boolean isHelmholtzLoginEnabled() {
+		return rsdLoginProviders().contains("HELMHOLTZAAI");
 	}
 
-	public static boolean isOrcidEnabled() {
-		return rsdAuthProviders().contains("ORCID");
+	public static boolean isOrcidCoupleEnabled() {
+		return rsdAuthCoupleProviders().contains("ORCID");
 	}
 
-	public static boolean isAzureEnabled() {
-		return rsdAuthProviders().contains("AZURE");
+	public static boolean isOrcidLoginEnabled() {
+		return rsdLoginProviders().contains("ORCID");
+	}
+
+	public static boolean isAzureLoginEnabled() {
+		return rsdLoginProviders().contains("AZURE");
 	}
 
 	public static String userMailWhitelist() {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -90,7 +90,7 @@ public class Main {
 		Javalin app = Javalin.create().start(7000);
 		app.get("/", ctx -> ctx.json("{\"Module\": \"rsd/auth\", \"Status\": \"live\"}"));
 
-		if (Config.isLocalEnabled()) {
+		if (Config.isLocalLoginEnabled()) {
 			System.out.println("********************");
 			System.out.println("Warning: local accounts are enabled, this is not safe for production!");
 			System.out.println("********************");
@@ -107,7 +107,7 @@ public class Main {
 			});
 		}
 
-		if (Config.isSurfConextEnabled()) {
+		if (Config.isSurfConextLoginEnabled()) {
 			app.post("/login/surfconext", ctx -> {
 				String code = ctx.formParam("code");
 				String redirectUrl = Config.surfconextRedirect();
@@ -122,7 +122,7 @@ public class Main {
 			});
 		}
 
-		if (Config.isHelmholtzEnabled()) {
+		if (Config.isHelmholtzLoginEnabled()) {
 			app.get("/login/helmholtzaai", ctx -> {
 				String code = ctx.queryParam("code");
 				String redirectUrl = Config.helmholtzAaiRedirect();
@@ -137,7 +137,7 @@ public class Main {
 			});
 		}
 
-		if (Config.isOrcidEnabled()) {
+		if (Config.isOrcidLoginEnabled()) {
 			app.get("/login/orcid", ctx -> {
 				String code = ctx.queryParam("code");
 				String redirectUrl = Config.orcidRedirect();
@@ -146,7 +146,9 @@ public class Main {
 				AccountInfo accountInfo = new PostgrestCheckOrcidWhitelistedAccount(new PostgrestAccount()).account(orcidInfo, OpenidProvider.orcid);
 				createAndSetToken(ctx, accountInfo);
 			});
+		}
 
+		if (Config.isOrcidCoupleEnabled()) {
 			app.get("/couple/orcid", ctx -> {
 				String code = ctx.queryParam("code");
 				String redirectUrl = Config.orcidRedirectCouple();
@@ -166,7 +168,7 @@ public class Main {
 			});
 		}
 
-		if (Config.isAzureEnabled()) {
+		if (Config.isAzureLoginEnabled()) {
 			app.get("/login/azure", ctx -> {
 				String code = ctx.queryParam("code");
 				String redirectUrl = Config.azureRedirect();

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -3,6 +3,8 @@ SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2022 dv4all
 SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
@@ -52,6 +54,7 @@ The default index.css and settings.json are already in the frontend image. If yo
       - POSTGREST_URL
       - PGRST_JWT_SECRET
       - RSD_AUTH_URL
+      - RSD_AUTH_COUPLE_PROVIDERS
       - RSD_AUTH_PROVIDERS
       - MATOMO_URL
       - MATOMO_ID

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
 # SPDX-FileCopyrightText: 2022 dv4all
@@ -60,6 +60,7 @@ services:
       # it uses values from .env file
       - RSD_ENVIRONMENT
       - POSTGREST_URL
+      - RSD_AUTH_COUPLE_PROVIDERS
       - RSD_AUTH_PROVIDERS
       - RSD_AUTH_USER_MAIL_WHITELIST
       - SURFCONEXT_CLIENT_ID
@@ -104,6 +105,7 @@ services:
       - PGRST_JWT_SECRET
       - RSD_AUTH_URL
       - RSD_AUTH_PROVIDERS
+      - RSD_AUTH_COUPLE_PROVIDERS
       - MATOMO_URL
       - MATOMO_ID
       - SURFCONEXT_CLIENT_ID

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,6 @@ services:
       - DUID
       - DGID
   ports:
-    - "3000:3000"
     - "9229:9229"
   volumes:
     - ./frontend:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,6 +62,7 @@ services:
       # it uses values from .env file
       - RSD_ENVIRONMENT
       - POSTGREST_URL
+      - RSD_AUTH_COUPLE_PROVIDERS
       - RSD_AUTH_PROVIDERS
       - RSD_AUTH_USER_MAIL_WHITELIST
       - SURFCONEXT_CLIENT_ID
@@ -116,6 +117,7 @@ services:
       - PGRST_JWT_SECRET
       - RSD_AUTH_URL
       - RSD_AUTH_PROVIDERS
+      - RSD_AUTH_COUPLE_PROVIDERS
       - MATOMO_URL
       - MATOMO_ID
       - SURFCONEXT_CLIENT_ID

--- a/documentation/docs/03-rsd-instance/02-configurations.md
+++ b/documentation/docs/03-rsd-instance/02-configurations.md
@@ -13,6 +13,7 @@ RSD offers following customization options:
 - Main locations for customizing RSD are:
   - `.env` file at the same location as your docker-compose.yml
   - `settings.json` that should be (volume) mounted into the frontend service in your docker-compose.yml
+- When configuring your production instance, replace `localhost` and `www.localhost` with the domain of your RSD
 :::
 
 ## Authentication providers
@@ -63,31 +64,18 @@ AZURE_DESCRIPTION_HTML="Sign in with your institutional credentials"
 AZURE_ORGANISATION=
 ```
 
-### Enable ORCID authentication
+### Enable ORCID authentication and coupling
+
+The RSD offers an integration with ORCID which can be used for login and coupling the user's RSD account with their ORCID. Both integrations can be used independently.
 
 Please refer to [ORCID OAuth documentation](https://info.orcid.org/documentation/integration-guide/getting-started-with-your-orcid-integration/) in order to setup ORCID authentication service for RSD.
 
-In the RSD `.env` file you need to provide following information to enable this authenitcation service.
-
-:::tip
-RSD offers public profile page that use ORCID as unique key. In order to enable linking of orcid account
-for public profile page ORCID authentication need to be enabled. ORCID_REDIRECT_COUPLE variable is used specifically for linking the ORCID account.
-
-- For more [info about public profile page see documentation](/users/user-settings/#public-profile)
-- After user links ORCID to RSD account he/she will be able to login using ORCID credentials too
-:::
+For both integrations (login and coupling) these common variables need to be defined in `.env`:
 
 ```bash
-# Ensure ORCID key is included in the list
-RSD_AUTH_PROVIDERS=ORCID
-
 # ORCID
 # consumed by: authentication, frontend/utils/loginHelpers
 ORCID_CLIENT_ID=
-# consumed by: authentication, frontend/utils/loginHelpers
-ORCID_REDIRECT=http://localhost/auth/login/orcid
-# consumed by: authentication, frontend/utils/loginHelpers
-ORCID_REDIRECT_COUPLE=http://localhost/auth/couple/orcid
 # consumed by: authentication, frontend/utils/loginHelpers
 ORCID_WELL_KNOWN_URL=
 # consumed by: authentication, frontend/utils/loginHelpers
@@ -95,11 +83,45 @@ ORCID_SCOPES=openid
 # consumed by: frontend/utils/loginHelpers
 ORCID_RESPONSE_MODE=query
 
+# consumed by services: authentication
+AUTH_ORCID_CLIENT_SECRET=
+```
+
+#### ORCID authentication
+
+To enable login via ORCID, provide ythe following information in `.env`:
+
+```bash
+# Ensure ORCID key is included in the list
+RSD_AUTH_PROVIDERS=ORCID
+
+# consumed by: authentication, frontend/utils/loginHelpers
+ORCID_REDIRECT=http://www.localhost/auth/login/orcid
 ```
 
 :::warning
 When using ORCID authentication only, each ORCID user need to be added to ORCID users list. See [ORCID users page](/rsd-instance/administration/#orcid-users) in the administration section.
 :::
+
+#### ORCID coupling
+
+For ORCID account coupling to be enabled, the following variables need to be set in `.env`:
+
+```bash
+# consumed by: authentication, frontend/utils/loginHelpers
+ORCID_REDIRECT_COUPLE=http://www.localhost/auth/couple/orcid
+# Enable ORCID account coupling
+RSD_AUTH_COUPLE_PROVIDERS=ORCID
+```
+
+If `RSD_AUTH_COUPLE_PROVIDERS` is undefined, ORCID account coupling is disabled.
+
+:::danger
+If ORCID login is disabled and ORCID coupling is enabled, users are added to the ORCID login allowlist after coupling their accounts.
+:::
+
+- For more [info about public profile page see documentation](/users/user-settings/#public-profile).
+- If ORCID login is enabled: after a user links an ORCID to their RSD account they will be able to login using ORCID credentials too.
 
 ### Enable SURFconext authentication
 

--- a/documentation/docs/03-rsd-instance/02-configurations.md.license
+++ b/documentation/docs/03-rsd-instance/02-configurations.md.license
@@ -1,5 +1,7 @@
 SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/frontend/components/user/settings/apiLinkOrcidProps.ts
+++ b/frontend/components/user/settings/apiLinkOrcidProps.ts
@@ -51,6 +51,11 @@ async function orcidAuthEndpoint(wellknownUrl:string){
  */
 export async function orcidCoupleProps() {
   try{
+    const coupleProviders = process.env.RSD_AUTH_COUPLE_PROVIDERS ?? null
+    if (!coupleProviders?.includes('ORCID')) {
+      // Do not continue if ORCID coupling not enabled
+      return null
+    }
     // extract well known url from env
     const wellknownUrl = process.env.ORCID_WELL_KNOWN_URL ?? null
     if (wellknownUrl) {


### PR DESCRIPTION
# Distinguish between login and coupling auth providers

Fixes #1095 #1097

Changes proposed in this pull request:

* Distinguish between auth providers used for login and for account coupling. This allows couple an ORCID account to an RSD account without having to allow ORCID login simultaneously
* :exclamation: This PR adds a new environment variable `RSD_AUTH_COUPLE_PROVIDERS`
* contains minor fix: removed the port mapping for the frontend dev mode because this was not necessary

How to test:

* in `.env`, set:
  ```
  RSD_AUTH_PROVIDERS="SURFCONEXT;LOCAL"
  RSD_AUTH_COUPLE_PROVIDERS=ORCID
  ```
* `docker compose build --parallel && docker compose up --scale scrapers=0`
* open login dialogue and verify that providers are Surf and Local only
* login
* navigate to user profile and link an ORCID account to the rsd account
* `docker compose down`
* add `ORCID` to `RSD_AUTH_PROVIDERS` and repeat previous steps. Verify that ORCID login works
* `docker compose down`
* in `.env`, comment out `RSD_AUTH_COUPLE_PROVIDERS`, or set it to something else than `ORCID`
* launch RSD and verify that ORCID login works but coupling button is not shown
* open the user documentation http://localhost/documentation/rsd-instance/configurations/ and check for updated content about the ORCID integration

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
