### PR TITLE
Add anchor elements to links

### DIFF
--- a/frontend/components/layout/EditPageButton.tsx
+++ b/frontend/components/layout/EditPageButton.tsx
@@ -3,14 +3,15 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
-import {useRouter} from 'next/router'
 import EditFab from './EditFab'
 import PageContainer from './PageContainer'
+import Link from 'next/link'
 
 type EditButtonProps = {
   title: string,
@@ -25,7 +26,6 @@ type EditButtonProps = {
  * @returns
  */
 export default function EditPageButton({title, url, isMaintainer, variant}: EditButtonProps) {
-  const router = useRouter()
   // console.log('EditPageButton...', title)
   if (isMaintainer) {
     if (variant === 'fab') {
@@ -61,10 +61,8 @@ export default function EditPageButton({title, url, isMaintainer, variant}: Edit
             textTransform:'capitalize'
             // minWidth: '6rem'
           }}
-          onClick={() => {
-            // const slug = router.query['slug']
-            router.push(url)
-          }}
+          href={url}
+          LinkComponent={Link}
         >
           {/* Edit page */}
           {title}

--- a/frontend/components/layout/EditPageButton.tsx
+++ b/frontend/components/layout/EditPageButton.tsx
@@ -58,7 +58,12 @@ export default function EditPageButton({title, url, isMaintainer, variant}: Edit
             right: {
               lg:'1rem'
             },
-            textTransform:'capitalize'
+            textTransform:'capitalize',
+            // we need to overwrite global link styling from tailwind
+            // because the type of button is a link (we use href param)
+            ':hover':{
+              color:'primary.contrastText'
+            }
             // minWidth: '6rem'
           }}
           href={url}

--- a/frontend/components/layout/ViewPageButton.tsx
+++ b/frontend/components/layout/ViewPageButton.tsx
@@ -3,12 +3,13 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined'
 import Button from '@mui/material/Button'
-import {useRouter} from 'next/router'
+import Link from 'next/link'
 
 type ViewButtonProps = {
   title: string,
@@ -18,7 +19,6 @@ type ViewButtonProps = {
 }
 
 export default function ViewPageButton({title,label,url,disabled}:ViewButtonProps) {
-  const router = useRouter()
   return (
     <Button
       data-testid="view-page-button"
@@ -29,10 +29,8 @@ export default function ViewPageButton({title,label,url,disabled}:ViewButtonProp
         minWidth: '6rem',
         textTransform:'capitalize'
       }}
-      onClick={() => {
-        // const slug = router.query['slug']
-        router.push(url)
-      }}
+      href={url}
+      LinkComponent={Link}
       disabled={disabled}
     >
       {/* View page */}

--- a/frontend/components/layout/ViewPageButton.tsx
+++ b/frontend/components/layout/ViewPageButton.tsx
@@ -27,7 +27,12 @@ export default function ViewPageButton({title,label,url,disabled}:ViewButtonProp
       startIcon={<ArticleOutlinedIcon />}
       sx={{
         minWidth: '6rem',
-        textTransform:'capitalize'
+        textTransform:'capitalize',
+        // we need to overwrite global link styling from tailwind
+        // because the type of button is a link (we use href param)
+        ':hover':{
+          color:'primary.contrastText'
+        }
       }}
       href={url}
       LinkComponent={Link}

--- a/frontend/components/organisation/overview/useOrganisationOverviewParams.tsx
+++ b/frontend/components/organisation/overview/useOrganisationOverviewParams.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +17,7 @@ import {getDocumentCookie} from '~/utils/userSettings'
 export default function useOrganisationOverviewParams() {
   const router = useRouter()
 
-  function handleQueryChange(key: string, value: string | string[]) {
+  function createUrl(key: string, value: string | string[]) {
     const params: QueryParams = {
       // take existing params from url (query)
       ...ssrOrganisationParams(router.query),
@@ -32,6 +33,11 @@ export default function useOrganisationOverviewParams() {
     }
     // construct url with all query params
     const url = ssrOrganisationUrl(params)
+    return url
+  }
+
+  function handleQueryChange(key: string, value: string | string[]) {
+    const url = createUrl(key, value)
     if (key === 'page') {
       // when changin page we scroll to top
       router.push(url, url, {scroll: true})
@@ -48,6 +54,7 @@ export default function useOrganisationOverviewParams() {
 
   return {
     handleQueryChange,
-    resetFilters
+    resetFilters,
+    createUrl
   }
 }

--- a/frontend/components/projects/overview/useProjectOverviewParams.ts
+++ b/frontend/components/projects/overview/useProjectOverviewParams.ts
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,7 +17,7 @@ import {getDocumentCookie} from '~/utils/userSettings'
 export default function useProjectOverviewParams() {
   const router = useRouter()
 
-  function handleQueryChange(key: string, value: string | string[]) {
+  function createUrl(key: string, value: string | string[]) {
     const params: QueryParams = {
       // take existing params from url (query)
       ...ssrProjectsParams(router.query),
@@ -32,6 +33,11 @@ export default function useProjectOverviewParams() {
     }
     // construct url with all query params
     const url = ssrProjectsUrl(params)
+    return url
+  }
+
+  function handleQueryChange(key: string, value: string | string[]) {
+    const url = createUrl(key, value)
     // debugger
     if (key === 'page') {
       // when changin page we scroll to top
@@ -51,6 +57,7 @@ export default function useProjectOverviewParams() {
 
   return {
     handleQueryChange,
-    resetFilters
+    resetFilters,
+    createUrl
   }
 }

--- a/frontend/components/software/overview/useSoftwareOverviewParams.ts
+++ b/frontend/components/software/overview/useSoftwareOverviewParams.ts
@@ -1,8 +1,9 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,8 +17,8 @@ import {getDocumentCookie} from '../../../utils/userSettings'
 export default function useSoftwareOverviewParams() {
   const router = useRouter()
 
-  function handleQueryChange(key: string, value: string | string[]) {
-    const params:QueryParams = {
+  function createUrl(key: string, value: string | string[]) {
+    const params: QueryParams = {
       // take existing params from url (query)
       ...ssrSoftwareParams(router.query),
       [key]: value,
@@ -26,12 +27,17 @@ export default function useSoftwareOverviewParams() {
     if (key !== 'page') {
       params['page'] = 1
     }
-    if (typeof params['rows'] === 'undefined' || params['rows']===null) {
+    if (typeof params['rows'] === 'undefined' || params['rows'] === null) {
       // extract from cookie or use default
       params['rows'] = getDocumentCookie('rsd_page_rows', rowsPerPageOptions[0])
     }
     // construct url with all query params
     const url = ssrSoftwareUrl(params)
+    return url
+  }
+
+  function handleQueryChange(key: string, value: string | string[]) {
+    const url = createUrl(key, value)
     if (key === 'page') {
       // when changin page we scroll to top
       router.push(url, url, {scroll: true})
@@ -50,7 +56,8 @@ export default function useSoftwareOverviewParams() {
 
   return {
     handleQueryChange,
-    resetFilters
+    resetFilters,
+    createUrl
   }
 }
 

--- a/frontend/components/user/settings/UserAgreementModal.tsx
+++ b/frontend/components/user/settings/UserAgreementModal.tsx
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -66,7 +67,7 @@ export default function UserAgrementModal() {
   */
   useEffect(() => {
     let abort = false
-    if (loading === false &&
+    if (loading === false && user?.role !== 'rsd_admin' &&
       (agree_terms === false || notice_privacy_statement === false)
     ) {
       if (abort===false) setOpen(true)

--- a/frontend/pages/organisations/index.tsx
+++ b/frontend/pages/organisations/index.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,6 +10,8 @@ import {MouseEvent, ChangeEvent} from 'react'
 import {GetServerSidePropsContext} from 'next/types'
 import TablePagination from '@mui/material/TablePagination'
 import Pagination from '@mui/material/Pagination'
+import Link from 'next/link'
+import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '../../config/app'
 import PageTitle from '../../components/layout/PageTitle'
@@ -41,7 +44,7 @@ const pageDesc = 'List of organizations involved in the development of research 
 export default function OrganisationsOverviewPage({
   organisations = [], count, page, rows, search
 }: OrganisationsOverviewPageProps) {
-  const {handleQueryChange} = useOrganisationOverviewParams()
+  const {handleQueryChange, createUrl} = useOrganisationOverviewParams()
   const numPages = Math.ceil(count / rows)
 
   // console.group('OrganisationsOverviewPage')
@@ -123,8 +126,18 @@ export default function OrganisationsOverviewPage({
               <Pagination
                 count={numPages}
                 page={page}
-                onChange={(_, page) => {
-                  handleQueryChange('page',page.toString())
+                renderItem={item => {
+                  if (item.page !== null) {
+                    return (
+                      <Link href={createUrl('page', item.page.toString())}>
+                        <PaginationItem {...item}/>
+                      </Link>
+                    )
+                  } else {
+                    return (
+                      <PaginationItem {...item}/>
+                    )
+                  }
                 }}
               />
             </div>

--- a/frontend/pages/projects/[slug]/edit/[page].tsx
+++ b/frontend/pages/projects/[slug]/edit/[page].tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -49,6 +51,9 @@ export default function ProjectEditPage({pageIndex,project}:ProjectEditPageProps
       <Head>
         <title>{pageTitle}</title>
       </Head>
+      <noscript>
+        <p style={{fontSize: '2rem', textAlign: 'center'}}>Please enable JavaScript to use this page</p>
+      </noscript>
       <ProtectedContent slug={project.slug} pageType="project">
         <UserAgrementModal />
         {/* edit project context is share project info between pages */}

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,6 +11,8 @@ import {GetServerSidePropsContext} from 'next'
 
 import Pagination from '@mui/material/Pagination'
 import useMediaQuery from '@mui/material/useMediaQuery'
+import Link from 'next/link'
+import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
 import {ProjectListItem} from '~/types/Project'
@@ -75,7 +78,7 @@ export default function ProjectsOverviewPage({
   page, rows, count, layout,
   projects
 }: ProjectOverviewPageProps) {
-  const {handleQueryChange} = useProjectOverviewParams()
+  const {createUrl} = useProjectOverviewParams()
   const smallScreen = useMediaQuery('(max-width:640px)')
   const [modal,setModal] = useState(false)
   // if masonry we change to grid
@@ -181,8 +184,18 @@ export default function ProjectsOverviewPage({
                   <Pagination
                     count={numPages}
                     page={page}
-                    onChange={(_, page) => {
-                      handleQueryChange('page',page.toString())
+                    renderItem={item => {
+                      if (item.page !== null) {
+                        return (
+                          <Link href={createUrl('page', item.page.toString())}>
+                            <PaginationItem {...item}/>
+                          </Link>
+                        )
+                      } else {
+                        return (
+                          <PaginationItem {...item}/>
+                        )
+                      }
                     }}
                   />
                 </div>

--- a/frontend/pages/software/[slug]/edit/[page].tsx
+++ b/frontend/pages/software/[slug]/edit/[page].tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -53,6 +54,9 @@ export default function SoftwareEditPages({pageIndex,software}:SoftwareEditPageP
       <Head>
         <title>{pageTitle}</title>
       </Head>
+      <noscript>
+        <p style={{fontSize: '2rem', textAlign: 'center'}}>Please enable JavaScript to use this page</p>
+      </noscript>
       <ProtectedContent slug={software.slug}>
         <UserAgrementModal />
         <EditSoftwareProvider state={state}>

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -10,6 +10,8 @@ import {useState} from 'react'
 import {GetServerSidePropsContext} from 'next/types'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import Pagination from '@mui/material/Pagination'
+import Link from 'next/link'
+import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
 import {getBaseUrl} from '~/utils/fetchHelpers'
@@ -75,7 +77,7 @@ export default function SoftwareOverviewPage({
   licensesList, software, highlights
 }: SoftwareOverviewProps) {
   const smallScreen = useMediaQuery('(max-width:640px)')
-  const {handleQueryChange} = useSoftwareOverviewParams()
+  const {createUrl} = useSoftwareOverviewParams()
   const [modal,setModal] = useState(false)
   // if no layout - default is masonry
   const initView = layout ?? 'masonry'
@@ -180,8 +182,18 @@ export default function SoftwareOverviewPage({
                   <Pagination
                     count={numPages}
                     page={page}
-                    onChange={(_, page) => {
-                      handleQueryChange('page',page.toString())
+                    renderItem={item => {
+                      if (item.page !== null) {
+                        return (
+                          <Link href={createUrl('page', item.page.toString())}>
+                            <PaginationItem {...item}/>
+                          </Link>
+                        )
+                      } else {
+                        return (
+                          <PaginationItem {...item}/>
+                        )
+                      }
                     }}
                   />
                 }


### PR DESCRIPTION
## Add anchor elements to links

Changes proposed in this pull request:

* Add anchor element to software, project and organisation pagination and to view/edit software/project buttons
* Admins don't get the modal with terms of service and privacy statement anymore

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Paginate software, projects and organisation, it should still work without a full page reload, but you can also open them in a new tab
* Login as admin, check the view/edit software/project buttons, it should still work without a full page reload, but you can also open them in a new tab
* As admin, you don't get to see the modal where you have to accept the terms of service and privacy statement when you want to edit a page

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests