### PR TITLE
feat: upgrade backend dependencies

### DIFF
--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 
@@ -32,14 +32,14 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.6.1</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.7.1</version>
 
 				<configuration>
 					<descriptorRefs>
@@ -98,7 +98,14 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>io.javalin</groupId>
 			<artifactId>javalin</artifactId>
-			<version>5.6.3</version>
+			<version>6.1.3</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
+		<dependency>
+			<groupId>org.jetbrains</groupId>
+			<artifactId>annotations</artifactId>
+			<version>24.1.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Main.java
@@ -14,7 +14,6 @@ import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
-import io.javalin.util.ConcurrencyUtil;
 
 import java.util.Base64;
 import java.util.UUID;
@@ -86,8 +85,7 @@ public class Main {
 	}
 
 	public static void main(String[] args) {
-		ConcurrencyUtil.INSTANCE.setUseLoom(false);
-		Javalin app = Javalin.create().start(7000);
+		Javalin app = Javalin.create(c -> c.useVirtualThreads = false).start(7000);
 		app.get("/", ctx -> ctx.json("{\"Module\": \"rsd/auth\", \"Status\": \"live\"}"));
 
 		if (Config.isLocalLoginEnabled()) {

--- a/backend-postgrest/Dockerfile
+++ b/backend-postgrest/Dockerfile
@@ -1,7 +1,7 @@
-# SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgrest/postgrest:v11.2.2
+FROM postgrest/postgrest:v12.0.2

--- a/database/002-create-image-table.sql
+++ b/database/002-create-image-table.sql
@@ -1,6 +1,6 @@
--- SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
--- SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 dv4all
 -- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 --
@@ -45,7 +45,9 @@ CREATE TRIGGER sanitise_update_image BEFORE UPDATE ON image FOR EACH ROW EXECUTE
 -- cache incrased to 1 year based on lighthouse audit
 -- ----------------------------------------
 
-CREATE FUNCTION get_image(uid VARCHAR(40)) RETURNS BYTEA STABLE LANGUAGE plpgsql AS
+CREATE DOMAIN "application/octet-stream" AS BYTEA;
+
+CREATE FUNCTION get_image(uid VARCHAR(40)) RETURNS "application/octet-stream" STABLE LANGUAGE plpgsql AS
 $$
 DECLARE headers TEXT;
 DECLARE blob BYTEA;

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgres:15.4
+FROM postgres:15.6
 RUN chmod a+rwx /docker-entrypoint-initdb.d
 COPY --chown=postgres:postgres *.sh /docker-entrypoint-initdb.d/
 COPY --chown=postgres:postgres *.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:2.4.0
+    image: rsd/database:2.4.1
     ports:
       # enable connection from outside (development mode)
       - "5432:5432"
@@ -36,7 +36,7 @@ services:
 
   backend:
     build: ./backend-postgrest
-    image: rsd/backend-postgrest:1.12.2
+    image: rsd/backend-postgrest:1.13.0
     expose:
       - 3500
     environment:
@@ -53,7 +53,7 @@ services:
 
   auth:
     build: ./authentication
-    image: rsd/auth:1.4.1
+    image: rsd/auth:1.5.0
     ports:
       - 5005:5005
     expose:
@@ -157,7 +157,7 @@ services:
 
   scrapers:
     build: ./scrapers
-    image: rsd/scrapers:1.8.0
+    image: rsd/scrapers:1.8.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL
@@ -212,7 +212,7 @@ services:
   nginx:
     build:
       context: ./nginx
-    image: rsd/nginx:1.1.3
+    image: rsd/nginx:1.1.4
     ports:
       - "80:80"
       - "443:443"

--- a/frontend/utils/editImage.ts
+++ b/frontend/utils/editImage.ts
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +26,7 @@ export async function upsertImage({data, mime_type, token}: {
         mime_type
       })
     })
-    if (resp.status === 201) {
+    if (resp.ok) {
       const id = resp.headers.get('location')?.split('.')[1]
       if (id) {
         return {

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,8 +1,8 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM nginx:1.25.2
+FROM nginx:1.25.4
 RUN apt-get update && apt-get install --yes certbot python3-certbot-nginx
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/scrapers/pom.xml
+++ b/scrapers/pom.xml
@@ -34,14 +34,14 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.6.1</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-assembly-plugin</artifactId>
-				<version>3.3.0</version>
+				<version>3.7.1</version>
 
 				<configuration>
 					<descriptorRefs>


### PR DESCRIPTION
## Backend upgrades

Changes proposed in this pull request:

* Upgrade dependencies as in #1169
* Create a domain for images as described in the [documentation for PostgREST 12](https://postgrest.org/en/v12/how-tos/providing-images-for-img.html)
* Adapt to status code `200` instead of `201` being returned when uploading an existing image

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Browse various pages, sign in and edit pages, check the [API](http://localhost/api/v1/) and [Swagger](http://localhost/swagger/)

Closes #1169

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests