### PR TITLE
More CodeMeta data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
 
   codemeta:
     build: ./codemeta
-    image: rsd/codemeta:v1.1.0
+    image: rsd/codemeta:v1.2.0
     expose:
       - "8000"
     environment:


### PR DESCRIPTION
## More CodeMeta metadata

Changes proposed in this pull request:

* Add programming languages to CodeMeta metadata
* Add reference papers to CodeMeta metadata
* Change description from a string to an array of strings, that can contain the short statement, description and description URL

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Add a software page, publish it, add a reference paper, add a valid GitHub URL and let the scraper scrape its programming languages (`docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages`)
* Visit http://localhost/metadata/codemeta and inspect the data of your page
* Play around with having a short statement, description and description URL and check the data again

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
