### PR TITLE
1107 mentions performance

### DIFF
--- a/frontend/components/AppHeader/JavascriptSupportWarning.tsx
+++ b/frontend/components/AppHeader/JavascriptSupportWarning.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,8 +10,15 @@ import Alert from '@mui/material/Alert'
 export default function JavascriptSupportWarning() {
   return (
     <noscript>
-      <Alert severity="warning" sx={{margin:'0rem 2rem'}}>
-        Limited functionality: Your browser does not support JavaScript.
+      <Alert
+        severity="warning"
+        sx={{
+          width: '100vw',
+          justifyContent: 'center',
+          marginTop: '1rem',
+          zIndex:9
+        }}>
+          Limited functionality: Your browser does not support JavaScript.
       </Alert>
     </noscript>
   )

--- a/frontend/components/AppHeader/index.tsx
+++ b/frontend/components/AppHeader/index.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -159,14 +159,11 @@ export default function AppHeader() {
 
             {/* LOGIN / USER MENU */}
             <LoginButton/>
-
           </div>
-          <JavascriptSupportWarning/>
         </div>
-
-
         <GlobalSearchAutocomplete className="xl:hidden mt-4"/>
       </div>
+      <JavascriptSupportWarning/>
     </header>
   )
 }

--- a/frontend/components/mention/MentionViewList.tsx
+++ b/frontend/components/mention/MentionViewList.tsx
@@ -1,25 +1,39 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {useState} from 'react'
 import Accordion from '@mui/material/Accordion'
 import AccordionSummary from '@mui/material/AccordionSummary'
 import AccordionDetails from '@mui/material/AccordionDetails'
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore'
 import Badge from '@mui/material/Badge'
-import {MentionItemProps, MentionTypeKeys} from '~/types/Mention'
+import {MentionItemProps} from '~/types/Mention'
 import MentionViewItem from './MentionViewItem'
+import useListPagination from './useListPagination'
+import Button from '@mui/material/Button'
 
 type MentionSectionListProps = {
   title: string
-  type: MentionTypeKeys,
   items: MentionItemProps[]
 }
 
-export default function MentionViewList({title, type, items}: MentionSectionListProps) {
+export default function MentionViewList({title, items}: MentionSectionListProps) {
+  // show top 50 items, use hasMore to show button to load more items
+  const [limit,setLimit] = useState(50)
+  const {selection,hasMore} = useListPagination({items,limit})
   // do not render accordion/section if no items
   if (!items || items.length===0) return null
+
+  // console.group('MentionViewList')
+  // console.log('items...', items)
+  // console.log('selection...', selection)
+  // console.log('hasMore...', hasMore)
+  // console.groupEnd()
+
   // debugger
   return (
     <Accordion
@@ -56,7 +70,7 @@ export default function MentionViewList({title, type, items}: MentionSectionList
       >
         <Badge
           badgeContent={items.length ?? null}
-          max={999}
+          max={9999}
           color="secondary"
           sx={{
             '& .MuiBadge-badge': {
@@ -80,7 +94,7 @@ export default function MentionViewList({title, type, items}: MentionSectionList
         padding: '0rem 0rem'
       }}>
         <ul>
-          {items.map((item, pos) => {
+          {selection.map((item, pos) => {
             return (
               <li key={pos} className="p-4">
                 <MentionViewItem
@@ -90,6 +104,21 @@ export default function MentionViewList({title, type, items}: MentionSectionList
               </li>
             )
           })
+          }
+          {
+            hasMore ?
+              <li key="show-all-button" className="p-4">
+                <Button
+                  title='Show more items'
+                  aria-label="Show more items"
+                  onClick={()=>setLimit(limit * 2)}
+                  size="large"
+                  startIcon = {<ExpandMoreIcon />}
+                >
+                Show more
+                </Button>
+              </li>
+              : null
           }
         </ul>
       </AccordionDetails>

--- a/frontend/components/mention/MentionViewList.tsx
+++ b/frontend/components/mention/MentionViewList.tsx
@@ -22,7 +22,7 @@ type MentionSectionListProps = {
 }
 
 export default function MentionViewList({title, items}: MentionSectionListProps) {
-  // show top 50 items, use hasMore to show button to load more items
+  // show top 50 items, use hasMore to show button to load all items
   const [limit,setLimit] = useState(50)
   const {selection,hasMore} = useListPagination({items,limit})
   // do not render accordion/section if no items
@@ -111,11 +111,11 @@ export default function MentionViewList({title, items}: MentionSectionListProps)
                 <Button
                   title='Show more items'
                   aria-label="Show more items"
-                  onClick={()=>setLimit(limit * 2)}
+                  onClick={()=>setLimit(items.length)}
                   size="large"
                   startIcon = {<ExpandMoreIcon />}
                 >
-                Show more
+                Show all
                 </Button>
               </li>
               : null

--- a/frontend/components/mention/MentionsSection.tsx
+++ b/frontend/components/mention/MentionsSection.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -53,7 +53,6 @@ export default function MentionsSection({title, mentions}: MentionsSectionProps)
               <MentionViewList
                 key={key}
                 title={title}
-                type={key}
                 items={items}
               />
             )

--- a/frontend/components/mention/useListPagination.tsx
+++ b/frontend/components/mention/useListPagination.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+type UseListPaginationProps<T>={
+  items: T[]
+  limit: number,
+}
+
+export default function useListPagination<T>({items,limit=50}:UseListPaginationProps<T>){
+  let selection:T[] = []
+
+  if (limit >= items.length && selection.length < items.length){
+    selection = [
+      ...items
+    ]
+  }
+
+  if (limit < items.length && selection.length !== limit){
+    selection = items.slice(0,limit)
+  }
+
+  // console.group('useListPagination')
+  // console.log('items...', items)
+  // console.log('selection...', selection)
+  // console.log('limit...', limit)
+  // console.groupEnd()
+
+  return {
+    selection,
+    hasMore: selection?.length < items?.length
+  }
+}


### PR DESCRIPTION
# Improve mentions performance

Closes #1107 

Changes proposed in this pull request:
* Render only first 50 mention items per group. Show all button is displayed at the bottom of the list to load all items.
* Loading first 50 items applies to all "mention" sections: reference papers, mentions, output and impact because this component is shared.
* All items are (still) loaded server side. I did not move api request to the frontend because when Javascript is disabled the mentions will not be loaded at all.
* The Javascript support message is moved below other header elements (search & nav). The notification message was not properly shown on the smaller screens (tablet & smartphone).

How to test:
* `make start` to build an create test data. This example is better tested without many data, so remove test data `docker compose down --volumes & docker compose up`
* login as rsd admin
* create software item
* add reference paper [10.1021/ja026939x](https://doi.org/10.1021%2Fja026939x)
* wait for scrapers to scrape reference papers, it should scrape 2575 references
* visit software page and confirm mentions are loaded,
* visit software overview page and confirm improved load time. On my machine the performance is improved from ~3.75sec. to ~1.2sec. on my machine. See images

## Performance measured on PC AMD Ryzen 9 3900X 
- **Old approach (~ 3.75 sec)**
![Main-Mentions-2024-02-05 20-32-37](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/df8c8d17-1657-45e2-9442-5477c7ba50ad)

- **Improved approach (~1.2sec)**
![Mentions-2024-02-05 20-27-35](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/f0c69656-e0c0-43b7-a994-541e59a99759)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
