### PR TITLE
Don't scroll to top of the website when changing page in software overview

### DIFF
--- a/frontend/components/software/overview/useSoftwareOverviewParams.ts
+++ b/frontend/components/software/overview/useSoftwareOverviewParams.ts
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -34,7 +36,7 @@ export default function useSoftwareOverviewParams() {
     const url = ssrSoftwareUrl(params)
     if (key === 'page') {
       // when changin page we scroll to top
-      router.push(url, url, {scroll: true})
+      router.push(url+'#list-top', url+'#list-top')
     } else {
       // update page url but keep scroll position
       router.push(url,url,{scroll: false})


### PR DESCRIPTION
Fixes #1112

Changes proposed in this pull request:

* Scrolls to `#list-top` when changing page on software overview, so that users don't have to scroll past the Software Highlights on every page change

How to test:

* `docker compose build --parallel && docker compose up --scale data-generation=1`
* make sure that there are software highlights visible, if not add some via the admin interface
* open the software overview page
* navigate through the pages and verify that on page change, the browser scrolls to the "All software" headline

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
