### PR TITLE
Add user.role to dependency and fix typo

### DIFF
--- a/frontend/components/organisation/projects/index.tsx
+++ b/frontend/components/organisation/projects/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,7 @@ import {useState} from 'react'
 import Pagination from '@mui/material/Pagination'
 import useMediaQuery from '@mui/material/useMediaQuery'
 
-import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
+import UserAgreementModal from '~/components/user/settings/UserAgreementModal'
 import FiltersPanel from '~/components/filter/FiltersPanel'
 import {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
 import {setDocumentCookie} from '~/utils/userSettings'
@@ -51,7 +51,7 @@ export default function OrganisationProjects() {
 
   return (
     <>
-      {isMaintainer && <UserAgrementModal />}
+      {isMaintainer && <UserAgreementModal />}
       {/* Page grid with 2 sections: left filter panel and main content */}
       <div className="flex-1 grid md:grid-cols-[1fr,2fr] xl:grid-cols-[1fr,4fr] gap-4 mb-12">
         {/* Filters panel large screen */}

--- a/frontend/components/organisation/settings/index.tsx
+++ b/frontend/components/organisation/settings/index.tsx
@@ -2,13 +2,13 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import ProtectedOrganisationPage from '../ProtectedOrganisationPage'
-import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
+import UserAgreementModal from '~/components/user/settings/UserAgreementModal'
 import useOrganisationContext from '../context/useOrganisationContext'
 import BaseSurfaceRounded from '~/components/layout/BaseSurfaceRounded'
 import SettingsNav from './SettingsNav'
@@ -23,7 +23,7 @@ export default function OrganisationSettings() {
     <ProtectedOrganisationPage
       isMaintainer={isMaintainer}
     >
-      <UserAgrementModal />
+      <UserAgreementModal />
       <div className="flex-1 grid grid-cols-[1fr,4fr] gap-4">
         <BaseSurfaceRounded
           className="mb-12 p-4"

--- a/frontend/components/organisation/software/index.tsx
+++ b/frontend/components/organisation/software/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,7 @@ import {useState} from 'react'
 import Pagination from '@mui/material/Pagination'
 import useMediaQuery from '@mui/material/useMediaQuery'
 
-import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
+import UserAgreementModal from '~/components/user/settings/UserAgreementModal'
 import useOrganisationContext from '../context/useOrganisationContext'
 import {useUserSettings} from '../context/UserSettingsContext'
 import {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
@@ -55,7 +55,7 @@ export default function OrganisationSoftware() {
   return (
     <>
       {/* Only when maintainer */}
-      {isMaintainer && <UserAgrementModal />}
+      {isMaintainer && <UserAgreementModal />}
       {/* Page grid with 2 sections: left filter panel and main content */}
       <div className="flex-1 grid md:grid-cols-[1fr,2fr] xl:grid-cols-[1fr,4fr] gap-4 mb-12">
         {/* Filters panel large screen */}

--- a/frontend/components/organisation/units/index.tsx
+++ b/frontend/components/organisation/units/index.tsx
@@ -29,7 +29,7 @@ import ResearchUnitList from './ResearchUnitList'
 import ResearchUnitModal from './ResearchUnitModal'
 import {upsertImage} from '~/utils/editImage'
 import {getPropsFromObject} from '~/utils/getPropsFromObject'
-import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
+import UserAgreementModal from '~/components/user/settings/UserAgreementModal'
 import useOrganisationContext from '../context/useOrganisationContext'
 import BaseSurfaceRounded from '~/components/layout/BaseSurfaceRounded'
 
@@ -212,7 +212,7 @@ export default function ResearchUnits() {
       className="flex-1 flex flex-col mb-12 p-4"
     >
       {/* Only when maintainer */}
-      {isMaintainer && <UserAgrementModal />}
+      {isMaintainer && <UserAgreementModal />}
       <section className="flex justify-between py-4">
         <h2>Research Units ({count ?? 0})</h2>
         {renderAddBtn()}

--- a/frontend/components/user/settings/UserAgreementModal.tsx
+++ b/frontend/components/user/settings/UserAgreementModal.tsx
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
@@ -32,7 +32,7 @@ type UserSettingsModalForm = UserSettingsType & {
   account: string
 }
 
-export default function UserAgrementModal() {
+export default function UserAgreementModal() {
   const {host} = useRsdSettings()
   const {token,user} = useSession()
   const smallScreen = useMediaQuery('(max-width:600px)')
@@ -51,7 +51,7 @@ export default function UserAgrementModal() {
 
   const [agreeTerms, privacyStatement] = watch(['agree_terms','notice_privacy_statement'])
 
-  // console.group('UserAgrementModal')
+  // console.group('UserAgreementModal')
   // console.log('loading...', loading)
   // console.log('agree_terms...', agree_terms)
   // console.log('notice_privacy_statement...', notice_privacy_statement)
@@ -74,7 +74,7 @@ export default function UserAgrementModal() {
     }
 
     return () => { abort = true }
-  },[loading,agree_terms,notice_privacy_statement])
+  },[loading,agree_terms,notice_privacy_statement,user?.role])
 
   function onSubmit(data: UserSettingsModalForm) {
     // console.log('onSubmit.data...', data)

--- a/frontend/pages/projects/[slug]/edit/[page].tsx
+++ b/frontend/pages/projects/[slug]/edit/[page].tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
@@ -15,7 +16,7 @@ import ProtectedContent from '~/auth/ProtectedContent'
 import {getProjectItem} from '~/utils/getProjects'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import ContentLoader from '~/components/layout/ContentLoader'
-import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
+import UserAgreementModal from '~/components/user/settings/UserAgreementModal'
 import {EditProjectProvider, ProjectInfo} from '~/components/projects/edit/editProjectContext'
 import {editProjectPage} from '~/components/projects/edit/editProjectPages'
 import EditProjectNav from '~/components/projects/edit/EditProjectNav'
@@ -55,7 +56,7 @@ export default function ProjectEditPage({pageIndex,project}:ProjectEditPageProps
         <p style={{fontSize: '2rem', textAlign: 'center'}}>Please enable JavaScript to use this page</p>
       </noscript>
       <ProtectedContent slug={project.slug} pageType="project">
-        <UserAgrementModal />
+        <UserAgreementModal />
         {/* edit project context is share project info between pages */}
         <EditProjectProvider state={state}>
           <EditProjectStickyHeader />

--- a/frontend/pages/projects/add.tsx
+++ b/frontend/pages/projects/add.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +13,7 @@ import PageContainer from '~/components/layout/PageContainer'
 import AppFooter from '~/components/AppFooter'
 
 import AddProjectCard from '../../components/projects/add/AddProjectCard'
-import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
+import UserAgreementModal from '~/components/user/settings/UserAgreementModal'
 
 /**
  * Add new project. This page enables creation of project with 2 fields:
@@ -23,7 +25,7 @@ export default function AddSoftware() {
       <AppHeader />
       <ProtectedContent>
         <PageContainer className="flex-1 px-4 py-6 lg:py-12">
-          <UserAgrementModal />
+          <UserAgreementModal />
           <AddProjectCard />
         </PageContainer>
       </ProtectedContent>

--- a/frontend/pages/software/[slug]/edit/[page].tsx
+++ b/frontend/pages/software/[slug]/edit/[page].tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
@@ -17,7 +17,7 @@ import {getSoftwareToEdit} from '~/utils/editSoftware'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import ContentLoader from '~/components/layout/ContentLoader'
 import {EditSoftwareProvider, SoftwareInfo} from '~/components/software/edit/editSoftwareContext'
-import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
+import UserAgreementModal from '~/components/user/settings/UserAgreementModal'
 import {editSoftwarePage} from '~/components/software/edit/editSoftwarePages'
 import EditSoftwareStickyHeader from '~/components/software/edit/EditSoftwareStickyHeader'
 import EditSoftwareNav from '~/components/software/edit/EditSoftwareNav'
@@ -58,7 +58,7 @@ export default function SoftwareEditPages({pageIndex,software}:SoftwareEditPageP
         <p style={{fontSize: '2rem', textAlign: 'center'}}>Please enable JavaScript to use this page</p>
       </noscript>
       <ProtectedContent slug={software.slug}>
-        <UserAgrementModal />
+        <UserAgreementModal />
         <EditSoftwareProvider state={state}>
           <EditSoftwareStickyHeader />
           <section className="md:flex gap-[3rem] mb-8">

--- a/frontend/pages/software/add.tsx
+++ b/frontend/pages/software/add.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +14,7 @@ import AppFooter from '~/components/AppFooter'
 
 // import AddSoftwareModal from '../../components/software/add/AddSoftwareModal'
 import AddSoftwareCard from '../../components/software/add/AddSoftwareCard'
-import UserAgrementModal from '~/components/user/settings/UserAgreementModal'
+import UserAgreementModal from '~/components/user/settings/UserAgreementModal'
 
 /**
  * Add new software. This page is only showing a modal with 2 fields:
@@ -24,7 +26,7 @@ export default function AddSoftware() {
       <AppHeader />
       <ProtectedContent>
         <PageContainer className="flex-1 px-4 py-6 lg:py-12">
-          <UserAgrementModal />
+          <UserAgreementModal />
           <AddSoftwareCard />
         </PageContainer>
       </ProtectedContent>


### PR DESCRIPTION
# Fix typing error in the component name

Changes proposed in this pull request:
* Include user?.role in the dependency array of useEffect hook (fix linter warning)
* Fix typo in the name of UserAgreementModal  component

How to test:
* `make start` to build and generate test data
* login with first user, that will be rsd-admin role. Confirm by seeing Adminstration option in user menu
* try to add software. As rsd admin you will not see UserAgreementModal
* login as different user, not rsd-admin.
* try to add software. You should see UserAgreementModal only once to accept user agreement

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
