### PR TITLE
Upgrade GitHub actions

### DIFF
--- a/.github/workflows/_cff.yml
+++ b/.github/workflows/_cff.yml
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -28,18 +30,18 @@ jobs:
     steps:
       - name: checkout ${{inputs.branch}}
         # https://github.com/actions/checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{inputs.branch}}
 
       - name: download ${{inputs.artifact}}
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: ${{inputs.artifact}}
 
       - name: commit CITATION.cff
         # https://github.com/stefanzweifel/git-auto-commit-action
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: ${{inputs.commit_message}}
           file_pattern: CITATION.cff

--- a/.github/workflows/_ghcr.yml
+++ b/.github/workflows/_ghcr.yml
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -49,7 +51,7 @@ jobs:
     steps:
       - name: checkout
         # https://github.com/actions/checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: build
         id: build_image
         run: |

--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +14,7 @@ jobs:
   fe-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "install node v18.5 and cash yarn"
         uses: actions/setup-node@v3
         with:
@@ -34,7 +34,7 @@ jobs:
   api-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "backend tests with docker compose"
         working-directory: backend-tests
         run: |
@@ -44,7 +44,7 @@ jobs:
   scrapers-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
@@ -60,7 +60,7 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v3
         with:
           node-version: 18.5

--- a/.github/workflows/authentication_tests.yml
+++ b/.github/workflows/authentication_tests.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
 #
@@ -22,7 +22,7 @@ jobs:
   authentication-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: actions/setup-java@v3

--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
 #
@@ -26,7 +26,7 @@ jobs:
   api-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: "backend tests with docker compose"
         working-directory: backend-tests
         run: |

--- a/.github/workflows/cff_validate.yml
+++ b/.github/workflows/cff_validate.yml
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Check out a copy of the repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       # https://github.com/citation-file-format/cffconvert-github-action
       - name: validate citation metadata in CITATION.cff

--- a/.github/workflows/database_scan.yml
+++ b/.github/workflows/database_scan.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +21,7 @@ jobs:
     name: Build and analyse with SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Cache SonarCloud packages

--- a/.github/workflows/e2e_tests_chrome.yml
+++ b/.github/workflows/e2e_tests_chrome.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 #
@@ -34,55 +34,55 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18.5
-        cache: 'npm'
-        cache-dependency-path: e2e/package-lock.json
-    - name: get playwright version
-      id: playwright-version
-      working-directory: e2e
-      run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
-    - name: cache playwright binaries
-      uses: actions/cache@v3
-      id: playwright-cache
-      with:
-        path: |
-          ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-    - name: install dependencies
-      working-directory: e2e
-      run: npm ci
-    - name: install browsers
-      working-directory: e2e
-      run: npx playwright install chromium chrome --with-deps
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-    - name: build rsd
-      working-directory: .
-      run: |
-        cp e2e/.env.e2e .env
-        docker compose build --parallel database backend auth frontend documentation nginx
-    - name: start rsd
-      working-directory: .
-      run: |
-        docker compose up --detach database backend auth frontend documentation nginx swagger
-        sleep 5
-    - name: run e2e tests in chrome
-      working-directory: e2e
-      run: npm run e2e:chrome:action
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: e2e/playwright-report/
-        retention-days: 30
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: browser state and .env file
-        path: |
-          e2e/state/
-          .env
-        retention-days: 30
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.5
+          cache: 'npm'
+          cache-dependency-path: e2e/package-lock.json
+      - name: get playwright version
+        id: playwright-version
+        working-directory: e2e
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+      - name: install dependencies
+        working-directory: e2e
+        run: npm ci
+      - name: install browsers
+        working-directory: e2e
+        run: npx playwright install chromium chrome --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - name: build rsd
+        working-directory: .
+        run: |
+          cp e2e/.env.e2e .env
+          docker compose build --parallel database backend auth frontend documentation nginx
+      - name: start rsd
+        working-directory: .
+        run: |
+          docker compose up --detach database backend auth frontend documentation nginx swagger
+          sleep 5
+      - name: run e2e tests in chrome
+        working-directory: e2e
+        run: npm run e2e:chrome:action
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 30
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: browser state and .env file
+          path: |
+            e2e/state/
+            .env
+          retention-days: 30
 

--- a/.github/workflows/e2e_tests_firefox.yml
+++ b/.github/workflows/e2e_tests_firefox.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 #
@@ -16,55 +16,55 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18.5
-        cache: 'npm'
-        cache-dependency-path: e2e/package-lock.json
-    - name: get playwright version
-      id: playwright-version
-      working-directory: e2e
-      run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
-    - name: cache playwright binaries
-      uses: actions/cache@v3
-      id: playwright-cache
-      with:
-        path: |
-          ~/.cache/ms-playwright
-        key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
-    - name: install dependencies
-      working-directory: e2e
-      run: npm ci
-    - name: install browsers
-      working-directory: e2e
-      run: npx playwright install chromium chrome firefox --with-deps
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-    - name: build rsd
-      working-directory: .
-      run: |
-        cp e2e/.env.e2e .env
-        docker compose build --parallel database backend auth frontend documentation nginx
-    - name: start rsd
-      working-directory: .
-      run: |
-        docker compose up --detach database backend auth frontend documentation nginx swagger
-        sleep 5
-    - name: run e2e tests in firefox
-      working-directory: e2e
-      run: npm run e2e:ff:action
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: e2e/playwright-report/
-        retention-days: 30
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: browser state and .env file
-        path: |
-          e2e/state/
-          .env
-        retention-days: 30
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.5
+          cache: 'npm'
+          cache-dependency-path: e2e/package-lock.json
+      - name: get playwright version
+        id: playwright-version
+        working-directory: e2e
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+      - name: install dependencies
+        working-directory: e2e
+        run: npm ci
+      - name: install browsers
+        working-directory: e2e
+        run: npx playwright install chromium chrome firefox --with-deps
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+      - name: build rsd
+        working-directory: .
+        run: |
+          cp e2e/.env.e2e .env
+          docker compose build --parallel database backend auth frontend documentation nginx
+      - name: start rsd
+        working-directory: .
+        run: |
+          docker compose up --detach database backend auth frontend documentation nginx swagger
+          sleep 5
+      - name: run e2e tests in firefox
+        working-directory: e2e
+        run: npm run e2e:ff:action
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 30
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: browser state and .env file
+          path: |
+            e2e/state/
+            .env
+          retention-days: 30
 

--- a/.github/workflows/e2e_tests_macos.yml
+++ b/.github/workflows/e2e_tests_macos.yml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-# SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -14,48 +14,48 @@ on:
         type: choice
         description: Select browser
         options:
-        - chrome
-        - msedge
-        - firefox
-        - webkit
+          - chrome
+          - msedge
+          - firefox
+          - webkit
 jobs:
   macos-v12:
     timeout-minutes: 30
     name: ${{inputs.browser}} macos v12
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v3
-    - name: get playwright version
-      id: playwright-version
-      working-directory: e2e
-      run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
-    - name: cache playwright binaries
-      uses: actions/cache@v3
-      id: playwright-cache
-      with:
-        path: |
-          ~/.cache/ms-playwright
-        key: ${{runner.os}}-playwright-${{env.PLAYWRIGHT_VERSION}}-${{inputs.browser}}
-    - name: install dependencies
-      working-directory: e2e
-      run: npm ci
-    - name: install browsers
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      working-directory: e2e
-      run: npx playwright install chromium ${{inputs.browser}} --with-deps
-    - name: run e2e tests
-      working-directory: e2e
-      run: npm run e2e:${{inputs.browser}}:dev
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: macos-playwright-report-${{inputs.browser}}
-        path: e2e/playwright-report/
-        retention-days: 30
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: macos browser ${{inputs.browser}} state
-        path: |
-          e2e/state/
-        retention-days: 30
+      - uses: actions/checkout@v4
+      - name: get playwright version
+        id: playwright-version
+        working-directory: e2e
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{runner.os}}-playwright-${{env.PLAYWRIGHT_VERSION}}-${{inputs.browser}}
+      - name: install dependencies
+        working-directory: e2e
+        run: npm ci
+      - name: install browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: e2e
+        run: npx playwright install chromium ${{inputs.browser}} --with-deps
+      - name: run e2e tests
+        working-directory: e2e
+        run: npm run e2e:${{inputs.browser}}:dev
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: macos-playwright-report-${{inputs.browser}}
+          path: e2e/playwright-report/
+          retention-days: 30
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: macos browser ${{inputs.browser}} state
+          path: |
+            e2e/state/
+          retention-days: 30

--- a/.github/workflows/e2e_tests_ubuntu.yml
+++ b/.github/workflows/e2e_tests_ubuntu.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 #
@@ -17,55 +17,55 @@ jobs:
     timeout-minutes: 30
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 18.5
-        cache: 'npm'
-        cache-dependency-path: e2e/package-lock.json
-    - name: get playwright version
-      id: playwright-version
-      working-directory: e2e
-      run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
-    - name: cache playwright binaries
-      uses: actions/cache@v3
-      id: playwright-cache
-      with:
-        path: |
-          ~/.cache/ms-playwright
-        key: ${{runner.os}}-playwright-${{env.PLAYWRIGHT_VERSION}}
-    - name: install dependencies
-      working-directory: e2e
-      run: npm ci
-    - name: install browsers
-      if: steps.playwright-cache.outputs.cache-hit != 'true'
-      working-directory: e2e
-      run: npx playwright install chromium chrome firefox --with-deps
-    - name: build rsd
-      working-directory: .
-      run: |
-        cp e2e/.env.e2e .env
-        docker compose build --parallel database backend auth frontend documentation nginx
-    - name: start rsd
-      working-directory: .
-      run: |
-        docker compose up --detach database backend auth frontend documentation nginx swagger
-        sleep 5
-    - name: run e2e tests
-      working-directory: e2e
-      run: npm run e2e:ubuntu
-    - uses: actions/upload-artifact@v3
-      if: always()
-      with:
-        name: playwright-report
-        path: e2e/playwright-report/
-        retention-days: 30
-    - uses: actions/upload-artifact@v3
-      if: failure()
-      with:
-        name: browser state and .env file
-        path: |
-          e2e/state/
-          .env
-        retention-days: 30
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18.5
+          cache: 'npm'
+          cache-dependency-path: e2e/package-lock.json
+      - name: get playwright version
+        id: playwright-version
+        working-directory: e2e
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: cache playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+          key: ${{runner.os}}-playwright-${{env.PLAYWRIGHT_VERSION}}
+      - name: install dependencies
+        working-directory: e2e
+        run: npm ci
+      - name: install browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: e2e
+        run: npx playwright install chromium chrome firefox --with-deps
+      - name: build rsd
+        working-directory: .
+        run: |
+          cp e2e/.env.e2e .env
+          docker compose build --parallel database backend auth frontend documentation nginx
+      - name: start rsd
+        working-directory: .
+        run: |
+          docker compose up --detach database backend auth frontend documentation nginx swagger
+          sleep 5
+      - name: run e2e tests
+        working-directory: e2e
+        run: npm run e2e:ubuntu
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 30
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: browser state and .env file
+          path: |
+            e2e/state/
+            .env
+          retention-days: 30
 

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 - 2023 dv4all
+# SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-# SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +23,7 @@ jobs:
   fe-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: "install node v20.10 and cash yarn"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-# SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +24,7 @@ jobs:
     steps:
       - name: checkout all history
         # https://github.com/actions/checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # checkout whole history
           fetch-depth: 0
@@ -32,7 +32,7 @@ jobs:
       - name: calculate new version and create changelog content
         id: changelog
         # https://github.com/TriPSs/conventional-changelog-action
-        uses: TriPSs/conventional-changelog-action@v3
+        uses: TriPSs/conventional-changelog-action@v5
         with:
           # you can also create separate token to trace action
           github-token: "${{secrets.GITHUB_TOKEN}}"
@@ -168,7 +168,7 @@ jobs:
     steps:
       - name: checkout branch
         # https://github.com/actions/checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: update docker-compose.yml
         run: |
@@ -216,7 +216,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: get deployment.zip
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: deployment
 

--- a/.github/workflows/scrapers_tests.yml
+++ b/.github/workflows/scrapers_tests.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
 #
@@ -22,7 +22,7 @@ jobs:
   scrapers-tests:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - uses: actions/setup-java@v3


### PR DESCRIPTION
## Upgrade GitHub actions

Changes proposed in this pull request:

* Upgrade the GitHub actions as described in #1096

How to test:

We can only test this when we do an actual release, but the respective documentation pages suggest we should not expect any breaking changes for us:

* https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes
* https://github.com/actions/checkout/releases
* https://github.com/TriPSs/conventional-changelog-action/releases
	* https://github.com/conventional-changelog/conventional-changelog/blob/master/packages/conventional-recommended-bump/CHANGELOG.md
	* https://github.com/conventional-changelog/conventional-changelog/releases
* https://github.com/stefanzweifel/git-auto-commit-action/releases

Closes #1096

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
