### PR TITLE
CodeMeta overview page

### DIFF
--- a/codemeta/Dockerfile
+++ b/codemeta/Dockerfile
@@ -11,6 +11,8 @@ COPY **.go .
 
 RUN go build -v -o /usr/local/bin/app
 
+COPY **.gohtml .
+
 RUN useradd user
 USER user
 

--- a/codemeta/overview.go
+++ b/codemeta/overview.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"encoding/json"
+	"html/template"
+	"io"
+)
+
+type SoftwareBasicData struct {
+	Slug           string `json:"slug"`
+	BrandName      string `json:"brand_name"`
+	ShortStatement string `json:"short_statement"`
+}
+
+var tmpl = template.Must(template.ParseFiles("overview.gohtml"))
+
+func GenerateOverview(bytes []byte, writer io.Writer) error {
+	var software []SoftwareBasicData
+	err := json.Unmarshal(bytes, &software)
+	if err != nil {
+		return err
+	}
+
+	err = tmpl.Execute(writer, software)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/codemeta/overview.gohtml
+++ b/codemeta/overview.gohtml
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>CodeMeta overview</title>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2.0.3/css/pico.min.css">
+</head>
+<body class="container">
+<h1>
+	CodeMeta overview
+</h1>
+<section>
+	This page gives a succinct overview of all software pages that export to CodeMeta.
+	<mark><strong>Warning</strong>: this feature is still in development, so the generated CodeMeta data might still
+		change.
+	</mark>
+</section>
+<section>{{range .}}
+		<article>
+			<header><a href="v3/{{.Slug}}/">{{.BrandName}}</a></header>{{.ShortStatement}}
+		</article>{{end}}
+</section>
+</body>
+</html>

--- a/codemeta/utils.go
+++ b/codemeta/utils.go
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"errors"
+	"io"
+	"log"
+	"net/http"
+)
+
+func GetAndReadBody(url string) (body []byte, err error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return nil, err
+	}
+
+	defer func(Body io.ReadCloser) {
+		closeErr := Body.Close()
+		if closeErr != nil {
+			log.Printf("Unknown error when closing response body for URL %v overview with error: %v", url, closeErr)
+			err = errors.Join(closeErr, err)
+		}
+	}(resp.Body)
+
+	body, err = io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	return body, err
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
 
   codemeta:
     build: ./codemeta
-    image: rsd/codemeta:v1.0.0
+    image: rsd/codemeta:v1.1.0
     expose:
       - "8000"
     environment:


### PR DESCRIPTION
## CodeMeta overview page

Changes proposed in this pull request:

* Add a simple overview page where visitors can find links to all CodeMeta pages

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Visit http://localhost/metadata/codemeta/ and check that the links work.

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
