### PR TITLE
974 improve maven scraper

### DIFF
--- a/data-generation/real-data.js
+++ b/data-generation/real-data.js
@@ -83,13 +83,14 @@ const packageManagerLinks = [
 	{url: 'https://pypi.org/project/cffconvert/', type: 'pypi'},
 	{url: 'https://pypi.org/project/flask', type: 'pypi'},
 	{url: 'https://packages.debian.org/search?keywords=libcdk-java', type: 'debian'},
-	{url: 'https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle/overview', type: 'sonatype'},
+	{url: 'https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle/', type: 'sonatype'},
 	{url: 'https://community.chocolatey.org/packages/openchrom', type: 'chocolatey'},
 	{url: 'https://snapcraft.io/openchrom', type: 'snapcraft'},
 	{url: 'https://github.com/orgs/research-software-directory/packages?repo_name=RSD-as-a-service', type: 'github'},
 	{url: 'https://gitlab.com/gitlab-org/gitlab/container_registry', type: 'gitlab'},
-	{url: 'https://crates.io/crates/serde', type: 'crates'},
-	{url: 'https://pkg.go.dev/strconv', type: 'golang'},
+	{url: 'https://crates.io/crates/tokio', type: 'crates'},
+	{url: 'https://pkg.go.dev/github.com/gin-gonic/gin', type: 'golang'},
+	{url: 'https://pkg.go.dev/google.golang.org/grpc', type: 'golang'},
 ]
 
 export {conceptDois, dois, packageManagerLinks};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:2.5.2
+    image: rsd/frontend:2.5.3
     environment:
       # it uses values from .env file
       - POSTGREST_URL
@@ -157,7 +157,7 @@ services:
 
   scrapers:
     build: ./scrapers
-    image: rsd/scrapers:1.5.2
+    image: rsd/scrapers:1.6.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL
@@ -220,7 +220,7 @@ services:
   #----------------------------------------------
   data-generation:
     build: ./data-generation
-    image: rsd/generation:1.4.0
+    image: rsd/generation:1.4.1
     environment:
       # it needs to be here to use values from .env file
       - PGRST_JWT_SECRET
@@ -231,7 +231,7 @@ services:
       - net
     deploy:
       replicas: 0
- 
+
 # define name for docker network
 # it should have name: rsd-as-a-service_net
 networks:

--- a/frontend/components/software/edit/package-managers/PackageManagerItem.tsx
+++ b/frontend/components/software/edit/package-managers/PackageManagerItem.tsx
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
@@ -34,16 +34,16 @@ function RsdScraperStatus({services,download_count,download_count_scraped_at,rev
     return <span>RSD scraper services not available</span>
   }
   if (services.includes('downloads')===true){
-    if (download_count_scraped_at){
-      html.push(<span key="downloads">Downloads: {download_count ?? 0}</span>)
+    if (download_count_scraped_at && Number.isInteger(download_count)){
+      html.push(<span key="downloads">Downloads: {download_count}</span>)
 
     }else{
       html.push(<span key="downloads">Downloads: no info</span>)
     }
   }
   if (services.includes('dependents')===true){
-    if (reverse_dependency_count_scraped_at){
-      html.push(<span key="dependents">Dependents: {reverse_dependency_count ?? 0}</span>)
+    if (reverse_dependency_count_scraped_at && Number.isInteger(reverse_dependency_count)){
+      html.push(<span key="dependents">Dependents: {reverse_dependency_count}</span>)
     }else{
       html.push(<span key="dependents">Dependents: no info</span>)
     }

--- a/frontend/components/software/edit/package-managers/apiPackageManager.ts
+++ b/frontend/components/software/edit/package-managers/apiPackageManager.ts
@@ -36,7 +36,7 @@ export const packageManagerSettings = {
     name: 'Crates.io',
     icon: '/images/rust-cargo-logo.png',
     hostname: ['crates.io'],
-    services: []
+    services: ['dependents']
   },
   chocolatey: {
     name: 'Chocolatey',
@@ -72,7 +72,7 @@ export const packageManagerSettings = {
     name: 'Golang',
     icon: '/images/go-logo-blue.svg',
     hostname: ['pkg.go.dev'],
-    services: []
+    services: ['dependents']
   },
   maven: {
     name: 'Maven',

--- a/frontend/components/software/edit/package-managers/apiPackageManager.ts
+++ b/frontend/components/software/edit/package-managers/apiPackageManager.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -96,7 +96,7 @@ export const packageManagerSettings = {
     name: 'Sonatype',
     icon: '/images/sonatype-logo.svg',
     hostname: ['central.sonatype.com'],
-    services: []
+    services: ['dependents']
   },
   snapcraft:{
     name: 'Snapcraft',

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MainPackageManager.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MainPackageManager.java
@@ -9,6 +9,13 @@ import nl.esciencecenter.rsd.scraper.Config;
 import nl.esciencecenter.rsd.scraper.RsdRateLimitException;
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
 import nl.esciencecenter.rsd.scraper.Utils;
+import nl.esciencecenter.rsd.scraper.package_manager.scrapers.AnacondaScraper;
+import nl.esciencecenter.rsd.scraper.package_manager.scrapers.CranScraper;
+import nl.esciencecenter.rsd.scraper.package_manager.scrapers.DockerHubScraper;
+import nl.esciencecenter.rsd.scraper.package_manager.scrapers.MavenScraper;
+import nl.esciencecenter.rsd.scraper.package_manager.scrapers.NpmScraper;
+import nl.esciencecenter.rsd.scraper.package_manager.scrapers.PackageManagerScraper;
+import nl.esciencecenter.rsd.scraper.package_manager.scrapers.PypiScraper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MainPackageManager.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MainPackageManager.java
@@ -11,7 +11,9 @@ import nl.esciencecenter.rsd.scraper.RsdResponseException;
 import nl.esciencecenter.rsd.scraper.Utils;
 import nl.esciencecenter.rsd.scraper.package_manager.scrapers.AnacondaScraper;
 import nl.esciencecenter.rsd.scraper.package_manager.scrapers.CranScraper;
+import nl.esciencecenter.rsd.scraper.package_manager.scrapers.CratesScraper;
 import nl.esciencecenter.rsd.scraper.package_manager.scrapers.DockerHubScraper;
+import nl.esciencecenter.rsd.scraper.package_manager.scrapers.GoScraper;
 import nl.esciencecenter.rsd.scraper.package_manager.scrapers.MavenScraper;
 import nl.esciencecenter.rsd.scraper.package_manager.scrapers.NpmScraper;
 import nl.esciencecenter.rsd.scraper.package_manager.scrapers.PackageManagerScraper;
@@ -86,7 +88,9 @@ public class MainPackageManager {
 		return switch (type) {
 			case anaconda -> new AnacondaScraper(url);
 			case cran -> new CranScraper(url);
+			case crates -> new CratesScraper(url);
 			case dockerhub -> new DockerHubScraper(url);
+			case golang -> new GoScraper(url);
 			case maven, sonatype -> new MavenScraper(url);
 			case npm -> new NpmScraper(url);
 			case pypi -> new PypiScraper(url);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MainPackageManager.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MainPackageManager.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,6 +9,8 @@ import nl.esciencecenter.rsd.scraper.Config;
 import nl.esciencecenter.rsd.scraper.RsdRateLimitException;
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
 import nl.esciencecenter.rsd.scraper.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.time.ZonedDateTime;
@@ -21,18 +23,15 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 public class MainPackageManager {
-	
+
 	private static final Logger LOGGER = LoggerFactory.getLogger(MainPackageManager.class);
-	
+
 	public static void main(String[] args) {
 		LOGGER.info("Start scraping package manager data");
-		
+
 		long t1 = System.currentTimeMillis();
-		
+
 		PostgrestConnector postgrestConnector = new PostgrestConnector(Config.backendBaseUrl() + "/package_manager");
 		Collection<BasicPackageManagerData> downloadsToScrape = postgrestConnector.oldestDownloadCounts(10);
 		Collection<BasicPackageManagerData> revDepsToScrape = postgrestConnector.oldestReverseDependencyCounts(10);
@@ -60,8 +59,8 @@ public class MainPackageManager {
 					completedTask.get();
 				} catch (ExecutionException | InterruptedException e) {
 					Utils.saveExceptionInDatabase("Package manager scraper", "package_manager", null, e);
-					
-					if (e instanceof InterruptedException) { 
+
+					if (e instanceof InterruptedException) {
 						Thread.currentThread().interrupt();
 					}
 				}
@@ -70,9 +69,9 @@ public class MainPackageManager {
 			Utils.saveExceptionInDatabase("Package manager scraper", "package_manager", null, e);
 			Thread.currentThread().interrupt();
 		}
-		
+
 		long time = System.currentTimeMillis() - t1;
-		
+
 		LOGGER.info("Done scraping package manager data ({} ms.)", time);
 	}
 
@@ -81,7 +80,7 @@ public class MainPackageManager {
 			case anaconda -> new AnacondaScraper(url);
 			case cran -> new CranScraper(url);
 			case dockerhub -> new DockerHubScraper(url);
-			case maven -> new MavenScraper(url);
+			case maven, sonatype -> new MavenScraper(url);
 			case npm -> new NpmScraper(url);
 			case pypi -> new PypiScraper(url);
 			case other -> throw new RuntimeException("Package manager scraper requested for 'other'");

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MavenScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/MavenScraper.java
@@ -17,8 +17,8 @@ import java.util.regex.Pattern;
 
 public class MavenScraper implements PackageManagerScraper {
 
-	private final String groupId;
-	private final String artifactId;
+	final String groupId;
+	final String artifactId;
 	private static final Pattern mvnPattern = Pattern.compile("https://mvnrepository\\.com/artifact/([^/]+)/([^/]+)/?");
 	private static final Pattern sonatypePattern = Pattern.compile("https://central\\.sonatype\\.com/artifact/([^/]+)/([^/]+)/?");
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PackageManagerType.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PackageManagerType.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,5 +12,6 @@ public enum PackageManagerType {
 	maven,
 	npm,
 	pypi,
+	sonatype,
 	other
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PackageManagerType.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PackageManagerType.java
@@ -8,7 +8,9 @@ package nl.esciencecenter.rsd.scraper.package_manager;
 public enum PackageManagerType {
 	anaconda,
 	cran,
+	crates,
 	dockerhub,
+	golang,
 	maven,
 	npm,
 	pypi,

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
@@ -35,7 +35,7 @@ public class PostgrestConnector {
 	}
 
 	public Collection<BasicPackageManagerData> oldestReverseDependencyCounts(int limit) {
-		String filter = "or=(package_manager.eq.anaconda,package_manager.eq.cran,package_manager.eq.maven,package_manager.eq.npm,package_manager.eq.pypi,package_manager.eq.sonatype)";
+		String filter = "or=(package_manager.eq.anaconda,package_manager.eq.cran,package_manager.eq.crates,package_manager.eq.golang,package_manager.eq.maven,package_manager.eq.npm,package_manager.eq.pypi,package_manager.eq.sonatype)";
 		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=id,url,package_manager&order=reverse_dependency_count_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("reverse_dependency_count_scraped_at"));
 		return parseBasicJsonData(data);
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
@@ -35,7 +35,7 @@ public class PostgrestConnector {
 	}
 
 	public Collection<BasicPackageManagerData> oldestReverseDependencyCounts(int limit) {
-		String filter = "or=(package_manager.eq.anaconda,package_manager.eq.cran,package_manager.eq.maven,package_manager.eq.npm,package_manager.eq.pypi)";
+		String filter = "or=(package_manager.eq.anaconda,package_manager.eq.cran,package_manager.eq.maven,package_manager.eq.npm,package_manager.eq.pypi,package_manager.eq.sonatype)";
 		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=id,url,package_manager&order=reverse_dependency_count_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("reverse_dependency_count_scraped_at"));
 		return parseBasicJsonData(data);
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/AnacondaScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/AnacondaScraper.java
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package nl.esciencecenter.rsd.scraper.package_manager;
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CranScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CranScraper.java
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package nl.esciencecenter.rsd.scraper.package_manager;
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CratesScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CratesScraper.java
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class CratesScraper implements PackageManagerScraper {
+
+	final String packageName;
+	private static final Pattern cratesPattern = Pattern.compile("https://crates\\.io/crates/([^/]+)/?");
+
+	public CratesScraper(String url) {
+		Objects.requireNonNull(url);
+
+		Matcher cratesMatcher = cratesPattern.matcher(url);
+		if (cratesMatcher.matches()) {
+			this.packageName = cratesMatcher.group(1);
+			return;
+		}
+
+		throw new RuntimeException("Invalid crates.io URL: " + url);
+	}
+
+	@Override
+	public Long downloads() {
+		throw new UnsupportedOperationException();
+	}
+
+	// Example URL: https://libraries.io/api/cargo/tokio
+	@Override
+	public Integer reverseDependencies() throws IOException, InterruptedException, RsdResponseException {
+		String data = PackageManagerScraper.doLibrariesIoRequest("https://libraries.io/api/cargo/" + packageName);
+		JsonElement tree = JsonParser.parseString(data);
+		return tree.getAsJsonObject().getAsJsonPrimitive("dependents_count").getAsInt();
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/DockerHubScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/DockerHubScraper.java
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package nl.esciencecenter.rsd.scraper.package_manager;
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonParser;
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
@@ -36,7 +36,7 @@ public class DockerHubScraper implements PackageManagerScraper {
 	}
 
 	@Override
-	public Long downloads() throws RsdResponseException{
+	public Long downloads() throws RsdResponseException {
 		String url;
 		if (owner.equals("_")) url = "https://hub.docker.com/v2/repositories/library/" + packageName;
 		else url = "https://hub.docker.com/v2/repositories/" + owner + "/" + packageName;
@@ -55,7 +55,7 @@ public class DockerHubScraper implements PackageManagerScraper {
 						throw new RsdResponseException(response.statusCode(), request.uri(), response.body(), "Unexpected response");
 			};
 		} catch (InterruptedException e) {
-			 Thread.currentThread().interrupt();
+			Thread.currentThread().interrupt();
 			throw new RuntimeException(e);
 		} catch (IOException e) {
 			throw new RuntimeException(e);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/GoScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/GoScraper.java
@@ -1,0 +1,48 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
+import nl.esciencecenter.rsd.scraper.Utils;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GoScraper implements PackageManagerScraper {
+
+	final String packageName;
+	private static final Pattern goPattern = Pattern.compile("https://pkg\\.go\\.dev/(\\S+?)/?");
+
+	public GoScraper(String url) {
+		Objects.requireNonNull(url);
+
+		Matcher goMatcher = goPattern.matcher(url);
+		if (goMatcher.matches()) {
+			this.packageName = goMatcher.group(1);
+			return;
+		}
+
+		throw new RuntimeException("Invalid Go URL: " + url);
+	}
+
+	@Override
+	public Long downloads() {
+		throw new UnsupportedOperationException();
+	}
+
+	// Example URL: https://libraries.io/api/go/github.com%2Fgin-gonic%2Fgin
+	// Example URL: https://libraries.io/api/go/google.golang.org%2Fgrpc
+	@Override
+	public Integer reverseDependencies() throws IOException, InterruptedException, RsdResponseException {
+		String data = PackageManagerScraper.doLibrariesIoRequest("https://libraries.io/api/go/" + Utils.urlEncode(packageName));
+		JsonElement tree = JsonParser.parseString(data);
+		return tree.getAsJsonObject().getAsJsonPrimitive("dependents_count").getAsInt();
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraper.java
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package nl.esciencecenter.rsd.scraper.package_manager;
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/NpmScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/NpmScraper.java
@@ -1,30 +1,31 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package nl.esciencecenter.rsd.scraper.package_manager;
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class PypiScraper implements PackageManagerScraper {
+public class NpmScraper implements PackageManagerScraper {
 
 	private final String packageName;
-	private static final Pattern urlPattern = Pattern.compile("https://pypi\\.org/project/([^/]+)/?");
+	private static final Pattern urlPattern = Pattern.compile("https://www\\.npmjs\\.com/package/(.+?)/?");
 
-	public PypiScraper(String url) {
+	public NpmScraper(String url) {
 		Objects.requireNonNull(url);
 		Matcher urlMatcher = urlPattern.matcher(url);
 		if (!urlMatcher.matches()) {
-			throw new RuntimeException("Invalid PyPi URL: " + url);
+			throw new RuntimeException("Invalid NPM URL: " + url);
 		}
 
 		packageName = urlMatcher.group(1);
@@ -37,7 +38,7 @@ public class PypiScraper implements PackageManagerScraper {
 
 	@Override
 	public Integer reverseDependencies() throws IOException, InterruptedException, RsdResponseException {
-		String data = PackageManagerScraper.doLibrariesIoRequest("https://libraries.io/api/pypi/" + packageName);
+		String data = PackageManagerScraper.doLibrariesIoRequest("https://libraries.io/api/npm/" + Utils.urlEncode(packageName));
 		JsonElement tree = JsonParser.parseString(data);
 		return tree.getAsJsonObject().getAsJsonPrimitive("dependents_count").getAsInt();
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PackageManagerScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PackageManagerScraper.java
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package nl.esciencecenter.rsd.scraper.package_manager;
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import nl.esciencecenter.rsd.scraper.Config;
 import nl.esciencecenter.rsd.scraper.RsdRateLimitException;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PypiScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PypiScraper.java
@@ -1,31 +1,30 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package nl.esciencecenter.rsd.scraper.package_manager;
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
-import nl.esciencecenter.rsd.scraper.Utils;
 
 import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class NpmScraper implements PackageManagerScraper {
+public class PypiScraper implements PackageManagerScraper {
 
 	private final String packageName;
-	private static final Pattern urlPattern = Pattern.compile("https://www\\.npmjs\\.com/package/(.+?)/?");
+	private static final Pattern urlPattern = Pattern.compile("https://pypi\\.org/project/([^/]+)/?");
 
-	public NpmScraper(String url) {
+	public PypiScraper(String url) {
 		Objects.requireNonNull(url);
 		Matcher urlMatcher = urlPattern.matcher(url);
 		if (!urlMatcher.matches()) {
-			throw new RuntimeException("Invalid NPM URL: " + url);
+			throw new RuntimeException("Invalid PyPi URL: " + url);
 		}
 
 		packageName = urlMatcher.group(1);
@@ -38,7 +37,7 @@ public class NpmScraper implements PackageManagerScraper {
 
 	@Override
 	public Integer reverseDependencies() throws IOException, InterruptedException, RsdResponseException {
-		String data = PackageManagerScraper.doLibrariesIoRequest("https://libraries.io/api/npm/" + Utils.urlEncode(packageName));
+		String data = PackageManagerScraper.doLibrariesIoRequest("https://libraries.io/api/pypi/" + packageName);
 		JsonElement tree = JsonParser.parseString(data);
 		return tree.getAsJsonObject().getAsJsonPrimitive("dependents_count").getAsInt();
 	}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/MavenScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/MavenScraperTest.java
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper.package_manager;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class MavenScraperTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle,org.openscience.cdk,cdk-bundle",
+			"https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle/,org.openscience.cdk,cdk-bundle",
+			"https://mvnrepository.com/artifact/io.github.sanctuuary/APE,io.github.sanctuuary,APE",
+			"https://mvnrepository.com/artifact/io.github.sanctuuary/APE/,io.github.sanctuuary,APE",
+	})
+	void givenValidMavenOrSonatypeUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNamesCorrect(
+			String url,
+			String expectedGroupId,
+			String expectedArtifactID
+	) {
+		MavenScraper mavenScraper = Assertions.assertDoesNotThrow(() -> new MavenScraper(url));
+		Assertions.assertEquals(expectedGroupId, mavenScraper.groupId);
+		Assertions.assertEquals(expectedArtifactID, mavenScraper.artifactId);
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = {
+			"https://central.sonatype.com/artifact",
+			"https://mvnrepository.com/artifact/",
+			"https://central.sonatype.com/artifact/org.openscience.cdk",
+			"https://mvnrepository.com/artifact/io.github.sanctuuary/",
+			"https://www.example.com",
+			"https://www.example.com/artifact/org.openscience.cdk/cdk-bundle",
+			""
+	})
+	void givenInvalidUrl_whenCallingConstructor_thenExceptionThrown(String url) {
+		Assertions.assertThrowsExactly(RuntimeException.class, () -> new MavenScraper(url));
+	}
+
+	@ParameterizedTest
+	@NullSource
+	void givenNullUrl_whenCallingConstructor_thenExceptionThrown(String url) {
+		Assertions.assertThrowsExactly(NullPointerException.class, () -> new MavenScraper(url));
+	}
+}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CranScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CranScraperTest.java
@@ -1,9 +1,9 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package nl.esciencecenter.rsd.scraper.package_manager;
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CratesScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CratesScraperTest.java
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+public class CratesScraperTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"https://crates.io/crates/tokio,tokio",
+			"https://crates.io/crates/tokio/,tokio",
+	})
+	void givenValidCratesUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNamesCorrect(
+			String url,
+			String expectedPackageName
+	) {
+		CratesScraper cratesScraper = Assertions.assertDoesNotThrow(() -> new CratesScraper(url));
+		Assertions.assertEquals(expectedPackageName, cratesScraper.packageName);
+	}
+
+	@ParameterizedTest
+	@NullSource
+	void givenNullUrl_whenCallingConstructor_thenExceptionThrown(String url) {
+		Assertions.assertThrowsExactly(NullPointerException.class, () -> new CratesScraper(url));
+	}
+}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/GoScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/GoScraperTest.java
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullSource;
+
+public class GoScraperTest {
+
+	@ParameterizedTest
+	@CsvSource({
+			"https://pkg.go.dev/github.com/gin-gonic/gin,github.com/gin-gonic/gin",
+			"https://pkg.go.dev/github.com/gin-gonic/gin/,github.com/gin-gonic/gin",
+			"https://pkg.go.dev/google.golang.org/grpc,google.golang.org/grpc",
+			"https://pkg.go.dev/google.golang.org/grpc/,google.golang.org/grpc",
+	})
+	void givenValidGoUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNameCorrect(
+			String url,
+			String expectedPackageName
+	) {
+		GoScraper goScraper = Assertions.assertDoesNotThrow(() -> new GoScraper(url));
+		Assertions.assertEquals(expectedPackageName, goScraper.packageName);
+	}
+
+	@ParameterizedTest
+	@NullSource
+	void givenNullUrl_whenCallingConstructor_thenExceptionThrown(String url) {
+		Assertions.assertThrowsExactly(NullPointerException.class, () -> new GoScraper(url));
+	}
+}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraperTest.java
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-package nl.esciencecenter.rsd.scraper.package_manager;
+package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraperTest.java
@@ -20,7 +20,7 @@ public class MavenScraperTest {
 			"https://mvnrepository.com/artifact/io.github.sanctuuary/APE,io.github.sanctuuary,APE",
 			"https://mvnrepository.com/artifact/io.github.sanctuuary/APE/,io.github.sanctuuary,APE",
 	})
-	void givenValidMavenOrSonatypeUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNamesCorrect(
+	void givenValidMavenOrSonatypeUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNameCorrect(
 			String url,
 			String expectedGroupId,
 			String expectedArtifactID


### PR DESCRIPTION
## More package manager scrapers

Changes proposed in this pull request:

* Add package manager scrapers for Sonatype, Go and Crates.io.
* Fix small bug where `0` is reported when `null` is returned from the database for package managers
* Improve package manager examples to data generation
* Move scrapers to dedicated package

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Create a software page with the following package managers:
	* https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle/
	* https://crates.io/crates/tokio
	* https://pkg.go.dev/github.com/gin-gonic/gin
	* https://pkg.go.dev/google.golang.org/grpc
* Run the scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.package_manager.MainPackageManager`
* Check the results on the Package manager tab and the Background services tab
* Login as admin and check the error logs, they should have no related errors
* Also add https://pkg.go.dev/google.golang.org/does/not/exist and run the scaper again; the Package manager should report `no info` instead of `0`

Closes #974
Related to #1081

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests
