### PR TITLE
1076 scrape project impact

### DIFF
--- a/database/105-project-views.sql
+++ b/database/105-project-views.sql
@@ -1,10 +1,136 @@
--- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+-- SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+-- SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 dv4all
 --
 -- SPDX-License-Identifier: Apache-2.0
+
+-- UNIQUE CITATIONS BY PROJECT ID
+-- Scraped citation using output as reference
+CREATE FUNCTION citation_by_project() RETURNS TABLE (
+	project UUID,
+	id UUID,
+	doi CITEXT,
+	url VARCHAR,
+	title VARCHAR,
+	authors VARCHAR,
+	publisher VARCHAR,
+	publication_year SMALLINT,
+	journal VARCHAR,
+	page VARCHAR,
+	image_url VARCHAR,
+	mention_type mention_type,
+	source VARCHAR,
+	reference_papers UUID[]
+) LANGUAGE sql STABLE AS
+$$
+SELECT
+	output_for_project.project,
+	mention.id,
+	mention.doi,
+	mention.url,
+	mention.title,
+	mention.authors,
+	mention.publisher,
+	mention.publication_year,
+	mention.journal,
+	mention.page,
+	mention.image_url,
+	mention.mention_type,
+	mention.source,
+	ARRAY_AGG(
+		output_for_project.mention
+	) AS reference_paper
+FROM
+	output_for_project
+INNER JOIN
+	citation_for_mention ON citation_for_mention.mention = output_for_project.mention
+INNER JOIN
+	mention ON mention.id = citation_for_mention.citation
+GROUP BY
+	output_for_project.project,
+	mention.id,
+	mention.doi,
+	mention.url,
+	mention.title,
+	mention.authors,
+	mention.publisher,
+	mention.publication_year,
+	mention.journal,
+	mention.page,
+	mention.image_url,
+	mention.mention_type,
+	mention.source
+;
+$$;
+
+
+-- UNIQUE MENTIONS & CITATIONS BY PROJECT ID
+-- UNION will deduplicate exact entries
+CREATE FUNCTION impact_by_project() RETURNS TABLE (
+	project UUID,
+	id UUID,
+	doi CITEXT,
+	url VARCHAR,
+	title VARCHAR,
+	authors VARCHAR,
+	publisher VARCHAR,
+	publication_year SMALLINT,
+	journal VARCHAR,
+	page VARCHAR,
+	image_url VARCHAR,
+	mention_type mention_type,
+	source VARCHAR,
+	note VARCHAR
+) LANGUAGE sql STABLE AS
+$$
+-- impact for project
+SELECT
+	impact_for_project.project,
+	mention.id,
+	mention.doi,
+	mention.url,
+	mention.title,
+	mention.authors,
+	mention.publisher,
+	mention.publication_year,
+	mention.journal,
+	mention.page,
+	mention.image_url,
+	mention.mention_type,
+	mention.source,
+	mention.note
+FROM
+	mention
+INNER JOIN
+	impact_for_project ON impact_for_project.mention = mention.id
+-- will deduplicate identical entries
+-- from scraped citations
+UNION
+-- scraped citations from reference papers
+SELECT
+	project,
+	id,
+	doi,
+	url,
+	title,
+	authors,
+	publisher,
+	publication_year,
+	journal,
+	page,
+	image_url,
+	mention_type,
+	source,
+	-- scraped citations have no note prop
+	-- we need this prop in the edit impact section
+	NULL as note
+FROM
+	citation_by_project()
+;
+$$;
+
 
 CREATE FUNCTION count_project_team_members() RETURNS TABLE (
 	project UUID,
@@ -129,12 +255,12 @@ CREATE FUNCTION count_project_impact() RETURNS TABLE (
 ) LANGUAGE sql STABLE AS
 $$
 SELECT
-	impact_for_project.project,
-	COUNT(impact_for_project.mention)
+	impact_by_project.project,
+	COUNT(impact_by_project.id)
 FROM
-	impact_for_project
+	impact_by_project()
 GROUP BY
-	impact_for_project.project;
+	impact_by_project.project;
 $$;
 
 

--- a/database/109-mention-views.sql
+++ b/database/109-mention-views.sql
@@ -1,6 +1,6 @@
+-- SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 -- SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
--- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -17,13 +17,17 @@ $$
 	FROM mention
 	LEFT JOIN citation_for_mention ON mention.id = citation_for_mention.mention
 	LEFT JOIN mention AS citation ON citation_for_mention.citation = citation.id
-	WHERE mention.id IN (
-		SELECT mention FROM reference_paper_for_software
-	)
-	OR
-	mention.id IN (
-		SELECT mention FROM output_for_project
-	)
+	WHERE
+	-- ONLY items with DOI
+		mention.doi IS NOT NULL AND (
+			mention.id IN (
+				SELECT mention FROM reference_paper_for_software
+			)
+			OR
+			mention.id IN (
+				SELECT mention FROM output_for_project
+			)
+		)
 	GROUP BY mention.id
 $$;
 
@@ -142,125 +146,5 @@ SELECT
 	source
 FROM
 	citation_by_software()
-;
-$$;
-
-
--- UNIQUE CITATIONS BY PROJECT ID
-CREATE FUNCTION citation_by_project() RETURNS TABLE (
-	project UUID,
-	id UUID,
-	doi CITEXT,
-	url VARCHAR,
-	title VARCHAR,
-	authors VARCHAR,
-	publisher VARCHAR,
-	publication_year SMALLINT,
-	journal VARCHAR,
-	page VARCHAR,
-	image_url VARCHAR,
-	mention_type mention_type,
-	source VARCHAR,
-	reference_papers UUID[]
-) LANGUAGE sql STABLE AS
-$$
-SELECT
-	output_for_project.project,
-	mention.id,
-	mention.doi,
-	mention.url,
-	mention.title,
-	mention.authors,
-	mention.publisher,
-	mention.publication_year,
-	mention.journal,
-	mention.page,
-	mention.image_url,
-	mention.mention_type,
-	mention.source,
-	ARRAY_AGG(
-		output_for_project.mention
-	) AS reference_paper
-FROM
-	output_for_project
-INNER JOIN
-	citation_for_mention ON citation_for_mention.mention = output_for_project.mention
-INNER JOIN
-	mention ON mention.id = citation_for_mention.citation
-GROUP BY
-	output_for_project.project,
-	mention.id,
-	mention.doi,
-	mention.url,
-	mention.title,
-	mention.authors,
-	mention.publisher,
-	mention.publication_year,
-	mention.journal,
-	mention.page,
-	mention.image_url,
-	mention.mention_type,
-	mention.source
-;
-$$;
-
-
--- UNIQUE MENTIONS & CITATIONS BY PROJECT ID
--- UNION will deduplicate exact entries
-CREATE FUNCTION impact_by_project() RETURNS TABLE (
-	project UUID,
-	id UUID,
-	doi CITEXT,
-	url VARCHAR,
-	title VARCHAR,
-	authors VARCHAR,
-	publisher VARCHAR,
-	publication_year SMALLINT,
-	journal VARCHAR,
-	page VARCHAR,
-	image_url VARCHAR,
-	mention_type mention_type,
-	source VARCHAR
-) LANGUAGE sql STABLE AS
-$$
--- impact for project
-SELECT
-	impact_for_project.project,
-	mention.id,
-	mention.doi,
-	mention.url,
-	mention.title,
-	mention.authors,
-	mention.publisher,
-	mention.publication_year,
-	mention.journal,
-	mention.page,
-	mention.image_url,
-	mention.mention_type,
-	mention.source
-FROM
-	mention
-INNER JOIN
-	impact_for_project ON impact_for_project.mention = mention.id
--- will deduplicate identical entries
--- from scraped citations
-UNION
--- scraped citations from reference papers
-SELECT
-	project,
-	id,
-	doi,
-	url,
-	title,
-	authors,
-	publisher,
-	publication_year,
-	journal,
-	page,
-	image_url,
-	mention_type,
-	source
-FROM
-	citation_by_project()
 ;
 $$;

--- a/frontend/components/mention/AccordionForLightTheme.tsx
+++ b/frontend/components/mention/AccordionForLightTheme.tsx
@@ -1,0 +1,89 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Accordion from '@mui/material/Accordion'
+import AccordionSummary from '@mui/material/AccordionSummary'
+import AccordionDetails from '@mui/material/AccordionDetails'
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
+import Badge from '@mui/material/Badge'
+
+type AccordionForLightThemeProps = {
+  title: string
+  badgeContent: number|null
+  children: any
+  maxBadgeCount?: number
+}
+
+export default function AccordionForLightTheme({
+  title,badgeContent,maxBadgeCount=9999,children
+}: AccordionForLightThemeProps) {
+  // do not render accordion/section if no items
+  // if (!items || items.length===0) return null
+  // debugger
+  return (
+    <Accordion
+      data-testid='mentions-section-for-type'
+      sx={{
+        boxShadow: 0,
+        borderTop: '1px solid',
+        borderColor: 'divider',
+        backgroundColor: 'background.paper',
+        // remove line above the accordion
+        '&:before': {
+          height: '0px'
+        },
+        '&:last-child': {
+          borderBottom: '1px solid',
+          borderColor: 'divider'
+        }
+      }}>
+      <AccordionSummary
+        expandIcon={
+          <ExpandMoreIcon />
+        }
+        sx={{
+          position: 'sticky',
+          top: 0,
+          // FF fix for list items mixing with section title
+          // when scrolling through long list
+          backgroundColor: 'background.paper',
+          padding: '0rem',
+          '&:hover': {
+            opacity:0.95
+          }
+        }}
+      >
+        <Badge
+          badgeContent={badgeContent}
+          max={maxBadgeCount}
+          color="primary"
+          sx={{
+            '& .MuiBadge-badge': {
+              right: '-1rem',
+              top: '0.25rem',
+              border: '1px solid',
+              borderColor: 'primary.contrastText',
+              color: 'primary.contrastText',
+              fontWeight: 500
+            },
+          }}
+        >
+          <div className="text-xl">{title}</div>
+        </Badge>
+      </AccordionSummary>
+      <AccordionDetails sx={{
+        // set max height to avoid large shifts
+        maxHeight: '32rem',
+        //avoid resizing when scrollbar appears
+        overflow: 'overlay',
+        padding: '0rem 0rem'
+      }}>
+        {children}
+      </AccordionDetails>
+    </Accordion>
+  )
+}

--- a/frontend/components/projects/edit/citations/CitationsByType.tsx
+++ b/frontend/components/projects/edit/citations/CitationsByType.tsx
@@ -1,0 +1,95 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Alert from '@mui/material/Alert'
+
+import {useSession} from '~/auth'
+import EditSectionTitle from '~/components/layout/EditSectionTitle'
+import ContentLoader from '~/components/layout/ContentLoader'
+import useProjectContext from '../useProjectContext'
+import {cfgCitations as config} from './config'
+import useCitationsForProject from './useCitationsForProject'
+import {clasifyMentionsByType} from '~/utils/editMentions'
+import {getMentionType, getMentionTypeOrder} from '~/components/mention/config'
+import {sortOnNumProp} from '~/utils/sortFn'
+import CitationsList from './CitationsList'
+import NoCitationItems from './NoCitationItems'
+import {MentionItemProps} from '~/types/Mention'
+
+
+function CitationListByType({mentions}:{mentions:MentionItemProps[]}){
+  // we do not have feature mentions for citations (scraped mentions)
+  const {mentionByType} = clasifyMentionsByType(mentions)
+  const mentionTypes = getMentionTypeOrder(mentionByType)
+
+  // render
+  return mentionTypes.map((key) => {
+    const items = mentionByType[key]?.sort((a, b) => {
+      // sort mentions on date, newest at the top
+      return sortOnNumProp(a,b,'publication_year','desc')
+    })
+    if (items){
+      const title = getMentionType(key,'plural')
+      return (
+        <CitationsList
+          key={key}
+          title={title}
+          items={items}
+        />
+      )
+    }
+  })
+}
+
+export default function CitationsByType() {
+  const {project} = useProjectContext()
+  const {token} = useSession()
+  const {loading, mentions} = useCitationsForProject({
+    project: project.id,
+    token
+  })
+
+  // console.group('CitationsByType')
+  // console.log('citationCnt...', citationCnt)
+  // console.log('loading...', loading)
+  // console.log('project...', project)
+  // console.log('token...', token)
+  // console.groupEnd()
+
+  if (loading) {
+    return (
+      <ContentLoader />
+    )
+  }
+
+  return (
+    <>
+      <EditSectionTitle
+        title={config.title}
+      >
+        <h2>{mentions?.length ?? 0}</h2>
+      </EditSectionTitle>
+      <div className="py-2" />
+      <Alert severity="info">
+        Here you see all citations RSD is able to scrape from OpenAlex.
+        We use publication DOI you provided in the output section to look for citations of the project output.
+        RSD scraper will periodically search for citation of your publications using the DOI.
+        On the project page these citations are showed in the impact section together with the items you added manually.
+      </Alert>
+      <div className="py-2" />
+      {/* render citations by type */}
+      { mentions?.length===0 ?
+        <NoCitationItems />
+        :
+        <CitationListByType
+          mentions={mentions}
+        />
+      }
+    </>
+  )
+}

--- a/frontend/components/projects/edit/citations/CitationsList.tsx
+++ b/frontend/components/projects/edit/citations/CitationsList.tsx
@@ -6,35 +6,35 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {MentionItemProps} from '~/types/Mention'
-import MentionEditItem from './MentionEditItem'
-import AccordionForLightTheme from './AccordionForLightTheme'
+import MentionViewItem from '~/components/mention/MentionViewItem'
+import AccordionForLightTheme from '~/components/mention/AccordionForLightTheme'
 
 type MentionSectionListProps = {
   title: string
   items: MentionItemProps[]
 }
 
-export default function MentionEditList({title, items}: MentionSectionListProps) {
+export default function CitationsList({title, items}: MentionSectionListProps) {
   // do not render accordion/section if no items
   if (!items || items.length===0) return null
 
+  // debugger
   return (
     <AccordionForLightTheme
       title={title}
       badgeContent={items.length}
     >
       <ul>
-        {
-          items.map((item, pos) => {
-            return (
-              <li key={item.id ?? pos} className="p-4 hover:bg-base-200 hover:text-base-900">
-                <MentionEditItem
-                  pos={pos + 1}
-                  item={item}
-                />
-              </li>
-            )
-          })
+        {items.map((item, pos) => {
+          return (
+            <li key={item.id ?? pos} className="p-4">
+              <MentionViewItem
+                pos={pos+1}
+                item={item}
+              />
+            </li>
+          )
+        })
         }
       </ul>
     </AccordionForLightTheme>

--- a/frontend/components/projects/edit/citations/NoCitationItems.tsx
+++ b/frontend/components/projects/edit/citations/NoCitationItems.tsx
@@ -8,11 +8,11 @@
 import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 
-export default function NoOutputItems() {
+export default function NoCitationItems() {
   return (
     <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
-      <AlertTitle sx={{fontWeight:500}}>No output items to show</AlertTitle>
-      Add one using <strong>search, import or create options!</strong>
+      <AlertTitle sx={{fontWeight:500}}>No citations to show</AlertTitle>
+      Provide project publications <strong>in the output section</strong>.
     </Alert>
   )
 }

--- a/frontend/components/projects/edit/citations/config.ts
+++ b/frontend/components/projects/edit/citations/config.ts
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export const cfgCitations = {
+  title: 'Citations',
+}

--- a/frontend/components/projects/edit/citations/index.tsx
+++ b/frontend/components/projects/edit/citations/index.tsx
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import EditSection from '~/components/layout/EditSection'
+import CitationsByType from './CitationsByType'
+
+export default function ProjectCitations() {
+  // const {token} = useSession()
+  // const {project} = useProjectContext()
+
+  // console.group('ProjectImpact')
+  // console.log('session...', session)
+  // console.groupEnd()
+
+  return (
+    <EditSection className='pt-4 pb-8'>
+      <CitationsByType />
+    </EditSection>
+  )
+}

--- a/frontend/components/projects/edit/citations/useCitationsForProject.tsx
+++ b/frontend/components/projects/edit/citations/useCitationsForProject.tsx
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+
+import {sortOnNumProp} from '~/utils/sortFn'
+import {MentionItemProps} from '~/types/Mention'
+import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import logger from '~/utils/logger'
+
+type ImpactForProjectProps = {
+  project: string,
+  token:string
+}
+
+export async function getCitationsByProject({project, token}:
+  {project: string, token?: string}) {
+  try {
+    // the content is ordered by type ascending
+    const query = `project=eq.${project}&order=mention_type.asc`
+    // construct url
+    const url = `${getBaseUrl()}/rpc/citation_by_project?${query}`
+    // make request
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+      }
+    })
+    if (resp.status === 200) {
+      const json = await resp.json()
+      // extract mentions from software object
+      const mentions: MentionItemProps[] = json ?? []
+      return mentions
+    }
+    logger(`getCitationsByProject: [${resp.status}] [${url}]`, 'error')
+    // query not found
+    return []
+  } catch (e: any) {
+    logger(`getCitationsByProject: ${e?.message}`, 'error')
+    return []
+  }
+}
+
+
+export default function useCitationsForProject({project, token}: ImpactForProjectProps) {
+  const [loading,setLoading] = useState(false)
+  const [mentions, setMentions] = useState<MentionItemProps[]>([])
+
+  useEffect(() => {
+    let abort = false
+    async function getImpactFromApi() {
+      setLoading(true)
+
+      const mentionsForProject = await getCitationsByProject({
+        project,
+        token
+      })
+      if (abort === false) {
+        const mentions:MentionItemProps[] = mentionsForProject
+          .map((item:MentionItemProps) =>{
+            // we need to select only props that fit into mention type
+            // in order to update items (rsd-admin feature only)
+            return {
+              id: item.id,
+              doi: item.doi,
+              url: item.url,
+              title: item.title,
+              authors: item.authors,
+              publisher: item.publisher,
+              publication_year: item.publication_year,
+              journal: item.journal,
+              page: item.page,
+              image_url: item.image_url,
+              mention_type: item.mention_type,
+              source: item.source,
+              note: item.note
+            }
+          })
+          .sort((a, b) => {
+            // sort mentions on publication year, newest at the top
+            return sortOnNumProp(a,b,'publication_year','desc')
+          })
+        // debugger
+        setMentions(mentions)
+        setLoading(false)
+      }
+    }
+    if (project && token) {
+      getImpactFromApi()
+    }
+    return () => { abort = true }
+  },[project,token])
+
+  // console.group('useCitationsForProject')
+  // console.log('loading...', loading)
+  // console.log('project...', project)
+  // console.log('citationCnt...', mentions.length)
+  // console.groupEnd()
+
+  return {
+    loading,
+    mentions
+  }
+}

--- a/frontend/components/projects/edit/editProjectPages.tsx
+++ b/frontend/components/projects/edit/editProjectPages.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,7 @@ import ShareIcon from '@mui/icons-material/Share'
 import PersonAddIcon from '@mui/icons-material/PersonAdd'
 import TerminalIcon from '@mui/icons-material/Terminal'
 import ContentLoader from '~/components/layout/ContentLoader'
-
+import JoinInnerIcon from '@mui/icons-material/JoinInner'
 
 // import ProjectInformation from './information'
 // import ProjectTeam from './team'
@@ -41,6 +41,9 @@ const ProjectImpact = dynamic(() => import('./impact'),{
   loading: ()=><ContentLoader />
 })
 const ProjectOutput = dynamic(() => import('./output'),{
+  loading: ()=><ContentLoader />
+})
+const ProjectCitations = dynamic(() => import('./citations'),{
   loading: ()=><ContentLoader />
 })
 const RelatedProjects = dynamic(() => import('./related-projects'),{
@@ -84,13 +87,6 @@ export const editProjectPage: EditProjectPageProps[] = [
     status: 'Optional information'
   },
   {
-    id: 'impact',
-    label: 'Impact',
-    icon: <AccessibilityNewIcon />,
-    render: () => <ProjectImpact />,
-    status: 'Optional information'
-  },
-  {
     id: 'output',
     label: 'Output',
     icon: <OutboundIcon />,
@@ -98,9 +94,23 @@ export const editProjectPage: EditProjectPageProps[] = [
     status: 'Optional information'
   },
   {
+    id: 'impact',
+    label: 'Impact',
+    icon: <AccessibilityNewIcon />,
+    render: () => <ProjectImpact />,
+    status: 'Optional information'
+  },
+  {
+    id: 'citations',
+    label: 'Citations',
+    icon: <ShareIcon />,
+    render: () => <ProjectCitations />,
+    status: 'Scraped information'
+  },
+  {
     id: 'related-projects',
     label: 'Related projects',
-    icon: <ShareIcon />,
+    icon: <JoinInnerIcon />,
     render: () => <RelatedProjects />,
     status: 'Optional information'
   },

--- a/frontend/components/projects/edit/editProjectPages.tsx
+++ b/frontend/components/projects/edit/editProjectPages.tsx
@@ -70,62 +70,62 @@ export const editProjectPage: EditProjectPageProps[] = [
     label: 'Information',
     icon: <InfoIcon />,
     render: () => <ProjectInformation />,
-    status: 'Required information'
+    status: ''
   },
   {
     id: 'team',
     label: 'Team',
     icon: <TeamsIcon />,
     render: () => <ProjectTeam />,
-    status: 'Required information'
+    status: ''
   },
   {
     id: 'organisations',
     label: 'Organisations',
     icon: <FactoryIcon />,
     render: () => <ProjectOrganisations />,
-    status: 'Optional information'
+    status: ''
   },
   {
     id: 'output',
     label: 'Output',
     icon: <OutboundIcon />,
     render: () => <ProjectOutput />,
-    status: 'Optional information'
+    status: ''
   },
   {
     id: 'impact',
     label: 'Impact',
     icon: <AccessibilityNewIcon />,
     render: () => <ProjectImpact />,
-    status: 'Optional information'
+    status: ''
   },
   {
     id: 'citations',
     label: 'Citations',
     icon: <ShareIcon />,
     render: () => <ProjectCitations />,
-    status: 'Scraped information'
+    status: ''
   },
   {
     id: 'related-projects',
     label: 'Related projects',
     icon: <JoinInnerIcon />,
     render: () => <RelatedProjects />,
-    status: 'Optional information'
+    status: ''
   },
   {
     id: 'related-software',
     label: 'Related software',
     icon: <TerminalIcon />,
     render: () => <RelatedSoftware />,
-    status: 'Optional information'
+    status: ''
   },
   {
     id: 'maintainers',
     label: 'Maintainers',
     icon: <PersonAddIcon />,
     render: () => <ProjectMaintainers />,
-    status: 'Optional information'
+    status: ''
   }
 ]

--- a/frontend/components/projects/edit/impact/EditProjectImpactIndex.test.tsx
+++ b/frontend/components/projects/edit/impact/EditProjectImpactIndex.test.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/projects/edit/impact/ImpactByType.tsx
+++ b/frontend/components/projects/edit/impact/ImpactByType.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -46,7 +48,8 @@ export default function ImpactByType() {
         Here you can add results of the project which had impact on others.
         This could be papers by others re-using your software or data,
         articles or videos in the press describing the results, policy
-        documents based on these results, etc.
+        documents based on these results, etc. If you added publications
+        in the output section RSD will scrape OpenAlex for the citations.
       </Alert>
       <div className="py-2" />
       <MentionEditSection />

--- a/frontend/components/projects/edit/impact/NoImpactItems.tsx
+++ b/frontend/components/projects/edit/impact/NoImpactItems.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +12,7 @@ export default function NoImpactItems() {
   return (
     <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
       <AlertTitle sx={{fontWeight:500}}>No impact items to show</AlertTitle>
-      Add one using <strong>search or add options!</strong>
+      You can manually add new items by using <strong>search, import or create options!</strong>
     </Alert>
   )
 }

--- a/frontend/components/projects/edit/impact/index.tsx
+++ b/frontend/components/projects/edit/impact/index.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/projects/edit/impact/useImpactForProject.tsx
+++ b/frontend/components/projects/edit/impact/useImpactForProject.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,6 @@ import {getMentionsForProject} from '~/utils/getProjects'
 
 import {sortOnNumProp} from '~/utils/sortFn'
 import useEditMentionReducer from '~/components/mention/useEditMentionReducer'
-import {MentionItemProps} from '~/types/Mention'
 
 type ImpactForProjectProps = {
   project: string,
@@ -26,18 +25,19 @@ export default function useImpactForProject({project, token}: ImpactForProjectPr
     let abort = false
     async function getImpactFromApi() {
       setLoading(true)
+
       const mentionsForProject = await getMentionsForProject({
         project,
         table:'impact_for_project',
         token
       })
-      if (mentionsForProject && abort === false) {
-        const mentions:MentionItemProps[] = mentionsForProject.sort((a, b) => {
+
+      if (abort === false) {
+        mentionsForProject.sort((a, b) => {
           // sort mentions on publication year, newest at the top
           return sortOnNumProp(a,b,'publication_year','desc')
         })
-        // debugger
-        setMentions(mentions)
+        setMentions(mentionsForProject)
         setLoadedProject(project)
         setLoading(false)
       }

--- a/frontend/components/projects/edit/output/OutputByType.tsx
+++ b/frontend/components/projects/edit/output/OutputByType.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -41,6 +43,7 @@ export default function OutputByType() {
       <Alert severity="info">
         Here you can add things which were produced by the project itself.
         These can be papers, books, articles, software, datasets, blogs, etc.
+        RSD will scrape citations of your output using OpenAlex.
       </Alert>
       <div className="py-2" />
       <MentionEditSection />

--- a/frontend/components/projects/edit/output/ScrapersInfo.tsx
+++ b/frontend/components/projects/edit/output/ScrapersInfo.tsx
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Alert from '@mui/material/Alert'
+
+export default function ScrapersInfo() {
+  return (
+    <>
+      <h3 className="pt-4 pb-2 text-lg">Scrapers</h3>
+      <Alert
+        severity="success"
+      >
+        RSD can automatically scrape all references to the publications using DOI. Scraped citations are shown in the citations section.
+      </Alert>
+    </>
+  )
+}

--- a/frontend/components/projects/edit/output/index.tsx
+++ b/frontend/components/projects/edit/output/index.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,6 +14,7 @@ import AddOutput from './AddOutput'
 import EditOutputProvider from './EditOutputProvider'
 import useProjectContext from '../useProjectContext'
 import ImportProjectOutput from './ImportProjectOutput'
+import ScrapersInfo from './ScrapersInfo'
 
 export default function ProjectOutput() {
   const {token} = useSession()
@@ -32,6 +34,7 @@ export default function ProjectOutput() {
           <FindOutput />
           <ImportProjectOutput/>
           <AddOutput />
+          <ScrapersInfo />
         </div>
       </EditSection>
     </EditOutputProvider>

--- a/frontend/pages/projects/[slug]/index.tsx
+++ b/frontend/pages/projects/[slug]/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +16,7 @@ import {
   getProjectItem, getRelatedSoftwareForProject,
   getTeamForProject, getResearchDomainsForProject,
   getKeywordsForProject, getRelatedProjectsForProject,
-  getMentionsForProject
+  getMentionsForProject, getImpactByProject
 } from '~/utils/getProjects'
 import {
   KeywordForProject, Project, ProjectLink,
@@ -180,7 +180,7 @@ export async function getServerSideProps(context:any) {
       // Output
       getMentionsForProject({project: project.id, token, table:'output_for_project'}),
       // Impact
-      getMentionsForProject({project: project.id, token, table:'impact_for_project'}),
+      getImpactByProject({project: project.id, token}),
       getTeamForProject({project: project.id, token}),
       getRelatedSoftwareForProject({project: project.id, token, frontend: false}),
       getRelatedProjectsForProject({project: project.id, token, frontend: false}),

--- a/frontend/utils/getProjects.ts
+++ b/frontend/utils/getProjects.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -267,6 +267,35 @@ export async function getMentionsForProject({project, token, table}:
     return []
   } catch (e: any) {
     logger(`getMentionsForProject: ${e?.message}`, 'error')
+    return []
+  }
+}
+
+export async function getImpactByProject({project, token}:
+  {project: string, token?: string}) {
+  try {
+    // the content is ordered by type ascending
+    const query = `project=eq.${project}&order=mention_type.asc`
+    // construct url
+    const url = `${getBaseUrl()}/rpc/impact_by_project?${query}`
+    // make request
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+      }
+    })
+    if (resp.status === 200) {
+      const json = await resp.json()
+      // extract mentions from software object
+      const mentions: MentionItemProps[] = json ?? []
+      return mentions
+    }
+    logger(`getImpactForProject: [${resp.status}] [${url}]`, 'error')
+    // query not found
+    return []
+  } catch (e: any) {
+    logger(`getImpactForProject: ${e?.message}`, 'error')
     return []
   }
 }


### PR DESCRIPTION
# Scrape project impact

Closes #1076 

Changes proposed in this pull request:
* Enable mentions scraper to scrape project citation based on items provided in the output
* Updated info text in output and impact section
* Moved output section before the impact section on the project edit page. On the project view page the order is reversed.
* Added citation section to show scraped citations. It shows scraped citations separately.
* Update rpc to include scraped impact items into the total impact item count
* Changed reference_papers_to_scrape to filter only on items with DOI

How to test:
* `make start` to build the solution and generate test data. In this example it is better to start without test data so remove data using `docker compose down --volumes` and then re-start `docker compose up`
* login to RSD as rsd-admin. If you have latest .env settings, first user will be promoted to rsd-admin in dev mode
* crate new project 
* add following items in the output section:
    * doi:10.1186/s13321-017-0220-4
    * 10.1186/1758-2946-6-3
* navigate to impact section. Add one item manually. 
* wait for 10 minutes or more for scrapers to run
* confirm that scraper section is populated (280 items). 
* preview project and confirm all impact items are shown. It includes all items from impact and citation sections. 

## Remarks
- On the software page we use reference papers and mentions as "key terms". The scraped citations are shown in the second tab of the reference paper in the edit section while on the public software page scraped citations are integrated into mentions. I find confusing that "public" page might show more mention items than the edit mention section.
- On the project page we use output and impact as "key terms". We use output as base for scraper and show all scraped items in the impact section. Currently there is no any visual indication which items are created manually and which items are scraped (added automatically). The user can delete both manual and scraped item but the scraped items will be added by scraper again. We should indicate scraped items and disable delete button.
- We use different approaches for showing scraped mentions/citations/publications on software and project page. Although the users might be different I think that using one approach could be beneficial

**After talking to Jason we think that showing scraped items in the separate citations section is most appropriate approach. If we agree on this approach we will need to update edit software page to use similar approach.**

## Edit project - output
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/6d9e3084-a619-44a5-b2f2-d1a5c650f90c)

## Edit project - impact (manually added)
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/27648d34-566d-4990-a24f-5873af8e667a)

## Edit project - citation (scraped)
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/c151ea61-224b-4ab6-ae64-ffcde2f49990)

## Project page - impact & output

Scraped citations and manual added impact items are shown as impact.
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/f2da4c89-c63a-4218-8c0b-281fd4bc8261)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
