### PR TITLE
feat: add last login date to login table

### DIFF
--- a/database/011-create-account-table.sql
+++ b/database/011-create-account-table.sql
@@ -66,6 +66,7 @@ CREATE TABLE login_for_account (
 	name VARCHAR(200),
 	email VARCHAR(200),
 	home_organisation VARCHAR(200),
+	last_login_date TIMESTAMPTZ,
 	created_at TIMESTAMPTZ NOT NULL,
 	updated_at TIMESTAMPTZ NOT NULL,
 	UNIQUE(provider, sub)

--- a/frontend/components/admin/rsd-users/RsdLoginList.tsx
+++ b/frontend/components/admin/rsd-users/RsdLoginList.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,10 +12,11 @@ export default function RsdLoginForAccount({logins}:{logins:RsdAccount[]}) {
   return (
     <ul className="text-sm">
       {logins.map(login => {
-        const {id, name, email, home_organisation, provider} = login
+        const {id, name, email, home_organisation, provider, last_login_date} = login
         return (
           <li key={id}>
             {name ? name : 'Name missing'}{email ? `, ${email}`:', Email missing'}{home_organisation ? `, ${home_organisation}`:', Affiliation missing'} {provider ? `, ${provider}`:', Provider missing'}
+            <br/>Last login: {last_login_date ? new Date(last_login_date).toUTCString() : 'missing'}
           </li>
         )
       })}

--- a/frontend/components/admin/rsd-users/RsdUsersList.tsx
+++ b/frontend/components/admin/rsd-users/RsdUsersList.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -41,7 +42,7 @@ export default function RsdUsersList() {
       <section className="flex-1">
         <Alert severity="warning" sx={{marginTop:'0.5rem'}}>
           <AlertTitle sx={{fontWeight:500}}>No users</AlertTitle>
-          An user is <strong>automatically added after first login</strong>.
+          A user is <strong>automatically added after first login</strong>.
         </Alert>
       </section>
     )

--- a/frontend/components/admin/rsd-users/apiRsdUsers.ts
+++ b/frontend/components/admin/rsd-users/apiRsdUsers.ts
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +22,7 @@ type getLoginApiParams = {
 export async function getRsdAccounts({page,rows,token,searchFor}:getLoginApiParams) {
   try {
     // pagination
-    let query = `select=id,login_for_account!inner(id,provider,name,email,home_organisation),admin_account!left(account_id)${paginationUrlParams({rows, page})}`
+    let query = `select=id,login_for_account!inner(id,provider,name,email,home_organisation,last_login_date),admin_account!left(account_id)${paginationUrlParams({rows, page})}`
     // search
     if (searchFor) {
       if (searchFor.match(/^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i) !== null) {

--- a/frontend/components/admin/rsd-users/useRsdAccounts.tsx
+++ b/frontend/components/admin/rsd-users/useRsdAccounts.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,6 +15,7 @@ export type RsdAccount = {
   name: string|null,
   email: string | null,
   home_organisation: string | null,
+  last_login_date: Date | null,
 }
 
 export type RsdAccountInfo = {


### PR DESCRIPTION
## Last login date

Changes proposed in this pull request:

* Add column `last_login_date` to `login_for_account` table that gets updated everytime a user logs in
* Show the last login date on the admin view

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Login as admin and browse http://localhost/admin/rsd-users, all fake accounts should say `Last login date missing`; your own account should display the date
* Logging is as regular user, logging in again and coupling accounts should still work

Closes #1054

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
