### PR TITLE
feat: show highlights carousel only on first page

### DIFF
--- a/frontend/components/software/overview/SoftwareHighlights.tsx
+++ b/frontend/components/software/overview/SoftwareHighlights.tsx
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -12,6 +12,7 @@ import ContentContainer from '~/components/layout/ContentContainer'
 import {HighlightsCarousel} from './highlights/HighlightsCarousel'
 import {SoftwareHighlight} from '~/components/admin/software-highlights/apiSoftwareHighlights'
 import useRsdSettings from '~/config/useRsdSettings'
+import {useRouter} from 'next/router'
 
 export default function SoftwareHighlights({highlights}: { highlights: SoftwareHighlight[] }) {
   // console.group('SoftwareHighlights')
@@ -19,9 +20,13 @@ export default function SoftwareHighlights({highlights}: { highlights: SoftwareH
   // console.log('highlights...', highlights)
   // console.groupEnd()
   const {host} = useRsdSettings()
+  const router = useRouter()
 
   // if there are no hightlights we do not show this section
   if (highlights.length===0) return null
+
+  // show carousel only on first page
+  if (typeof router.query.page === 'string' && parseInt(router.query.page) > 1) return null
 
   return (
     <div className="mt-8">


### PR DESCRIPTION
# Show highlights carousel only on first page

Fixes #1167 

Changes proposed in this pull request:

* hides the highlights carousel on second and consecutive pages of the software overview

How to test:

* `make start`
* navigate to software overview, highlights carousel is shown
* navigate to second and further pages and verify that carousel is hidden

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
