### PR TITLE
Prevent duplicate releases

### DIFF
--- a/frontend/components/organisation/releases/ReleaseList.tsx
+++ b/frontend/components/organisation/releases/ReleaseList.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -52,7 +53,7 @@ export default function ReleaseList({release_year}: ReleaseYearProps) {
         </div>
       </div>
 
-      {releases.map((release,pos)=><ReleaseItem key={release.release_doi ?? pos} release={release} />)}
+      {releases.map((release,pos)=><ReleaseItem key={pos} release={release} />)}
 
     </section>
   )

--- a/frontend/components/organisation/releases/index.tsx
+++ b/frontend/components/organisation/releases/index.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +14,7 @@ import NoContent from '~/components/layout/NoContent'
 import BaseSurfaceRounded from '~/components/layout/BaseSurfaceRounded'
 import useOrganisationContext from '../context/useOrganisationContext'
 
-import ReleaseYear from './ReleaseList'
+import ReleaseList from './ReleaseList'
 import ReleaseNavButton from './ReleaseNavButton'
 import ScrollToTopButton from './ScrollToTopButton'
 import useReleaseCount from './useReleaseCount'
@@ -64,7 +65,7 @@ export default function SoftwareReleases() {
         }
       </nav>
       {/* Release items of selected year */}
-      <ReleaseYear release_year={selected_year} />
+      <ReleaseList release_year={selected_year} />
       <ScrollToTopButton minOffset={200} />
     </BaseSurfaceRounded>
   )


### PR DESCRIPTION
## Prevent duplicate releases

Changes proposed in this pull request:

* Fix the key in a React component to prevent duplicate releases being shown

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin, create two published software pages with the same concept DOI, e.g. `10.5281/zenodo.7614737`
* Link the two pages to the same organisation
* Run the releases scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases`
* Look at the releases of the org page, switch between years, no releases should 'stick'

Closes #1163

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
