### PR TITLE
ci: use token to commit to protected branch

### DIFF
--- a/.github/workflows/_cff.yml
+++ b/.github/workflows/_cff.yml
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 # SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 #
@@ -22,6 +23,12 @@ on:
         required: true
         description: Commit message to use
         type: string
+    secrets:
+      # need to pass PAT token to reusable workflow via secrets in order to commit to protected branch
+      # see https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow
+      token:
+        required: true
+        description: PAT_RELEASE token
 
 jobs:
   commit_cff:
@@ -33,6 +40,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{inputs.branch}}
+          # use PAT secret to be able to commit to protected master branch
+          token: ${{secrets.token}}
 
       - name: download ${{inputs.artifact}}
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,9 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 # SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-# SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -265,5 +265,10 @@ jobs:
       artifact: citation
       branch: main
       commit_message: "chore(release): update citation file"
+    secrets:
+      # need to pass PAT using secrets prop to reusable workflow (module)
+      # the secrets are not passed automatically to child modules
+      # see https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#passing-inputs-and-secrets-to-a-reusable-workflow
+      token: ${{ secrets.PAT_RELEASE }}
 
 


### PR DESCRIPTION
# Enable commit to protected branch from action

In order for action to be able to push commit to protected branch during release we needed to add a secret to action.

## Requirements
- Create PAT token for an admin account in the repo
- Add this token to action/repository secrets. The action expects secret wit name `PAT_RELEASE`

Changes proposed in this pull request:
* Add token to _cff.yml "reusable" action
* Pass token to _cff.yml  from "reselease" action

How to test:
* Not possible to test except for running release action
* I have tested this approach in a (personal) [test repo](https://github.com/dmijatovic/rsd-saas-test)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
