### PR TITLE
Increase character limit for mention title

### DIFF
--- a/database/009-create-mention-table.sql
+++ b/database/009-create-mention-table.sql
@@ -1,5 +1,5 @@
--- SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 dv4all
 --
@@ -32,7 +32,7 @@ CREATE TABLE mention (
 	doi CITEXT UNIQUE CHECK (doi ~ '^10(\.\w+)+/\S+$' AND LENGTH(doi) <= 255),
 	doi_registration_date TIMESTAMPTZ,
 	url VARCHAR(500) CHECK (url ~ '^https?://'),
-	title VARCHAR(500) NOT NULL,
+	title VARCHAR(3000) NOT NULL,
 	authors VARCHAR(50000),
 	publisher VARCHAR(255),
 	publication_year SMALLINT,

--- a/frontend/components/mention/config.ts
+++ b/frontend/components/mention/config.ts
@@ -46,8 +46,8 @@ export const mentionModal = {
         message: 'Minimum length is 5'
       },
       maxLength: {
-        value: 500,
-        message: 'Maximum length is 500'
+        value: 3000,
+        message: 'Maximum length is 3000'
       }
     }
   },
@@ -57,8 +57,8 @@ export const mentionModal = {
     validation: {
       required: false,
       maxLength: {
-        value: 1000,
-        message: 'Maximum length is 1000'
+        value: 50000,
+        message: 'Maximum length is 50000'
       }
     }
   },
@@ -66,7 +66,11 @@ export const mentionModal = {
     label: 'Publisher',
     help: 'Name of publisher',
     validation: {
-      required: false
+      required: false,
+      maxLength: {
+        value: 255,
+        message: 'Maximum length is 255'
+      }
     }
   },
   journal: {
@@ -84,7 +88,11 @@ export const mentionModal = {
     label: 'Page',
     help: 'Page or page range',
     validation: {
-      required: false
+      required: false,
+      maxLength: {
+        value: 50,
+        message: 'Maximum length is 50'
+      }
     }
   },
   mentionType: {


### PR DESCRIPTION
## Increase character limit for mention title

Changes proposed in this pull request:

* Increase the character limit for mention titles from 500 to 3000 in the database
* Adapt the frontend to this limit
* Set other limits in the frontend in line with the database

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin, create a software or project page, add a mention with DOI `10.1103/physrevd.108.072003` and with `10.1103/physrevlett.131.251802`, this should work without an error
* On the mentions overview for admins, when editing this mention, you should see the new limit
* Same when adding a new manual mention
* Also check if the other values in the frontend config are in line with the database

Closes #1205

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests