### PR TITLE
Scraper fixes

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -163,6 +163,7 @@ services:
     restart: unless-stopped
 
   codemeta:
+    container_name: codemeta
     image: ghcr.io/research-software-directory/rsd-saas/codemeta:latest
     expose:
       - "8000"
@@ -175,6 +176,7 @@ services:
     restart: unless-stopped
 
   swagger:
+    container_name: swagger
     image: swaggerapi/swagger-ui:v4.15.0
     expose:
       - "8080"

--- a/frontend/components/mention/ImportMentions/apiImportMentions.tsx
+++ b/frontend/components/mention/ImportMentions/apiImportMentions.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -133,7 +135,7 @@ export async function validateInputList(doiList: string[], mentions: MentionItem
         mentionResultPerDoi.set(doi, {
           doi,
           status: 'valid',
-          source: 'Crossref',
+          source: 'DataCite',
           include: true,
           mention
         })

--- a/frontend/types/Datacite.ts
+++ b/frontend/types/Datacite.ts
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,8 +26,8 @@ type DoiAttributes = {
   ]
   referenceCount: number
   citationCount: number
-  // and many more but we are initially interesed in these
-  // see exapleResponse for more or response from
+  // and many more, but we are initially interested in these
+  // see exampleResponse for more or response from
   // https://api.datacite.org/dois/10.5281/zenodo.1051064
   // documentation https://support.datacite.org/reference/get_dois-id
 }
@@ -92,7 +94,9 @@ const exampleWork = {
       'title': 'CellProfiler and KNIME: Open-Source Tools for High-Content Screening'
     }
   ],
-  'publisher': 'Springer Science and Business Media LLC',
+  'publisher': {
+    'name': 'Springer Science and Business Media LLC'
+  },
   'publicationYear': 2019,
   'creators': [
     {

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -27,7 +27,9 @@ function graphQLDoiQuery(doi:string) {
       descriptions(first:1){
         description
       },
-      publisher,
+      publisher {
+        name
+      },
       publicationYear,
       creators{
         givenName,
@@ -66,7 +68,9 @@ function graphQLDoisQuery(dois: string[]) {
         descriptions(first:1){
           description
         },
-        publisher,
+        publisher {
+          name
+        },
         publicationYear,
         creators{
           givenName,
@@ -118,7 +122,9 @@ function gqlWorksByTitleQuery(title: string) {
         descriptions(first:1){
           description
         },
-        publisher,
+        publisher {
+          name
+        },
         publicationYear,
         creators{
           givenName,
@@ -172,7 +178,7 @@ export function dataCiteGraphQLItemToMentionItem(item: WorkResponse) {
     url: makeDoiRedirectUrl(item.doi),
     title: item.titles[0].title,
     authors: extractAuthors(item),
-    publisher: item.publisher,
+    publisher: item.publisher.name,
     publication_year: item.publicationYear,
     journal: null,
     page: null,
@@ -264,8 +270,10 @@ export async function getDataciteItemsByTitleGraphQL(title: string) {
         query,
       }),
     })
+    console.log(resp)
     if (resp.status === 200) {
       const json: DataciteWorksGraphQLResponse = await resp.json()
+      console.log(JSON.stringify(json))
       if (json.data.works && json.data.works.nodes) return json.data.works.nodes
       return []
     }

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -258,7 +258,7 @@ export async function getDataciteItemsByDoiGraphQL(dois: string[]) {
 
 export async function getDataciteItemsByTitleGraphQL(title: string) {
   try {
-    const query = gqlWorksByTitleQuery(title)
+    const query = gqlWorksByTitleQuery(title.replace(':', '\\\\:'))
     const url = 'https://api.datacite.org/graphql'
 
     const resp = await fetch(url, {
@@ -270,10 +270,8 @@ export async function getDataciteItemsByTitleGraphQL(title: string) {
         query,
       }),
     })
-    console.log(resp)
     if (resp.status === 200) {
       const json: DataciteWorksGraphQLResponse = await resp.json()
-      console.log(JSON.stringify(json))
       if (json.data.works && json.data.works.nodes) return json.data.works.nodes
       return []
     }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +10,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import nl.esciencecenter.rsd.scraper.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URI;
 import java.time.Instant;
@@ -24,9 +26,6 @@ import java.util.TreeSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DataciteMentionRepository implements MentionRepository {
 
@@ -49,7 +48,9 @@ public class DataciteMentionRepository implements MentionRepository {
 			      titles(first: 1) {
 			        title
 			      }
-			      publisher
+			      publisher {
+			        name
+			      }
 			      publicationYear
 			      registered
 			      creators {
@@ -154,7 +155,7 @@ public class DataciteMentionRepository implements MentionRepository {
 		}
 		result.authors = String.join(", ", authors);
 
-		result.publisher = Utils.stringOrNull(work.get("publisher"));
+		result.publisher = Utils.stringOrNull(work.getAsJsonObject("publisher").get("name"));
 		result.publicationYear = Utils.integerOrNull(work.get("publicationYear"));
 		String doiRegistrationDateString = Utils.stringOrNull(work.get("registered"));
 		if (doiRegistrationDateString != null) {

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexCitations.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexCitations.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,6 +20,9 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
 
 public class OpenAlexCitations {
 
@@ -135,16 +138,15 @@ public class OpenAlexCitations {
 		}
 
 		JsonArray authorsArray = citationObject.getAsJsonArray("authorships");
-		Collection<String> authors = new ArrayList<>();
-		for (JsonElement jsonElement : authorsArray) {
-			authors.add(
-					jsonElement
-							.getAsJsonObject()
-							.getAsJsonPrimitive("raw_author_name")
-							.getAsString()
-			);
+		mention.authors = StreamSupport.stream(authorsArray.spliterator(), false)
+				.map(JsonElement::getAsJsonObject)
+				.map(jo -> jo.get("raw_author_name"))
+				.filter(Predicate.not(JsonElement::isJsonNull))
+				.map(JsonElement::getAsString)
+				.collect(Collectors.joining(", "));
+		if (mention.authors.isBlank()) {
+			mention.authors = null;
 		}
-		mention.authors = String.join(", ", authors);
 
 		mention.publisher = null;
 


### PR DESCRIPTION
## Scraper fixes

Changes proposed in this pull request:

* Fix bug where an OpenAlex raw author was wrongly assumed to be not null
* Adapt to the changed DataCite GraphQL API, where the publisher now has sub fields
* Escape colons when searching in the DataCite GraphQL API on title
* Show DataCite instead of Crossref when DataCite was used as the source in bulk import
* Set the container names for Swagger and CodeMeta in production

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Create a software or project page, publish it
* Add the following DataCite mentions directly, then remove them, then add them with bulk import:
	* 10.48550/arxiv.2310.12084
	* 10.5281/zenodo.1140396
* Search for the title `CellProfiler and KNIME: Open-Source Tools for High-Content Screening`, a DataCite result should be shown, add it.
* Run the mentions scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions`
* The scraper should run without errors, the `scraped_at` fields should be set at http://localhost/api/v1/mention
* Add the following reference papers:
	* 10.1021/acs.jpclett.9b01634
	* 10.1021/ja026939x
* Run the citation scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations`, it should run without errors


PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
