### PR TITLE
Enable `howfairis` GitHub action

### DIFF
--- a/.github/workflows/fair_software.yml
+++ b/.github/workflows/fair_software.yml
@@ -1,19 +1,19 @@
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Jurriaan Spaaks (Netherlands eScience Center) <j.maassen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 #
 # SPDX-License-Identifier: Apache-2.0
 
 name: FAIR software
 
 on:
-  # moved to manual until licenses issue is resolved
-  # pull_request:
-  #   branches:
-  #     - main
-  #   paths:
-  #     - README.md
+  pull_request:
+    branches:
+      - main
+    paths:
+      - README.m
   workflow_dispatch:
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 SPDX-FileCopyrightText: 2021 - 2022 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2021 - 2022 Jason Maassen (Netherlands eScience Center) <j.maassen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2021 - 2022 dv4all
-SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 SPDX-FileCopyrightText: 2021 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -18,7 +18,7 @@ SPDX-License-Identifier: CC-BY-4.0
 [![DOI](https://zenodo.org/badge/413814951.svg)](https://zenodo.org/badge/latestdoi/413814951)
 [![Research Software Directory](https://img.shields.io/badge/rsd-RSD--as--a--service-00a3e3.svg)](https://research-software-directory.org/software/rsd-ng)
 [![GitHub license](https://img.shields.io/badge/license-Apache--2.0%20-blue.svg)](https://github.com/research-software-directory/RSD-as-a-service/blob/main/LICENSE)
-[![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8B%20%20%E2%97%8F%20%20%E2%97%8B-orange)](https://fair-software.eu)
+[![fair-software.eu](https://img.shields.io/badge/fair--software.eu-%E2%97%8F%20%20%E2%97%8B%20%20%E2%97%8F%20%20%E2%97%8F%20%20%E2%97%8F-yellow)](https://fair-software.eu)
 [![CII Best Practices](https://bestpractices.coreinfrastructure.org/projects/6336/badge)](https://bestpractices.coreinfrastructure.org/projects/6336)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md)
 ![Frontend tests](https://github.com/research-software-directory/RSD-as-a-service/actions/workflows/frontend_tests.yml/badge.svg)


### PR DESCRIPTION
This will enable the [howfairis-github-action](https://github.com/fair-software/howfairis-github-action). The action currently fails, because the README in our `main` branch does not match the badge we should have. This PR includes the correct badge, so *after* merging this PR, it should succeed again.

Closes #322