### PR TITLE
fix: check if fields present in author before adding mention

### DIFF
--- a/frontend/utils/getCrossref.ts
+++ b/frontend/utils/getCrossref.ts
@@ -25,10 +25,21 @@ export function addPoliteEmail(url:string) {
 function extractAuthors(item: CrossrefSelectItem) {
   if (item.author) {
     return item.author.map(author => {
-      return `${author.given} ${author.family}`
+      if (author.given && author.family) {
+        return `${author.given} ${author.family}`
+      }
+      if (author.name) {
+        return author.name
+      }
+      if (author.given) {
+        return author.given
+      }
+      if (author.family) {
+        return author.family
+      }
     }).join(', ')
   }
-  return ''
+  return null
 }
 
 function extractYearPublished(item: CrossrefSelectItem) {

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -69,7 +69,7 @@ public class CrossrefMention implements Mention {
 	}
 
 	@Override
-	public MentionRecord mentionData() throws IOException, InterruptedException, RsdResponseException{
+	public MentionRecord mentionData() throws IOException, InterruptedException, RsdResponseException {
 		StringBuilder url = new StringBuilder("https://api.crossref.org/works/" + Utils.urlEncode(doi));
 		Config.crossrefContactEmail().ifPresent(email -> url.append("?mailto=").append(email));
 		String responseJson = Utils.get(url.toString());
@@ -87,10 +87,16 @@ public class CrossrefMention implements Mention {
 			for (JsonObject authorJson : authorsJson) {
 				String givenName = Utils.stringOrNull(authorJson.get("given"));
 				String familyName = Utils.stringOrNull(authorJson.get("family"));
-				if (givenName == null && familyName == null) continue;
-				if (givenName == null) authors.add(familyName);
-				else if (familyName == null) authors.add(givenName);
-				else authors.add(givenName + " " + familyName);
+				String name = Utils.stringOrNull(authorJson.get("name"));
+				if (givenName != null && familyName != null) {
+					authors.add(givenName + " " + familyName);
+				} else if (name != null) {
+					authors.add(name);
+				} else if (givenName != null) {
+					authors.add(givenName);
+				} else if (familyName != null) {
+					authors.add(familyName);
+				}
 			}
 			result.authors = String.join(", ", authors);
 		}


### PR DESCRIPTION
## Prevent undefined authors in mentions

Changes proposed in this pull request:

* Prevent Crossref mentions form having undefined authors by checking if the fields are present first
* Try to use the `name` field if either `given` or `family` is missing
* Apply the same logic to the Crossref scraper

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Create some page, add a mention with DOI `10.1103/physrevd.108.072003`
* Check the last author, this should be `ATLAS Collaboration`
* The words `undefined` or `null` should not be part of the authors
* Run the mention scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions`
* The last author should be unchanged
* The words `undefined` or `null` should not be part of the authors

Closes #1208

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests