### PR TITLE
feat: add community membership on the software page

### DIFF
--- a/frontend/components/admin/mentions/MentionsOverviewList.tsx
+++ b/frontend/components/admin/mentions/MentionsOverviewList.tsx
@@ -9,13 +9,14 @@ import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import EditIcon from '@mui/icons-material/Edit'
 import IconButton from '@mui/material/IconButton'
+import Alert from '@mui/material/Alert'
+import {useSession} from '~/auth'
+import {createJsonHeaders} from '~/utils/fetchHelpers'
+import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
 import {MentionItemProps} from '~/types/Mention'
 import MentionViewItem from '~/components/mention/MentionViewItem'
 import EditMentionModal from '~/components/mention/EditMentionModal'
-import {createJsonHeaders} from '~/utils/fetchHelpers'
-import {useSession} from '~/auth'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
 
 function leaveOutSomeFieldsReplacer(key: string, value: any) {
   if (key === 'id' || key === 'doi_registration_date' || key === 'created_at' || key === 'updated_at') {
@@ -49,8 +50,11 @@ export default function MentionsOverviewList({list, onUpdate}: { list: MentionIt
   }
 
   if (list.length === 0) {
-    return 'No mentions to show'
-
+    return (
+      <Alert severity="info" sx={{margin:'1rem 0rem'}}>
+        No mentions to show
+      </Alert>
+    )
   }
 
   return (

--- a/frontend/components/admin/organisations/OrganisationsAdminList.tsx
+++ b/frontend/components/admin/organisations/OrganisationsAdminList.tsx
@@ -13,6 +13,7 @@ import ContentLoader from '~/components/layout/ContentLoader'
 import {OrganisationList} from '~/types/Organisation'
 import {RemoveOrganisationProps} from './apiOrganisation'
 import OrganisationItem from './OrganisationItem'
+import Alert from '@mui/material/Alert'
 
 type DeleteOrganisationModal = {
   open: boolean,
@@ -32,6 +33,14 @@ export default function OrganisationsAdminList({organisations,loading,page,onDel
   })
 
   if (loading && !page) return <ContentLoader />
+
+  if (organisations.length === 0){
+    return (
+      <Alert severity="info" sx={{margin:'1.5rem 0rem'}}>
+        No organisation to show.
+      </Alert>
+    )
+  }
 
   function onDelete(organisation:OrganisationList) {
     if (organisation) {

--- a/frontend/components/admin/organisations/index.tsx
+++ b/frontend/components/admin/organisations/index.tsx
@@ -5,19 +5,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useContext} from 'react'
-
 import {useSession} from '~/auth'
 import Pagination from '~/components/pagination/Pagination'
 import Searchbox from '~/components/search/Searchbox'
-import PaginationContext from '~/components/pagination/PaginationContext'
 import OrganisationsAdminList from './OrganisationsAdminList'
 import AddOrganisation from './AddOrganisation'
 import {useOrganisations} from './apiOrganisation'
 
 export default function OrganisationsAdminPage() {
   const {token} = useSession()
-  const {pagination:{count}} = useContext(PaginationContext)
   const {organisations, loading, page, addOrganisation, removeOrganisation} = useOrganisations(token)
 
   // console.group('OrganisationAdminPage')
@@ -27,10 +23,6 @@ export default function OrganisationsAdminPage() {
   return (
     <section className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr,2fr] xl:px-0 xl:gap-8">
       <div>
-        {/* <h2 className="flex pr-4 pb-4 justify-between">
-          <span>RSD organisations</span>
-          <span>{count}</span>
-        </h2> */}
         <div className="flex flex-wrap items-center justify-end">
           <Searchbox />
           <Pagination />

--- a/frontend/components/category/CategoryEditTree.tsx
+++ b/frontend/components/category/CategoryEditTree.tsx
@@ -80,7 +80,7 @@ export default function CategoryEditTree({roots, community, title, onMutation}:C
               )})
           :
           !showAddChildForm &&
-          <Alert severity="info">
+          <Alert severity="info" sx={{margin:'2rem 0rem'}}>
               There are no categories, add one using &quot;Add&quot; button above.
           </Alert>
         }

--- a/frontend/components/software/CommunitiesSection.tsx
+++ b/frontend/components/software/CommunitiesSection.tsx
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {getImageUrl} from '~/utils/editImage'
+import useRsdSettings from '~/config/useRsdSettings'
+import PageContainer from '~/components/layout/PageContainer'
+import CommunityItem from './CommunityItem'
+import {OrganisationGridSection} from './OrganisationsSection'
+
+type CommunitiesSectionProps=Readonly<{
+  communities:{
+    slug: string,
+    name: string,
+    logo_id: string|null
+  }[]
+}>
+
+
+export default function CommunitiesSection({communities = []}: CommunitiesSectionProps) {
+  const {host} = useRsdSettings()
+  // do not render section if no data
+  if (communities?.length === 0) return null
+  // do not render section if module is not enabled
+  if (host?.modules?.includes('communities')===false) return null
+
+  return (
+    <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
+      <h2
+        data-testid="software-communities-section-title"
+        className="pb-8 text-[2rem] text-primary leading-10">
+        Member of community
+      </h2>
+      <OrganisationGridSection>
+        {communities.map((item, pos) => {
+          return (
+            <CommunityItem
+              key={item.slug}
+              slug={item.slug}
+              name={item.name}
+              logo_url={item.logo_id ? getImageUrl(item.logo_id) : null}
+            />
+          )
+        })}
+      </OrganisationGridSection>
+    </PageContainer>
+  )
+}

--- a/frontend/components/software/CommunityItem.tsx
+++ b/frontend/components/software/CommunityItem.tsx
@@ -7,10 +7,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import Link from 'next/link'
-import {ParticipatingOrganisationProps} from '../../types/Organisation'
+
 import LogoAvatar from '~/components/layout/LogoAvatar'
 
-export default function ParticipatingOrganisation({rsd_path, name, website, logo_url}: ParticipatingOrganisationProps) {
+export type CommunityItemProps = Readonly<{
+  slug: string
+  name: string
+  logo_url: string | null
+}>
+
+export default function CommunityItem({slug, name, logo_url}: CommunityItemProps) {
 
   function renderLogo() {
     return (
@@ -23,7 +29,7 @@ export default function ParticipatingOrganisation({rsd_path, name, website, logo
             maxHeight: '100%',
             // width: 'auto',
             maxWidth: '100%',
-            // we need to fit thisone properly
+            // we need to fit this one properly
             objectFit: 'scale-down'
           }
         }}
@@ -31,32 +37,16 @@ export default function ParticipatingOrganisation({rsd_path, name, website, logo
     )
   }
 
-  let url: string=''
-  if (rsd_path) {
-    // internal RSD link to organisation
-    url = `/organisations/${rsd_path}`
+  if (slug) {
+    // internal RSD link to community
     return (
-      <Link href={url}
+      <Link href={`/communities/${slug}/software`}
         title={name}
         className="flex flex-col items-center" rel="noreferrer"
-        passHref>
+        passHref
+      >
         {renderLogo()}
-        {/* show name only for research units */}
-        {rsd_path.includes('/',2)===true ? name : null}
       </Link>
-    )
-  }
-
-  if (website) {
-    // organisation website
-    url = website
-    return (
-      <a href={url}
-        target="_blank"
-        title={name}
-        className="flex items-center" rel="noreferrer">
-        {renderLogo()}
-      </a>
     )
   }
 

--- a/frontend/components/software/OrganisationsSection.tsx
+++ b/frontend/components/software/OrganisationsSection.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,7 +10,7 @@ import {ParticipatingOrganisationProps} from '../../types/Organisation'
 import PageContainer from '../layout/PageContainer'
 import ParticipatingOrganisation from './ParticipatingOrganisation'
 
-const OrganisationGridSection = styled('section')(({theme}) => ({
+export const OrganisationGridSection = styled('section')(({theme}) => ({
   flex: 1,
   display: 'grid',
   gridGap: '2rem',
@@ -31,7 +33,7 @@ export default function OrganisationsSection({organisations = []}: { organisatio
         {organisations.map((item, pos) => {
           return (
             <ParticipatingOrganisation
-              key={pos}
+              key={item.rsd_path}
               {...item}
             />
           )

--- a/frontend/components/software/edit/editSoftwarePages.tsx
+++ b/frontend/components/software/edit/editSoftwarePages.tsx
@@ -113,6 +113,12 @@ export const editSoftwarePage:EditSoftwarePageProps[] = [{
   render: () => <PackageManagers />,
   status: ''
 },{
+  id: 'communities',
+  label: 'Communities',
+  icon: <Diversity3Icon />,
+  render: () => <SoftwareCommunities />,
+  status: ''
+},{
   id: 'related-software',
   label: 'Related software',
   icon: <JoinInnerIcon />,
@@ -123,12 +129,6 @@ export const editSoftwarePage:EditSoftwarePageProps[] = [{
   label: 'Related projects',
   icon: <DonutLargeIcon />,
   render: () => <RelatedProjects />,
-  status: ''
-},{
-  id: 'communities',
-  label: 'Communities',
-  icon: <Diversity3Icon />,
-  render: () => <SoftwareCommunities />,
   status: ''
 },{
   id: 'maintainers',

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -18,7 +18,7 @@
       "limit": 5,
       "description": null
     },
-    "modules":["software","projects","organisations","communities"]
+    "modules":["software","projects","organisations"]
   },
   "links": [
     {

--- a/frontend/types/SoftwareTypes.ts
+++ b/frontend/types/SoftwareTypes.ts
@@ -208,4 +208,3 @@ export type SoftwareForSoftware = {
   origin: string,
   relation: string
 }
-

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -11,10 +11,11 @@
 
 import logger from './logger'
 import {CategoriesForSoftware, KeywordForSoftware, LicenseForSoftware, RepositoryInfo, SoftwareItem, SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
+import {CategoryID} from '~/types/Category'
+import {RelatedProjectForSoftware} from '~/types/Project'
+import {CommunitiesOfSoftware} from '~/components/software/edit/communities/apiSoftwareCommunities'
 import {extractCountFromHeader} from './extractCountFromHeader'
 import {createJsonHeaders, getBaseUrl} from './fetchHelpers'
-import {RelatedProjectForSoftware} from '~/types/Project'
-import {CategoryID} from '~/types/Category'
 
 /*
  * Software list for the software overview page
@@ -329,6 +330,34 @@ export async function getRelatedProjectsForSoftware({software, token, frontend, 
     return []
   } catch (e: any) {
     logger(`getRelatedProjects: ${e?.message}`, 'error')
+    return []
+  }
+}
+
+type GetCommunitiesOfSoftware={
+  software:string
+  token?:string
+}
+
+export async function getCommunitiesOfSoftware({software,token}:GetCommunitiesOfSoftware){
+  try{
+    const query = `software_id=${software}&status=eq.approved&order=software_cnt.desc.nullslast,name`
+    const url = `${getBaseUrl()}/rpc/communities_of_software?${query}`
+
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token)
+      }
+    })
+    if (resp.ok){
+      const json:CommunitiesOfSoftware[] = await resp.json()
+      return json
+    }
+    logger(`getCommunitiesOfSoftware: ${resp.status}:${resp.statusText}`, 'warn')
+    return []
+  }catch(e:any){
+    logger(`getCommunitiesOfSoftware: ${e?.message}`, 'error')
     return []
   }
 }


### PR DESCRIPTION
# Add community membership to software page

Closes #1223

Changes proposed in this pull request:
*  Additional section "Member of community" is added after "Testimonials". The position of menu item in edit software is also placed at the same position (after testimonials)
* The section is not shown if communities module is not enabled.
* Minor layout changes in the admin section (no items messages)

How to test:
* enable communities module
* `make start` to build app and generate test data
* login as rsd-admin
* navigate to existing software, add community to software
* navigate to community and accept membership
* confirm that community is shown on software. Click to visit community page
* edit software and add 2 more communities
* navigate to community page and reject the request
* navigate to software page and confirm that communities are not listed (pending and rejected communities are not listed on the software page).

## Edit software (communites menu position)
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/5177dca9-c571-4fd4-ae0d-23ea95057939)

## Software page (member of community page position)
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/598bf708-1609-4492-8980-ccce3df59a77)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
