### PR TITLE
Improve global search function

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -1,9 +1,9 @@
 -- SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2021 - 2023 dv4all
 -- SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
--- SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
--- SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 --
 -- SPDX-License-Identifier: Apache-2.0
@@ -1091,47 +1091,45 @@ BEGIN
 END
 $$;
 
+
 -- GLOBAL SEARCH
--- we use search_text to concatenate all values to use
-CREATE FUNCTION global_search() RETURNS TABLE(
+CREATE FUNCTION global_search(query VARCHAR) RETURNS TABLE(
 	slug VARCHAR,
 	name VARCHAR,
 	source TEXT,
 	is_published BOOLEAN,
-	search_text TEXT
-) LANGUAGE plpgsql STABLE AS
+	score INTEGER
+) LANGUAGE sql STABLE AS
 $$
-BEGIN RETURN QUERY
 	-- SOFTWARE search item
 	SELECT
-		software_overview.slug,
-		software_overview.brand_name AS name,
+		software.slug,
+		software.brand_name AS name,
 		'software' AS "source",
-		software_overview.is_published,
-		CONCAT_WS(
-			' ',
-			software_overview.brand_name,
-			software_overview.short_statement,
-			software_overview.keywords_text
-		) AS search_text
+		software.is_published,
+		(CASE
+			WHEN software.slug ILIKE query OR software.brand_name ILIKE query THEN 3
+			WHEN software.slug ILIKE CONCAT(query, '%') OR software.brand_name ILIKE CONCAT(query, '%') THEN 2
+			ELSE 1
+		END) AS score
 	FROM
-		software_overview()
+		software
+	WHERE software.slug ILIKE CONCAT('%', query, '%') OR software.brand_name ILIKE CONCAT('%', query, '%')
 	UNION
 	-- PROJECT search item
 	SELECT
-		project_overview.slug,
-		project_overview.title AS name,
+		project.slug,
+		project.title AS name,
 		'projects' AS "source",
-		project_overview.is_published,
-		CONCAT_WS(
-			' ',
-			project_overview.title,
-			project_overview.subtitle,
-			project_overview.keywords_text,
-			project_overview.research_domain_text
-		) AS search_text
+		project.is_published,
+		(CASE
+			WHEN project.slug ILIKE query OR project.title ILIKE query THEN 3
+			WHEN project.slug ILIKE CONCAT(query, '%') OR project.title ILIKE CONCAT(query, '%') THEN 2
+			ELSE 1
+		END) AS score
 	FROM
-		project_overview()
+		project
+	WHERE project.slug ILIKE CONCAT('%', query, '%') OR project.title ILIKE CONCAT('%', query, '%')
 	UNION
 	-- ORGANISATION search item
 	SELECT
@@ -1139,19 +1137,21 @@ BEGIN RETURN QUERY
 		organisation."name",
 		'organisations' AS "source",
 		TRUE AS is_published,
-		CONCAT_WS(
-			' ',
-			organisation."name",
-			organisation.website
-		) AS search_text
+		(CASE
+			WHEN organisation.slug ILIKE query OR organisation."name" ILIKE query THEN 3
+			WHEN organisation.slug ILIKE CONCAT(query, '%') OR organisation."name" ILIKE CONCAT(query, '%') THEN 2
+			ELSE 1
+		END) AS score
 	FROM
 		organisation
 	WHERE
 	-- ONLY TOP LEVEL ORGANISATIONS
 		organisation.parent IS NULL
+		AND
+		organisation.slug ILIKE CONCAT('%', query, '%') OR organisation."name" ILIKE CONCAT('%', query, '%')
 ;
-END
 $$;
+
 
 -- Check whether user agreed on Terms of Service and read the Privacy Statement
 CREATE FUNCTION user_agreements_stored(account_id UUID) RETURNS BOOLEAN LANGUAGE plpgsql STABLE AS

--- a/documentation/docs/01-users/02-navigation.md
+++ b/documentation/docs/01-users/02-navigation.md
@@ -18,8 +18,11 @@ Currently, the search will match the following fields:
 
 * the name of software, projects and organisations
 * the slug of software, projects and organisations
+* the keywords of software and projects
+* the short description of software
+* the subtitle of projects
 
-At the moment, we do not yet match on descriptions of software, projects and organisations, but we expect to do so in the future.
+At the moment, we do not yet match on the long descriptions of software, projects and organisations, but we expect to do so in the future.
 
 ## Software Overview
 

--- a/documentation/docs/01-users/02-navigation.md
+++ b/documentation/docs/01-users/02-navigation.md
@@ -16,12 +16,10 @@ For more advanced users, we also offer a [REST API](/API/rest-api/), allowing yo
 Using the search bar in the header, you can perform a global search of all data in the RSD by simply providing a search term.
 Currently, the search will match the following fields:
 
-* the name of software, projects and organizations
-* the short description of software and projects
-* the keywords of software and projects
-* the research domains of projects
+* the name of software, projects and organisations
+* the slug of software, projects and organisations
 
-At the moment, we do not yet match on the long descriptions of software, projects and organizations, but we expect to do so in the future.
+At the moment, we do not yet match on descriptions of software, projects and organisations, but we expect to do so in the future.
 
 ## Software Overview
 

--- a/documentation/docs/01-users/02-navigation.md.license
+++ b/documentation/docs/01-users/02-navigation.md.license
@@ -1,5 +1,6 @@
-SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/frontend/components/GlobalSearchAutocomplete/GlobalsSearchAutocomplete.test.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/GlobalsSearchAutocomplete.test.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -37,7 +39,7 @@ it('shows 3 navigation option on focus', async () => {
 })
 
 it('calls search api on input', async () => {
-  const expectedUrl = '/api/v1/rpc/global_search?search_text=ilike.*Search text*&limit=30'
+  const expectedUrl = '/api/v1/rpc/global_search?query=Search text&limit=30&order=score.desc'
   const expectPayload = {
     'headers': {
       'Content-Type': 'application/json'

--- a/frontend/components/GlobalSearchAutocomplete/GlobalsSearchAutocomplete.test.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/GlobalsSearchAutocomplete.test.tsx
@@ -39,7 +39,7 @@ it('shows 3 navigation option on focus', async () => {
 })
 
 it('calls search api on input', async () => {
-  const expectedUrl = '/api/v1/rpc/global_search?query=Search text&limit=30&order=score.desc'
+  const expectedUrl = '/api/v1/rpc/global_search?query=Search text&limit=30&order=rank.asc,index_found.asc'
   const expectPayload = {
     'headers': {
       'Content-Type': 'application/json'

--- a/frontend/components/GlobalSearchAutocomplete/globalSearchAutocomplete.api.ts
+++ b/frontend/components/GlobalSearchAutocomplete/globalSearchAutocomplete.api.ts
@@ -25,7 +25,7 @@ export type GlobalSearchResults = {
 export async function getGlobalSearch(searchText: string, token: string,) {
   try {
     // call the function query
-    const query = `rpc/global_search?query=${searchText}&limit=30&order=score.desc`
+    const query = `rpc/global_search?query=${searchText}&limit=30&order=rank.asc,index_found.asc`
     let url = `/api/v1/${query}`
 
     const resp = await fetch(url, {

--- a/frontend/components/GlobalSearchAutocomplete/globalSearchAutocomplete.api.ts
+++ b/frontend/components/GlobalSearchAutocomplete/globalSearchAutocomplete.api.ts
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +25,7 @@ export type GlobalSearchResults = {
 export async function getGlobalSearch(searchText: string, token: string,) {
   try {
     // call the function query
-    const query = `rpc/global_search?search_text=ilike.*${searchText}*&limit=30`
+    const query = `rpc/global_search?query=${searchText}&limit=30&order=score.desc`
     let url = `/api/v1/${query}`
 
     const resp = await fetch(url, {

--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -48,7 +49,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
   }, [inputValue])
 
   useEffect(() => {
-    if (lastValue.length > 0) {
+    if (lastValue.length > 1) {
       setOpen(true)
       fetchData(lastValue)
     }


### PR DESCRIPTION
## Improve global search function

Changes proposed in this pull request:

* Use SQL instead of PL/pgSQL as the language for the `global_search` function
* Only search on slug and title (not keywords, research domains or short descriptions anymore)
* Give each result a score, based on exact match on the slug or title, the query being a prefix of the slug or title, or the query appearing anywhere in the slug or title
* Adapt the frontend to use the new function

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Test out the global search with the fake data
* Log in and create software pages with the following titles: `abc`, `abc def` and `ghi abc def`. Global search on `abc`, they should be returned in the order above.

**Discussion:** Should the function enforce a minimum length for its input?

Closes #1108

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [ ] Tests
