### PR TITLE
Update auth container dependencies

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -126,7 +126,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>com.nimbusds</groupId>
 			<artifactId>oauth2-oidc-sdk</artifactId>
-			<version>9.32</version>
+			<version>11.10.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->


### PR DESCRIPTION
# Update auth container dependencies

Changes proposed in this pull request:

* updates `oauth2-oidc-sdk` which is being used in HelmholtzID login

How to test:

* `docker compose build --parallel && docker compose up`
* verify that login via Helmholtz ID still works

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
