### PR TITLE
Small performance improvements

### DIFF
--- a/frontend/components/organisation/apiOrganisations.ts
+++ b/frontend/components/organisation/apiOrganisations.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -173,7 +173,8 @@ export async function getOrganisationById({uuid,token,isMaintainer=false}:
 
 export async function getOrganisationChildren({uuid, token}:
   { uuid: string, token: string}) {
-  const query = `rpc/organisations_overview?parent=eq.${uuid}&order=name.asc`
+  const selectList = 'name,primary_maintainer,slug,website,logo_id'
+  const query = `organisation?parent=eq.${uuid}&order=name.asc&select=${selectList}`
   let url = `${getBaseUrl()}/${query}`
 
   const resp = await fetch(url, {
@@ -241,7 +242,7 @@ export async function getSoftwareForOrganisation({
     let url = `${baseUrl}/rpc/software_by_organisation?organisation_id=${organisation}`
     // search
     if (searchFor) {
-      // use diffrerrent RPC for search
+      // use different RPC for search
       const encodedSearch = encodeURIComponent(searchFor)
       url = `${baseUrl}/rpc/software_by_organisation_search?organisation_id=${organisation}&search=${encodedSearch}`
     }
@@ -312,7 +313,7 @@ export async function getProjectsForOrganisation({
     let url = `${baseUrl}/rpc/projects_by_organisation?organisation_id=${organisation}`
     // search
     if (searchFor) {
-      // use diffrerrent RPC for search
+      // use different RPC for search
       const encodedSearch = encodeURIComponent(searchFor)
       url = `${baseUrl}/rpc/projects_by_organisation_search?organisation_id=${organisation}&search=${encodedSearch}`
     }

--- a/frontend/pages/organisations/[...slug].tsx
+++ b/frontend/pages/organisations/[...slug].tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -117,7 +118,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       user
     })
     // console.log('organisation...', organisation)
-    if (typeof resp == 'undefined'){
+    if (resp === undefined){
       // returning notFound triggers 404 page
       return {
         notFound: true,

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -281,7 +281,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     softwareKeywordsFilter({search, keywords, prog_lang, licenses}),
     softwareLanguagesFilter({search, keywords, prog_lang, licenses}),
     softwareLicensesFilter({search, keywords, prog_lang, licenses}),
-    getSoftwareHighlights({
+    page !== 1 ? Promise.resolve({highlights: []}) : getSoftwareHighlights({
       limit: settings.host?.software_highlights?.limit ?? 3,
       offset: 0
     })


### PR DESCRIPTION
## Small performance improvements

Changes proposed in this pull request:

* Use the `organisation` table directly when getting research units and only select the necessary columns
* Only request the software highlights on the first page of the software overview page

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Check the software overview page and use its pagination
* Login as admin add a research unit to an organisation, view its units (compare its performance to e.g. https://research-software-directory.org/organisations/netherlands-escience-center?tab=units)

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
