### PR TITLE
Add anchor tags to drop down menu and user page

### DIFF
--- a/frontend/components/layout/UserMenu.tsx
+++ b/frontend/components/layout/UserMenu.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import router from 'next/router'
 import {useState} from 'react'
 import IconButton from '@mui/material/IconButton'
 import Menu from '@mui/material/Menu'
@@ -17,6 +18,7 @@ import {MenuItemType} from '../../config/menuItems'
 import {getDisplayInitials, splitName} from '../../utils/getDisplayName'
 import CaretIcon from '~/components/icons/caret.svg'
 import useDisableScrollLock from '~/utils/useDisableScrollLock'
+import Link from 'next/link'
 
 type UserMenuType = {
   image?: string
@@ -38,9 +40,6 @@ export default function UserMenu(props: UserMenuType) {
     if (item?.fn) {
       // call function if provided
       item.fn(item)
-    } else if (item?.path) {
-      // push to route if provided
-      router.push(item.path)
     }
     setAnchorEl(null)
   }
@@ -52,17 +51,40 @@ export default function UserMenu(props: UserMenuType) {
           if (item?.type === 'divider') {
             return <Divider key={item.label}/>
           }
-          return (
-            <MenuItem
-              data-testid="user-menu-option"
-              key={item.label}
-              onClick={() => handleClose(item)}>
-              <ListItemIcon>
-                {item.icon}
-              </ListItemIcon>
-              {item.label}
-            </MenuItem>
-          )
+          if (item.path) {
+            return (
+              <MenuItem
+                data-testid="user-menu-option"
+                key={item.label}
+                onClick={() => handleClose(item)}
+                component = {Link}
+                href = {item.path}
+                sx = {{
+                  ':hover': {
+                    color: 'text.primary'
+                  }
+                }}
+              >
+                <ListItemIcon>
+                  {item.icon}
+                </ListItemIcon>
+                {item.label}
+              </MenuItem>
+            )
+          } else {
+            return (
+              <MenuItem
+                data-testid="user-menu-option"
+                key={item.label}
+                onClick={() => handleClose(item)}
+              >
+                <ListItemIcon>
+                  {item.icon}
+                </ListItemIcon>
+                {item.label}
+              </MenuItem>
+            )
+          }
         })
       )
     }

--- a/frontend/components/user/UserNav.tsx
+++ b/frontend/components/user/UserNav.tsx
@@ -2,15 +2,16 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useRouter} from 'next/router'
 import List from '@mui/material/List'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
+import Link from 'next/link'
 
 import {editMenuItemButtonSx} from '~/config/menuItems'
 import {userMenu} from './UserNavItems'
@@ -24,7 +25,6 @@ export type UserCounts = {
 
 export default function UserNav({selected, counts}:
   {selected:string, counts:UserCounts}) {
-  const router = useRouter()
   const menuItems = Object.keys(userMenu)
   return (
     <nav>
@@ -38,11 +38,12 @@ export default function UserNav({selected, counts}:
               data-testid="user-nav-item"
               key={`step-${pos}`}
               selected={item.id === selected}
-              onClick={() => {
-                // debugger
-                router.push(`/user/${key}`)
-              }}
-              sx={editMenuItemButtonSx}
+              href = {`/user/${key}`}
+              component = {Link}
+              sx={{...editMenuItemButtonSx,
+                ':hover': {
+                  color: 'text.primary'
+                }}}
             >
               <ListItemIcon>
                 {item.icon}


### PR DESCRIPTION
## Add anchor tags to drop-down menu and user page

Changes proposed in this pull request:

* Add anchor elements to drop-down menu when logged in
* Add anchor elements to tabs on user page

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Log in, test out the items in the drop-down menu of your avatar. Clicking them normally should *not* trigger a full page reload. You can also right click them or open them in a new tab with the middle mouse button
* Go to e.g. http://localhost/user/software, test the same for the different tabs
* Check that the styling (especially on mouse hover) is ok

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests