### PR TITLE
ci: add token for release workflow

### DIFF
--- a/.github/workflows/_cff.yml
+++ b/.github/workflows/_cff.yml
@@ -33,6 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{inputs.branch}}
+          token: ${{ secrets.PAT_RELEASE }}
 
       - name: download ${{inputs.artifact}}
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This should allow the release workflow to push the `CITATION.cff` file without requiring us to disable branch protection. Followed instructions from [here](https://github.com/stefanzweifel/git-auto-commit-action?tab=readme-ov-file#push-to-protected-branches).