### PR TITLE
fix: deduplicate maintainers on frontend

### DIFF
--- a/frontend/components/organisation/settings/maintainers/useOrganisationMaintainers.tsx
+++ b/frontend/components/organisation/settings/maintainers/useOrganisationMaintainers.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -82,17 +83,36 @@ export function rawMaintainersToMaintainers(raw_maintainers: RawMaintainerOfOrga
   try {
     const maintainers:MaintainerOfOrganisation[] = []
     raw_maintainers.forEach(item => {
+      let maintainerWithMostInfo: MaintainerOfOrganisation | null = null
+      let bestScore = -1
       // use name as second loop indicator
       item.name.forEach((name, pos) => {
-        const maintainer = {
+        let score = 0
+        if (name) {
+          score += 1
+        }
+        if (item.email[pos]) {
+          score += 1
+        }
+        if (item.affiliation[pos]) {
+          score += 1
+        }
+
+        if (score <= bestScore) {
+          return
+        }
+        const maintainer: MaintainerOfOrganisation = {
           account: item.maintainer,
           name,
           email: item.email[pos] ? item.email[pos] : '',
           affiliation: item.affiliation[pos] ? item.affiliation[pos] : '',
           is_primary: item?.is_primary ?? false
         }
-        maintainers.push(maintainer)
+
+        maintainerWithMostInfo = maintainer
+        bestScore = score
       })
+      maintainers.push(maintainerWithMostInfo as unknown as MaintainerOfOrganisation)
     })
     return maintainers
   } catch (e:any) {

--- a/frontend/components/projects/edit/maintainers/useProjectMaintainer.tsx
+++ b/frontend/components/projects/edit/maintainers/useProjectMaintainer.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -91,16 +93,35 @@ export function rawMaintainersToMaintainers(raw_maintainers: RawMaintainerOfProj
   try {
     const maintainers:MaintainerOfProject[] = []
     raw_maintainers.forEach(item => {
+      let maintainerWithMostInfo: MaintainerOfProject | null = null
+      let bestScore = -1
       // use name as second loop indicator
       item.name.forEach((name, pos) => {
-        const maintainer = {
+        let score = 0
+        if (name) {
+          score += 1
+        }
+        if (item.email[pos]) {
+          score += 1
+        }
+        if (item.affiliation[pos]) {
+          score += 1
+        }
+
+        if (score <= bestScore) {
+          return
+        }
+        const maintainer: MaintainerOfProject = {
           account: item.maintainer,
           name,
           email: item.email[pos] ? item.email[pos] : '',
           affiliation: item.affiliation[pos] ? item.affiliation[pos] : ''
         }
-        maintainers.push(maintainer)
+
+        maintainerWithMostInfo = maintainer
+        bestScore = score
       })
+      maintainers.push(maintainerWithMostInfo as unknown as MaintainerOfProject)
     })
     return maintainers
   } catch (e:any) {

--- a/frontend/components/software/edit/maintainers/useSoftwareMaintainers.tsx
+++ b/frontend/components/software/edit/maintainers/useSoftwareMaintainers.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -92,16 +94,35 @@ export function rawMaintainersToMaintainers(raw_maintainers: RawMaintainerOfSoft
   try {
     const maintainers:MaintainerOfSoftware[] = []
     raw_maintainers.forEach(item => {
+      let maintainerWithMostInfo: MaintainerOfSoftware | null = null
+      let bestScore = -1
       // use name as second loop indicator
       item.name.forEach((name, pos) => {
-        const maintainer = {
+        let score = 0
+        if (name) {
+          score += 1
+        }
+        if (item.email[pos]) {
+          score += 1
+        }
+        if (item.affiliation[pos]) {
+          score += 1
+        }
+
+        if (score <= bestScore) {
+          return
+        }
+        const maintainer: MaintainerOfSoftware = {
           account: item.maintainer,
           name,
           email: item.email[pos] ? item.email[pos] : '',
           affiliation: item.affiliation[pos] ? item.affiliation[pos] : ''
         }
-        maintainers.push(maintainer)
+
+        maintainerWithMostInfo = maintainer
+        bestScore = score
       })
+      maintainers.push(maintainerWithMostInfo as unknown as MaintainerOfSoftware)
     })
     return maintainers
   } catch (e:any) {


### PR DESCRIPTION
## Deduplicate maintainers

Changes proposed in this pull request:

* Deduplicate maintainers by using the login info with most present fields of name, email and affiliation

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Log in with a non-ORCID account and create a software page, project page and organisation (make sure you're a maintainer of this organisation)
* Couple an ORCID to this account
* Check the maintainers of the pages you created above; only one maintainer should be visible on each

Closes #1091

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
