### PR TITLE
feat: add community keywords

### DIFF
--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -902,6 +902,7 @@ const communityPromise = postToBackend('/community', generateCommunities())
 	.then(resp => resp.json())
 	.then(async commArray => {
 		idsCommunities = commArray.map(comm => comm['id']);
+		postToBackend('/keyword_for_community', generateKeywordsForEntity(idsCommunities, idsKeywords, 'community'))
 	});
 
 await postToBackend('/meta_pages', generateMetaPages()).then(() => console.log('meta pages done'));

--- a/database/124-community-views.sql
+++ b/database/124-community-views.sql
@@ -23,7 +23,7 @@ GROUP BY
 $$;
 
 -- rpc for community overview page
--- incl. software count
+-- incl. software count and keyword list (for card)
 CREATE FUNCTION communities_overview() RETURNS TABLE (
 	id UUID,
 	slug VARCHAR,
@@ -32,6 +32,7 @@ CREATE FUNCTION communities_overview() RETURNS TABLE (
 	logo_id VARCHAR,
 	primary_maintainer UUID,
 	software_cnt BIGINT,
+	keywords CITEXT[],
 	description VARCHAR,
 	created_at TIMESTAMPTZ
 ) LANGUAGE sql STABLE AS
@@ -44,12 +45,15 @@ SELECT
 	community.logo_id,
 	community.primary_maintainer,
 	software_count_by_community.software_cnt,
+	keyword_filter_for_community.keywords,
 	community.description,
 	community.created_at
 FROM
 	community
 LEFT JOIN
 	software_count_by_community() ON community.id = software_count_by_community.community
+LEFT JOIN
+	keyword_filter_for_community() ON community.id=keyword_filter_for_community.community
 ;
 $$;
 

--- a/database/124-community-views.sql
+++ b/database/124-community-views.sql
@@ -22,6 +22,77 @@ GROUP BY
 ;
 $$;
 
+
+-- Keywords with the count used by
+-- by search to show existing keywords with the count
+CREATE FUNCTION keyword_count_for_community() RETURNS TABLE (
+	id UUID,
+	keyword CITEXT,
+	cnt BIGINT
+) LANGUAGE sql STABLE AS
+$$
+	SELECT
+		keyword.id,
+		keyword.value AS keyword,
+		keyword_count.cnt
+	FROM
+		keyword
+	LEFT JOIN
+		(SELECT
+				keyword_for_community.keyword,
+				COUNT(keyword_for_community.keyword) AS cnt
+			FROM
+				keyword_for_community
+			GROUP BY keyword_for_community.keyword
+		) AS keyword_count ON keyword.id = keyword_count.keyword;
+$$;
+
+-- Keywords by community
+-- for editing keywords of specific community
+CREATE FUNCTION keywords_by_community() RETURNS TABLE (
+	id UUID,
+	keyword CITEXT,
+	community UUID
+) LANGUAGE sql STABLE AS
+$$
+	SELECT
+		keyword.id,
+		keyword.value AS keyword,
+		keyword_for_community.community
+	FROM
+		keyword_for_community
+	INNER JOIN
+		keyword ON keyword.id = keyword_for_community.keyword;
+$$;
+-- using filter ?community=eq.UUID
+
+-- Keywords grouped by community for filtering
+-- We use array for selecting community with specific keywords
+-- We use text value for "wild card" search
+CREATE FUNCTION keyword_filter_for_community() RETURNS TABLE (
+	community UUID,
+	keywords CITEXT[],
+	keywords_text TEXT
+) LANGUAGE sql STABLE AS
+$$
+	SELECT
+		keyword_for_community.community AS community,
+		ARRAY_AGG(
+			keyword.value
+			ORDER BY value
+		) AS keywords,
+		STRING_AGG(
+			keyword.value,' '
+			ORDER BY value
+		) AS keywords_text
+	FROM
+		keyword_for_community
+	INNER JOIN
+		keyword ON keyword.id = keyword_for_community.keyword
+	GROUP BY keyword_for_community.community;
+$$;
+
+
 -- rpc for community overview page
 -- incl. software count and keyword list (for card)
 CREATE FUNCTION communities_overview() RETURNS TABLE (
@@ -56,4 +127,3 @@ LEFT JOIN
 	keyword_filter_for_community() ON community.id=keyword_filter_for_community.community
 ;
 $$;
-

--- a/frontend/components/communities/CommunityPage.tsx
+++ b/frontend/components/communities/CommunityPage.tsx
@@ -8,15 +8,15 @@ import BaseSurfaceRounded from '../layout/BaseSurfaceRounded'
 import PageBreadcrumbs from '../layout/PageBreadcrumbs'
 import {UserSettingsProvider} from '../organisation/context/UserSettingsContext'
 import {LayoutType} from '../software/overview/search/ViewToggleGroup'
-import {CommunityListProps} from './apiCommunities'
 import CommunityMetadata from './metadata'
 import {TabKey} from './tabs/CommunityTabItems'
 import CommunityTabs from './tabs'
 import {CommunityProvider} from './context'
+import {EditCommunityProps} from './apiCommunities'
 
 type CommunityPageProps={
   selectTab: TabKey
-  community: CommunityListProps
+  community: EditCommunityProps
   slug: string[]
   isMaintainer: boolean
   rsd_page_layout: LayoutType
@@ -64,7 +64,7 @@ export default function CommunityPage({
             />
           </BaseSurfaceRounded>
           {/* TAB CONTENT */}
-          <section className="flex md:min-h-[60rem]">
+          <section className="flex md:min-h-[55rem]">
             {children}
           </section>
         </CommunityProvider>

--- a/frontend/components/communities/about/CommunityAboutIndex.test.tsx
+++ b/frontend/components/communities/about/CommunityAboutIndex.test.tsx
@@ -1,8 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,7 +12,7 @@ describe('frontend/components/community/about/index.tsx', () => {
 
   it('renders markdown title # About page', () => {
     render(
-      <AboutPage description={mockCommunity.description} />
+      <AboutPage description={mockCommunity?.description ?? undefined} />
     )
     const aboutPage = screen.getByText(/# About page/)
     expect(aboutPage).toBeInTheDocument()

--- a/frontend/components/communities/about/index.tsx
+++ b/frontend/components/communities/about/index.tsx
@@ -1,7 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +12,7 @@ export default function AboutCommunityPage({description}:{description?:string}) 
     return (
       <BaseSurfaceRounded
         className="flex-1 mb-12 p-4 flex justify-center"
-        type="section"
+        type="div"
       >
         {description ?
           <ReactMarkdownWithSettings

--- a/frontend/components/communities/apiCommunities.ts
+++ b/frontend/components/communities/apiCommunities.ts
@@ -8,17 +8,25 @@ import {extractCountFromHeader} from '~/utils/extractCountFromHeader'
 import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
 import {paginationUrlParams} from '~/utils/postgrestUrl'
+import {KeywordForCommunity} from './settings/general/apiCommunityKeywords'
+import {Community} from '../admin/communities/apiCommunities'
 
-export type CommunityListProps = {
+// New type based on Community but replace
+// id with new type
+export type CommunityListProps = Omit<Community,'id'> & {
+  // id is always present
   id: string,
-  slug: string,
-  name: string,
-  short_description: string | null,
-  logo_id: string | null,
+  // additional props
   software_cnt: number | null,
-  primary_maintainer: string | null
-  description?: string
+  keywords: string[] | null
 }
+
+// New type based on CommunityListProps but replace
+// the keywords type
+export type EditCommunityProps = Omit<CommunityListProps,'keywords'> & {
+  keywords: KeywordForCommunity[]
+}
+
 
 type GetCommunityListParams={
   page: number,

--- a/frontend/components/communities/context/index.tsx
+++ b/frontend/components/communities/context/index.tsx
@@ -4,22 +4,33 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {PropsWithChildren, createContext, useCallback, useContext, useState} from 'react'
-import {Community} from '~/components/admin/communities/apiCommunities'
-import {CommunityListProps} from '~/components/communities/apiCommunities'
+import {EditCommunityProps} from '~/components/communities/apiCommunities'
 
 type UpdateCommunityProps = {
-  key: keyof Community,
+  key: keyof EditCommunityProps,
   value: any
 }
 
 type CommunityContextProps = PropsWithChildren & {
-  community: CommunityListProps | null,
+  community: EditCommunityProps,
   isMaintainer: boolean,
   updateCommunity: ({key,value}:UpdateCommunityProps)=>void
 }
 
+const emptyCommunity:EditCommunityProps = {
+  id:'',
+  name: '',
+  slug: '',
+  short_description: null,
+  description: null,
+  primary_maintainer: null,
+  logo_id: null,
+  software_cnt: null,
+  keywords: [],
+}
+
 const CommunityContext = createContext<CommunityContextProps>({
-  community: null,
+  community: emptyCommunity,
   isMaintainer: false,
   updateCommunity: ({key,value}:UpdateCommunityProps)=> {}
 })
@@ -51,7 +62,7 @@ export function CommunityProvider({community:initCommunity,isMaintainer:initMain
 export function useCommunityContext(){
   const {community,isMaintainer,updateCommunity} = useContext(CommunityContext)
   return {
-    ...community,
+    community,
     isMaintainer,
     updateCommunity
   }

--- a/frontend/components/communities/metadata/index.tsx
+++ b/frontend/components/communities/metadata/index.tsx
@@ -4,37 +4,44 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import BaseSurfaceRounded from '~/components/layout/BaseSurfaceRounded'
-import Links, {LinksProps} from '~/components/organisation/metadata/Links'
-import { useCommunityContext } from '../context'
+import {useCommunityContext} from '../context'
 import CommunityLogo from './CommunityLogo'
+import KeywordList from '~/components/cards/KeywordList'
 
 export default function CommunityMetadata() {
-  const {id,name,logo_id,isMaintainer,short_description} = useCommunityContext()
+  const {community,isMaintainer} = useCommunityContext()
+  // generate simple list
+  const keywordList = community?.keywords?.map(keyword=>keyword.keyword)
+
+  // console.group('CommunityMetadata')
+  // console.log('isMaintainer...', isMaintainer)
+  // console.log('keywordList...', keywordList)
+  // console.log('community...', community)
+  // console.groupEnd()
 
   return (
     <section className="grid  md:grid-cols-[1fr,2fr] xl:grid-cols-[1fr,4fr] gap-4">
       <BaseSurfaceRounded className="flex justify-center p-8 overflow-hidden relative">
         <CommunityLogo
-          id={id ?? ""}
-          name={name ?? ""}
-          logo_id={logo_id ?? null}
+          id={community?.id ?? ''}
+          name={community?.name ?? ''}
+          logo_id={community?.logo_id ?? null}
           isMaintainer={isMaintainer}
         />
       </BaseSurfaceRounded>
-      <BaseSurfaceRounded className="grid lg:grid-cols-[3fr,1fr] lg:gap-8 xl:grid-cols-[4fr,1fr] p-4">
-        <div>
-          <h1
-            title={name}
-            className="text-xl font-medium line-clamp-1">
-            {name}
-          </h1>
-          <p className="text-base-700 line-clamp-3 break-words py-4">
-            {short_description}
-          </p>
-        </div>
-        {/* <div className="flex flex-col gap-4">
-          <Links links={links} />
-        </div> */}
+      <BaseSurfaceRounded className="flex flex-col justify-start gap-2 p-4">
+        <h1
+          title={community?.name}
+          className="text-xl font-medium line-clamp-1">
+          {community?.name}
+        </h1>
+        <p className="flex-1 text-base-700 line-clamp-3 break-words py-4">
+          {community?.short_description}
+        </p>
+        <KeywordList
+          keywords={keywordList}
+          visibleNumberOfKeywords={7}
+        />
       </BaseSurfaceRounded>
     </section>
   )

--- a/frontend/components/communities/overview/CommunityCard.tsx
+++ b/frontend/components/communities/overview/CommunityCard.tsx
@@ -1,8 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,9 +9,9 @@ import CardTitleSubtitle from '~/components/cards/CardTitleSubtitle'
 import ImageWithPlaceholder from '~/components/layout/ImageWithPlaceholder'
 import CardImageFrame from '~/components/cards/CardImageFrame'
 import CardContentFrame from '~/components/cards/CardContentFrame'
-import OrganisationCardMetrics from '~/components/organisation/overview/card/OrganisationCardMetrics'
 import {CommunityListProps} from '../apiCommunities'
-// import CountryLabel from './CountryLabel'
+import KeywordList from '~/components/cards/KeywordList'
+import CommunityMetrics from './CommunityMetrics'
 
 export default function CommunityCard({community}:{community:CommunityListProps}) {
 
@@ -37,23 +34,23 @@ export default function CommunityCard({community}:{community:CommunityListProps}
             />
           </CardImageFrame>
           <CardContentFrame>
-            <div className="flex-1">
-              {/* <CountryLabel country={organisation.country} /> */}
-              <CardTitleSubtitle
-                title={community.name}
-                subtitle={community.short_description ?? ''}
+
+            {/* title & subtitle  */}
+            <CardTitleSubtitle
+              title={community.name}
+              subtitle={community.short_description ?? ''}
+            />
+
+            {/* keywords */}
+            <div className="flex-1 overflow-auto py-2">
+              <KeywordList
+                keywords={community.keywords}
               />
             </div>
-            <div className="flex gap-8 justify-evenly text-center">
-              {/* Software packages count */}
-              <div>
-                <div className='text-5xl font-light'>
-                  {community.software_cnt ?? 0}
-                </div>
-                <div className='text-center text-sm'>
-                  software <br />package{community.software_cnt === 1 ? '' : 's'}
-                </div>
-              </div>
+
+            {/* Metrics */}
+            <div className="flex gap-4 justify-end text-center">
+              <CommunityMetrics software_cnt={community.software_cnt ?? 0} />
             </div>
           </CardContentFrame>
         </div>

--- a/frontend/components/communities/settings/SettingsContent.tsx
+++ b/frontend/components/communities/settings/SettingsContent.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/communities/settings/SettingsNav.tsx
+++ b/frontend/components/communities/settings/SettingsNav.tsx
@@ -1,7 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/communities/settings/SettingsNavItems.tsx
+++ b/frontend/components/communities/settings/SettingsNavItems.tsx
@@ -1,8 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/communities/settings/about-page/AutosaveCommunityDescription.tsx
+++ b/frontend/components/communities/settings/about-page/AutosaveCommunityDescription.tsx
@@ -22,7 +22,7 @@ export default function AutosaveCommunityDescription(props: AutosaveControlledMa
   const {showErrorMessage} = useSnackbar()
   const {name,maxLength} = props
   const {register,control,resetField} = useFormContext()
-  const {id,updateCommunity} = useCommunityContext()
+  const {community,updateCommunity} = useCommunityContext()
   const {field:{value},fieldState:{isDirty,error}} = useController({
     control,
     name
@@ -36,7 +36,7 @@ export default function AutosaveCommunityDescription(props: AutosaveControlledMa
     if (value !== '') description = value
     // patch community table
     const resp = await patchCommunityTable({
-      id: id ?? '',
+      id: community?.id ?? '',
       data: {
         [name]: description
       },

--- a/frontend/components/communities/settings/about-page/index.tsx
+++ b/frontend/components/communities/settings/about-page/index.tsx
@@ -19,13 +19,13 @@ type AboutPageFormProps = {
 
 
 export default function CommunityAboutPage() {
-  const {id, description} = useCommunityContext()
+  const {community} = useCommunityContext()
 
   const methods = useForm<AboutPageFormProps>({
     mode: 'onChange',
     defaultValues: {
-      id,
-      description
+      id: community?.id,
+      description: community?.description
     }
   })
 

--- a/frontend/components/communities/settings/general/AutosaveCommunityKeywords.tsx
+++ b/frontend/components/communities/settings/general/AutosaveCommunityKeywords.tsx
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Chip from '@mui/material/Chip'
+import {useFormContext} from 'react-hook-form'
+
+import {useSession} from '~/auth'
+import {createOrGetKeyword, silentKeywordDelete} from '~/utils/editKeywords'
+import {sortOnStrProp} from '~/utils/sortFn'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import FindKeyword, {Keyword} from '~/components/keyword/FindKeyword'
+import {EditCommunityProps} from '~/components/communities/apiCommunities'
+import {
+  KeywordForCommunity,
+  addKeywordsToCommunity, deleteKeywordFromCommunity
+} from './apiCommunityKeywords'
+import {searchForCommunityKeyword} from './searchForCommunityKeyword'
+import config from './config'
+import {useCommunityContext} from '../../context'
+
+export type SoftwareKeywordsProps={
+  software_id:string,
+  concept_doi?:string
+}
+
+export default function AutosaveCommunityKeywords(){
+  const {token} = useSession()
+  const {showErrorMessage, showInfoMessage} = useSnackbar()
+  const {watch,setValue} = useFormContext<EditCommunityProps>()
+  const {updateCommunity} = useCommunityContext()
+  const [id,keywords] = watch(['id','keywords'])
+
+  // console.group('AutosaveCommunityKeywords')
+  // console.log('id...', id)
+  // console.log('keywords...', keywords)
+  // console.groupEnd()
+
+  function setKeywords(items:KeywordForCommunity[]){
+    // save keywords in the form context
+    setValue('keywords',items,{
+      shouldDirty: false,
+      shouldTouch: false,
+      shouldValidate: false
+    })
+    // update in the context
+    updateCommunity({
+      key:'keywords',
+      value: items
+    })
+  }
+
+  async function onAdd(selected: Keyword) {
+    // check if already added
+    const find = keywords.filter(item => item.keyword.trim().toLowerCase() === selected.keyword.trim().toLowerCase())
+    // debugger
+    let resp
+    if (find.length === 0) {
+      resp = await addKeywordsToCommunity({
+        data:{
+          community:id,
+          keyword: selected.id
+        },
+        token
+      })
+      if (resp.status===200){
+        const items = [
+          ...keywords,
+          {
+            ...selected,
+            community:id
+          }
+        ].sort((a,b)=>sortOnStrProp(a,b,'keyword'))
+        setKeywords(items)
+      }else{
+        showErrorMessage(`Failed to save keyword. ${resp.message}`)
+      }
+    }else{
+      showInfoMessage(`${selected.keyword.trim()} is already in the list`)
+    }
+  }
+
+  async function onCreate(selected: string) {
+    // check if already exists
+    const find = keywords.filter(item => item.keyword.trim().toLowerCase() === selected.trim().toLowerCase())
+    // debugger
+    if (find.length === 0) {
+      // create or get existing keyword
+      let resp = await createOrGetKeyword({
+        keyword: selected,
+        token
+      })
+      if (resp.status === 201) {
+        const keyword = {
+          id: resp.message.id,
+          keyword: resp.message.value,
+          software: id,
+          cnt: null
+        }
+        // add keyword after created
+        await onAdd(keyword)
+      }else{
+        showErrorMessage(`Failed to save keyword. ${resp.message}`)
+      }
+    }else{
+      showInfoMessage(`${selected.trim()} is already in the list`)
+    }
+  }
+
+  async function onRemove(pos:number) {
+    const item = keywords[pos]
+    if (item.community && item.id){
+      const resp = await deleteKeywordFromCommunity({
+        community: item.community,
+        keyword: item.id,
+        token
+      })
+      if (resp.status===200){
+        const items=[
+          ...keywords.slice(0,pos),
+          ...keywords.slice(pos+1)
+        ]
+        setKeywords(items)
+        // try to delete this keyword from keyword table
+        // delete will fail if the keyword is referenced
+        // therefore we do not check the status
+        const del = await silentKeywordDelete({
+          keyword: item.keyword,
+          token
+        })
+      }else{
+        showErrorMessage(`Failed to delete keyword. ${resp.message}`)
+      }
+    }
+  }
+
+  return (
+    <div className="py-8">
+      <FindKeyword
+        config={{
+          freeSolo: false,
+          minLength: config.keywords.validation.minLength,
+          label: config.keywords.label,
+          help: config.keywords.help,
+          reset: true
+        }}
+        searchForKeyword={searchForCommunityKeyword}
+        onAdd={onAdd}
+        onCreate={onCreate}
+      />
+      <div className="flex flex-wrap py-2">
+        {keywords.map((item, pos) => {
+          return(
+            <div
+              key={item.id}
+              className="py-1 pr-1"
+            >
+              <Chip
+                data-testid="keyword-chip"
+                title={item.keyword}
+                label={item.keyword}
+                onDelete={() => onRemove(pos)}
+                sx={{
+                  textTransform:'capitalize'
+                }}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/communities/settings/general/AutosaveCommunityTextField.tsx
+++ b/frontend/components/communities/settings/general/AutosaveCommunityTextField.tsx
@@ -11,8 +11,8 @@ import AutosaveControlledTextField, {OnSaveProps} from '~/components/form/Autosa
 import {ControlledTextFieldOptions} from '~/components/form/ControlledTextField'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {Community} from '~/components/admin/communities/apiCommunities'
-import {patchCommunityTable} from '../../apiCommunities'
-import {useCommunityContext} from '../../context'
+import {patchCommunityTable} from '~/components/communities/apiCommunities'
+import {useCommunityContext} from '~/components/communities/context'
 
 export type AutosaveCommunityTextFieldProps = {
   options: ControlledTextFieldOptions<Community>
@@ -22,7 +22,7 @@ export type AutosaveCommunityTextFieldProps = {
 export default function AutosaveCommunityTextField({options,rules}:AutosaveCommunityTextFieldProps) {
   const router = useRouter()
   const {token} = useSession()
-  const {id,updateCommunity} = useCommunityContext()
+  const {community,updateCommunity} = useCommunityContext()
   const {showErrorMessage} = useSnackbar()
   const {control, resetField} = useFormContext()
 
@@ -34,7 +34,7 @@ export default function AutosaveCommunityTextField({options,rules}:AutosaveCommu
     // console.groupEnd()
     // patch project table
     const resp = await patchCommunityTable({
-      id: id ?? '',
+      id: community?.id ?? '',
       data: {
         [name]:value
       },

--- a/frontend/components/communities/settings/general/CommunityAdminSection.tsx
+++ b/frontend/components/communities/settings/general/CommunityAdminSection.tsx
@@ -1,9 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/communities/settings/general/apiCommunityKeywords.ts
+++ b/frontend/components/communities/settings/general/apiCommunityKeywords.ts
@@ -1,0 +1,90 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
+
+export type CommunityKeyword = {
+  community: string
+  keyword: string
+}
+
+export type KeywordForCommunity = {
+  id: string
+  community: string
+  keyword: string
+}
+
+/**
+ * Loading community keywords for editing
+ * @param uuid
+ * @param token
+ * @returns
+ */
+export async function getKeywordsByCommunity(uuid:string,token?:string){
+  try{
+    const query = `rpc/keywords_by_community?community=eq.${uuid}&order=keyword.asc`
+    let url = `${getBaseUrl()}/${query}`
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: createJsonHeaders(token)
+    })
+    if (resp.status===200){
+      const data:KeywordForCommunity[] = await resp.json()
+      return data
+    }
+    logger(`getKeywordsByCommunity ${resp.status} ${resp.statusText}`,'warn')
+    return []
+  }catch(e:any){
+    logger(`getKeywordsByCommunity: ${e?.message}`,'error')
+    return []
+  }
+}
+
+export async function addKeywordsToCommunity({data, token}:
+  {data: CommunityKeyword | CommunityKeyword[], token: string }) {
+  try {
+    // POST
+    const url = '/api/v1/keyword_for_community'
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token),
+        // this will add new items and update existing
+        'Prefer': 'resolution=merge-duplicates'
+      },
+      body: JSON.stringify(data)
+    })
+    return extractReturnMessage(resp, '')
+  } catch (e: any) {
+    logger(`addKeywordsToCommunity: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}
+
+export async function deleteKeywordFromCommunity({community, keyword, token}:
+  { community: string, keyword: string, token: string }) {
+  try {
+    // DELETE record based on community and keyword uuid
+    const query = `keyword_for_community?community=eq.${community}&keyword=eq.${keyword}`
+    const url = `/api/v1/${query}`
+    const resp = await fetch(url, {
+      method: 'DELETE',
+      headers: {
+        ...createJsonHeaders(token)
+      }
+    })
+    return extractReturnMessage(resp, community ?? '')
+  } catch (e: any) {
+    logger(`deleteKeywordFromCommunity: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}

--- a/frontend/components/communities/settings/general/config.ts
+++ b/frontend/components/communities/settings/general/config.ts
@@ -41,7 +41,15 @@ const config = {
       minLength: {value: 36, message: 'Minimum length is 36'},
       maxLength: {value: 36, message: 'Maximum length is 36'}
     }
-  }
+  },
+  keywords: {
+    label: 'Find or add keyword',
+    help: 'Select from top 30 list or start typing for more suggestions',
+    validation: {
+      //use in find keyword input box
+      minLength: 1,
+    }
+  },
 }
 
 export default config

--- a/frontend/components/communities/settings/general/index.tsx
+++ b/frontend/components/communities/settings/general/index.tsx
@@ -8,22 +8,22 @@ import {FormProvider, useForm} from 'react-hook-form'
 import {useSession} from '~/auth'
 import BaseSurfaceRounded from '~/components/layout/BaseSurfaceRounded'
 import {useCommunityContext} from '~/components/communities/context'
-import {Community} from '~/components/admin/communities/apiCommunities'
 import config from './config'
 import CommunityAdminSection from './CommunityAdminSection'
 import AutosaveCommunityTextField from './AutosaveCommunityTextField'
+import AutosaveCommunityKeywords from './AutosaveCommunityKeywords'
+import {EditCommunityProps} from '../../apiCommunities'
+
 
 export default function CommunityGeneralSettings() {
   const {user} = useSession()
-  const {isMaintainer,...community} = useCommunityContext()
-  const methods = useForm<Community>({
+  const {community} = useCommunityContext()
+  const methods = useForm<EditCommunityProps>({
     mode: 'onChange',
     defaultValues: community
   })
   // extract used methods
-  const {
-    watch, register, formState
-  } = methods
+  const {watch, register} = methods
 
   const [name,short_description]=watch(['name','short_description'])
 
@@ -74,7 +74,8 @@ export default function CommunityGeneralSettings() {
             }}
             rules={config.short_description.validation}
           />
-          <div className="py-4"></div>
+
+          <AutosaveCommunityKeywords />
 
           {/* RSD admin section */}
           {user?.role === 'rsd_admin' ?

--- a/frontend/components/communities/settings/general/searchForCommunityKeyword.test.ts
+++ b/frontend/components/communities/settings/general/searchForCommunityKeyword.test.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {mockResolvedValueOnce} from '~/utils/jest/mockFetch'
+import {searchForCommunityKeyword} from './searchForCommunityKeyword'
+
+beforeEach(() => {
+  jest.clearAllMocks()
+})
+
+it('searchForCommunityKeyword calls api with proper params', async() => {
+  const searchFor = 'Search for keyword'
+  const expectUrl = `/api/v1/rpc/keyword_count_for_community?keyword=ilike.*${encodeURIComponent(searchFor)}*&order=cnt.desc.nullslast,keyword.asc&limit=30`
+  const expectPayload = {
+    'method': 'GET'
+  }
+
+  mockResolvedValueOnce('OK')
+
+  const resp = await searchForCommunityKeyword({searchFor})
+
+  // validate api call
+  expect(global.fetch).toBeCalledTimes(1)
+  expect(global.fetch).toBeCalledWith(expectUrl, expectPayload)
+})

--- a/frontend/components/communities/settings/general/searchForCommunityKeyword.ts
+++ b/frontend/components/communities/settings/general/searchForCommunityKeyword.ts
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {Keyword} from '~/components/keyword/FindKeyword'
+import {getBaseUrl} from '~/utils/fetchHelpers'
+
+
+// this is always frontend call
+export async function searchForCommunityKeyword(
+  {searchFor}: { searchFor: string }
+) {
+  try {
+    const searchForEncoded = encodeURIComponent(searchFor)
+    const baseUrl = getBaseUrl()
+    let query = ''
+    if (searchForEncoded) {
+      query = `keyword=ilike.*${searchForEncoded}*&order=cnt.desc.nullslast,keyword.asc&limit=30`
+    } else {
+      query = 'order=cnt.desc.nullslast,keyword.asc&limit=30'
+    }
+    // GET top 30 matches
+    const url = `${baseUrl}/rpc/keyword_count_for_community?${query}`
+    const resp = await fetch(url, {
+      method: 'GET'
+    })
+
+    if (resp.status === 200) {
+      const json: Keyword[] = await resp.json()
+      return json
+    }
+    // return extractReturnMessage(resp, project ?? '')
+    logger(`searchForCommunityKeyword: ${resp.status} ${resp.statusText}`, 'warn')
+    return []
+  } catch (e: any) {
+    logger(`searchForCommunityKeyword: ${e?.message}`, 'error')
+    return []
+  }
+}
+

--- a/frontend/components/communities/settings/index.tsx
+++ b/frontend/components/communities/settings/index.tsx
@@ -1,9 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/communities/settings/maintainers/CommunityMaintainersIndex.test.tsx
+++ b/frontend/components/communities/settings/maintainers/CommunityMaintainersIndex.test.tsx
@@ -1,8 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/communities/settings/maintainers/CommunityMaintainersLinks.tsx
+++ b/frontend/components/communities/settings/maintainers/CommunityMaintainersLinks.tsx
@@ -11,8 +11,8 @@ import {useCommunityContext} from '~/components/communities/context'
 import {useCommunityInvitations} from './useCommunityInvitations'
 
 export default function CommunityMaintainerLinks() {
-  const {id,name} = useCommunityContext()
-  const {unusedInvitations,createInvitation,deleteInvitation} = useCommunityInvitations({community:id})
+  const {community} = useCommunityContext()
+  const {unusedInvitations,createInvitation,deleteInvitation} = useCommunityInvitations({community:community?.id ?? ''})
 
   // console.group('CommunityMaintainerLinks')
   // console.log('id...', id)
@@ -37,8 +37,8 @@ export default function CommunityMaintainerLinks() {
       </Button>
       <div className="py-4"></div>
       <InvitationList
-        subject={`Maintainer invite for community ${encodeURIComponent(name ?? '')}`}
-        body={`Please use the following link to become a maintainer of ${encodeURIComponent(name ?? '')} community.`}
+        subject={`Maintainer invite for community ${encodeURIComponent(community?.name ?? '')}`}
+        body={`Please use the following link to become a maintainer of ${encodeURIComponent(community?.name ?? '')} community.`}
         invitations={unusedInvitations}
         onDelete={deleteInvitation}
       />

--- a/frontend/components/communities/settings/maintainers/index.tsx
+++ b/frontend/components/communities/settings/maintainers/index.tsx
@@ -22,8 +22,8 @@ type DeleteModal = {
 }
 
 export default function CommunityMaintainersPage() {
-  const {id} = useCommunityContext()
-  const {loading,maintainers,deleteMaintainer} = useCommunityMaintainers({community: id})
+  const {community} = useCommunityContext()
+  const {loading,maintainers,deleteMaintainer} = useCommunityMaintainers({community: community?.id})
   const [modal, setModal] = useState<DeleteModal>({
     open: false
   })

--- a/frontend/components/communities/settings/maintainers/useCommunityMaintainers.tsx
+++ b/frontend/components/communities/settings/maintainers/useCommunityMaintainers.tsx
@@ -1,8 +1,5 @@
-// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/communities/tabs/CommunityTabItems.tsx
+++ b/frontend/components/communities/tabs/CommunityTabItems.tsx
@@ -1,7 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/organisation/about/index.tsx
+++ b/frontend/components/organisation/about/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,7 +27,7 @@ export function AboutPagePlaceholder() {
     <Alert severity="info" sx={{marginTop:'0.5rem'}}>
       <AlertTitle sx={{fontWeight: 500}}>About section not defined</AlertTitle>
       <p>
-        The about section is not visible to vistors because it does not have any content.
+        The about section is not visible to visitors because it does not have any content.
       </p>
       <span>To activate the about section, add content to the about section <strong>
         <button onClick={goToSettings}>in the settings.</button>
@@ -43,8 +43,8 @@ export default function AboutPage() {
   if (description) {
     return (
       <BaseSurfaceRounded
-        className="flex-1 mb-12 p-4"
-        type="section"
+        className="flex-1 flex justify-center mb-12 p-4"
+        type="div"
       >
         <ReactMarkdownWithSettings
           className="pt-4"

--- a/frontend/pages/communities/[slug]/about.tsx
+++ b/frontend/pages/communities/[slug]/about.tsx
@@ -8,16 +8,17 @@ import {GetServerSidePropsContext} from 'next'
 import {app} from '~/config/app'
 import {getUserFromToken} from '~/auth'
 import {getUserSettings} from '~/utils/userSettings'
-import {CommunityListProps, getCommunityBySlug} from '~/components/communities/apiCommunities'
+import {EditCommunityProps, getCommunityBySlug} from '~/components/communities/apiCommunities'
 import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
 import PageMeta from '~/components/seo/PageMeta'
 import CanonicalUrl from '~/components/seo/CanonicalUrl'
 import {isCommunityMaintainer} from '~/auth/permissions/isMaintainerOfCommunity'
 import AboutCommunityPage from '~/components/communities/about'
 import CommunityPage from '~/components/communities/CommunityPage'
+import {getKeywordsByCommunity} from '~/components/communities/settings/general/apiCommunityKeywords'
 
 type CommunityAboutPage={
-  community: CommunityListProps,
+  community: EditCommunityProps,
   slug: string[],
   isMaintainer: boolean,
   rsd_page_rows: number,
@@ -61,7 +62,7 @@ export default function CommunityAboutPage({
         rsd_page_layout={rsd_page_layout}
         selectTab='about'
       >
-        <AboutCommunityPage description={community?.description} />
+        <AboutCommunityPage description={community?.description ?? ''} />
       </CommunityPage>
     </>
   )
@@ -92,17 +93,24 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       }
     }
     // get info if the user is maintainer
-    const isMaintainer = await isCommunityMaintainer({
-      community: community.id,
-      role: user?.role,
-      account: user?.account,
-      token
-    })
+    const [isMaintainer,keywords] = await Promise.all([
+      isCommunityMaintainer({
+        community: community.id ?? '',
+        role: user?.role,
+        account: user?.account,
+        token
+      }),
+      getKeywordsByCommunity(community.id,token)
+    ])
 
     return {
       // passed to the page component as props
       props: {
-        community,
+        community:{
+          ...community,
+          // use keywords for editing
+          keywords
+        },
         slug: [params?.slug],
         tab: query?.tab ?? null,
         isMaintainer,

--- a/frontend/pages/communities/[slug]/software.tsx
+++ b/frontend/pages/communities/[slug]/software.tsx
@@ -8,15 +8,16 @@ import {GetServerSidePropsContext} from 'next'
 import {app} from '~/config/app'
 import {getUserFromToken} from '~/auth'
 import {getUserSettings} from '~/utils/userSettings'
-import {CommunityListProps, getCommunityBySlug} from '~/components/communities/apiCommunities'
+import {EditCommunityProps, getCommunityBySlug} from '~/components/communities/apiCommunities'
 import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
 import PageMeta from '~/components/seo/PageMeta'
 import CanonicalUrl from '~/components/seo/CanonicalUrl'
 import {isCommunityMaintainer} from '~/auth/permissions/isMaintainerOfCommunity'
 import CommunityPage from '~/components/communities/CommunityPage'
+import {getKeywordsByCommunity} from '~/components/communities/settings/general/apiCommunityKeywords'
 
 type CommunitySoftwareProps={
-  community: CommunityListProps,
+  community: EditCommunityProps,
   slug: string[],
   isMaintainer: boolean,
   rsd_page_rows: number,
@@ -90,17 +91,24 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       }
     }
     // get info if the user is maintainer
-    const isMaintainer = await isCommunityMaintainer({
-      community: community.id,
-      role: user?.role,
-      account: user?.account,
-      token
-    })
+    const [isMaintainer,keywords] = await Promise.all([
+      isCommunityMaintainer({
+        community: community.id ?? '',
+        role: user?.role,
+        account: user?.account,
+        token
+      }),
+      getKeywordsByCommunity(community.id,token)
+    ])
 
     return {
       // passed to the page component as props
       props: {
-        community,
+        community:{
+          ...community,
+          // use keywords for editing
+          keywords
+        },
         slug: [params?.slug],
         tab: query?.tab ?? null,
         isMaintainer,


### PR DESCRIPTION
# Add keywords to community

Closes #1196

Changes proposed in this pull request:
* Community maintainer can add keywords 
* The keywords are shown in the community card in the overview
* The keywords are shown on the community page
* Changed card design: 
    * the number of software items is placed bottom right (similar to software card)
    * the keywords are added to card (similar to software card)

How to test:
* `make start` to build and created test data
* login as rsd admin
* change community settings, add keywords. The keywords should be shown on the page
* conform that keywords are also shown in the card

## Example community overview using keywords
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/9541608f-8f16-4d37-8979-0ce9f227b32a)

## Example community settings with keywords
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/0c419a1a-9cc8-421c-a026-884e3c5e2e78)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
