### PR TITLE
See inactive accounts in admin interface

### DIFF
--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -771,7 +771,8 @@ function generateLoginForAccount(accountIds, orcids) {
 				email: faker.internet.email({firstName: firstName, lastName: givenName}),
 				sub: orcid,
 				provider: 'orcid',
-				home_organisation: faker.helpers.arrayElement(homeOrganisations)
+				home_organisation: faker.helpers.arrayElement(homeOrganisations),
+				last_login_date: faker.helpers.maybe(() => faker.date.past({years: 3}), {probability: 0.8}) ?? null
 			});
 		} else {
 			login_for_accounts.push({
@@ -780,7 +781,8 @@ function generateLoginForAccount(accountIds, orcids) {
 				email: faker.internet.email({firstName: firstName, lastName: givenName}),
 				sub: faker.string.alphanumeric(30),
 				provider: faker.helpers.arrayElement(providers),
-				home_organisation: faker.helpers.arrayElement(homeOrganisations)
+				home_organisation: faker.helpers.arrayElement(homeOrganisations),
+				last_login_date: faker.helpers.maybe(() => faker.date.past({years: 3}), {probability: 0.8}) ?? null
 			});
 		}
 	})

--- a/frontend/components/admin/rsd-users/RsdUsersList.tsx
+++ b/frontend/components/admin/rsd-users/RsdUsersList.tsx
@@ -23,9 +23,9 @@ export type DeleteAccountModal = {
   account?: RsdAccountInfo
 }
 
-export default function RsdUsersList() {
+export default function RsdUsersList({adminsOnly}) {
   const {token} = useSession()
-  const {loading, accounts, deleteAccount} = useRsdAccounts(token)
+  const {loading, accounts, deleteAccount} = useRsdAccounts(token, adminsOnly)
   const [modal, setModal] = useState<DeleteAccountModal>({
     open: false
   })

--- a/frontend/components/admin/rsd-users/RsdUsersList.tsx
+++ b/frontend/components/admin/rsd-users/RsdUsersList.tsx
@@ -23,9 +23,9 @@ export type DeleteAccountModal = {
   account?: RsdAccountInfo
 }
 
-export default function RsdUsersList({adminsOnly}) {
+export default function RsdUsersList({adminsOnly, inactiveDays}: {adminsOnly: boolean, inactiveDays: number}) {
   const {token} = useSession()
-  const {loading, accounts, deleteAccount} = useRsdAccounts(token, adminsOnly)
+  const {loading, accounts, deleteAccount} = useRsdAccounts(token, adminsOnly, inactiveDays)
   const [modal, setModal] = useState<DeleteAccountModal>({
     open: false
   })

--- a/frontend/components/admin/rsd-users/apiRsdUsers.ts
+++ b/frontend/components/admin/rsd-users/apiRsdUsers.ts
@@ -17,12 +17,13 @@ type getLoginApiParams = {
   page: number
   rows: number
   searchFor?:string
+  adminsOnly: boolean
 }
 
-export async function getRsdAccounts({page,rows,token,searchFor}:getLoginApiParams) {
+export async function getRsdAccounts({page,rows,token,searchFor,adminsOnly}:getLoginApiParams) {
   try {
     // pagination
-    let query = `select=id,login_for_account!inner(id,provider,name,email,home_organisation,last_login_date),admin_account!left(account_id)${paginationUrlParams({rows, page})}`
+    let query = `select=id,login_for_account!inner(id,provider,name,email,home_organisation,last_login_date),admin_account!${adminsOnly ? 'inner' : 'left'}(account_id)${paginationUrlParams({rows, page})}`
     // search
     if (searchFor) {
       if (searchFor.match(/^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i) !== null) {

--- a/frontend/components/admin/rsd-users/apiRsdUsers.ts
+++ b/frontend/components/admin/rsd-users/apiRsdUsers.ts
@@ -17,13 +17,19 @@ type getLoginApiParams = {
   page: number
   rows: number
   searchFor?:string
-  adminsOnly: boolean
+  adminsOnly: boolean,
+  inactiveDays: number
 }
 
-export async function getRsdAccounts({page,rows,token,searchFor,adminsOnly}:getLoginApiParams) {
+export async function getRsdAccounts({page,rows,token,searchFor,adminsOnly,inactiveDays}:getLoginApiParams) {
   try {
     // pagination
-    let query = `select=id,login_for_account!inner(id,provider,name,email,home_organisation,last_login_date),admin_account!${adminsOnly ? 'inner' : 'left'}(account_id)${paginationUrlParams({rows, page})}`
+    let query = `select=id,login_for_account(id,provider,name,email,home_organisation,last_login_date),login_for_account_text_filter:login_for_account!inner(),login_for_account_inactivity_filter:login_for_account!inner(),admin_account!${adminsOnly ? 'inner' : 'left'}(account_id)${paginationUrlParams({rows, page})}`
+    if (inactiveDays > 0) {
+      const then = new Date()
+      then.setDate(then.getDate() - inactiveDays)
+      query += `&login_for_account_inactivity_filter.or=(last_login_date.is.null,last_login_date.lt.${then.toISOString()})`
+    }
     // search
     if (searchFor) {
       if (searchFor.match(/^[0-9A-F]{8}-[0-9A-F]{4}-[4][0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i) !== null) {
@@ -31,7 +37,7 @@ export async function getRsdAccounts({page,rows,token,searchFor,adminsOnly}:getL
         query += `&id=eq.${searchFor}`
       } else {
         // else we search by name, email or organisation
-        query+=`&login_for_account.or=(name.ilike.*${searchFor}*,email.ilike.*${searchFor}*,home_organisation.ilike.*${searchFor}*)`
+        query+=`&login_for_account_text_filter.or=(name.ilike.*${searchFor}*,email.ilike.*${searchFor}*,home_organisation.ilike.*${searchFor}*)`
       }
     }
     // complete url

--- a/frontend/components/admin/rsd-users/index.tsx
+++ b/frontend/components/admin/rsd-users/index.tsx
@@ -7,27 +7,46 @@
 
 import Pagination from '~/components/pagination/Pagination'
 import Searchbox from '~/components/search/Searchbox'
-import {Switch} from '@mui/material'
+import Switch from '@mui/material/Switch'
+import TextField from '@mui/material/TextField'
 import {useState} from 'react'
 
 import RsdUsersList from './RsdUsersList'
 
+const digitsOnlyPattern = new RegExp('^\\d+$')
 
 export default function RsdUsersPage() {
   const [adminsOnly, setAdminsOnly] = useState<boolean>(false)
+  const [inactiveDays, setInactiveDays] = useState<number>(0)
+  const [inactiveDaysError, setInactiveDaysError] = useState<boolean>(false)
 
   function handleAdminsOnlyChange(event : React.ChangeEvent<HTMLInputElement>) {
     setAdminsOnly(event.target.checked)
   }
 
+  function handleInactiveDaysChange(event : React.ChangeEvent<HTMLInputElement>) {
+    if (!event.target.value) {
+      setInactiveDays(0)
+      setInactiveDaysError(false)
+    } else if (!digitsOnlyPattern.test(event.target.value)) {
+      setInactiveDaysError(true)
+    } else {
+      setInactiveDays(parseInt(event.target.value))
+      setInactiveDaysError(false)
+    }
+  }
+
   return (
     <section className="flex-1">
       <div className="flex flex-wrap items-center justify-end">
-        <Searchbox />
-        Admins only: <Switch onChange={handleAdminsOnlyChange} />
-        <Pagination />
+        <Searchbox/>
+        Admins only: <Switch onChange={handleAdminsOnlyChange}/>
+        <Pagination/>
       </div>
-      <RsdUsersList adminsOnly={adminsOnly} />
+      <div>
+        <TextField variant="standard" error={inactiveDaysError} label="Accounts inactive by days" onChange={handleInactiveDaysChange}/>
+      </div>
+      <RsdUsersList adminsOnly={adminsOnly} inactiveDays={inactiveDays}/>
     </section>
   )
 }

--- a/frontend/components/admin/rsd-users/index.tsx
+++ b/frontend/components/admin/rsd-users/index.tsx
@@ -1,21 +1,33 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Pagination from '~/components/pagination/Pagination'
 import Searchbox from '~/components/search/Searchbox'
+import {Switch} from '@mui/material'
+import {useState} from 'react'
 
 import RsdUsersList from './RsdUsersList'
 
+
 export default function RsdUsersPage() {
+  const [adminsOnly, setAdminsOnly] = useState<boolean>(false)
+
+  function handleAdminsOnlyChange(event : React.ChangeEvent<HTMLInputElement>) {
+    setAdminsOnly(event.target.checked)
+  }
+
   return (
     <section className="flex-1">
       <div className="flex flex-wrap items-center justify-end">
         <Searchbox />
+        Admins only: <Switch onChange={handleAdminsOnlyChange} />
         <Pagination />
       </div>
-      <RsdUsersList />
+      <RsdUsersList adminsOnly={adminsOnly} />
     </section>
   )
 }

--- a/frontend/components/admin/rsd-users/index.tsx
+++ b/frontend/components/admin/rsd-users/index.tsx
@@ -1,17 +1,19 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {useState} from 'react'
 import Pagination from '~/components/pagination/Pagination'
 import Searchbox from '~/components/search/Searchbox'
 import Switch from '@mui/material/Switch'
-import TextField from '@mui/material/TextField'
-import {useState} from 'react'
+import Input from '@mui/material/Input'
 
 import RsdUsersList from './RsdUsersList'
+import FormControlLabel from '@mui/material/FormControlLabel'
 
 const digitsOnlyPattern = new RegExp('^\\d+$')
 
@@ -38,13 +40,24 @@ export default function RsdUsersPage() {
 
   return (
     <section className="flex-1">
-      <div className="flex flex-wrap items-center justify-end">
+      <div className="flex flex-wrap items-center justify-end gap-4">
         <Searchbox/>
-        Admins only: <Switch onChange={handleAdminsOnlyChange}/>
+        <Input
+          type="number"
+          error={inactiveDaysError}
+          placeholder="Last login (days)"
+          onChange={handleInactiveDaysChange}
+          className="max-w-[9rem]"
+        />
+        <FormControlLabel
+          label="Admin"
+          control={
+            <Switch
+              onChange={handleAdminsOnlyChange}
+            />
+          }
+        />
         <Pagination/>
-      </div>
-      <div>
-        <TextField variant="standard" error={inactiveDaysError} label="Accounts inactive by days" onChange={handleInactiveDaysChange}/>
       </div>
       <RsdUsersList adminsOnly={adminsOnly} inactiveDays={inactiveDays}/>
     </section>

--- a/frontend/components/admin/rsd-users/useRsdAccounts.tsx
+++ b/frontend/components/admin/rsd-users/useRsdAccounts.tsx
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -26,7 +26,7 @@ export type RsdAccountInfo = {
 
 export default function useRsdAccounts(token: string, adminsOnly: boolean, inactiveDays: number) {
   const {showErrorMessage}=useSnackbar()
-  const {searchFor, page, rows, setCount} = usePaginationWithSearch('Find user by account id (exact match) or by name, email or affiliation (partial match)')
+  const {searchFor, page, rows, setCount} = usePaginationWithSearch('Find user by account id, name, email or affiliation')
   const [accounts, setAccounts] = useState<RsdAccountInfo[]>([])
   // show loading only on inital load
   const [loading, setLoading] = useState(true)

--- a/frontend/components/admin/rsd-users/useRsdAccounts.tsx
+++ b/frontend/components/admin/rsd-users/useRsdAccounts.tsx
@@ -24,7 +24,7 @@ export type RsdAccountInfo = {
   admin_account: string[] | null
 }
 
-export default function useRsdAccounts(token: string, adminsOnly: boolean) {
+export default function useRsdAccounts(token: string, adminsOnly: boolean, inactiveDays: number) {
   const {showErrorMessage}=useSnackbar()
   const {searchFor, page, rows, setCount} = usePaginationWithSearch('Find user by account id (exact match) or by name, email or affiliation (partial match)')
   const [accounts, setAccounts] = useState<RsdAccountInfo[]>([])
@@ -38,7 +38,8 @@ export default function useRsdAccounts(token: string, adminsOnly: boolean) {
         searchFor,
         page,
         rows,
-        adminsOnly
+        adminsOnly,
+        inactiveDays
       })
       setAccounts(accounts)
       setCount(count)
@@ -49,7 +50,7 @@ export default function useRsdAccounts(token: string, adminsOnly: boolean) {
     }
   // we do not include setCount in order to avoid loop
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token,searchFor,page,rows,adminsOnly])
+  }, [token,searchFor,page,rows,adminsOnly,inactiveDays])
 
 
   async function deleteAccount(id: string) {

--- a/frontend/components/admin/rsd-users/useRsdAccounts.tsx
+++ b/frontend/components/admin/rsd-users/useRsdAccounts.tsx
@@ -24,7 +24,7 @@ export type RsdAccountInfo = {
   admin_account: string[] | null
 }
 
-export default function useRsdAccounts(token: string) {
+export default function useRsdAccounts(token: string, adminsOnly: boolean) {
   const {showErrorMessage}=useSnackbar()
   const {searchFor, page, rows, setCount} = usePaginationWithSearch('Find user by account id (exact match) or by name, email or affiliation (partial match)')
   const [accounts, setAccounts] = useState<RsdAccountInfo[]>([])
@@ -37,7 +37,8 @@ export default function useRsdAccounts(token: string) {
         token,
         searchFor,
         page,
-        rows
+        rows,
+        adminsOnly
       })
       setAccounts(accounts)
       setCount(count)
@@ -48,7 +49,7 @@ export default function useRsdAccounts(token: string) {
     }
   // we do not include setCount in order to avoid loop
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [token,searchFor,page,rows])
+  }, [token,searchFor,page,rows,adminsOnly])
 
 
   async function deleteAccount(id: string) {


### PR DESCRIPTION
## See inactive accounts in admin interface

Changes proposed in this pull request:

* In the user overview of admins, you can choose to only see admins
* In the user overview of admins, you can filter on accounts that have a login method that hasn't been used in `n` days (or that never logged in since we kept track of the last login date)
* Add last login dates to data generation

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Log in as admin, go to http://localhost/admin/rsd-users
* Assign some more admins, toggle the extra switch, you should only see admins
* Enter a positive number in the `Last login` input, you should only see accounts that have a login method where the last login date is either missing or older than the amount of days you entered
* Combine multiple filters together, is the output correct?

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
