### PR TITLE
chore: ignore all tar files to prevent backups from being committed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2021 - 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2021 - 2022 dv4all
-# SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -54,3 +54,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 .history
+
+**.tar


### PR DESCRIPTION
ignore all tar files to prevent backups from being committed