### PR TITLE
fix: support for custom GitLab package and container registries

### DIFF
--- a/frontend/components/software/edit/package-managers/EditPackageManagerIndex.test.tsx
+++ b/frontend/components/software/edit/package-managers/EditPackageManagerIndex.test.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -124,6 +124,11 @@ describe('frontend/components/software/edit/package-managers/index.tsx', () => {
       fireEvent.click(saveBtn)
       // wait for edit modal to be removed
       await waitForElementToBeRemoved(editModal)
+      // screen.debug()
     })
+
+    // validate package_manager label by text
+    const pacman = `${mockManagers[0].package_manager.slice(0,1).toUpperCase()}${mockManagers[0].package_manager.slice(1)}`
+    await screen.findByText(pacman)
   })
 })

--- a/frontend/components/software/edit/package-managers/EditPackageManagerModal.tsx
+++ b/frontend/components/software/edit/package-managers/EditPackageManagerModal.tsx
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,8 +19,7 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 
 import {useForm} from 'react-hook-form'
 
-import logger from '~/utils/logger'
-import ControlledTextField from '../../../form/ControlledTextField'
+import ControlledTextField from '~/components/form/ControlledTextField'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
 import {
   getPackageManagerTypeFromUrl, NewPackageManager,
@@ -26,7 +27,6 @@ import {
 } from './apiPackageManager'
 import PackageManagerInfo from './PackageManagerInfo'
 import {config} from './config'
-import {getBaseUrl} from '~/utils/fetchHelpers'
 
 type EditPackageManagerModalProps = {
   open: boolean,
@@ -54,37 +54,23 @@ export default function EditPackageManagerModal({open, onCancel, onSubmit, packa
   const [url] = watch(['url'])
 
   useEffect(() => {
-    const fetchPackageManagerType = async () => {
+    async function fetchPackageManagerType(){
       // extract manager type from url
       const pm_key = await getPackageManagerTypeFromUrl(url)
-
-      if (pm_key) {
-        // const manager = PackageManagerInfo[pm_key as PackageManagerTypes]
-        setValue('package_manager', pm_key as PackageManagerTypes, {
-          shouldValidate: true,
-          shouldDirty: true
-        })
-      } else {
-        setValue('package_manager', 'other' as PackageManagerTypes,{
-          shouldValidate: true,
-          shouldDirty: true
-        })
-      }
+      // save value
+      setValue('package_manager', pm_key as PackageManagerTypes, {
+        shouldValidate: true,
+        shouldDirty: true
+      })
     }
-
-    try {
-      if (typeof errors['url'] === 'undefined' && url.length > 5) {
-        fetchPackageManagerType()
-      }
-    } catch (e: any) {
-      logger(`useEffect.getPackageManagerTypeFromUrl...${e.message}`, 'warn')
+    if (typeof errors['url'] === 'undefined' && url.length > 5) {
+      fetchPackageManagerType()
     }
   },[url,setValue,errors])
 
   // console.group('EditPackageManagerModal')
   // console.log('isValid...', isValid)
   // console.log('isDirty...', isDirty)
-  // console.log('packman...', packman)
   // console.log('url...', url)
   // console.groupEnd()
 

--- a/frontend/components/software/edit/package-managers/EditPackageManagerModal.tsx
+++ b/frontend/components/software/edit/package-managers/EditPackageManagerModal.tsx
@@ -26,6 +26,7 @@ import {
 } from './apiPackageManager'
 import PackageManagerInfo from './PackageManagerInfo'
 import {config} from './config'
+import {getBaseUrl} from '~/utils/fetchHelpers'
 
 type EditPackageManagerModalProps = {
   open: boolean,
@@ -53,23 +54,27 @@ export default function EditPackageManagerModal({open, onCancel, onSubmit, packa
   const [url] = watch(['url'])
 
   useEffect(() => {
+    const fetchPackageManagerType = async () => {
+      // extract manager type from url
+      const pm_key = await getPackageManagerTypeFromUrl(url)
+
+      if (pm_key) {
+        // const manager = PackageManagerInfo[pm_key as PackageManagerTypes]
+        setValue('package_manager', pm_key as PackageManagerTypes, {
+          shouldValidate: true,
+          shouldDirty: true
+        })
+      } else {
+        setValue('package_manager', 'other' as PackageManagerTypes,{
+          shouldValidate: true,
+          shouldDirty: true
+        })
+      }
+    }
+
     try {
       if (typeof errors['url'] === 'undefined' && url.length > 5) {
-        // extract manager type from url
-        const pm_key = getPackageManagerTypeFromUrl(url)
-
-        if (pm_key) {
-          // const manager = PackageManagerInfo[pm_key as PackageManagerTypes]
-          setValue('package_manager', pm_key as PackageManagerTypes, {
-            shouldValidate: true,
-            shouldDirty: true
-          })
-        } else {
-          setValue('package_manager', 'other' as PackageManagerTypes,{
-            shouldValidate: true,
-            shouldDirty: true
-          })
-        }
+        fetchPackageManagerType()
       }
     } catch (e: any) {
       logger(`useEffect.getPackageManagerTypeFromUrl...${e.message}`, 'warn')

--- a/frontend/components/software/edit/package-managers/__mocks__/apiPackageManager.ts
+++ b/frontend/components/software/edit/package-managers/__mocks__/apiPackageManager.ts
@@ -1,8 +1,13 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
+/**
+ * DEFAULT MOCKS OF apiPackageManager methods
+ */
+
+import {PackageManagerSettings} from '../apiPackageManager'
 import mockPackageManagers from './package_manager.json'
 
 export const packageManagerSettings = {
@@ -99,5 +104,25 @@ export async function deletePackageManager({id, token}: { id: string, token: str
   return {
     status: 200,
     message: 'OK'
+  }
+}
+
+export async function getPackageManagerTypeFromUrl(url:string) {
+  try {
+    const urlObject = new URL(url)
+    const keys = Object.keys(packageManagerSettings) as PackageManagerTypes[]
+
+    // find first key to match the hostname
+    const pm_key = keys.find(key => {
+      const manager = packageManagerSettings[key as PackageManagerTypes] as PackageManagerSettings
+      // match hostname
+      return manager.hostname.includes(urlObject.hostname)
+    })
+    if (pm_key) {
+      return pm_key
+    }
+    return 'other' as PackageManagerTypes
+  } catch (e: any) {
+    return 'other' as PackageManagerTypes
   }
 }

--- a/frontend/components/software/edit/package-managers/apiPackageManager.ts
+++ b/frontend/components/software/edit/package-managers/apiPackageManager.ts
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -273,7 +275,7 @@ export async function deletePackageManager({id,token}:{id: string,token:string})
   }
 }
 
-export function getPackageManagerTypeFromUrl(url:string) {
+export async function getPackageManagerTypeFromUrl(url:string) {
   try {
     const urlObject = new URL(url)
     const keys = Object.keys(packageManagerSettings)
@@ -287,6 +289,24 @@ export function getPackageManagerTypeFromUrl(url:string) {
     if (pm_key) {
       return pm_key as PackageManagerTypes
     }
+
+    // Try to infer from platforms already in the RSD
+    const baseApiUrl = getBaseUrl()
+    const resp = await fetch(
+      `${baseApiUrl}/rpc/suggest_platform`,
+      {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({hostname: urlObject.host})
+      }
+    )
+    if (resp.status === 200) {
+      const platform_type = await resp.json()
+      if (platform_type !== null) {
+        return platform_type
+      }
+    }
+
     return 'other' as PackageManagerTypes
   } catch (e: any) {
     return 'other' as PackageManagerTypes

--- a/frontend/components/software/edit/package-managers/apiPackageManager.ts
+++ b/frontend/components/software/edit/package-managers/apiPackageManager.ts
@@ -278,22 +278,23 @@ export async function deletePackageManager({id,token}:{id: string,token:string})
 export async function getPackageManagerTypeFromUrl(url:string) {
   try {
     const urlObject = new URL(url)
-    const keys = Object.keys(packageManagerSettings)
+    const keys = Object.keys(packageManagerSettings) as PackageManagerTypes[]
 
+    // find first key to match the hostname
     const pm_key = keys.find(key => {
-      const manager = packageManagerSettings[key as PackageManagerTypes] as PackageManagerSettings
+      const manager:PackageManagerSettings = packageManagerSettings[key]
       // match hostname
       return manager.hostname.includes(urlObject.hostname)
     })
-
     if (pm_key) {
-      return pm_key as PackageManagerTypes
+      return pm_key
     }
 
-    // Try to infer from platforms already in the RSD
-    const baseApiUrl = getBaseUrl()
+    // If type not found in the pre-defined list
+    // try to infer from the platforms already in the RSD
+    // This is needed for Gitlab and other on premisses solutions
     const resp = await fetch(
-      `${baseApiUrl}/rpc/suggest_platform`,
+      `${getBaseUrl()}/rpc/suggest_platform`,
       {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
@@ -301,12 +302,12 @@ export async function getPackageManagerTypeFromUrl(url:string) {
       }
     )
     if (resp.status === 200) {
-      const platform_type = await resp.json()
+      const platform_type:PackageManagerTypes = await resp.json()
       if (platform_type !== null) {
         return platform_type
       }
+      return 'other' as PackageManagerTypes
     }
-
     return 'other' as PackageManagerTypes
   } catch (e: any) {
     return 'other' as PackageManagerTypes


### PR DESCRIPTION
Fixes #1156 

Changes proposed in this pull request:

* use `rpc/suggest_platform` to suggest the type for package registries

How to test:

* `docker compose build --parallel && docker compose up`
* login
* create a new software or open an existing one in edit mode
* in the "Information" tab, add `https://codebase.helmholtz.cloud/research-software-directory/RSD-as-a-service` and set the repository type to GitLab
* open "Package managers" tab and add a new package manager with the same url as above
* GitLab should be detected as type and the GitLab logo will be shown

This approach is a very simple solution to achieve support for custom GitLab registries. On the other hand, existing package managers are not updated and must either be updated by the maintainers, or with a script by the administrators.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
