### PR TITLE
fix: only call ORCID well known endpoint on settings page

### DIFF
--- a/frontend/auth/api/authHelpers.ts
+++ b/frontend/auth/api/authHelpers.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,7 +16,7 @@ export type RedirectToProps = {
   scope: string,
   response_mode: string,
   prompt?: string,
-  redirect_couple_uri?:string,
+  redirect_couple_uri?:string | null,
   claims?: any
 }
 

--- a/frontend/components/user/settings/LinkOrcidButton.tsx
+++ b/frontend/components/user/settings/LinkOrcidButton.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,8 +11,14 @@ export default function LinkOrcidButton({orcidAuthLink,disabled}:{orcidAuthLink:
       <Button
         disabled={disabled}
         href={orcidAuthLink}
-        variant="outlined"
-        color="info"
+        variant="contained"
+        sx={{
+          // we need to overwrite global link styling from tailwind
+          // because the type of button is a link (we use href param)
+          ':hover':{
+            color:'primary.contrastText'
+          }
+        }}
       >
           Link your ORCID account
       </Button>

--- a/frontend/components/user/settings/apiLinkOrcidProps.ts
+++ b/frontend/components/user/settings/apiLinkOrcidProps.ts
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {RedirectToProps, getAuthorisationEndpoint} from '~/auth/api/authHelpers'
+
+// save timer as public variable
+let timer:NodeJS.Timer
+// save authorisation endpoint info as public variable
+let orcid_endpoint:string|null=null
+/**
+ * We save authorization_endpoint in memory
+ * to avoid repeating calls when user is navigating between sections
+ */
+async function orcidAuthEndpoint(wellknownUrl:string){
+  try{
+    const refreshInterval = 60*60*1000
+    // if already present return existing value
+    if (orcid_endpoint) {
+      // console.log('orcidAuthEndpoint...CACHE used...', new Date())
+      return orcid_endpoint
+    }
+    // if not present request endpoint info
+    orcid_endpoint = await getAuthorisationEndpoint(wellknownUrl) ?? null
+    // we set timer only in the production because hot-reloading creates multiple instances
+    // TODO! investigate other approaches that work identical in dev and production
+    if (process.env.NODE_ENV==='production'){
+      // clear previous timer to avoid mem leaks
+      if (timer){
+        // console.log('orcidAuthEndpoint...CLEAR INTERVAL...', new Date())
+        clearInterval(timer)
+      }
+      // create refresh interval and store it
+      timer = setInterval(async()=>{
+        // console.log('orcidAuthEndpoint...REFRESH INFO...', new Date())
+        orcid_endpoint = await getAuthorisationEndpoint(wellknownUrl) ?? null
+      },refreshInterval)
+    }
+    // console.log('orcidAuthEndpoint...REQUEST made...', new Date())
+    return orcid_endpoint
+  }catch(e:any){
+    logger(`orcidAuthEndpoint: ${e.message}`, 'error')
+    return null
+  }
+}
+
+/**
+ * Obtain the orcid redirect props for linking ORCID account [server side]
+ */
+export async function orcidCoupleProps() {
+  try{
+    // extract well known url from env
+    const wellknownUrl = process.env.ORCID_WELL_KNOWN_URL ?? null
+    if (wellknownUrl) {
+      // get (cached) authorisation endpoint from well known url
+      const authorization_endpoint = await orcidAuthEndpoint(wellknownUrl)
+      if (authorization_endpoint) {
+        // construct all props needed for redirectUrl
+        const props: RedirectToProps = {
+          authorization_endpoint,
+          redirect_uri: process.env.ORCID_REDIRECT ?? 'https://research-software.nl/auth/login/orcid',
+          redirect_couple_uri: process.env.ORCID_REDIRECT_COUPLE ?? null,
+          client_id: process.env.ORCID_CLIENT_ID ?? 'www.research-software.nl',
+          scope: process.env.ORCID_SCOPES ?? 'openid',
+          response_mode: process.env.ORCID_RESPONSE_MODE ?? 'query'
+        }
+        return props
+      } else {
+        const message = 'authorization_endpoint is missing'
+        logger(`orcidCoupleProps: ${message}`, 'error')
+        return null
+      }
+    } else {
+      const message = 'ORCID_WELL_KNOWN_URL is missing'
+      logger(`orcidCoupleProps: ${message}`, 'error')
+      return null
+    }
+  }catch(e:any){
+    logger(`orcidCoupleProps: ${e.message}`, 'error')
+    return null
+  }
+}

--- a/frontend/pages/api/fe/auth/orcid.ts
+++ b/frontend/pages/api/fe/auth/orcid.ts
@@ -4,7 +4,7 @@
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,38 +15,43 @@
 
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import type {NextApiRequest, NextApiResponse} from 'next'
-import {getAuthorisationEndpoint, RedirectToProps, getRedirectUrl} from '~/auth/api/authHelpers'
 import logger from '~/utils/logger'
+import {RedirectToProps, getAuthorisationEndpoint, getRedirectUrl} from '~/auth/api/authHelpers'
 import {Provider, ApiError} from '.'
 
 type Data = Provider | ApiError
 
 export async function orcidRedirectProps() {
-  // extract well known url from env
-  const wellknownUrl = process.env.ORCID_WELL_KNOWN_URL ?? null
-  if (wellknownUrl) {
-    // extract authorisation endpoint from well known response
-    const authorization_endpoint = await getAuthorisationEndpoint(wellknownUrl)
-    if (authorization_endpoint) {
-      // construct all props needed for redirectUrl
-      const props: RedirectToProps = {
-        authorization_endpoint,
-        redirect_uri: process.env.ORCID_REDIRECT ?? 'https://research-software.nl/auth/login/orcid',
-        redirect_couple_uri: process.env.ORCID_REDIRECT_COUPLE ?? null,
-        client_id: process.env.ORCID_CLIENT_ID ?? 'www.research-software.nl',
-        scope: process.env.ORCID_SCOPES ?? 'openid',
-        response_mode: process.env.ORCID_RESPONSE_MODE ?? 'query'
+  try{
+    // extract well known url from env
+    const wellknownUrl = process.env.ORCID_WELL_KNOWN_URL ?? null
+    if (wellknownUrl) {
+      // get (cached) authorisation endpoint from well known url
+      const authorization_endpoint = await getAuthorisationEndpoint(wellknownUrl) ?? null
+      if (authorization_endpoint) {
+        // construct all props needed for redirectUrl
+        const props: RedirectToProps = {
+          authorization_endpoint,
+          redirect_uri: process.env.ORCID_REDIRECT ?? 'https://research-software.nl/auth/login/orcid',
+          redirect_couple_uri: process.env.ORCID_REDIRECT_COUPLE ?? null,
+          client_id: process.env.ORCID_CLIENT_ID ?? 'www.research-software.nl',
+          scope: process.env.ORCID_SCOPES ?? 'openid',
+          response_mode: process.env.ORCID_RESPONSE_MODE ?? 'query'
+        }
+        return props
+      } else {
+        const message = 'authorization_endpoint is missing'
+        logger(`orcidRedirectProps: ${message}`, 'error')
+        return null
       }
-      return props
     } else {
-      const message = 'authorization_endpoint is missing'
-      logger(`api/fe/auth/orcid: ${message}`, 'error')
-      throw new Error(message)
+      const message = 'ORCID_WELL_KNOWN_URL is missing'
+      logger(`orcidRedirectProps: ${message}`, 'error')
+      return null
     }
-  } else {
-    const message = 'ORCID_WELL_KNOWN_URL is missing'
-    logger(`api/fe/auth/orcid: ${message}`, 'error')
-    throw new Error(message)
+  }catch(e:any){
+    logger(`orcidRedirectProps: ${e.message}`, 'error')
+    return null
   }
 }
 

--- a/frontend/pages/api/fe/auth/orcid.ts
+++ b/frontend/pages/api/fe/auth/orcid.ts
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
@@ -22,17 +22,17 @@ import {Provider, ApiError} from '.'
 type Data = Provider | ApiError
 
 export async function orcidRedirectProps() {
-  // extract wellknow url from env
+  // extract well known url from env
   const wellknownUrl = process.env.ORCID_WELL_KNOWN_URL ?? null
   if (wellknownUrl) {
-    // extract authorisation endpoint from wellknow response
+    // extract authorisation endpoint from well known response
     const authorization_endpoint = await getAuthorisationEndpoint(wellknownUrl)
     if (authorization_endpoint) {
       // construct all props needed for redirectUrl
       const props: RedirectToProps = {
         authorization_endpoint,
         redirect_uri: process.env.ORCID_REDIRECT ?? 'https://research-software.nl/auth/login/orcid',
-        redirect_couple_uri: process.env.ORCID_REDIRECT_COUPLE ?? 'MISSING',
+        redirect_couple_uri: process.env.ORCID_REDIRECT_COUPLE ?? null,
         client_id: process.env.ORCID_CLIENT_ID ?? 'www.research-software.nl',
         scope: process.env.ORCID_SCOPES ?? 'openid',
         response_mode: process.env.ORCID_RESPONSE_MODE ?? 'query'

--- a/frontend/pages/user/[section].tsx
+++ b/frontend/pages/user/[section].tsx
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
@@ -24,7 +24,7 @@ import {SearchProvider} from '~/components/search/SearchContext'
 import UserTitle from '~/components/user/UserTitle'
 import UserNav, {UserCounts} from '~/components/user/UserNav'
 import {getUserCounts} from '~/components/user/getUserCounts'
-import {orcidRedirectProps} from '../api/fe/auth/orcid'
+import {orcidCoupleProps} from '~/components/user/settings/apiLinkOrcidProps'
 
 type UserPagesProps = {
   section: string,
@@ -91,9 +91,10 @@ export default function UserPages({section,counts,orcidAuthLink}:UserPagesProps)
 export async function getServerSideProps(context:GetServerSidePropsContext) {
   try{
     const {params, req} = context
-
     const section = params?.section
     const token = req?.cookies['rsd_token']
+    // placeholder for orcid couple link
+    let orcidAuthLink:string|null=null
 
     // console.log('getServerSideProps...params...', params)
     // console.log('getServerSideProps...token...', token)
@@ -120,23 +121,18 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       frontend: false
     })
 
-    let orcidAuthLink:string|null=null
     if (section === 'settings') {
-      try {
-        const orcid = await orcidRedirectProps()
-        if (orcid){
-          if (orcid?.redirect_couple_uri){
-            // getRedirectUrl uses redirect_uri to construct redirectURL
-            orcid.redirect_uri = orcid.redirect_couple_uri
-            orcidAuthLink = getRedirectUrl(orcid)
-          }
-        }
-      } catch (error) {
+      // only relevant for settings page
+      const orcid = await orcidCoupleProps()
+      if (orcid && orcid?.redirect_couple_uri){
+        // getRedirectUrl uses redirect_uri to construct redirectURL
+        orcid.redirect_uri = orcid.redirect_couple_uri
+        orcidAuthLink = getRedirectUrl(orcid)
       }
     }
 
     return {
-      // passed to the page component as props
+      // passed to page component as props
       props: {
         section,
         counts,

--- a/frontend/pages/user/[section].tsx
+++ b/frontend/pages/user/[section].tsx
@@ -2,9 +2,10 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -120,12 +121,17 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     })
 
     let orcidAuthLink:string|null=null
-    const orcid = await orcidRedirectProps()
-    if (orcid){
-      if (orcid?.redirect_couple_uri){
-        // getRedirectUrl uses redirect_uri to construct redirectURL
-        orcid.redirect_uri = orcid.redirect_couple_uri
-        orcidAuthLink = getRedirectUrl(orcid)
+    if (section === 'settings') {
+      try {
+        const orcid = await orcidRedirectProps()
+        if (orcid){
+          if (orcid?.redirect_couple_uri){
+            // getRedirectUrl uses redirect_uri to construct redirectURL
+            orcid.redirect_uri = orcid.redirect_couple_uri
+            orcidAuthLink = getRedirectUrl(orcid)
+          }
+        }
+      } catch (error) {
       }
     }
 


### PR DESCRIPTION
## Fix ORCID requests

Changes proposed in this pull request:

* Only call ORCID well known endpoint on section page
* Replace string `'MISSING'` with `null` if coupling URL is missing
* Wrap code in try-catch statement to always be able to show the settings page

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Log in with a non-ORCID account
* Navigate various user pages, like http://localhost/user/projects and http://localhost/user/settings. There should only be a noticable delay on the settings page

**Note:** It would be better to only fetch the data when needed when clicking the button, or asynchronously in the background. It might also be good to use caching. However, this PR only implements the minimum necessary, as this code is also being worked on in #1100.

Closes #1103

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
