### PR TITLE
Fix typos

### DIFF
--- a/.github/workflows/codemeta_scan_build.yml
+++ b/.github/workflows/codemeta_scan_build.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        go-version: [ '1.22.1' ]
+        go-version: [ '1.22.2' ]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -29,7 +29,7 @@ jobs:
       - name: "Build application with Go"
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22.1'
+          go-version: '1.22.2'
       - run: |
           go build -v
         working-directory: codemeta

--- a/codemeta/Dockerfile
+++ b/codemeta/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.22.1-bookworm AS builder
+FROM golang:1.22.2-bookworm AS builder
 
 WORKDIR /usr/src/app
 COPY go.mod .

--- a/codemeta/README.md
+++ b/codemeta/README.md
@@ -13,7 +13,7 @@ If your instance of the RSD is hosted on https://example.com/, you can access th
 
 ## Developing
 
-This module is written in Go, version 1.22.1. You can find the installation instruction [here](https://go.dev/doc/install). If this page lists a newer version than the one we use, you can find all versions [here](https://go.dev/dl/). We currently don't have any external dependencies, except [Pico CSS](https://picocss.com/), which is dynamically linked in the HTML.
+This module is written in Go, version 1.22.2. You can find the installation instruction [here](https://go.dev/doc/install). If this page lists a newer version than the one we use, you can find all versions [here](https://go.dev/dl/). We currently don't have any external dependencies, except [Pico CSS](https://picocss.com/), which is dynamically linked in the HTML.
 
 When developing and running it locally, you need a locally running RSD instance, and you should set the `POSTGREST_URL` environment variable to a value at which the PostgREST backend can be reached. This will probably be `http://localhost/api/v1`. You can also point it to a dev or production server instead.
 

--- a/codemeta/go.mod
+++ b/codemeta/go.mod
@@ -5,4 +5,4 @@
 
 module codemeta
 
-go 1.22.1
+go 1.22.2

--- a/codemeta/main.go
+++ b/codemeta/main.go
@@ -85,7 +85,7 @@ type SoftwareApplication struct {
 	Description          []string           `json:"description"`
 	CodeRepository       *string            `json:"codeRepository"`
 	Author               []Person           `json:"author"`
-	Keyword              []string           `json:"keyword"`
+	Keywords             []string           `json:"keywords"`
 	ProgrammingLanguage  []string           `json:"programmingLanguage"`
 	License              []CreativeWork     `json:"license"`
 	ReferencePublication []ScholarlyArticle `json:"referencePublication"`
@@ -236,7 +236,7 @@ func convertRsdToCodeMeta(bytes []byte) ([]byte, error) {
 		Name:                 rsdResponse.BrandName,
 		Description:          extractDescription(rsdResponse),
 		Author:               extractContributors(rsdResponse),
-		Keyword:              extractKeywords(rsdResponse),
+		Keywords:             extractKeywords(rsdResponse),
 		ProgrammingLanguage:  extractProgrammingLanguages(rsdResponse),
 		License:              extractLicenses(rsdResponse),
 		ReferencePublication: extractReferencePublications(rsdResponse),

--- a/frontend/components/projects/edit/organisations/config.ts
+++ b/frontend/components/projects/edit/organisations/config.ts
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +11,7 @@ export const cfgOrganisations = {
     title: 'Add organisation',
     subtitle: 'We search by name in the RSD and the ROR databases',
     label: 'Find or add organisation',
-    help: 'At least the fist 2 letters of the organisation name',
+    help: 'At least the first 2 letters of the organisation name',
     validation: {
       // custom validation rule, not in use by react-hook-form
       minLength: 2,

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -265,7 +265,7 @@ export const organisationInformation = {
     title: 'Add organisation',
     subtitle: 'We search by name in the RSD and the ROR databases',
     label: 'Find or add organisation',
-    help: 'At least the fist 2 letters of the organisation name',
+    help: 'At least the first 2 letters of the organisation name',
     validation: {
       // custom validation rule, not in use by react-hook-form
       minLength: 2,


### PR DESCRIPTION
## Fix typos and upgrade Go patch version

Changes proposed in this pull request:

* Fix `fist` to `first` in two instances of helper text
* Fix `keyword` to `keywords` in CodeMeta metadata, in agreement with their [terms](https://codemeta.github.io/terms/)
* Upgrade from Go 1.22.1 to 1.22.2

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Check that http://localhost/metadata/codemeta still works and that `keywords` is now used
* Check the helper text when adding an organisation to softare or a project

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests