### PR TITLE
feat: same items per page on all pages with pagination (save user choice and reuse it)

### DIFF
--- a/frontend/components/cookies/useCookieConsent.tsx
+++ b/frontend/components/cookies/useCookieConsent.tsx
@@ -1,22 +1,12 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useCallback, useEffect, useState} from 'react'
 import logger from '~/utils/logger'
-
-export function getCoookieValue(name:string) {
-  try {
-    const value = document.cookie
-      .split(';')
-      .find((item) => item.trim().startsWith(`${name}=`))
-      ?.split('=')[1]
-    return value
-  } catch (e:any) {
-    logger(`useCookieConsent.getCoookieValue error: ${e.message}`,'error')
-  }
-}
 
 export function hasConsentCookie(name:string){
   try {
@@ -32,7 +22,7 @@ export function hasConsentCookie(name:string){
 
 export function setConsentCookie(value:string,name:string='rsd_consent',path:string='/') {
   try {
-    // match matomo cookie exiration time of 400 days
+    // match matomo cookie expiration time of 400 days
     const maxAgeInSeconds = 60 * 60 * 24 * (400)
     document.cookie = `${name}=${value};path=${path};SameSite=Lax;Secure;Max-Age=${maxAgeInSeconds};`
   } catch (e: any) {

--- a/frontend/components/filter/useFilterQueryChange.tsx
+++ b/frontend/components/filter/useFilterQueryChange.tsx
@@ -6,14 +6,13 @@
 import {useCallback} from 'react'
 import {useRouter} from 'next/router'
 
-import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import {encodeQueryValue} from '~/utils/extractQueryParam'
 import {QueryParams} from '~/utils/postgrestUrl'
-import {getDocumentCookie} from '~/utils/userSettings'
-
 
 export default function useFilterQueryChange(){
   const router = useRouter()
+  const {rsd_page_rows, setPageRows} = useUserSettings()
 
   const handleQueryChange = useCallback((key: string, value: string | string[]) => {
     const params: QueryParams = {
@@ -25,7 +24,10 @@ export default function useFilterQueryChange(){
     }
     if (typeof params['rows'] === 'undefined' || params['rows'] === null) {
       // extract from cookie or use default
-      params['rows'] = getDocumentCookie('rsd_page_rows', rowsPerPageOptions[0])
+      params['rows'] = rsd_page_rows
+    } else if (key === 'rows'){
+      // save number of rows in user settings (saves to cookie too)
+      setPageRows(parseInt(value.toString()))
     }
 
     // update query parameters
@@ -52,7 +54,7 @@ export default function useFilterQueryChange(){
       // console.groupEnd()
       router.push({query},undefined,{scroll: false})
     }
-  }, [router])
+  }, [router,rsd_page_rows,setPageRows])
 
   return {
     handleQueryChange

--- a/frontend/components/pagination/Pagination.tsx
+++ b/frontend/components/pagination/Pagination.tsx
@@ -8,40 +8,24 @@
 import {ChangeEvent,MouseEvent} from 'react'
 import TablePagination from '@mui/material/TablePagination'
 
-import {setDocumentCookie} from '~/utils/userSettings'
 import {usePaginationContext} from './PaginationContext'
 
 export default function Pagination() {
-  const {count,page,rows,rowsOptions,labelRowsPerPage, setPagination} = usePaginationContext()
+  const {count,page,rows,rowsOptions,labelRowsPerPage,setPage,setRows} = usePaginationContext()
 
   // next/previous page button
   function handlePageChange(
     event: MouseEvent<HTMLButtonElement> | null,
     newPage: number,
   ) {
-    setPagination({
-      count,
-      rows,
-      rowsOptions,
-      labelRowsPerPage,
-      page: newPage
-    })
+    setPage(newPage)
   }
 
   // change number of cards per page
   function handleItemsPerPage(
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) {
-    setPagination({
-      count,
-      rowsOptions,
-      labelRowsPerPage,
-      // reset to first page
-      page: 0,
-      rows: parseInt(event.target.value),
-    })
-    // save change to cookie
-    setDocumentCookie(event.target.value,'rsd_page_rows')
+    setRows(parseInt(event.target.value))
   }
 
   return (

--- a/frontend/components/projects/overview/useProjectOverviewParams.test.ts
+++ b/frontend/components/projects/overview/useProjectOverviewParams.test.ts
@@ -1,10 +1,12 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import useProjectOverviewParams from './useProjectOverviewParams'
 
+// mock userSettings hook
+jest.mock('~/config/UserSettingsContext')
 
 // mock next router
 const mockBack = jest.fn()

--- a/frontend/components/projects/overview/useProjectOverviewParams.ts
+++ b/frontend/components/projects/overview/useProjectOverviewParams.ts
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -8,14 +8,13 @@
 
 import {useRouter} from 'next/router'
 
-import {rowsPerPageOptions} from '~/config/pagination'
 import {ssrProjectsParams} from '~/utils/extractQueryParam'
 import {QueryParams, ssrProjectsUrl} from '~/utils/postgrestUrl'
-import {getDocumentCookie} from '~/utils/userSettings'
-
+import {useUserSettings} from '~/config/UserSettingsContext'
 
 export default function useProjectOverviewParams() {
   const router = useRouter()
+  const {rsd_page_rows, setPageRows} = useUserSettings()
 
   function createUrl(key: string, value: string | string[]) {
     const params: QueryParams = {
@@ -28,8 +27,8 @@ export default function useProjectOverviewParams() {
       params['page'] = 1
     }
     if (typeof params['rows'] === 'undefined' || params['rows'] === null) {
-      // extract from cookie or use default
-      params['rows'] = getDocumentCookie('rsd_page_rows', rowsPerPageOptions[0])
+      // use value from user settings if none provided
+      params['rows'] = rsd_page_rows
     }
     // construct url with all query params
     const url = ssrProjectsUrl(params)
@@ -38,9 +37,13 @@ export default function useProjectOverviewParams() {
 
   function handleQueryChange(key: string, value: string | string[]) {
     const url = createUrl(key, value)
+    if (key === 'rows'){
+      // save number of rows in user settings (saves to cookie too)
+      setPageRows(parseInt(value.toString()))
+    }
     // debugger
     if (key === 'page') {
-      // when changin page we scroll to top
+      // when changing page we scroll to top
       router.push(url, url, {scroll: true})
     } else {
       // update page url but keep scroll position

--- a/frontend/components/search/SearchContext.tsx
+++ b/frontend/components/search/SearchContext.tsx
@@ -2,10 +2,12 @@
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {createContext, useState, useEffect} from 'react'
+import {createContext, useState, useEffect, useContext} from 'react'
 import {useDebounce} from '~/utils/useDebounce'
 
 export type SearchContextProps = {
@@ -71,6 +73,26 @@ export function SearchProvider(props:any) {
   // we pass children etc...
   {...props}
   />
+}
+
+
+export function useSearchContext(newPlaceholder:string){
+  const {setPlaceholder, searchFor, setSearchInput, placeholder} = useContext(SearchContext)
+
+  useEffect(()=>{
+    // update placeholder in the context
+    if (placeholder!=newPlaceholder){
+      setPlaceholder(newPlaceholder)
+    }
+  },[placeholder,newPlaceholder,setPlaceholder])
+
+  return {
+    searchFor,
+    placeholder,
+    setPlaceholder,
+    setSearchInput
+  }
+
 }
 
 

--- a/frontend/components/search/useSearchParams.test.tsx
+++ b/frontend/components/search/useSearchParams.test.tsx
@@ -5,6 +5,9 @@
 
 import useSearchParams from './useSearchParams'
 
+// mock userSettings hook
+jest.mock('~/config/UserSettingsContext')
+
 // mock next router
 const mockBack = jest.fn()
 const mockReplace = jest.fn()
@@ -22,7 +25,6 @@ jest.mock('next/router', () => ({
     }
   })
 }))
-
 
 beforeEach(() => {
   jest.resetAllMocks()

--- a/frontend/components/software/overview/useSoftwareOverviewParams.ts
+++ b/frontend/components/software/overview/useSoftwareOverviewParams.ts
@@ -14,11 +14,11 @@ import {useRouter} from 'next/router'
 import logger from '~/utils/logger'
 import {ssrSoftwareParams} from '~/utils/extractQueryParam'
 import {QueryParams, ssrViewUrl} from '~/utils/postgrestUrl'
-import {getDocumentCookie} from '~/utils/userSettings'
-import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
 
 export default function useSoftwareOverviewParams() {
   const router = useRouter()
+  const {rsd_page_rows, setPageRows} = useUserSettings()
 
   /**
  * NOTE! This hook is used on software and spotlight pages.
@@ -51,8 +51,8 @@ export default function useSoftwareOverviewParams() {
       params['page'] = 1
     }
     if (typeof params['rows'] === 'undefined' || params['rows'] === null) {
-      // extract from cookie or use default
-      params['rows'] = getDocumentCookie('rsd_page_rows', rowsPerPageOptions[0])
+      // use value from user settings if none provided
+      params['rows'] = rsd_page_rows
     }
     // construct url with all query params
     const url = ssrViewUrl({
@@ -64,6 +64,10 @@ export default function useSoftwareOverviewParams() {
 
   function handleQueryChange(key: string, value: string | string[]) {
     const url = createUrl(key, value)
+    if (key === 'rows'){
+      // save number of rows in user settings (saves to cookie too)
+      setPageRows(parseInt(value.toString()))
+    }
     if (key === 'page') {
       // when changing page we scroll to top
       router.push(url,url,{scroll: true})

--- a/frontend/components/user/communities/useUserCommunities.tsx
+++ b/frontend/components/user/communities/useUserCommunities.tsx
@@ -93,15 +93,14 @@ export default function useUserCommunities(){
   useEffect(()=>{
 
     if (user?.account){
-
       getCommunitiesForMaintainer({
         searchFor, page,rows,account:user?.account,token
       })
         .then(data=>{
           setData(data)
+          setCount(data.count)
         })
         .finally(()=>{
-          setCount(data.count)
           setLoading(false)
         })
     }

--- a/frontend/config/UserSettingsContext.tsx
+++ b/frontend/config/UserSettingsContext.tsx
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {createContext, useContext, useState} from 'react'
+
+import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
+import {rowsPerPageOptions} from './pagination'
+import {setDocumentCookie} from '~/utils/userSettings'
+
+export type UserSettingsProps={
+  rsd_page_layout: LayoutType,
+  rsd_page_rows: number
+}
+
+export type UserSettingsContextProps={
+  user: UserSettingsProps,
+  setUser:(user:UserSettingsProps)=>void
+}
+
+const defaultUserProps:UserSettingsProps={
+  rsd_page_layout: 'masonry',
+  rsd_page_rows: rowsPerPageOptions[0]
+}
+
+
+export const UserSettingsContext = createContext<UserSettingsContextProps>({
+  user: defaultUserProps,
+  setUser:()=>{}
+})
+
+export function UserSettingsProvider(props:any){
+  const initUser={
+    ...defaultUserProps,
+    ...props?.user
+  }
+  const [user,setUser] = useState(initUser)
+
+  // console.group('UserSettingsProvider')
+  // console.log('props?.user...', props?.user)
+  // console.log('initUser...', initUser)
+  // console.log('user...', user)
+  // console.groupEnd()
+
+  return <UserSettingsContext.Provider
+    value={{user,setUser}}
+    {...props}
+  />
+}
+
+export function useUserSettings(){
+  const {user,setUser} = useContext(UserSettingsContext)
+
+  function setPageLayout(layout:LayoutType){
+    // save to cookie
+    setDocumentCookie(layout,'rsd_page_layout')
+    // save to state
+    setUser({
+      ...user,
+      rsd_page_layout: layout
+    })
+  }
+
+  function setPageRows(rows:number){
+    // save to cookie
+    setDocumentCookie(rows.toString(),'rsd_page_rows')
+    // save to state
+    setUser({
+      ...user,
+      rsd_page_rows: rows
+    })
+  }
+
+  return {
+    ...user,
+    setPageLayout,
+    setPageRows
+  }
+}
+

--- a/frontend/config/__mocks__/UserSettingsContext.tsx
+++ b/frontend/config/__mocks__/UserSettingsContext.tsx
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// import {createContext, useContext, useState} from 'react'
+
+import {rowsPerPageOptions} from '../pagination'
+
+export function useUserSettings(){
+  return {
+    rsd_page_layout: 'masonry',
+    rsd_page_rows: rowsPerPageOptions[0],
+    setPageLayout: jest.fn(),
+    setPageRows: jest.fn()
+  }
+}
+

--- a/frontend/pages/admin/communities.tsx
+++ b/frontend/pages/admin/communities.tsx
@@ -7,6 +7,7 @@ import Head from 'next/head'
 
 import {app} from '~/config/app'
 import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
 import {adminPages} from '~/components/admin/AdminNav'
@@ -19,13 +20,17 @@ const pageTitle = `${adminPages['pages'].title} | Admin page | ${app.title}`
 const pagination = {
   count: 0,
   page: 0,
-  rows: rowsPerPageOptions[0],
+  rows: 12,
   rowsOptions: rowsPerPageOptions,
   labelRowsPerPage:'Per page'
 }
 
 
 export default function AdminCommunitiesPage() {
+  // use page rows from user settings
+  const {rsd_page_rows} = useUserSettings()
+  pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
+
   return (
     <DefaultLayout>
       <Head>

--- a/frontend/pages/admin/keywords.tsx
+++ b/frontend/pages/admin/keywords.tsx
@@ -1,13 +1,15 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Head from 'next/head'
 
-import {app} from '../../config/app'
+import {app} from '~/config/app'
+import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
 import {adminPages} from '~/components/admin/AdminNav'
@@ -27,6 +29,9 @@ const pagination = {
 }
 
 export default function AdminKeywordsPage() {
+  // use page rows from user settings
+  const {rsd_page_rows} = useUserSettings()
+  pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
 
   // console.group('AdminKeywordsPage')
   // console.log('keywords...', keywords)

--- a/frontend/pages/admin/logs.tsx
+++ b/frontend/pages/admin/logs.tsx
@@ -1,12 +1,14 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Head from 'next/head'
-import {app} from '../../config/app'
+import {app} from '~/config/app'
+import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import {adminPages} from '~/components/admin/AdminNav'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
@@ -25,6 +27,10 @@ const pagination = {
 }
 
 export default function AdminLogsPage() {
+  // use page rows from user settings
+  const {rsd_page_rows} = useUserSettings()
+  pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
+
   return (
     <DefaultLayout>
       <Head>

--- a/frontend/pages/admin/mentions.tsx
+++ b/frontend/pages/admin/mentions.tsx
@@ -10,7 +10,9 @@
 
 import Head from 'next/head'
 
-import {app} from '../../config/app'
+import {app} from '~/config/app'
+import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
 import {adminPages} from '~/components/admin/AdminNav'
@@ -29,6 +31,10 @@ const pagination = {
 }
 
 export default function MentionsOverviewPage(props: any) {
+  // use page rows from user settings
+  const {rsd_page_rows} = useUserSettings()
+  pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
+
   return (
     <DefaultLayout>
       <Head>

--- a/frontend/pages/admin/orcid-users.tsx
+++ b/frontend/pages/admin/orcid-users.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -9,6 +9,8 @@
 import Head from 'next/head'
 
 import {app} from '~/config/app'
+import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import {adminPages} from '~/components/admin/AdminNav'
 import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
@@ -28,6 +30,10 @@ const pagination = {
 
 
 export default function OrcidWitelistPage() {
+  // use page rows from user settings
+  const {rsd_page_rows} = useUserSettings()
+  pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
+
   return (
     <DefaultLayout>
       <Head>

--- a/frontend/pages/admin/organisations.tsx
+++ b/frontend/pages/admin/organisations.tsx
@@ -9,6 +9,7 @@ import Head from 'next/head'
 
 import {app} from '~/config/app'
 import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
 import {adminPages} from '~/components/admin/AdminNav'
@@ -21,13 +22,15 @@ const pageTitle = `${adminPages['organisations'].title} | Admin page | ${app.tit
 const pagination = {
   count: 0,
   page: 0,
-  rows: rowsPerPageOptions[0],
+  rows: 12,
   rowsOptions: rowsPerPageOptions,
   labelRowsPerPage:'Per page'
 }
 
 export default function AdminOrganisationsPage() {
-
+  // use page rows from user settings
+  const {rsd_page_rows} = useUserSettings()
+  pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
   // console.group('AdminOrganisationsPage')
   // console.log('domains...', domains)
   // console.groupEnd()

--- a/frontend/pages/admin/rsd-contributors.tsx
+++ b/frontend/pages/admin/rsd-contributors.tsx
@@ -1,15 +1,20 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {app} from '../../config/app'
+import Head from 'next/head'
+
+import {app} from '~/config/app'
+import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import {adminPages} from '~/components/admin/AdminNav'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
 import {SearchProvider} from '~/components/search/SearchContext'
 import {PaginationProvider} from '~/components/pagination/PaginationContext'
-import Head from 'next/head'
 import AdminRsdContributors from '~/components/admin/rsd-contributors'
 
 const pageTitle = `${adminPages['contributors'].title} | Admin page | ${app.title}`
@@ -23,6 +28,10 @@ const pagination = {
 }
 
 export default function AdminContributorsPage() {
+  // use page rows from user settings
+  const {rsd_page_rows} = useUserSettings()
+  pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
+
   return (
     <DefaultLayout>
       <Head>

--- a/frontend/pages/admin/rsd-users.tsx
+++ b/frontend/pages/admin/rsd-users.tsx
@@ -1,17 +1,21 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Head from 'next/head'
 
-import {app} from '../../config/app'
+import {app} from '~/config/app'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import DefaultLayout from '~/components/layout/DefaultLayout'
 import RsdUsersPage from '~/components/admin/rsd-users/'
 import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
 import {adminPages} from '~/components/admin/AdminNav'
 import {SearchProvider} from '~/components/search/SearchContext'
 import {PaginationProvider} from '~/components/pagination/PaginationContext'
+import {rowsPerPageOptions} from '~/config/pagination'
 
 const pageTitle = `${adminPages['accounts'].title} | Admin page | ${app.title}`
 
@@ -24,6 +28,9 @@ const pagination = {
 }
 
 export default function AdminRsdUsersPage() {
+  // use page rows from user settings
+  const {rsd_page_rows} = useUserSettings()
+  pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
   // console.group('AdminRsdUsersPage')
   // console.log('pageTitle...', pageTitle)
   // console.groupEnd()

--- a/frontend/pages/organisations/index.tsx
+++ b/frontend/pages/organisations/index.tsx
@@ -14,6 +14,7 @@ import Pagination from '@mui/material/Pagination'
 import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
+import {useUserSettings} from '~/config/UserSettingsContext'
 import PageTitle from '~/components/layout/PageTitle'
 import Searchbox from '~/components/form/Searchbox'
 import {OrganisationList} from '~/types/Organisation'
@@ -67,8 +68,6 @@ export default function OrganisationsOverviewPage({
     event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
   ) {
     handleQueryChange('rows', event.target.value)
-    // save to cookie
-    setDocumentCookie(event.target.value,'rsd_page_rows')
   }
 
   function handleSearch(searchFor: string) {

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -45,10 +45,11 @@ import {
   softwareLicensesFilter
 } from '~/components/software/overview/filters/softwareFiltersApi'
 import SoftwareFiltersModal from '~/components/software/overview/filters/SoftwareFiltersModal'
-import {getUserSettings, setDocumentCookie} from '~/utils/userSettings'
+import {getUserSettings} from '~/utils/userSettings'
 import {softwareOrderOptions} from '~/components/software/overview/filters/OrderSoftwareBy'
 import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
 import {getRsdSettings} from '~/config/getSettingsServerSide'
+import {useUserSettings} from '~/config/UserSettingsContext'
 
 type SoftwareOverviewProps = {
   search?: string | null
@@ -80,6 +81,7 @@ export default function SoftwareOverviewPage({
 }: SoftwareOverviewProps) {
   const smallScreen = useMediaQuery('(max-width:640px)')
   const {createUrl} = useSoftwareOverviewParams()
+  const {setPageLayout} = useUserSettings()
   const [modal,setModal] = useState(false)
   // if no layout - default is masonry
   const initView = layout ?? 'masonry'
@@ -116,8 +118,9 @@ export default function SoftwareOverviewPage({
   function setLayout(view: LayoutType) {
     // update local view
     setView(view)
-    // save to cookie
-    setDocumentCookie(view,'rsd_page_layout')
+    // save to context and cookie
+    setPageLayout(view)
+    // setDocumentCookie(view,'rsd_page_layout')
   }
 
   return (

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -18,7 +18,7 @@
       "limit": 5,
       "description": null
     },
-    "modules":["software","projects","organisations"]
+    "modules":["software","projects","organisations","communities"]
   },
   "links": [
     {

--- a/frontend/utils/usePaginationWithSearch.tsx
+++ b/frontend/utils/usePaginationWithSearch.tsx
@@ -6,13 +6,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {useState, useContext, useEffect} from 'react'
-import SearchContext from '../components/search/SearchContext'
-import PaginationContext from '../components/pagination/PaginationContext'
+import SearchContext from '~/components/search/SearchContext'
+import PaginationContext from '~/components/pagination/PaginationContext'
 
 export default function usePaginationWithSearch(placeholder:string) {
   const {setPlaceholder, searchFor, setSearchInput, placeholder:currentPlaceholder} = useContext(SearchContext)
   const {pagination, setPagination} = useContext(PaginationContext)
   const [search, setSearch] = useState(searchFor)
+
+
+  // console.group('usePaginationWithSearch')
+  // console.log('searchFor...',searchFor)
+  // console.log('search...',search)
+  // console.log('pagination...',pagination)
+  // console.groupEnd()
+
 
   useEffect(() => {
     if (placeholder !== currentPlaceholder) {


### PR DESCRIPTION
# Fix page rows error

Closes #1200

Changes proposed in this pull request:
* Added user settings context to be shared in all components
* Use user settings across the app. Select rows per page is used on all pages where pagination is enabled      

How to test:
* `make start` to build app and create test data
* Navigate to software overview page, change items per page. Refresh the page and confirm there are no console log errors (like the ones in the issue)
* Navigate to projects overview page and perform similar check (change items per page, reload and check browser console)
* Navigate to organisations page and perform similar check (change items per page, reload and check browser console)
* Navigate to communities page and perform similar check
* Navigate to news overview page and perform similar check
* Navigate to mySoftware page and perform similar check
* Navigate to admin pages: orcid, users, contributors, organisations, communities, keywords, mentions and error logs and  validate that the number of items per page is "memorized" and used in all cases. 

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
