### PR TITLE
fix: update contact people when new contact person is set

### DIFF
--- a/frontend/components/projects/edit/team/index.tsx
+++ b/frontend/components/projects/edit/team/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -75,6 +75,7 @@ export default function ProjectTeam() {
         if (i === pos) return member
         return item
       })
+      updateContactPeople(member, newMembersList)
       setMembers(newMembersList)
     } else {
       // append to bottom
@@ -82,8 +83,23 @@ export default function ProjectTeam() {
         ...members,
         member
       ]
+      updateContactPeople(member, newMembersList)
       setMembers(newMembersList)
     }
+  }
+
+  async function updateContactPeople(data: TeamMember, list: TeamMember[]) {
+    if (!data.is_contact_person) return
+
+    list.forEach(person => {
+      if (!person.is_contact_person || person === data) return
+      fetch(`/api/v1/team_member?id=eq.${person.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({is_contact_person: false}),
+        headers: {'content-type': 'application/json', Authorization: 'Bearer ' + token}
+      })
+      person.is_contact_person = false
+    })
   }
 
   function onEditMember(member: SaveTeamMember,pos?:number) {

--- a/frontend/components/software/edit/contributors/index.tsx
+++ b/frontend/components/software/edit/contributors/index.tsx
@@ -5,6 +5,7 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -83,6 +84,7 @@ export default function SoftwareContributors() {
         if (i === pos) return data
         return item
       })
+      updateContactPeople(data, list)
       // pass new list with addition contributor
       setContributors(list)
     } else {
@@ -91,8 +93,23 @@ export default function SoftwareContributors() {
         ...contributors,
         data
       ]
+      updateContactPeople(data, list)
       setContributors(list)
     }
+  }
+
+  async function updateContactPeople(data: Contributor, list: Contributor[]) {
+    if (!data.is_contact_person) return
+
+    list.forEach(person => {
+      if (!person.is_contact_person || person === data) return
+      fetch(`/api/v1/contributor?id=eq.${person.id}`, {
+        method: 'PATCH',
+        body: JSON.stringify({is_contact_person: false}),
+        headers: {'content-type': 'application/json', Authorization: 'Bearer ' + token}
+      })
+      person.is_contact_person = false
+    })
   }
 
   function loadContributorIntoModal(contributor: Contributor,pos?:number) {


### PR DESCRIPTION
## Prevent multiple contact people

Changes proposed in this pull request:

* When a contributor or team member is made to be a contact person, the other contributors/team members are set *not* to be a contact person

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin, edit a software contributor to be a contact person, the other contributors should not be a contact person anymore
* Repeat when adding a new contributor
* Try the same for the team members of a project

Closes #948

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests