### PR TITLE
feat: cache auth endpoints for all providers

### DIFF
--- a/frontend/auth/api/authEndpoint.ts
+++ b/frontend/auth/api/authEndpoint.ts
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {getAuthorisationEndpoint} from './authHelpers'
+
+type providers = 'surfconext'|'helmholtzid'|'orcid'|'azure'
+// how often we refresh auth endpoint
+const refreshInterval = 60*60*1000
+// save timer as public variable
+let timer:NodeJS.Timer
+// save authorisation endpoint info
+let cache:{
+  [key:string]:{
+    authEndpoint?: string
+    wellknownUrl: string
+  }
+}={}
+
+/**
+ * We save authorization_endpoint in memory to avoid repeating calls
+ * refreshInterval defined how often we refresh auth endpoint info.
+ *
+ */
+export async function getAuthEndpoint(wellknownUrl:string,provider:providers){
+  try{
+    // if already present return existing value
+    if (cache?.[provider]?.authEndpoint) {
+      // console.log('getAuthEndpoint...CACHE used...', new Date())
+      return cache[provider].authEndpoint
+    }
+    // if not present request endpoint info
+    cache[provider] = {
+      wellknownUrl,
+      authEndpoint: await getAuthorisationEndpoint(wellknownUrl)
+    }
+    // we set timer only in the production because hot-reloading creates multiple instances
+    if (process.env.NODE_ENV==='production'){
+      // clear previous timer to avoid mem leaks
+      if (timer){
+        // console.log('getAuthEndpoint...CLEAR INTERVAL...', new Date())
+        clearInterval(timer)
+      }
+      // create refresh interval and store it
+      timer = setInterval(async()=>{
+        // console.log('getAuthEndpoint...REFRESH INFO...', new Date())
+        // refresh all cached providers
+        const providers = Object.keys(cache)
+        const requests = providers.map(provider=>{
+          return getAuthorisationEndpoint(cache[provider].wellknownUrl)
+        })
+        // perform all requests in parallel
+        const endpoints = await Promise.all(requests)
+        // update all providers
+        providers.forEach((provider,pos)=>{
+          // update only if there is info
+          if (endpoints[pos]) {
+            // console.log(`getAuthEndpoint...${provider}...`, endpoints[pos])
+            cache[provider].authEndpoint = endpoints[pos]
+          }
+        })
+      },refreshInterval)
+    }
+    // console.log('getAuthEndpoint...REQUEST made...', new Date())
+    return cache[provider]?.authEndpoint
+  }catch(e:any){
+    logger(`getAuthEndpoint: ${e.message}`, 'error')
+    return undefined
+  }
+}

--- a/frontend/components/AppHeader/AppHeader.test.tsx
+++ b/frontend/components/AppHeader/AppHeader.test.tsx
@@ -8,7 +8,6 @@
 import {render, screen} from '@testing-library/react'
 
 import {WithAppContext} from '~/utils/jest/WithAppContext'
-import {menuItems} from '~/config/menuItems'
 import defaultSettings from '~/config/defaultSettings.json'
 import {RsdSettingsState} from '~/config/rsdSettingsReducer'
 import AppHeader from './index'

--- a/frontend/components/user/settings/apiLinkOrcidProps.ts
+++ b/frontend/components/user/settings/apiLinkOrcidProps.ts
@@ -4,47 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import logger from '~/utils/logger'
-import {RedirectToProps, getAuthorisationEndpoint} from '~/auth/api/authHelpers'
-
-// save timer as public variable
-let timer:NodeJS.Timer
-// save authorisation endpoint info as public variable
-let orcid_endpoint:string|null=null
-/**
- * We save authorization_endpoint in memory
- * to avoid repeating calls when user is navigating between sections
- */
-async function orcidAuthEndpoint(wellknownUrl:string){
-  try{
-    const refreshInterval = 60*60*1000
-    // if already present return existing value
-    if (orcid_endpoint) {
-      // console.log('orcidAuthEndpoint...CACHE used...', new Date())
-      return orcid_endpoint
-    }
-    // if not present request endpoint info
-    orcid_endpoint = await getAuthorisationEndpoint(wellknownUrl) ?? null
-    // we set timer only in the production because hot-reloading creates multiple instances
-    // TODO! investigate other approaches that work identical in dev and production
-    if (process.env.NODE_ENV==='production'){
-      // clear previous timer to avoid mem leaks
-      if (timer){
-        // console.log('orcidAuthEndpoint...CLEAR INTERVAL...', new Date())
-        clearInterval(timer)
-      }
-      // create refresh interval and store it
-      timer = setInterval(async()=>{
-        // console.log('orcidAuthEndpoint...REFRESH INFO...', new Date())
-        orcid_endpoint = await getAuthorisationEndpoint(wellknownUrl) ?? null
-      },refreshInterval)
-    }
-    // console.log('orcidAuthEndpoint...REQUEST made...', new Date())
-    return orcid_endpoint
-  }catch(e:any){
-    logger(`orcidAuthEndpoint: ${e.message}`, 'error')
-    return null
-  }
-}
+import {RedirectToProps} from '~/auth/api/authHelpers'
+import {getAuthEndpoint} from '~/auth/api/authEndpoint'
 
 /**
  * Obtain the orcid redirect props for linking ORCID account [server side]
@@ -60,7 +21,7 @@ export async function orcidCoupleProps() {
     const wellknownUrl = process.env.ORCID_WELL_KNOWN_URL ?? null
     if (wellknownUrl) {
       // get (cached) authorisation endpoint from well known url
-      const authorization_endpoint = await orcidAuthEndpoint(wellknownUrl)
+      const authorization_endpoint = await getAuthEndpoint(wellknownUrl,'orcid')
       if (authorization_endpoint) {
         // construct all props needed for redirectUrl
         const props: RedirectToProps = {

--- a/frontend/pages/api/fe/auth/azure.ts
+++ b/frontend/pages/api/fe/auth/azure.ts
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,18 +15,19 @@
 
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import type {NextApiRequest, NextApiResponse} from 'next'
-import {getAuthorisationEndpoint, RedirectToProps, getRedirectUrl} from '~/auth/api/authHelpers'
 import logger from '~/utils/logger'
+import {RedirectToProps, getRedirectUrl} from '~/auth/api/authHelpers'
+import {getAuthEndpoint} from '~/auth/api/authEndpoint'
 import {Provider, ApiError} from '.'
 
 type Data = Provider | ApiError
 
 export async function azureRedirectProps() {
-  // extract wellknow url from env
+  // extract wellknown url from env
   const wellknownUrl = process.env.AZURE_WELL_KNOWN_URL ?? null
   if (wellknownUrl) {
-    // extract authorisation endpoint from wellknow response
-    const authorization_endpoint = await getAuthorisationEndpoint(wellknownUrl)
+    // get (cached) authorisation endpoint from wellknown url
+    const authorization_endpoint = await getAuthEndpoint(wellknownUrl,'azure')
     if (authorization_endpoint) {
       // construct all props needed for redirectUrl
       const props: RedirectToProps = {

--- a/frontend/pages/api/fe/auth/helmholtzid.ts
+++ b/frontend/pages/api/fe/auth/helmholtzid.ts
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,8 +15,9 @@
 
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import type {NextApiRequest, NextApiResponse} from 'next'
-import {getAuthorisationEndpoint, RedirectToProps, getRedirectUrl} from '~/auth/api/authHelpers'
 import logger from '~/utils/logger'
+import {RedirectToProps, getRedirectUrl} from '~/auth/api/authHelpers'
+import {getAuthEndpoint} from '~/auth/api/authEndpoint'
 import {Provider, ApiError} from '.'
 
 type Data = Provider | ApiError
@@ -33,8 +34,8 @@ async function helmholtzRedirectProps() {
   // extract wellknow url from env
   const wellknownUrl = process.env.HELMHOLTZID_WELL_KNOWN_URL ?? null
   if (wellknownUrl) {
-    // extract authorisation endpoint from wellknow response
-    const authorization_endpoint = await getAuthorisationEndpoint(wellknownUrl)
+    // get (cached) authorisation endpoint from wellknown url
+    const authorization_endpoint = await getAuthEndpoint(wellknownUrl,'helmholtzid')
     if (authorization_endpoint) {
       // construct all props needed for redirectUrl
       // use default values if env not provided

--- a/frontend/pages/api/fe/auth/index.ts
+++ b/frontend/pages/api/fe/auth/index.ts
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -38,9 +38,6 @@ export type Provider = {
 
 type Data = Provider[] | ApiError
 
-// cached list of providers
-let loginProviders:Provider[] = []
-
 async function getRedirectInfo(provider: string) {
   // select provider
   switch (provider.toLocaleLowerCase()) {
@@ -63,37 +60,28 @@ async function getRedirectInfo(provider: string) {
 }
 
 async function getProvidersInfo(){
-  // only if we did not loaded info previously
-  if (loginProviders.length === 0){
-    // extract list of providers, default value surfconext
-    const strProviders = process.env.RSD_AUTH_PROVIDERS || 'surfconext'
-    // split providers to array on ;
-    const providers = strProviders.split(';')
+  // extract list of providers, default value surfconext
+  const strProviders = process.env.RSD_AUTH_PROVIDERS || 'surfconext'
+  // split providers to array on ;
+  const providers = strProviders.split(';')
 
-    // add all requests
-    const promises: Promise<Provider|null>[] = []
-    providers.forEach(provider => {
-      promises.push(
-        getRedirectInfo(provider)
-      )
-    })
-    // return providers with redirectUrl
-    const resp = await Promise.allSettled(promises)
-    // filter null responses (if any)
-    const info: Provider[] = []
-    resp.forEach(item => {
-      if (item.status === 'fulfilled') {
-        info.push(item.value as Provider)
-      }
-    })
-    // save response into cached variable
-    loginProviders = [
-      ...info
-    ]
-    return loginProviders
-  }
-  // console.log("getProvidersInfo...cached...loginProviders")
-  return loginProviders
+  // add all requests
+  const promises: Promise<Provider|null>[] = []
+  providers.forEach(provider => {
+    promises.push(
+      getRedirectInfo(provider)
+    )
+  })
+  // return providers with redirectUrl
+  const resp = await Promise.allSettled(promises)
+  // filter null responses (if any)
+  const info: Provider[] = []
+  resp.forEach(item => {
+    if (item.status === 'fulfilled') {
+      info.push(item.value as Provider)
+    }
+  })
+  return info
 }
 
 export default async function handler(

--- a/frontend/pages/api/fe/auth/orcid.ts
+++ b/frontend/pages/api/fe/auth/orcid.ts
@@ -16,7 +16,8 @@
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import type {NextApiRequest, NextApiResponse} from 'next'
 import logger from '~/utils/logger'
-import {RedirectToProps, getAuthorisationEndpoint, getRedirectUrl} from '~/auth/api/authHelpers'
+import {RedirectToProps, getRedirectUrl} from '~/auth/api/authHelpers'
+import {getAuthEndpoint} from '~/auth/api/authEndpoint'
 import {Provider, ApiError} from '.'
 
 type Data = Provider | ApiError
@@ -26,8 +27,8 @@ export async function orcidRedirectProps() {
     // extract well known url from env
     const wellknownUrl = process.env.ORCID_WELL_KNOWN_URL ?? null
     if (wellknownUrl) {
-      // get (cached) authorisation endpoint from well known url
-      const authorization_endpoint = await getAuthorisationEndpoint(wellknownUrl) ?? null
+      // get (cached) authorisation endpoint from wellknown url
+      const authorization_endpoint = await getAuthEndpoint(wellknownUrl,'orcid') ?? null
       if (authorization_endpoint) {
         // construct all props needed for redirectUrl
         const props: RedirectToProps = {

--- a/frontend/pages/api/fe/auth/surfconext.ts
+++ b/frontend/pages/api/fe/auth/surfconext.ts
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,8 +15,9 @@
 
 // Next.js API route support: https://nextjs.org/docs/api-routes/introduction
 import type {NextApiRequest, NextApiResponse} from 'next'
-import {getAuthorisationEndpoint, RedirectToProps, getRedirectUrl} from '~/auth/api/authHelpers'
 import logger from '~/utils/logger'
+import {RedirectToProps, getRedirectUrl} from '~/auth/api/authHelpers'
+import {getAuthEndpoint} from '~/auth/api/authEndpoint'
 import {Provider, ApiError} from '.'
 
 type Data = Provider | ApiError
@@ -30,11 +31,11 @@ const claims = {
 }
 
 export async function surfconextRedirectProps() {
-  // extract wellknow url from env
+  // extract wellknown url from env
   const wellknownUrl = process.env.SURFCONEXT_WELL_KNOWN_URL ?? null
   if (wellknownUrl) {
-    // extract authorisation endpoint from wellknow response
-    const authorization_endpoint = await getAuthorisationEndpoint(wellknownUrl)
+    // get (cached) authorisation endpoint from wellknown url
+    const authorization_endpoint = await getAuthEndpoint(wellknownUrl,'surfconext') ?? null
     if (authorization_endpoint) {
       // construct all props needed for redirectUrl
       const props: RedirectToProps = {


### PR DESCRIPTION
# Cache requests to well known endpoint

Closes #1106



Changes proposed in this pull request:
*   Cache requests to well known endpoint to obtain authorization endpoint url every **60 minutes**  

How to test:
* `make start` to build app and generate test data (not really required)
* observe console logs from the frontend. `docker compose logs frontend -f`

## Example console log
![image](https://github.com/research-software-directory/RSD-as-a-service/assets/9204081/f241e24f-9971-4ba6-87e2-d2b53663ce48)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
