### PR TITLE
Global search fix

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -923,7 +923,7 @@ $$
 	-- ONLY TOP LEVEL ORGANISATIONS
 		organisation.parent IS NULL
 		AND
-		organisation.slug ILIKE CONCAT('%', query, '%') OR organisation."name" ILIKE CONCAT('%', query, '%')
+		(organisation.slug ILIKE CONCAT('%', query, '%') OR organisation."name" ILIKE CONCAT('%', query, '%'))
 ;
 $$;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:2.2.1
+    image: rsd/database:2.2.2
     ports:
       # enable connection from outside (development mode)
       - "5432:5432"


### PR DESCRIPTION
## Global search fix

Changes proposed in this pull request:

* Fix the global search where it would show research units by accident

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Create a research unit
* Search globally for the unit's name and/or slug, it should not be shown

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
