### PR TITLE
Improve documentation for Markdown images

### DIFF
--- a/documentation/docs/01-users/05-adding-software.md
+++ b/documentation/docs/01-users/05-adding-software.md
@@ -12,11 +12,11 @@ To create a new software page provide a name and a short description (optional) 
 
 ## Description
 
-In this section, you can provide the basic information about the software, like a **description** of the software, which will be shown on the software page. You can use [custom markdown](#custom-markdown) to write the description or [link to existing markdown](#document-url) page on the web.
+In this section, you can provide the basic information about the software, like a **description** of the software, which will be shown on the software page. You can use [custom Markdown](#custom-markdown) to write the description or [link to existing Markdown](#document-url) page on the web.
 
-### Custom markdown
+### Custom Markdown
 
-The custom markdown supports basic markdown features: titles, bullet points, code area, simple table, task list, links and the images. The example below demonstrates widely used markdown features in RSD.
+The custom Markdown supports basic Markdown features: titles, bullet points, code area, simple table, task list, links and the images. The example below demonstrates widely used Markdown features in RSD.
 
 ```markdown
 <!--This section starts with What {software name} can do for you-->
@@ -59,7 +59,7 @@ This example is code area
 
 ## Images
 
-You need an image that allows CORS reference, otherwise image will not be loaded
+You need to use the full URL of the image and the image needs to send CORS headers, otherwise the image will not be loaded
 
 ![Mozilla](https://cdn.glitch.me/4c9ebeb9-8b9a-4adc-ad0a-238d9ae00bb5%2Fmdn_logo-only_color.svg)
 
@@ -67,10 +67,10 @@ You need an image that allows CORS reference, otherwise image will not be loaded
 
 ### Document URL
 
-You can link to a remote Markdown file which will be dynamically loaded by the RSD. An often used approach is to link to a readme file on the GitHub repository. In this case you need to link to the `raw` version of the readme file. For example, to link to the readme file of the RSD repository, we used the link https://raw.githubusercontent.com/research-software-directory/RSD-as-a-service/main/README.md. **Note that the url domain is different** `https://raw.githubusercontent.com/` from the default GitHub domain (https://github.com).
+You can link to a remote Markdown file which will be dynamically loaded by the RSD. An often used approach is to link to a readme file on the GitHub repository. In this case you need to link to the `raw` version of the readme file. For example, to link to the readme file of the RSD repository, we used the link https://raw.githubusercontent.com/research-software-directory/RSD-as-a-service/main/README.md. **Note that the URL domain is different** `https://raw.githubusercontent.com/` from the default GitHub domain (https://github.com).
 
 :::warning
-When using a Document URL to point to a remote markdown file on the GitHub, you need to provide a URL to a raw markdown file (see the animation below). In addition, all links used in the Markdown document need to be `absolute` (https://...). This is required, because Markdown content is loaded from the GitHub domain into the RSD website.
+When using a Document URL to point to a remote Markdown file on the GitHub, you need to provide a URL to a raw Markdown file (see the animation below). In addition, all links used in the Markdown document, like **images**, need to use the **full URL** (e.g. use `https://user-images.githubusercontent.com/4195550/136156498-736f915f-7623-43d2-8678-f30b06563a38.png`, not `/4195550/136156498-736f915f-7623-43d2-8678-f30b06563a38.png`). This is required, because the Markdown content is loaded from the GitHub domain into the RSD website.
 :::
 
 ### Logo

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -47,7 +47,7 @@ export const softwareInformation = {
   // field for markdown
   description: {
     label: (brand_name: string) => `What ${brand_name} can do for you`,
-    help: '/documentation/users/adding-software/#basic-information',
+    help: '/documentation/users/adding-software/#description',
     validation: {
       // we do not show error message for this one, we use only maxLength value
       maxLength: {value: 10000, message: 'Maximum length is 10000'},
@@ -58,21 +58,17 @@ export const softwareInformation = {
     label: 'Software Logo',
     help: 'Upload a logo of your software.'
   },
-  // field for markdown URL
+  // field for Markdown URL
   description_url: {
-    label: 'URL location of markdown file',
-    help: <>Point to the location of markdown file including the filename. Make sure to provide the <u><a
-      target='_blank'
-      href='https://raw.githubusercontent.com/research-software-directory/RSD-as-a-service/main/README.md'
-      rel="noreferrer">raw file</a></u> and <strong>not</strong> the <u><a target='_blank'
-      href='https://github.com/research-software-directory/RSD-as-a-service/blob/main/README.md'
-      rel="noreferrer">rendered
-      output</a></u>.</>,
+    label: 'URL of (raw) Markdown file',
+    help: <>
+      Read <u><a href="/documentation/users/adding-software/#document-url" target="_blank">here</a></u> how to properly link to a raw Markdown URL
+    </>,
     validation: {
       required: 'Valid markdown URL must be provided',
       maxLength: {value: 200, message: 'Maximum length is 200'},
       pattern: {
-        value: /^https?:\/\/.+\..+.md$/,
+        value: /^https?:\/\/.+\..+\.md$/,
         message: 'URL should start with http(s):// have at least one dot (.) and end with (.md)'
       }
     }


### PR DESCRIPTION
## Improve documentation for Markdown images

Changes proposed in this pull request:

* Improve the help texts on the software edit page under the `Description` tab
* Improve the documentation page

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin, edit a software page, check the helper text at when changing the description type to `Document URL`
* Check the question mark at the text `What {software} can do for you`
* Check the text at that link, including the warning box
* Alternatively, you can see the differences in the PR

Closes #249

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [ ] Tests
