### PR TITLE
1170 dedicated highlights page

### DIFF
--- a/deployment/rsd/data/settings.json
+++ b/deployment/rsd/data/settings.json
@@ -13,7 +13,10 @@
     "login_info_url": "https://research-software-directory.github.io/documentation/getting-access.html",
     "terms_of_service_url": "/page/terms-of-service/",
     "privacy_statement_url": "/page/privacy-statement/",
-    "software_highlights_title": "Software Highlights"
+    "software_highlights": {
+        "title": "Software Highlights",
+        "description": null
+      }
   },
   "links": [
     {

--- a/documentation/docs/03-rsd-instance/03-administration.md
+++ b/documentation/docs/03-rsd-instance/03-administration.md
@@ -1,9 +1,9 @@
 # Administration
 
-This section describes administration options avilable in the RSD.
+This section describes administration options available in the RSD.
 
 :::tip
-To be able to login as RSD administrator you first need to define a list of rsd admin users in the .env file.
+To be able to log in as RSD administrator you first need to define a list of rsd admin users in the .env file.
 See [Login as rsd administrator in the getting started section](/rsd-instance/getting-started/#login-as-rsd-adminstrator).
 :::
 
@@ -24,9 +24,9 @@ You need to activate "Publish" switch and reload the page in order to see change
 
 ## Software highlights
 
-The software overview page design has a highlights section. This section is **shown only when the software highlights are defined** by RSD admin.
+The software overview page design has a highlights section. This section is **shown only when software highlights are set** by an RSD admin.
 
-In addition to carousel, which is used on the software overview page and not suitable for showing a large number of items, we offer separate "All Highlights" page. All highlights page can be accessed using the "Browse All Highlights" button shown underneath the carousel.
+In addition to the carousel, which is shown on the software overview page, but is not suitable for showing a large number of items, we offer a separate "All Highlights" page. This page can be accessed using the "Browse all Highlights" button, shown underneath the carousel.
 
 :::tip
 You can customise the software highlights section in the `settings.json` by changing the values in the optional property `software_highlights`.
@@ -65,7 +65,7 @@ You can add, search and delete ORCIDs from the RSD. Use the bulk import button t
 
 ## RSD users
 
-This section shows all RSD users who logged in to RSD at least once. You can search for users, assign the adminstrator role (rsd_admin) or delete an user account.
+This section shows all RSD users who logged in to RSD at least once. You can search for users, assign the administrator role (rsd_admin) or delete user accounts.
 
 :::danger
 
@@ -77,7 +77,7 @@ This section shows all RSD users who logged in to RSD at least once. You can sea
 
 ## RSD contributors
 
-The page shows the list of all contributors and team members. You can search by name, email or ORCID. You can change the values in the table by clicking on the value. The values is automatically saved after you navigate out of the edit box. The link in the last column will open the software or project item where this contributor/team member is used.
+The page shows the list of all contributors and team members. You can search by name, email or ORCID. You can change the values in the table by clicking on the value. The values are automatically saved after you navigate out of the edit box. The link in the last column will open the software or project item where this contributor/team member is used.
 
 ![animation](img/admin-rsd-contributor.gif)
 
@@ -87,13 +87,13 @@ This page allows management of all organisations added to RSD. RSD users can add
 
 ### Add organisation
 
-Use search box to find the organisation in the ROR database. This is preferred approach. If the organisation cannot be found in ROR database you will see "Add..." option and you will be able to add basic organisation information manually.
+Use the search box to find organisations in the ROR database. This is the preferred approach. If the organisation cannot be found in ROR database, you will see the "Add..." option, and you will be able to add basic organisation information manually.
 
 ![animation](img/admin-add-organisation.gif)
 
 ### Define organisation primary maintainer
 
-The primary maintainer of an organisation is defined by rsd administrator. You need to provide user id in the general settings section. The user id is unique and it is automatically created by RSD after an user is logged in for the first time.
+The primary maintainer of an organisation is defined by an RSD administrator. You need to provide the user id in the general settings section. The user id is unique, and it is automatically created by RSD after a user is logged in for the first time.
 
 ![animation](img/organisation-maintainers-primary-invite.gif)
 
@@ -115,7 +115,7 @@ For editing the organisation see [maintaining the organisation section](/users/o
 
 ## Keywords
 
-RSD comes with an predefined list of keywords. You can change the list by adding new keywords or deleting the existing entries.
+RSD comes with a predefined list of keywords. You can change the list by adding new keywords or deleting the existing entries.
 
 :::warning
 You can delete the keyword only when it is not used in any software or project.
@@ -161,8 +161,8 @@ After news item is created you will be redirected to edit news item page. Here y
 - Summary is used in the latest news section of the homepage and in the news card on the news overview.
 - Publication date is shown in the header of the news title. It can be changed at any time. Note that changing the publication title also changes public url of the news item.
 - First uploaded image is used in the news card.
-- Using "Copy link" button you can copy the markdown syntax to the clipboard and the paste the link at the desired location of the body.
-- Using "Delete" button will delete image and the markdown link syntax from the news body.
+- Using "Copy link" button you can copy the Markdown syntax to the clipboard and the paste the link at the desired location of the body.
+- Using "Delete" button will delete image and the Markdown link syntax from the news body.
 
 :::
 
@@ -170,7 +170,7 @@ After news item is created you will be redirected to edit news item page. Here y
 
 ### Latest news
 
-The latest news selection is shown on the homepage after "Our Goals" section. It consist of 3 most recent items, based on the publication date, and "More news" button that links to the news overview page.
+The latest news selection is shown on the homepage after "Our Goals" section. It consists of the 3 most recent items, based on the publication date, and "More news" button that links to the news overview page.
 
 :::warning
 If there are no published news items the "Latest news" section is omitted from the homepage.

--- a/documentation/docs/03-rsd-instance/03-administration.md
+++ b/documentation/docs/03-rsd-instance/03-administration.md
@@ -27,7 +27,18 @@ You need to activate "Publish" switch and reload the page in order to see change
 The software overview page design has a highlights section. This section is **shown only when the software highlights are defined** by RSD admin.
 
 :::tip
-You can customise the software highlights section title in `settings.json` by providing a value for the optional property `software_highlights_title`.
+You can customise the software highlights section title in `settings.json` by providing a values for the optional property `software_highlights`:
+
+```json
+{
+  "host": {
+    "software_highlights": {
+      "title": "Software Highlights",
+      "description": "Descriptive text below page headline."
+    }
+  }
+}
+```
 :::
 
 ![animation](img/admin-software-highlights.gif)

--- a/documentation/docs/03-rsd-instance/03-administration.md
+++ b/documentation/docs/03-rsd-instance/03-administration.md
@@ -26,19 +26,27 @@ You need to activate "Publish" switch and reload the page in order to see change
 
 The software overview page design has a highlights section. This section is **shown only when the software highlights are defined** by RSD admin.
 
+In addition to carousel, which is used on the software overview page and not suitable for showing a large number of items, we offer separate "All Highlights" page. All highlights page can be accessed using the "Browse All Highlights" button shown underneath the carousel.
+
 :::tip
-You can customise the software highlights section title in `settings.json` by providing a values for the optional property `software_highlights`:
+You can customise the software highlights section in the `settings.json` by changing the values in the optional property `software_highlights`.
+
+- `title` value is shown in the admin section, as carousel title and as a title of all highlights page.
+- `limit` defines a maximum number of items to include in the carousel.
+- `description` is used on the all highlights page.
 
 ```json
 {
   "host": {
     "software_highlights": {
       "title": "Software Highlights",
+      "limit": 5,
       "description": "Descriptive text below page headline."
     }
   }
 }
 ```
+
 :::
 
 ![animation](img/admin-software-highlights.gif)

--- a/documentation/docs/03-rsd-instance/03-administration.md.license
+++ b/documentation/docs/03-rsd-instance/03-administration.md.license
@@ -3,5 +3,7 @@ SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2023 dv4all
+SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/frontend/components/admin/software-highlights/AdminSoftwareHighlightsPage.test.tsx
+++ b/frontend/components/admin/software-highlights/AdminSoftwareHighlightsPage.test.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,7 @@ import {WithAppContext, mockSession} from '~/utils/jest/WithAppContext'
 import AdminSoftwareHighlightsPage from './index'
 
 // MOCKS
-import mockSoftwareHighlighs from './__mocks__/software_for_highlight.json'
+import mockSoftwareHighlight from './__mocks__/software_for_highlight.json'
 // default api mock
 jest.mock('~/components/admin/software-highlights/apiSoftwareHighlights')
 
@@ -24,7 +24,7 @@ const testSession = {
 
 describe('components/admin/software-highlights/index.tsx', () => {
 
-  it('shows progressbar initialy', () => {
+  it('shows progressbar initially', () => {
     render(
       <WithAppContext options={{session: testSession}}>
         <AdminSoftwareHighlightsPage />
@@ -42,8 +42,8 @@ describe('components/admin/software-highlights/index.tsx', () => {
     // wait for loader to be removed
     await waitForElementToBeRemoved(screen.getByRole('progressbar'))
 
-    const rows = screen.getAllByTestId('admin-hightlight-item')
-    expect(rows.length).toEqual(mockSoftwareHighlighs.length)
+    const rows = screen.getAllByTestId('admin-highlight-item')
+    expect(rows.length).toEqual(mockSoftwareHighlight.length)
     // screen.debug(rows)
   })
 
@@ -56,8 +56,8 @@ describe('components/admin/software-highlights/index.tsx', () => {
     // wait for loader to be removed
     await waitForElementToBeRemoved(screen.getByRole('progressbar'))
 
-    const rows = screen.getAllByTestId('admin-hightlight-item')
-    expect(rows.length).toEqual(mockSoftwareHighlighs.length)
+    const rows = screen.getAllByTestId('admin-highlight-item')
+    expect(rows.length).toEqual(mockSoftwareHighlight.length)
 
     const deleteBtn = within(rows[0]).getByRole('button',{name:'delete'})
     fireEvent.click(deleteBtn)
@@ -66,7 +66,7 @@ describe('components/admin/software-highlights/index.tsx', () => {
       // get confirm delete
       const confirmDelete = screen.getByRole('dialog')
       // confirm first account from list - listed twice in modal
-      screen.getAllByText(mockSoftwareHighlighs[0].brand_name)
+      screen.getAllByText(mockSoftwareHighlight[0].brand_name)
       // confirm remove
       const removeBtn = within(confirmDelete).getByRole('button', {name: 'Remove'})
       fireEvent.click(removeBtn)

--- a/frontend/components/admin/software-highlights/SoftwareHighlightInfo.tsx
+++ b/frontend/components/admin/software-highlights/SoftwareHighlightInfo.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/* eslint-disable @next/next/no-html-link-for-pages */
+
+import Alert from '@mui/material/Alert'
+import useRsdSettings from '~/config/useRsdSettings'
+
+export default function SoftwareHighlightInfo() {
+  const {host} = useRsdSettings()
+  return (
+    <Alert
+      severity="info"
+    >
+      <p className="py-2"><strong>{host.software_highlights?.title}</strong></p>
+      <p>In this section you can select software items for the highlights.
+        Selected items are shown in the Carousel on the <a href="/software">software overview</a> page and on <a href="/spotlights?order=position">separate page</a>.
+      </p>
+      <p className="py-2"><strong>Carousel</strong></p>
+      <p>The limited number of the items ({host?.software_highlights?.limit ?? 3}) is shown in the carousel.
+      The amount of items to show in the carousel is defined in settings.json</p>
+      <p className="py-2"><strong>Order</strong></p>
+      <p>
+        The items are shown in the order displayed on this page. You can drag the item to change its position and the order.
+      </p>
+    </Alert>
+  )
+}

--- a/frontend/components/admin/software-highlights/SortableHighlightItem.tsx
+++ b/frontend/components/admin/software-highlights/SortableHighlightItem.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -17,25 +17,26 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 import {getImageUrl} from '~/utils/editImage'
 import {SoftwareHighlight} from './apiSoftwareHighlights'
 
-
 type HighlightProps = {
   pos: number,
   item: SoftwareHighlight,
+  inCarousel: boolean,
   onEdit: (pos: number) => void,
   onDelete: (pos: number) => void,
 }
 
-export default function SortableHighlightItem({pos, item, onEdit, onDelete}: HighlightProps) {
+export default function SortableHighlightItem({pos,item,inCarousel,onEdit,onDelete}: HighlightProps) {
   const smallScreen = useMediaQuery('(max-width:600px)')
   const {
     attributes,listeners,setNodeRef,
     transform,transition,isDragging
   } = useSortable({id: item.id ?? ''})
+
   const {brand_name, contributor_cnt, mention_cnt, image_id, is_published} = item
 
   return (
     <ListItem
-      data-testid="admin-hightlight-item"
+      data-testid="admin-highlight-item"
       // draggable
       ref={setNodeRef}
       {...attributes}
@@ -89,6 +90,7 @@ export default function SortableHighlightItem({pos, item, onEdit, onDelete}: Hig
             <span>Mentions: {mention_cnt ?? 0}</span>
             <span className="ml-4">Contributors: {contributor_cnt ?? 0}</span>
             <span className="ml-4">Published: {is_published ? 'Yes' : 'No'}</span>
+            <span className="ml-4">Carousel: {inCarousel ? 'Yes' : 'No'}</span>
           </>
         }
       />

--- a/frontend/components/admin/software-highlights/SortableHighlightList.tsx
+++ b/frontend/components/admin/software-highlights/SortableHighlightList.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -13,8 +13,9 @@ import AlertTitle from '@mui/material/AlertTitle'
 import ContentLoader from '~/components/layout/ContentLoader'
 import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
 import SortableList from '~/components/layout/SortableList'
-import SortableHighlightItem from './SortableHightlightItem'
+import SortableHighlightItem from './SortableHighlightItem'
 import {SoftwareHighlight} from './apiSoftwareHighlights'
+import useRsdSettings from '~/config/useRsdSettings'
 
 type DeleteOrganisationModal = {
   open: boolean,
@@ -30,9 +31,12 @@ type SoftwareHighlightsListProps = {
 
 export default function SortableHighlightsList({highlights, loading, onSorted, onDelete}: SoftwareHighlightsListProps) {
   const router = useRouter()
+  const {host} = useRsdSettings()
   const [modal, setModal] = useState<DeleteOrganisationModal>({
     open: false
   })
+  const limit = (host?.software_highlights?.limit ?? 3)
+  let publishedCnt = 0
 
   if (loading) return <ContentLoader />
 
@@ -65,11 +69,16 @@ export default function SortableHighlightsList({highlights, loading, onSorted, o
   }
 
   function onRenderItem(item: SoftwareHighlight, index?: number) {
+    // increase published items count (only published items are included in carousel)
+    if (item.is_published===true) publishedCnt += 1
+    // validate if limit is reached
+    const inCarousel = (limit >= publishedCnt) && item.is_published
     return (
       <SortableHighlightItem
         key={item.id}
         pos={index ?? 0}
         item={item}
+        inCarousel={inCarousel}
         onEdit={onEdit}
         onDelete={confirmDelete}
       />
@@ -90,7 +99,7 @@ export default function SortableHighlightsList({highlights, loading, onSorted, o
         body={
           <>
             <p>
-               Are you sure you want to delete software <strong>{modal?.highlight?.brand_name}</strong> from hightlight?
+               Are you sure you want to delete software <strong>{modal?.highlight?.brand_name}</strong> from highlights?
             </p>
           </>
         }

--- a/frontend/components/admin/software-highlights/index.tsx
+++ b/frontend/components/admin/software-highlights/index.tsx
@@ -1,18 +1,19 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useSession} from '~/auth'
+import useRsdSettings from '~/config/useRsdSettings'
 import AddSoftwareHighlights from './AddSoftwareHighlights'
 import SortableHighlightsList from './SortableHighlightList'
 import useSoftwareHighlights from './useSoftwareHighlights'
-import useRsdSettings from '~/config/useRsdSettings'
+import SoftwareHighlightInfo from './SoftwareHighlightInfo'
 
 export default function AdminSoftwareHighlightsPage() {
   const {token} = useSession()
@@ -37,10 +38,13 @@ export default function AdminSoftwareHighlightsPage() {
           onSorted={sortHighlights}
         />
       </div>
-      <AddSoftwareHighlights
-        highlights={highlights}
-        onAddSoftware={addHighlight}
-      />
+      <div>
+        <AddSoftwareHighlights
+          highlights={highlights}
+          onAddSoftware={addHighlight}
+        />
+        <SoftwareHighlightInfo />
+      </div>
     </section>
   )
 }

--- a/frontend/components/admin/software-highlights/index.tsx
+++ b/frontend/components/admin/software-highlights/index.tsx
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -27,7 +27,7 @@ export default function AdminSoftwareHighlightsPage() {
     <section className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr,2fr] xl:px-0 xl:gap-8">
       <div>
         <h2 className="flex pr-4 pb-4 justify-between">
-          <span>{host.software_highlights_title}</span>
+          <span>{host.software_highlights?.title}</span>
           <span>{highlights.length}</span>
         </h2>
         <SortableHighlightsList

--- a/frontend/components/admin/software-highlights/useSoftwareHighlights.tsx
+++ b/frontend/components/admin/software-highlights/useSoftwareHighlights.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,12 +22,7 @@ export default function useSoftwareHighlights(token: string) {
 
   const loadHighlight = useCallback(async() => {
     setLoading(true)
-    const {highlights, count} = await getSoftwareHighlights({
-      token,
-      searchFor,
-      page,
-      rows
-    })
+    const {highlights, count} = await getSoftwareHighlights({token, searchFor})
     setHighlights(highlights)
     setCount(count ?? 0)
     setLoading(false)

--- a/frontend/components/software/SoftwareKeywords.tsx
+++ b/frontend/components/software/SoftwareKeywords.tsx
@@ -1,14 +1,19 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import LocalOfferIcon from '@mui/icons-material/LocalOffer'
 import {KeywordForSoftware} from '../../types/SoftwareTypes'
 import TagChipFilter from '../layout/TagChipFilter'
-import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
+import {ssrViewUrl} from '~/utils/postgrestUrl'
+import {useRouter} from 'next/router'
 
 export default function SoftwareKeywords({keywords = []}: { keywords: KeywordForSoftware[] }) {
+  const router = useRouter()
+  const view = router.pathname.split('/')[1]
 
   function renderTags() {
     if (keywords.length === 0) {
@@ -19,7 +24,8 @@ export default function SoftwareKeywords({keywords = []}: { keywords: KeywordFor
     return (
       <div className="flex flex-wrap gap-2 py-1">
         {keywords.map((item, pos) => {
-          const url = ssrSoftwareUrl({keywords: [item.keyword]})
+          const params = {keywords: [item.keyword]}
+          const url = ssrViewUrl({view, params})
           return <TagChipFilter url={url} key={pos} label={item.keyword} />
         })}
       </div>

--- a/frontend/components/software/SoftwareKeywords.tsx
+++ b/frontend/components/software/SoftwareKeywords.tsx
@@ -1,31 +1,28 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import LocalOfferIcon from '@mui/icons-material/LocalOffer'
-import {KeywordForSoftware} from '../../types/SoftwareTypes'
-import TagChipFilter from '../layout/TagChipFilter'
-import {ssrViewUrl} from '~/utils/postgrestUrl'
-import {useRouter} from 'next/router'
+import {KeywordForSoftware} from '~/types/SoftwareTypes'
+import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
+import TagChipFilter from '~/components/layout/TagChipFilter'
 
 export default function SoftwareKeywords({keywords = []}: { keywords: KeywordForSoftware[] }) {
-  const router = useRouter()
-  const view = router.pathname.split('/')[1]
-
   function renderTags() {
     if (keywords.length === 0) {
       return (
-        <i>No keywords avaliable</i>
+        <i>No keywords available</i>
       )
     }
     return (
       <div className="flex flex-wrap gap-2 py-1">
         {keywords.map((item, pos) => {
-          const params = {keywords: [item.keyword]}
-          const url = ssrViewUrl({view, params})
+          const url = ssrSoftwareUrl({keywords: [item.keyword]})
           return <TagChipFilter url={url} key={pos} label={item.keyword} />
         })}
       </div>

--- a/frontend/components/software/overview/SoftwareHighlights.tsx
+++ b/frontend/components/software/overview/SoftwareHighlights.tsx
@@ -13,6 +13,8 @@ import {HighlightsCarousel} from './highlights/HighlightsCarousel'
 import {SoftwareHighlight} from '~/components/admin/software-highlights/apiSoftwareHighlights'
 import useRsdSettings from '~/config/useRsdSettings'
 import {useRouter} from 'next/router'
+import Button from '@mui/material/Button'
+import {KeyboardDoubleArrowRight} from '@mui/icons-material'
 
 export default function SoftwareHighlights({highlights}: { highlights: SoftwareHighlight[] }) {
   // console.group('SoftwareHighlights')
@@ -34,10 +36,28 @@ export default function SoftwareHighlights({highlights}: { highlights: SoftwareH
         <div
           className="text-3xl"
         >
-          {host.software_highlights_title}
+          {host.software_highlights?.title}
         </div>
       </ContentContainer>
+
       <HighlightsCarousel items={highlights} />
+
+      <ContentContainer className='flex justify-end'>
+        <Button
+          variant='contained'
+          href='/spotlights?order=position'
+          endIcon={<KeyboardDoubleArrowRight />}
+          sx={{
+            backgroundColor: 'primary.main',
+            marginLeft: 'auto',
+            ':hover': {
+              color: '#fff'
+            }
+          }}
+        >
+          Browse all Highlights
+        </Button>
+      </ContentContainer>
     </div>
   )
 }

--- a/frontend/components/software/overview/filters/OrderSoftwareBy.tsx
+++ b/frontend/components/software/overview/filters/OrderSoftwareBy.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,8 +16,26 @@ export const softwareOrderOptions = [
   {key: 'brand_name', label: 'Name', direction: 'asc.nullslast'},
 ]
 
+export const highlightOrderOptions = [
+  {key: 'position', label: 'Featured latest', direction: 'asc.nullslast'},
+  {key: 'contributor_cnt', label: 'Contributors', direction:'desc.nullslast'},
+  {key: 'mention_cnt', label: 'Mentions', direction:'desc.nullslast'},
+  {key: 'brand_name', label: 'Name', direction: 'asc.nullslast'},
+]
+
 type OrderByProps = {
   orderBy: string
+}
+
+export function OrderHighlightsBy({orderBy}: OrderByProps) {
+  const {handleQueryChange} = useSoftwareOverviewParams()
+  return (
+    <OrderBy
+      order={orderBy}
+      options={highlightOrderOptions}
+      handleQueryChange={handleQueryChange}
+    />
+  )
 }
 
 export default function OrderSoftwareBy({orderBy}: OrderByProps) {

--- a/frontend/components/software/overview/filters/index.tsx
+++ b/frontend/components/software/overview/filters/index.tsx
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +13,7 @@ import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
 import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import useSoftwareOverviewParams from '../useSoftwareOverviewParams'
-import OrderSoftwareBy from './OrderSoftwareBy'
+import OrderSoftwareBy, {OrderHighlightsBy} from './OrderSoftwareBy'
 import SoftwareKeywordsFilter from './SoftwareKeywordsFilter'
 import SoftwareLanguagesFilter from './SoftwareLanguagesFilter'
 import SoftwareLicensesFilter from './SoftwareLicensesFilter'
@@ -29,7 +31,8 @@ type SoftwareFilterProps = {
   licenses: string[]
   licensesList: LicensesFilterOption[]
   orderBy: string,
-  filterCnt: number
+  filterCnt: number,
+  highlightsOnly?: boolean
 }
 
 export default function SoftwareFilters({
@@ -40,7 +43,8 @@ export default function SoftwareFilters({
   licenses,
   licensesList,
   filterCnt,
-  orderBy
+  orderBy,
+  highlightsOnly = false
 }:SoftwareFilterProps) {
   const {resetFilters} = useSoftwareOverviewParams()
 
@@ -57,9 +61,8 @@ export default function SoftwareFilters({
         resetFilters={resetFilters}
       />
       {/* Order by */}
-      <OrderSoftwareBy
-        orderBy={orderBy}
-      />
+      {highlightsOnly && <OrderHighlightsBy orderBy={orderBy} />}
+      {!highlightsOnly && <OrderSoftwareBy orderBy={orderBy} />}
       {/* Keywords */}
       <SoftwareKeywordsFilter
         keywords={keywords}

--- a/frontend/components/software/overview/filters/softwareFiltersApi.ts
+++ b/frontend/components/software/overview/filters/softwareFiltersApi.ts
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +18,10 @@ type SoftwareFilterProps = {
   keywords?: string[] | null
   prog_lang?: string[] | null
   licenses?: string[] | null
+}
+
+type GenericSoftwareFilterProps = SoftwareFilterProps & {
+  rpc: string
 }
 
 type SoftwareFilterApiProps = {
@@ -45,10 +51,19 @@ export function buildSoftwareFilter({search, keywords, prog_lang, licenses}: Sof
   return filter
 }
 
-
 export async function softwareKeywordsFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+  const rpc = 'software_keywords_filter'
+  return genericSoftwareKeywordsFilter({search, keywords, prog_lang, licenses, rpc})
+}
+
+export async function highlightKeywordsFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+  const rpc = 'highlight_keywords_filter'
+  return genericSoftwareKeywordsFilter({search, keywords, prog_lang, licenses, rpc})
+}
+
+export async function genericSoftwareKeywordsFilter({search, keywords, prog_lang, licenses, rpc}: GenericSoftwareFilterProps) {
   try {
-    const query ='rpc/software_keywords_filter?order=keyword'
+    const query =`rpc/${rpc}?order=keyword`
     const url = `${getBaseUrl()}/${query}`
     const filter = buildSoftwareFilter({
       search,
@@ -73,18 +88,28 @@ export async function softwareKeywordsFilter({search, keywords, prog_lang, licen
       return json
     }
 
-    logger(`softwareKeywordsFilter: ${resp.status} ${resp.statusText}`, 'warn')
+    logger(`genericSoftwareKeywordsFilter (${rpc}): ${resp.status} ${resp.statusText}`, 'warn')
     return []
 
   } catch (e:any) {
-    logger(`softwareKeywordsFilter: ${e?.message}`, 'error')
+    logger(`genericSoftwareKeywordsFilter (${rpc}): ${e?.message}`, 'error')
     return []
   }
 }
 
 export async function softwareLanguagesFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+  const rpc = 'software_languages_filter'
+  return genericSoftwareLanguagesFilter({search, keywords, prog_lang, licenses, rpc})
+}
+
+export async function highlightLanguagesFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+  const rpc = 'highlight_languages_filter'
+  return genericSoftwareLanguagesFilter({search, keywords, prog_lang, licenses, rpc})
+}
+
+export async function genericSoftwareLanguagesFilter({search, keywords, prog_lang, licenses, rpc}: GenericSoftwareFilterProps) {
   try {
-    const query = 'rpc/software_languages_filter?order=prog_language'
+    const query = `rpc/${rpc}?order=prog_language`
     const url = `${getBaseUrl()}/${query}`
     const filter = buildSoftwareFilter({
       search,
@@ -109,18 +134,29 @@ export async function softwareLanguagesFilter({search, keywords, prog_lang, lice
       return json
     }
 
-    logger(`softwareLanguagesFilter: ${resp.status} ${resp.statusText}`, 'warn')
+    logger(`genericSoftwareLanguagesFilter (${rpc}): ${resp.status} ${resp.statusText}`, 'warn')
     return []
 
   } catch (e: any) {
-    logger(`softwareLanguagesFilter: ${e?.message}`, 'error')
+    logger(`genericSoftwareLanguagesFilter (${rpc}): ${e?.message}`, 'error')
     return []
   }
 }
 
 export async function softwareLicensesFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+  const rpc = 'software_licenses_filter'
+  return genericSoftwareLicensesFilter({search, keywords, prog_lang, licenses, rpc})
+}
+
+
+export async function highlightLicensesFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+  const rpc = 'highlight_licenses_filter'
+  return genericSoftwareLicensesFilter({search, keywords, prog_lang, licenses, rpc})
+}
+
+export async function genericSoftwareLicensesFilter({search, keywords, prog_lang, licenses, rpc}: GenericSoftwareFilterProps) {
   try {
-    const query = 'rpc/software_licenses_filter?order=license'
+    const query = `rpc/${rpc}?order=license`
     const url = `${getBaseUrl()}/${query}`
     const filter = buildSoftwareFilter({
       search,
@@ -140,11 +176,11 @@ export async function softwareLicensesFilter({search, keywords, prog_lang, licen
       return json
     }
 
-    logger(`softwareLicensesFilter: ${resp.status} ${resp.statusText}`, 'warn')
+    logger(`genericSoftwareLicensesFilter (${rpc}): ${resp.status} ${resp.statusText}`, 'warn')
     return []
 
   } catch (e: any) {
-    logger(`softwareLicensesFilter: ${e?.message}`, 'error')
+    logger(`genericSoftwareLicensesFilter (${rpc}): ${e?.message}`, 'error')
     return []
   }
 }

--- a/frontend/components/software/overview/useSoftwareOverviewParams.ts
+++ b/frontend/components/software/overview/useSoftwareOverviewParams.ts
@@ -3,7 +3,9 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,13 +13,15 @@ import {useRouter} from 'next/router'
 
 import {rowsPerPageOptions} from '~/config/pagination'
 import {ssrSoftwareParams} from '~/utils/extractQueryParam'
-import {QueryParams, ssrSoftwareUrl} from '~/utils/postgrestUrl'
+import {QueryParams, ssrViewUrl} from '~/utils/postgrestUrl'
 import {getDocumentCookie} from '../../../utils/userSettings'
 
 export default function useSoftwareOverviewParams() {
   const router = useRouter()
 
   function createUrl(key: string, value: string | string[]) {
+    const view = router.pathname.split('/')[1]
+
     const params: QueryParams = {
       // take existing params from url (query)
       ...ssrSoftwareParams(router.query),
@@ -32,7 +36,10 @@ export default function useSoftwareOverviewParams() {
       params['rows'] = getDocumentCookie('rsd_page_rows', rowsPerPageOptions[0])
     }
     // construct url with all query params
-    const url = ssrSoftwareUrl(params)
+    const url = ssrViewUrl({
+      view: view,
+      params: params
+    })
     return url
   }
 

--- a/frontend/components/software/overview/useSoftwareOverviewParams.ts
+++ b/frontend/components/software/overview/useSoftwareOverviewParams.ts
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
@@ -11,16 +11,35 @@
 
 import {useRouter} from 'next/router'
 
-import {rowsPerPageOptions} from '~/config/pagination'
+import logger from '~/utils/logger'
 import {ssrSoftwareParams} from '~/utils/extractQueryParam'
 import {QueryParams, ssrViewUrl} from '~/utils/postgrestUrl'
-import {getDocumentCookie} from '../../../utils/userSettings'
+import {getDocumentCookie} from '~/utils/userSettings'
+import {rowsPerPageOptions} from '~/config/pagination'
 
 export default function useSoftwareOverviewParams() {
   const router = useRouter()
 
+  /**
+ * NOTE! This hook is used on software and spotlight pages.
+ * We use router pathname to extract the current page to use.
+ * The default value is software page.
+ * @returns string
+ */
+  function getCurrentPage(){
+    try{
+      // extract page from the path (segment 1)
+      const paths = router.pathname?.split('/')
+      const view = paths?.length > 0 ? paths[1] : 'software'
+      return view
+    }catch(e:any){
+      logger(`getCurrentPage...${e.message}`,'warn')
+      // default is software page
+      return 'software'
+    }
+  }
+
   function createUrl(key: string, value: string | string[]) {
-    const view = router.pathname.split('/')[1]
 
     const params: QueryParams = {
       // take existing params from url (query)
@@ -37,7 +56,7 @@ export default function useSoftwareOverviewParams() {
     }
     // construct url with all query params
     const url = ssrViewUrl({
-      view: view,
+      view: getCurrentPage(),
       params: params
     })
     return url
@@ -46,8 +65,8 @@ export default function useSoftwareOverviewParams() {
   function handleQueryChange(key: string, value: string | string[]) {
     const url = createUrl(key, value)
     if (key === 'page') {
-      // when changin page we scroll to top
-      router.push(url, url, {scroll: true})
+      // when changing page we scroll to top
+      router.push(url,url,{scroll: true})
     } else {
       // update page url but keep scroll position
       router.push(url,url,{scroll: false})

--- a/frontend/config/defaultSettings.json
+++ b/frontend/config/defaultSettings.json
@@ -15,6 +15,7 @@
     "privacy_statement_url": "/page/privacy-statement/",
     "software_highlights": {
       "title": "Software Highlights",
+      "limit": 3,
       "description": null
     }
   },

--- a/frontend/config/defaultSettings.json
+++ b/frontend/config/defaultSettings.json
@@ -13,7 +13,10 @@
     "login_info_url": "https://research-software-directory.github.io/documentation/getting-access.html",
     "terms_of_service_url": "/page/terms-of-service/",
     "privacy_statement_url": "/page/privacy-statement/",
-    "software_highlights_title":  "Software Highlights"
+    "software_highlights": {
+      "title": "Software Highlights",
+      "description": null
+    }
   },
   "links": [
     {

--- a/frontend/config/defaultSettings.json.license
+++ b/frontend/config/defaultSettings.json.license
@@ -1,6 +1,6 @@
 SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2022 - 2023 dv4all
-SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 
 SPDX-License-Identifier: Apache-2.0

--- a/frontend/config/getSettingsServerSide.ts
+++ b/frontend/config/getSettingsServerSide.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -53,8 +53,8 @@ export async function getSettingsServerSide(req: IncomingMessage | undefined, qu
   ])
 
   // Set default values that should not be overwritten if they don't exist in settings.host
-  if (!settings.host.software_highlights_title) {
-    settings.host.software_highlights_title = defaultSettings.host.software_highlights_title
+  if (!settings.host.software_highlights) {
+    settings.host.software_highlights = defaultSettings.host.software_highlights
   }
 
   // compose all settings

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -35,6 +35,7 @@ export type RsdHost = {
   privacy_statement_url?: string,
   software_highlights?: {
     title: string,
+    limit: number,
     description?: string | null
   }
 }

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -33,7 +33,10 @@ export type RsdHost = {
   login_info_url?:string,
   terms_of_service_url?: string,
   privacy_statement_url?: string,
-  software_highlights_title?: string
+  software_highlights?: {
+    title: string,
+    description?: string | null
+  }
 }
 
 export type CustomLink = {

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -48,6 +48,7 @@ import SoftwareFiltersModal from '~/components/software/overview/filters/Softwar
 import {getUserSettings, setDocumentCookie} from '~/utils/userSettings'
 import {softwareOrderOptions} from '~/components/software/overview/filters/OrderSoftwareBy'
 import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
+import {getRsdSettings} from '~/config/getSettingsServerSide'
 
 type SoftwareOverviewProps = {
   search?: string | null
@@ -259,6 +260,9 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     offset
   })
 
+  // extract rsd settings
+  const settings = await getRsdSettings()
+
   // console.log('software...url...', url)
   // console.log('order...', order)
   // console.log('orderBy...', orderBy)
@@ -278,9 +282,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     softwareLanguagesFilter({search, keywords, prog_lang, licenses}),
     softwareLicensesFilter({search, keywords, prog_lang, licenses}),
     getSoftwareHighlights({
-      limit: 3,
-      offset: 0,
-      orderBy: 'position'
+      limit: settings.host?.software_highlights?.limit ?? 3,
+      offset: 0
     })
   ])
 

--- a/frontend/pages/spotlights/index.tsx
+++ b/frontend/pages/spotlights/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
@@ -17,8 +17,7 @@ import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
 import {getBaseUrl} from '~/utils/fetchHelpers'
-import {softwareListUrl} from '~/utils/postgrestUrl'
-import {getSoftwareList} from '~/utils/getSoftware'
+import {highlightsListUrl} from '~/utils/postgrestUrl'
 import {ssrSoftwareParams} from '~/utils/extractQueryParam'
 import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
 import MainContent from '~/components/layout/MainContent'
@@ -31,25 +30,24 @@ import CanonicalUrl from '~/components/seo/CanonicalUrl'
 import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
 import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
-import {
-  SoftwareHighlight,
-  getSoftwareHighlights
-} from '~/components/admin/software-highlights/apiSoftwareHighlights'
-import SoftwareHighlights from '~/components/software/overview/SoftwareHighlights'
 import SoftwareSearchSection from '~/components/software/overview/search/SoftwareSearchSection'
 import useSoftwareOverviewParams from '~/components/software/overview/useSoftwareOverviewParams'
 import SoftwareOverviewContent from '~/components/software/overview/SoftwareOverviewContent'
 import SoftwareFilters from '~/components/software/overview/filters/index'
 import {
-  softwareKeywordsFilter, softwareLanguagesFilter,
-  softwareLicensesFilter
+  highlightKeywordsFilter,
+  highlightLanguagesFilter,
+  highlightLicensesFilter,
 } from '~/components/software/overview/filters/softwareFiltersApi'
 import SoftwareFiltersModal from '~/components/software/overview/filters/SoftwareFiltersModal'
 import {getUserSettings, setDocumentCookie} from '~/utils/userSettings'
-import {softwareOrderOptions} from '~/components/software/overview/filters/OrderSoftwareBy'
+import {highlightOrderOptions} from '~/components/software/overview/filters/OrderSoftwareBy'
 import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
+import useRsdSettings from '~/config/useRsdSettings'
+import {getSoftwareList} from '~/utils/getSoftware'
 
-type SoftwareOverviewProps = {
+
+type SpotlightsOverviewProps = {
   search?: string | null
   keywords?: string[] | null,
   keywordsList: KeywordFilterOption[],
@@ -62,31 +60,31 @@ type SoftwareOverviewProps = {
   rows: number,
   count: number,
   layout: LayoutType,
-  software: SoftwareOverviewItemProps[],
-  highlights: SoftwareHighlight[]
+  highlights: SoftwareOverviewItemProps[]
 }
 
 const pageTitle = `Software | ${app.title}`
 const pageDesc = 'The list of research software registered in the Research Software Directory.'
 
-export default function SoftwareOverviewPage({
+export default function SpotlightsOverviewPage({
   search, keywords,
   prog_lang, licenses,
   order, page, rows,
   count, layout,
   keywordsList, languagesList,
-  licensesList, software, highlights
-}: SoftwareOverviewProps) {
+  licensesList, highlights
+}: SpotlightsOverviewProps) {
   const smallScreen = useMediaQuery('(max-width:640px)')
   const {createUrl} = useSoftwareOverviewParams()
   const [modal,setModal] = useState(false)
+  const {host} = useRsdSettings()
   // if no layout - default is masonry
   const initView = layout ?? 'masonry'
   const [view, setView] = useState<LayoutType>(initView)
   const numPages = Math.ceil(count / rows)
   const filterCnt = getFilterCount()
 
-  // console.group('SoftwareOverviewPage')
+  // console.group('SpotlightsOverviewPage')
   // console.log('search...', search)
   // console.log('keywords...', keywords)
   // console.log('prog_lang...', prog_lang)
@@ -99,8 +97,7 @@ export default function SoftwareOverviewPage({
   // console.log('keywordsList...', keywordsList)
   // console.log('languagesList...', languagesList)
   // console.log('licensesList...', licensesList)
-  // console.log('software...', software)
-  // console.log('highlights...', highlights)
+  // console.log('software...', highlights)
   // console.groupEnd()
 
   function getFilterCount() {
@@ -131,8 +128,6 @@ export default function SoftwareOverviewPage({
       <PageBackground>
         {/* App header */}
         <AppHeader />
-        {/* Software Highlights Carousel */}
-        <SoftwareHighlights highlights={highlights} />
         {/* Main page body */}
         <MainContent className='pb-12'>
           {/* Page title */}
@@ -141,8 +136,11 @@ export default function SoftwareOverviewPage({
             id="list-top"
             role="heading"
           >
-            All software
+            All {host.software_highlights?.title}
           </h1>
+          {host.software_highlights?.description &&
+            <p>{host.software_highlights?.description}</p>
+          }
           {/* Page grid with 2 sections: left filter panel and main content */}
           <div className="flex-1 grid md:grid-cols-[2fr,3fr] lg:grid-cols-[1fr,3fr] xl:grid-cols-[1fr,4fr] my-4 gap-8">
             {/* Filters panel large screen */}
@@ -157,6 +155,7 @@ export default function SoftwareOverviewPage({
                   licensesList={licensesList}
                   orderBy={order ?? ''}
                   filterCnt={filterCnt}
+                  highlightsOnly={true}
                 />
               </FiltersPanel>
             }
@@ -167,7 +166,7 @@ export default function SoftwareOverviewPage({
                 rows={rows}
                 count={count}
                 search={search}
-                placeholder={keywords?.length ? 'Find within selection' : 'Find software'}
+                placeholder={keywords?.length ? 'Find within selection' : `Find ${host.software_highlights?.title}`}
                 layout={view}
                 setView={setLayout}
                 setModal={setModal}
@@ -175,7 +174,7 @@ export default function SoftwareOverviewPage({
               {/* Software content: masonry, cards or list */}
               <SoftwareOverviewContent
                 layout={view}
-                software={software}
+                software={highlights}
               />
               {/* Pagination */}
               <div className="flex justify-center mt-8">
@@ -241,14 +240,14 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   if (order) {
     // extract order direction from definitions
-    const orderInfo = softwareOrderOptions.find(item=>item.key===order)
+    const orderInfo = highlightOrderOptions.find(item=>item.key===order)
     // ordering options require "stable" secondary order
     // to ensure proper pagination. We use slug for this purpose
     if (orderInfo) orderBy=`${order}.${orderInfo.direction},slug.asc`
   }
 
   // construct postgREST api url with query params
-  const url = softwareListUrl({
+  const url = highlightsListUrl({
     baseUrl: getBaseUrl(),
     search,
     keywords,
@@ -266,22 +265,15 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
 
   // get software items, filter options AND highlights
   const [
-    software,
+    highlights,
     keywordsList,
     languagesList,
-    licensesList,
-    // extract highlights from fn response (we don't need count)
-    {highlights}
+    licensesList
   ] = await Promise.all([
     getSoftwareList({url}),
-    softwareKeywordsFilter({search, keywords, prog_lang, licenses}),
-    softwareLanguagesFilter({search, keywords, prog_lang, licenses}),
-    softwareLicensesFilter({search, keywords, prog_lang, licenses}),
-    getSoftwareHighlights({
-      limit: 3,
-      offset: 0,
-      orderBy: 'position'
-    })
+    highlightKeywordsFilter({search, keywords, prog_lang, licenses}),
+    highlightLanguagesFilter({search, keywords, prog_lang, licenses}),
+    highlightLicensesFilter({search, keywords, prog_lang, licenses}),
   ])
 
   // passed as props to the page
@@ -299,9 +291,8 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       order,
       rows: page_rows,
       layout: rsd_page_layout,
-      count: software.count,
-      software: software.data,
-      highlights
+      count: highlights.count,
+      highlights: highlights.data,
     },
   }
 }

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -15,7 +15,8 @@
     "privacy_statement_url": "/page/privacy-statement/",
     "software_highlights": {
       "title": "Software Highlights",
-      "description": "Software Highlights description."
+      "limit": 5,
+      "description": null
     }
   },
   "links": [

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -12,7 +12,11 @@
     },
     "login_info_url":"https://research-software-directory.github.io/documentation/getting-access.html",
     "terms_of_service_url": "/page/terms-of-service/",
-    "privacy_statement_url": "/page/privacy-statement/"
+    "privacy_statement_url": "/page/privacy-statement/",
+    "software_highlights": {
+      "title": "Software Highlights",
+      "description": "Software Highlights description."
+    }
   },
   "links": [
     {

--- a/frontend/public/data/settings.json.license
+++ b/frontend/public/data/settings.json.license
@@ -1,6 +1,6 @@
 SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2022 - 2023 dv4all
-SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 
 SPDX-License-Identifier: Apache-2.0

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -1,10 +1,11 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -52,11 +53,49 @@ export async function getSoftwareList({url,token}:{url:string,token?:string }){
   }
 }
 
+
+/*
+ * Software list for the software overview page
+ * Note! url should contain all query params. Use softwareUrl helper fn to construct url.
+ */
+export async function getHighlightList({url,token}:{url:string,token?:string }){
+  try{
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+        'Prefer':'count=exact'
+      },
+    })
+
+    if ([200,206].includes(resp.status)){
+      const json: SoftwareOverviewItemProps[] = await resp.json()
+      // set
+      return {
+        count: extractCountFromHeader(resp.headers),
+        data: json
+      }
+    } else {
+      logger(`getHighlightList failed: ${resp.status} ${resp.statusText} ${url}`, 'warn')
+      return {
+        count:0,
+        data:[]
+      }
+    }
+  }catch(e:any){
+    logger(`getHighlightList: ${e?.message}`,'error')
+    return {
+      count:0,
+      data:[]
+    }
+  }
+}
+
 // query for software item page based on slug
 export async function getSoftwareItem(slug:string|undefined, token?:string){
   try {
     // console.log('token...', token)
-    // this request is always perfomed from backend
+    // this request is always performed from backend
     const url = `${process.env.POSTGREST_URL}/software?select=*,repository_url!left(url)&slug=eq.${slug}`
     let resp
     if (token) {
@@ -319,7 +358,7 @@ export async function getRemoteMarkdown(url: string) {
   }
 }
 
-// RELATED PROJECTS FOR SORFTWARE
+// RELATED PROJECTS FOR SOFTWARE
 export async function getRelatedProjectsForSoftware({software, token, frontend, approved=true}:
   { software: string, token?: string, frontend?: boolean, approved?:boolean }) {
   try {

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 //
@@ -46,44 +46,6 @@ export async function getSoftwareList({url,token}:{url:string,token?:string }){
     }
   }catch(e:any){
     logger(`getSoftwareList: ${e?.message}`,'error')
-    return {
-      count:0,
-      data:[]
-    }
-  }
-}
-
-
-/*
- * Software list for the software overview page
- * Note! url should contain all query params. Use softwareUrl helper fn to construct url.
- */
-export async function getHighlightList({url,token}:{url:string,token?:string }){
-  try{
-    const resp = await fetch(url, {
-      method: 'GET',
-      headers: {
-        ...createJsonHeaders(token),
-        'Prefer':'count=exact'
-      },
-    })
-
-    if ([200,206].includes(resp.status)){
-      const json: SoftwareOverviewItemProps[] = await resp.json()
-      // set
-      return {
-        count: extractCountFromHeader(resp.headers),
-        data: json
-      }
-    } else {
-      logger(`getHighlightList failed: ${resp.status} ${resp.statusText} ${url}`, 'warn')
-      return {
-        count:0,
-        data:[]
-      }
-    }
-  }catch(e:any){
-    logger(`getHighlightList: ${e?.message}`,'error')
     return {
       count:0,
       data:[]

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -51,6 +53,17 @@ export type QueryParams={
   project_status?: string | null,
   page?:number | null,
   rows?:number | null
+}
+
+export type ViewQueryParams = {
+  view: string,
+  params: QueryParams
+}
+
+export function ssrViewUrl(viewParams:ViewQueryParams) {
+  const {view, params} = viewParams
+  const url = buildFilterUrl(params, view)
+  return url
 }
 
 export function ssrSoftwareUrl(params:QueryParams){
@@ -296,6 +309,27 @@ export function softwareListUrl(props: PostgrestParams) {
   return url
 }
 
+export function highlightsListUrl(props: PostgrestParams) {
+  const {baseUrl, search} = props
+  let query = baseQueryString(props)
+
+  if (search) {
+    // console.log('softwareListUrl...keywords...', props.keywords)
+    const encodedSearch = encodeURIComponent(search)
+    // search query is performed in software_search RPC
+    // we search in title,subtitle,slug,keywords_text and prog_lang
+    // check rpc in 105-project-views.sql for exact filtering
+    query += `&search=${encodedSearch}`
+
+    const url = `${baseUrl}/rpc/highlight_search?${query}`
+    // console.log('softwareListUrl...', url)
+    return url
+  }
+
+  const url = `${baseUrl}/rpc/highlight_overview?${query}`
+  // console.log('softwareListUrl...', url)
+  return url
+}
 
 export function projectListUrl(props: PostgrestParams) {
   const {baseUrl, search} = props


### PR DESCRIPTION
# Dedicated highlights page

Fixes #1170

Changes proposed in this pull request:

* adds a dedicated page for software highlights
  ![image](https://github.com/research-software-directory/RSD-as-a-service/assets/14222414/9e631acc-5c0d-4f16-9251-4cf119a18719)
* the highlights are by default sorted "Latest featured", i.e. ascending position
* the filters in the sidebar show only properties of the highlights
* the software highlights page can be reached via a button below the highlights carousel
  ![image](https://github.com/research-software-directory/RSD-as-a-service/assets/14222414/1dbbc748-e135-4530-9d0b-a3d282da7bba)
* note that the configuration for software highlights in `settings.json` changes slightly

How to test:

* optionally: define `software_highlights` title and description in `settings.json`
* `docker compose down --volumes && docker compose build --parallel && docker compose up`
* in a second terminal window `docker compose run data-generation`
* navigate to software overview
* if there are no highlights, login as admin and add some
* click on the "Browse all Highlights" button below the highlights carousel
* verify that filters work correctly and offer options that correspond to the displayed highlights

Points to be regarded in followup PR:

* how to configure the amount of highlights shown in the carousel (e.g. settings.json vs switch in admnin frontend?)
* how to specify whether the "Browse all highlights" button is shown on software index page?
* as an administrator, does it make sense when adding a new highlight, the position will have the highest number and that it has to be moved manually to position 1?

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [x] Tests
