### PR TITLE
fix: use floating points for programming languages

### DIFF
--- a/codemeta/main.go
+++ b/codemeta/main.go
@@ -38,8 +38,8 @@ type RsdSoftware struct {
 		License string `json:"license"`
 	} `json:"license_for_software"`
 	RepositoryURL *struct {
-		URL       string            `json:"url"`
-		Languages map[string]uint64 `json:"languages"`
+		URL       string             `json:"url"`
+		Languages map[string]float64 `json:"languages"`
 	} `json:"repository_url"`
 	ReferencePapers []struct {
 		Doi   *string `json:"doi"`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -178,7 +178,7 @@ services:
 
   codemeta:
     build: ./codemeta
-    image: rsd/codemeta:v1.2.0
+    image: rsd/codemeta:v1.2.1
     expose:
       - "8000"
     environment:


### PR DESCRIPTION
## Fix CodeMeta percentage bug

Changes proposed in this pull request:

* Use `float64` instead of `uint64` for unmarshalling programming languages from the RSD

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Create two *public* software pages, one with repo URL https://github.com/research-software-directory/RSD-as-a-service and one with https://gitlab.com/open-darts/open-darts
* Go to http://localhost/metadata/codemeta and check both entries before they are scraped
* Run `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages`
* Check both entries again, they should display without an error

Closes #1173

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
