### PR TITLE
chore: remove redundant category types and use MUI component for sele…

### DIFF
--- a/frontend/components/category/CategoriesWithHeadlines.tsx
+++ b/frontend/components/category/CategoriesWithHeadlines.tsx
@@ -1,27 +1,34 @@
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import React from 'react'
 import {useCategoryTree} from '~/utils/categories'
 import {SidebarHeadline} from '../typography/SidebarHeadline'
-import {CategoryTreeLevel, CategoryTreeLevelProps} from './CategoryTree'
 import {CategoryPath} from '~/types/Category'
+import {CategoryTreeLevel} from '~/components/category/CategoryTree'
 
 type CategoriesWithHeadlinesProps = {
   categories: CategoryPath[]
-  onRemove?: CategoryTreeLevelProps['onRemove']
 }
 
-export const CategoriesWithHeadlines = ({categories, onRemove}: CategoriesWithHeadlinesProps) => {
+export const CategoriesWithHeadlines = ({categories}: CategoriesWithHeadlinesProps) => {
   const tree = useCategoryTree(categories)
 
-  return tree.map(({category, children}) => {
+  return tree.map(node => {
+    const category = node.getValue()
+    if (category === null) {
+      return null
+    }
+    const children = node.children()
+
     return <React.Fragment key={category.short_name}>
       <SidebarHeadline iconName={category.properties.icon} title={category.name} />
       <div className='ml-4'>
-        <CategoryTreeLevel items={children} onRemove={onRemove}/>
+        <CategoryTreeLevel items={children} />
       </div>
     </React.Fragment>
   })

--- a/frontend/components/category/CategoryTree.tsx
+++ b/frontend/components/category/CategoryTree.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -8,13 +9,13 @@
 import CancelIcon from '@mui/icons-material/Cancel'
 import Tooltip from '@mui/material/Tooltip'
 import IconButton from '@mui/material/IconButton'
-import {CategoryID, CategoryPath, CategoryTree as TCategoryTree} from '~/types/Category'
-import {useCategoryTree} from '~/utils/categories'
+import {CategoryEntry, CategoryID} from '~/types/Category'
+import {TreeNode} from '~/types/TreeNode'
 
 export type CategoryTreeLevelProps = {
-   items: TCategoryTree
-   showLongNames?: boolean
-   onRemove?: (categoryId: CategoryID) => void
+  items: TreeNode<CategoryEntry>[]
+  showLongNames?: boolean
+  onRemove?: (categoryId: CategoryID) => void
 }
 export const CategoryTreeLevel = ({onRemove, ...props}: CategoryTreeLevelProps) => {
 
@@ -29,33 +30,33 @@ export const CategoryTreeLevel = ({onRemove, ...props}: CategoryTreeLevelProps) 
 
 
 type TreeLevelProps = {
-  items: TCategoryTree
+  items: TreeNode<CategoryEntry>[]
   showLongNames?: boolean
   onRemoveHandler? : (event: React.MouseEvent<HTMLElement>) => void
 }
 const TreeLevel = ({items, showLongNames, onRemoveHandler}: TreeLevelProps) => {
   return <ul className={'list-disc list-outside pl-6'}>
-    {items.map((item) => (
-      <li key={item.category.id}>
-        <div className='flex flex-row justify-between items-start'>
-          <Tooltip title={showLongNames ? item.category.short_name : item.category.name} placement='left'>
-            <span className='pb-1'>{showLongNames ? item.category.name : item.category.short_name}</span>
-          </Tooltip>
-          {onRemoveHandler && item.children.length === 0 && <IconButton sx={{top:'-0.25rem'}} data-id={item.category.id} size='small' onClick={onRemoveHandler}><CancelIcon fontSize='small' /></IconButton>}
-        </div>
-        {item.children.length > 0 && <TreeLevel items={item.children} showLongNames={showLongNames} onRemoveHandler={onRemoveHandler}/> }
-      </li>
-    ))}
+    {items.map((item) => {
+      const category = item.getValue()
+      if (category === null) {
+        return null
+      }
+
+      const children: TreeNode<CategoryEntry>[] = item.children()
+      return (
+        <li key={category.id}>
+          <div className='flex flex-row justify-between items-start'>
+            <Tooltip title={showLongNames ? category.short_name : category.name} placement='left'>
+              <span className='pb-1'>{showLongNames ? category.name : category.short_name}</span>
+            </Tooltip>
+            {onRemoveHandler && children.length === 0 &&
+				<IconButton sx={{top: '-0.25rem'}} data-id={category.id} size='small'
+				  onClick={onRemoveHandler}><CancelIcon fontSize='small'/></IconButton>}
+          </div>
+          {children.length > 0 &&
+			  <TreeLevel items={children} showLongNames={showLongNames} onRemoveHandler={onRemoveHandler}/>}
+        </li>
+      )
+    })}
   </ul>
-}
-
-
-type CategoryTreeProps = {
-  categories: CategoryPath[]
-  showLongNames?: boolean
-  onRemove?: CategoryTreeLevelProps['onRemove']
-}
-export const CategoryTree = ({categories, showLongNames, onRemove}: CategoryTreeProps) => {
-  const tree = useCategoryTree(categories)
-  return <CategoryTreeLevel items={tree} showLongNames={showLongNames} onRemove={onRemove}/>
 }

--- a/frontend/components/category/apiCategories.ts
+++ b/frontend/components/category/apiCategories.ts
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {CategoryEntry} from '~/types/Category'
+import {CategoryEntry, CategoryID} from '~/types/Category'
 import {getBaseUrl} from '~/utils/fetchHelpers'
 import {TreeNode} from '~/types/TreeNode'
 
@@ -16,18 +16,23 @@ export async function loadCategoryRoots(community: string | null){
 
   const categoriesArr: CategoryEntry[] = await resp.json()
 
-  const map: Map<string, TreeNode<CategoryEntry>> = new Map()
+  return categoryEntriesToRoots(categoriesArr)
+
+}
+
+export function categoryEntriesToRoots(categoriesArr: CategoryEntry[]): TreeNode<CategoryEntry>[] {
+  const map: Map<CategoryID, TreeNode<CategoryEntry>> = new Map()
 
   for (const cat of categoriesArr) {
     const id = cat.id
-    let child
+    let node
 
     if (!map.has(id)) {
-      child = new TreeNode<CategoryEntry>(cat)
-      map.set(id, child)
+      node = new TreeNode<CategoryEntry>(cat)
+      map.set(id, node)
     } else {
-      child = map.get(id) as TreeNode<CategoryEntry>
-      child.setValue(cat)
+      node = map.get(id) as TreeNode<CategoryEntry>
+      node.setValue(cat)
     }
 
     if (cat.parent === null) {
@@ -39,10 +44,10 @@ export async function loadCategoryRoots(community: string | null){
       map.set(parentId, new TreeNode<CategoryEntry>(null))
     }
 
-      map.get(parentId)!.addChild(child)
+    map.get(parentId)!.addChild(node)
   }
 
-  const result:TreeNode<CategoryEntry>[] = []
+  const result: TreeNode<CategoryEntry>[] = []
 
   for (const node of map.values()) {
     if (node.getValue()!.parent === null) {
@@ -51,5 +56,4 @@ export async function loadCategoryRoots(community: string | null){
   }
 
   return result
-
 }

--- a/frontend/components/software/CategoriesSection.tsx
+++ b/frontend/components/software/CategoriesSection.tsx
@@ -1,12 +1,14 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {CategoryPath} from '~/types/Category'
 import PageContainer from '../layout/PageContainer'
 import {useCategoryTree} from '~/utils/categories'
-import {CategoryTreeLevel} from '../category/CategoryTree'
+import {CategoryTreeLevel} from '~/components/category/CategoryTree'
 
 export type CategoriesSectionProps = {
   categories: CategoryPath[]
@@ -14,17 +16,26 @@ export type CategoriesSectionProps = {
 export default function CategoriesSection({categories}: CategoriesSectionProps) {
   const tree = useCategoryTree(categories)
 
-  return tree.map((level, index) => (
-    <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]" key={level.category.id}>
-      <h2
-        data-testid="software-categories-section-title"
-        className="pb-8 text-[2rem] text-primary">
-        {level.category.name}
-      </h2>
-      <section>
-        <CategoryTreeLevel items={level.children} showLongNames/>
-      </section>
-    </PageContainer>
-  ))
+  return tree.map(node => {
+    const category = node.getValue()
+    if (category === null) {
+      return null
+    }
+
+    const children = node.children()
+
+    return (
+      <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]" key={category.id}>
+        <h2
+          data-testid="software-categories-section-title"
+          className="pb-8 text-[2rem] text-primary">
+          {category.name}
+        </h2>
+        <section>
+          <CategoryTreeLevel items={children} showLongNames/>
+        </section>
+      </PageContainer>
+    )
+  })
 
 }

--- a/frontend/components/software/TreeSelect.tsx
+++ b/frontend/components/software/TreeSelect.tsx
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Checkbox from '@mui/material/Checkbox'
+import FormControl from '@mui/material/FormControl'
+import InputLabel from '@mui/material/InputLabel'
+import ListItemText from '@mui/material/ListItemText'
+import ListSubheader from '@mui/material/ListSubheader'
+import MenuItem from '@mui/material/MenuItem'
+import Select from '@mui/material/Select'
+import {TreeNode} from '~/types/TreeNode'
+
+export type TreeSelectProps<Type> = {
+  roots: TreeNode<Type>[]
+  textExtractor: (value: Type) => string
+  keyExtractor: (value: Type) => string
+  onSelect: (node: TreeNode<Type>) => void
+  isSelected: (node: TreeNode<Type>) => boolean
+}
+
+type RecursiveTreeSelectProps<Type> = {
+  indent: number
+  nodes: TreeNode<Type>[]
+}
+
+export default function TreeSelect<Type>({
+  isSelected,
+  keyExtractor,
+  onSelect,
+  roots,
+  textExtractor
+}: Readonly<TreeSelectProps<Type>>) {
+  function RecursivelyGenerateItems(propsRecursive: RecursiveTreeSelectProps<Type>) {
+    return propsRecursive.nodes.map(node => {
+      const val = node.getValue()
+      if (val === null) {
+        return null
+      }
+
+      const key = keyExtractor(val)
+      const text = textExtractor(val)
+      if (node.childrenCount() === 0) {
+        return (
+          <MenuItem dense disableRipple key={key} onClick={() => onSelect(node)}>
+            <Checkbox disableRipple checked={isSelected(node)} />
+            <ListItemText primary={text} />
+          </MenuItem>
+        )
+      }
+
+      return (
+        <ListSubheader disableSticky key={key}>{text}
+          <ul>
+            <RecursivelyGenerateItems indent={propsRecursive.indent + 1} nodes={node.children()} />
+          </ul>
+        </ListSubheader>
+      )
+    })
+  }
+
+  return (
+    <FormControl fullWidth>
+      <InputLabel id="category-general-label">Select a category</InputLabel>
+      <Select labelId="category-general-label" label="Select a category">
+        <RecursivelyGenerateItems indent={0} nodes={roots}></RecursivelyGenerateItems>
+      </Select>
+    </FormControl>
+  )
+}

--- a/frontend/components/software/TreeSelect.tsx
+++ b/frontend/components/software/TreeSelect.tsx
@@ -12,27 +12,27 @@ import MenuItem from '@mui/material/MenuItem'
 import Select from '@mui/material/Select'
 import {TreeNode} from '~/types/TreeNode'
 
-export type TreeSelectProps<Type> = {
-  roots: TreeNode<Type>[]
-  textExtractor: (value: Type) => string
-  keyExtractor: (value: Type) => string
-  onSelect: (node: TreeNode<Type>) => void
-  isSelected: (node: TreeNode<Type>) => boolean
+export type TreeSelectProps<T> = {
+  roots: TreeNode<T>[]
+  textExtractor: (value: T) => string
+  keyExtractor: (value: T) => string
+  onSelect: (node: TreeNode<T>) => void
+  isSelected: (node: TreeNode<T>) => boolean
 }
 
-type RecursiveTreeSelectProps<Type> = {
+type RecursiveTreeSelectProps<T> = {
   indent: number
-  nodes: TreeNode<Type>[]
+  nodes: TreeNode<T>[]
 }
 
-export default function TreeSelect<Type>({
+export default function TreeSelect<T>({
   isSelected,
   keyExtractor,
   onSelect,
   roots,
   textExtractor
-}: Readonly<TreeSelectProps<Type>>) {
-  function RecursivelyGenerateItems(propsRecursive: RecursiveTreeSelectProps<Type>) {
+}: Readonly<TreeSelectProps<T>>) {
+  function RecursivelyGenerateItems(propsRecursive: RecursiveTreeSelectProps<T>) {
     return propsRecursive.nodes.map(node => {
       const val = node.getValue()
       if (val === null) {

--- a/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
+++ b/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
@@ -1,135 +1,142 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEventHandler, Fragment, useMemo, useState} from 'react'
-import {useSession} from '~/auth'
-import {ReorderedCategories, leaf, useCategoryTree} from '~/utils/categories'
+import {Fragment, useMemo, useState} from 'react'
+import {CategoryEntry, CategoryID} from '~/types/Category'
+import {categoryTreeNodesSort, ReorderedCategories} from '~/utils/categories'
+import TreeSelect from '~/components/software/TreeSelect'
+import {TreeNode} from '~/types/TreeNode'
 import {addCategoryToSoftware, deleteCategoryToSoftware} from '~/utils/getSoftware'
-import {CategoryID, CategoryPath, CategoryTree, CategoryTreeLevel as TCategoryTreeLevel} from '~/types/Category'
-import useSnackbar from '~/components/snackbar/useSnackbar'
-import EditSectionTitle from '~/components/layout/EditSectionTitle'
-import {config} from '~/components/software/edit/links/config'
+import {useSession} from '~/auth'
 import {CategoryTreeLevel} from '~/components/category/CategoryTree'
+import {config} from '~/components/software/edit/links/config'
+import EditSectionTitle from '~/components/layout/EditSectionTitle'
 
 export type SoftwareCategoriesProps = {
   softwareId: string
-  categories: CategoryPath[]
   reorderedCategories: ReorderedCategories
+  associatedCategoryIds: Set<CategoryID>
 }
-export default function AutosaveSoftwareCategories({softwareId, categories: defaultCategoryPaths, reorderedCategories}: SoftwareCategoriesProps) {
+
+export default function AutosaveSoftwareCategories({softwareId, reorderedCategories, associatedCategoryIds}: Readonly<SoftwareCategoriesProps>) {
+  // trick to force rerender
+  const [_, setAssociatedCategories] = useState<Set<CategoryID>>(associatedCategoryIds)
   const {token} = useSession()
-  const {showErrorMessage} = useSnackbar()
+  const selectedNodes: TreeNode<CategoryEntry>[] = []
+  for (const root of reorderedCategories.all) {
+    const rootSelectedSubTree= root.subTreeWhereLeavesSatisfy(value => associatedCategoryIds.has(value.id))
+    if (rootSelectedSubTree !== null) {
+      selectedNodes.push(rootSelectedSubTree)
+    }
+  }
 
   // want to show each highlighted category plus a general section
-  const availableCategoriesTree = useMemo(() => [
-    ...reorderedCategories.highlighted,
-    {
-      category: {
+  const availableCategoriesTree: TreeNode<CategoryEntry>[] = useMemo(() => {
+    const generalCategories = new TreeNode<CategoryEntry>(
+      {
         id: 'general',
         name: config.categories.title,
-        properties:{subtitle: config.categories.subtitle},
-      },
-      children: reorderedCategories.general
-    } as TCategoryTreeLevel,
-  ], [reorderedCategories])
-
-  // selected category items
-  const [categoryPaths, setCategoryPaths] = useState(defaultCategoryPaths)
-  const categoryTree = useCategoryTree(categoryPaths)
-  const selectedCategoryIDs = useMemo(() => {
-    const ids = new Set()
-    for (const category of categoryPaths ) {
-      ids.add(leaf(category).id)
-    }
-    return ids
-  },[categoryPaths])
-
-  const onAdd: ChangeEventHandler<HTMLSelectElement> = (event) => {
-    const categoryId = event.target.value
-    event.target.value = 'none'
-
-    const categoryPath = reorderedCategories.paths.find(path => leaf(path).id === categoryId)
-    if (!categoryPath) return
-
-    const category = leaf(categoryPath)
-    addCategoryToSoftware(softwareId, category.id, token).then(() => {
-      // Should we trust that this is the current value or should we re-fetch the values from backend?
-      setCategoryPaths([...categoryPaths, categoryPath])
-    }).catch((error) => {
-      showErrorMessage(error.message)
-    })
-  }
-
-  const onRemove = (categoryId: CategoryID) => {
-    deleteCategoryToSoftware(softwareId, categoryId, token).then(() => {
-      // Should we trust that this is the current value or should we re-fetch the values from backend?
-      setCategoryPaths(categoryPaths.filter(path => leaf(path).id != categoryId))
-    }).catch((error) => {
-      showErrorMessage(error.message)
-    })
-  }
-
-  const OptionsTree = ({items, indent=0}: {items: CategoryTree, indent?: number}) => {
-    return items.map((item, index) => {
-      const isLeaf = item.children.length === 0
-      const isSelected = selectedCategoryIDs.has(item.category.id)
-      const title = ' '.repeat(indent)+item.category.name
-      return <Fragment key={title}>
-        {isLeaf ?
-          <option disabled={isSelected} value={item.category.id}>{title}{isSelected && ' ✓'}</option>
-          :
-          <optgroup label={title} />
-        }
-        <OptionsTree items={item.children} indent={indent+1}/>
-      </Fragment>
-    })
-  }
-
-  const extractSelected = (treeLevel: TCategoryTreeLevel, categoryTree:CategoryTree) => {
-    if (treeLevel.category.id == 'general') {
-      const selectedItems = []
-      // scan the general top-level categories
-      for (const general of reorderedCategories.general) {
-        const l1 = categoryTree.find((entry) => entry.category.id == general.category.id )
-        if (l1) selectedItems.push(l1)
+        properties: {subtitle: config.categories.subtitle},
+        community: null, parent: null, provenance_iri: null, short_name: '',
       }
-      return selectedItems
+    )
+    for (const generalRoot of reorderedCategories.general) {
+      generalCategories.addChild(generalRoot)
     }
 
-    return categoryTree.find((entry) => entry.category.id == treeLevel.category.id )?.children
+    const result = [
+      ...reorderedCategories.highlighted,
+      generalCategories
+    ]
+
+    categoryTreeNodesSort(result)
+
+    return result
+  }, [reorderedCategories])
+
+  function deleteCategoryId(categoryId: CategoryID): void {
+    deleteCategoryToSoftware(softwareId, categoryId, token)
+    associatedCategoryIds.delete(categoryId)
+    setAssociatedCategories(new Set(associatedCategoryIds))
   }
 
-  if (reorderedCategories.all.length === 0) return null
+  function addOrDeleteCategory(node: TreeNode<CategoryEntry>): void {
+    const val = node.getValue()
+    if (val === null) {
+      return
+    }
 
-  return availableCategoriesTree.map(treeLevel => {
-    if (treeLevel.children.length == 0) return null
+    const categoryId = val.id
+    if (associatedCategoryIds.has(categoryId)) {
+      deleteCategoryToSoftware(softwareId, categoryId, token)
+      associatedCategoryIds.delete(categoryId)
+    } else {
+      addCategoryToSoftware(softwareId, categoryId, token)
+      associatedCategoryIds.add(categoryId)
+    }
 
-    const selectedItems = extractSelected(treeLevel, categoryTree)
+    setAssociatedCategories(new Set(associatedCategoryIds))
+  }
 
-    return (
-      <Fragment key={treeLevel.category.id}>
-        <div className="py-4"></div>
-        <EditSectionTitle
-          title={treeLevel.category.name}
-          subtitle={treeLevel.category.properties.subtitle}
-        />
-        <div className="mt-4 mb-2">
-          <select className="p-2 w-full" onChange={onAdd}>
-            <option value="none">Select a category</option>
-            <OptionsTree items={treeLevel.children} />
-          </select>
+  function extractSelectedRoots(root: TreeNode<CategoryEntry>): TreeNode<CategoryEntry>[] {
+    const result: TreeNode<CategoryEntry>[] = []
 
-          {selectedItems &&
-              <div className="mt-4">
-                <CategoryTreeLevel items={selectedItems} showLongNames onRemove={onRemove}/>
-              </div>
-          }
-        </div>
-      </Fragment>
-    )
-  })
+    if (root.getValue()!.properties.is_highlight) {
+      for (const selectedRoot of selectedNodes) {
+        if (root.getValue()!.id === selectedRoot.getValue()!.id) {
+          result.push(selectedRoot)
+          break
+        }
+      }
+    } else {
+      for (const selectedRoot of selectedNodes) {
+        if (root.children().some(entry => entry.getValue()?.id === selectedRoot.getValue()!.id)) {
+          result.push(selectedRoot)
+        }
+      }
+    }
+
+    return result
+  }
+
+  return (
+    <>
+      {availableCategoriesTree.map(root => {
+        const rootValue = root.getValue()
+        if (rootValue === null) {
+          return null
+        }
+        const children = root.children()
+
+        return (
+          <Fragment key={rootValue.id}>
+            <EditSectionTitle
+              title={rootValue.name}
+              subtitle={rootValue.properties.subtitle}
+              className="py-4"
+            />
+            <TreeSelect
+              roots={children}
+              textExtractor={value => value.name}
+              keyExtractor={value => value.id}
+              onSelect={node => addOrDeleteCategory(node)}
+              isSelected={node => {
+                const val = node.getValue()
+                return val === null ? false : associatedCategoryIds.has(val.id)
+              }}
+            />
+
+            <div className="mt-6"/>
+
+            <CategoryTreeLevel showLongNames items={extractSelectedRoots(root)} onRemove={deleteCategoryId}/>
+          </Fragment>
+        )
+      })}
+    </>
+  )
 }

--- a/frontend/components/software/edit/links/EditSoftwareMetadataForm.tsx
+++ b/frontend/components/software/edit/links/EditSoftwareMetadataForm.tsx
@@ -8,6 +8,7 @@ import {FormProvider, useForm} from 'react-hook-form'
 import {CategoriesForSoftware, CodePlatform, EditSoftwareItem, KeywordForSoftware, License} from '~/types/SoftwareTypes'
 import {AutocompleteOption} from '~/types/AutocompleteOptions'
 import EditSoftwareMetadataInputs from './EditSoftwareMetadataInputs'
+import {CategoryID} from '~/types/Category'
 
 type EditSoftwareMetadataFormProps={
   id: string
@@ -19,6 +20,7 @@ type EditSoftwareMetadataFormProps={
   licenses: AutocompleteOption<License>[]
   keywords: KeywordForSoftware[]
   categories: CategoriesForSoftware
+  categoryIds: Set<CategoryID>
 }
 
 /**

--- a/frontend/components/software/edit/links/EditSoftwareMetadataInputs.tsx
+++ b/frontend/components/software/edit/links/EditSoftwareMetadataInputs.tsx
@@ -28,7 +28,7 @@ export default function EditSoftwareMetadataInputs() {
   // use form context to interact with form data
   const {watch} = useFormContext<EditSoftwareItem>()
   // watch form data changes
-  const [id,get_started_url,categories] = watch(['id','get_started_url','categories'])
+  const [id, get_started_url, categoryForSoftwareIds] = watch(['id', 'get_started_url', 'categoryForSoftwareIds'])
 
   const reorderedCategories = useReorderedCategories(null)
 
@@ -69,8 +69,8 @@ export default function EditSoftwareMetadataInputs() {
         {/* dynamically shown if enabled/used */}
         <AutosaveSoftwareCategories
           softwareId={id}
-          categories={categories}
           reorderedCategories={reorderedCategories}
+          associatedCategoryIds={categoryForSoftwareIds}
         />
       </div>
       <div className="min-w-[21rem]">

--- a/frontend/components/software/edit/links/SoftwareLinksInfo.tsx
+++ b/frontend/components/software/edit/links/SoftwareLinksInfo.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
@@ -11,6 +12,7 @@ import {Fragment} from 'react'
 import Alert from '@mui/material/Alert'
 import {ReorderedCategories} from '~/utils/categories'
 import {config} from '~/components/software/edit/links/config'
+import {CategoryEntry} from '~/types/Category'
 
 type SoftwareLinksInfoProps = {
   readonly reorderedCategories: ReorderedCategories
@@ -57,7 +59,7 @@ function generateHelpOnCategories(reorderedCategories: ReorderedCategories) {
   const items = []
 
   for (const treeLevel of reorderedCategories.highlighted) {
-    const {category} = treeLevel
+    const category: CategoryEntry = treeLevel.getValue()!
     if (category.properties.is_highlight && category.properties.description) {
       items.push([category.name, category.properties.description])
     }

--- a/frontend/components/software/edit/links/useSoftwareToEdit.test.tsx
+++ b/frontend/components/software/edit/links/useSoftwareToEdit.test.tsx
@@ -2,12 +2,13 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {render, screen} from '@testing-library/react'
 
-import {CategoriesForSoftware} from '~/types/SoftwareTypes'
+import {CategoriesForSoftware, CategoryForSoftwareIds} from '~/types/SoftwareTypes'
 import useSoftwareToEdit from './useSoftwareToEdit'
 
 // MOCS
@@ -21,10 +22,12 @@ jest.mock('~/utils/editSoftware', () => ({
 // MOCK getKeywordsForSoftware, getLicenseForSoftware
 const mockGetKeywordsForSoftware = jest.fn(props => Promise.resolve([] as any))
 const mockGetCategoriesForSoftware = jest.fn(props => Promise.resolve([] as CategoriesForSoftware))
+const mockGetCategoriesForSoftwareIds = jest.fn(props => Promise.resolve(new Set() as CategoryForSoftwareIds))
 const mockGetLicenseForSoftware = jest.fn(props => Promise.resolve([] as any))
 jest.mock('~/utils/getSoftware', () => ({
   getKeywordsForSoftware: jest.fn(props => mockGetKeywordsForSoftware(props)),
   getCategoriesForSoftware: jest.fn(props => mockGetCategoriesForSoftware(props)),
+  getCategoryForSoftwareIds: jest.fn(props => mockGetCategoriesForSoftwareIds),
   getLicenseForSoftware: jest.fn(props => mockGetLicenseForSoftware(props)),
 }))
 

--- a/frontend/components/software/edit/links/useSoftwareToEdit.tsx
+++ b/frontend/components/software/edit/links/useSoftwareToEdit.tsx
@@ -5,6 +5,7 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -15,6 +16,7 @@ import {EditSoftwareItem, KeywordForSoftware, License, LicenseForSoftware} from 
 import {getSoftwareToEdit} from '~/utils/editSoftware'
 import {
   getCategoriesForSoftware,
+  getCategoryForSoftwareIds,
   getKeywordsForSoftware,
   getLicenseForSoftware
 } from '~/utils/getSoftware'
@@ -37,14 +39,16 @@ export async function getSoftwareInfoForEdit({slug, token}: { slug: string, toke
     const requests = [
       getKeywordsForSoftware(software.id, token),
       getCategoriesForSoftware(software.id, token),
+      getCategoryForSoftwareIds(software.id, token),
       getLicenseForSoftware(software.id, token),
     ] as const
     // other api requests
-    const [keywords, categories, respLicense] = await Promise.all(requests)
+    const [keywords, categories, categoryForSoftwareIds, respLicense] = await Promise.all(requests)
     const data:EditSoftwareItem = {
       ...software,
       keywords: keywords as KeywordForSoftware[],
       categories,
+      categoryForSoftwareIds,
       licenses: prepareLicenses(respLicense),
       image_b64: null,
       image_mime_type: null,

--- a/frontend/types/Category.ts
+++ b/frontend/types/Category.ts
@@ -26,9 +26,3 @@ export type CategoryEntry = {
 
 
 export type CategoryPath = CategoryEntry[]
-
-export type CategoryTreeLevel = {
-  category: CategoryEntry
-  children: CategoryTreeLevel[]
-}
-export type CategoryTree = CategoryTreeLevel[]

--- a/frontend/types/SoftwareTypes.ts
+++ b/frontend/types/SoftwareTypes.ts
@@ -15,7 +15,7 @@
  */
 
 import {AutocompleteOption} from './AutocompleteOptions'
-import {CategoryPath} from './Category'
+import {CategoryID, CategoryPath} from './Category'
 import {Status} from './Organisation'
 
 export type CodePlatform = 'github' | 'gitlab' | 'bitbucket' | 'other'
@@ -119,6 +119,7 @@ export type EditSoftwareImage = {
 export type EditSoftwareItem = SoftwareItem & EditSoftwareImage & {
   keywords: KeywordForSoftware[]
   categories: CategoriesForSoftware
+  categoryForSoftwareIds: CategoryForSoftwareIds
   licenses: AutocompleteOption<License>[]
 }
 
@@ -138,8 +139,10 @@ export type KeywordForSoftware = {
 
 export type CategoriesForSoftware = CategoryPath[]
 
+export type CategoryForSoftwareIds = Set<CategoryID>
+
 /**
- * LiCENSES
+ * LICENSES
  */
 
 export type LicenseForSoftware = {

--- a/frontend/types/TreeNode.ts
+++ b/frontend/types/TreeNode.ts
@@ -3,19 +3,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export class TreeNode<Type> {
-  #children: Set<TreeNode<Type>> = new Set()
-  #value: Type | null
+export class TreeNode<T> {
+  #children: Set<TreeNode<T>> = new Set()
+  #value: T | null
 
-  constructor(value: Type | null) {
+  constructor(value: T | null) {
     this.#value = value
   }
 
-  addChild(node: TreeNode<Type>) {
+  addChild(node: TreeNode<T>) {
     this.#children.add(node)
   }
 
-  deleteChild(node: TreeNode<Type>) {
+  deleteChild(node: TreeNode<T>) {
     this.#children.delete(node)
   }
 
@@ -27,20 +27,20 @@ export class TreeNode<Type> {
     return this.#value
   }
 
-  setValue(value: Type | null) {
+  setValue(value: T | null) {
     this.#value = value
   }
 
-  children(): TreeNode<Type>[] {
+  children(): TreeNode<T>[] {
     return Array.from(this.#children)
   }
 
-  subTreeWhereLeavesSatisfy(predicate: (value: Type) => boolean): TreeNode<Type> | null {
+  subTreeWhereLeavesSatisfy(predicate: (value: T) => boolean): TreeNode<T> | null {
     if (this.#children.size === 0) {
-      return (this.#value === null || !(predicate(this.#value)) ? null : new TreeNode<Type>(this.#value))
+      return (this.#value === null || !(predicate(this.#value)) ? null : new TreeNode<T>(this.#value))
     }
 
-    const newNode = new TreeNode<Type>(this.#value)
+    const newNode = new TreeNode<T>(this.#value)
     for (const child of this.#children) {
       const newSubTree = child.subTreeWhereLeavesSatisfy(predicate)
       if (newSubTree !== null) {
@@ -51,7 +51,7 @@ export class TreeNode<Type> {
     return newNode.#children.size === 0 ? null : newNode
   }
 
-  sortRecursively(comparator: (val1: Type, val2: Type) => number) {
+  sortRecursively(comparator: (val1: T, val2: T) => number) {
     const childrenArray = this.children()
     childrenArray.sort((n1, n2) => comparator(n1.#value!, n2.#value!))
     this.#children = new Set(childrenArray)

--- a/frontend/utils/getSoftware.ts
+++ b/frontend/utils/getSoftware.ts
@@ -10,10 +10,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import logger from './logger'
-import {CategoriesForSoftware, KeywordForSoftware, LicenseForSoftware, RepositoryInfo, SoftwareItem, SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
 import {CategoryID} from '~/types/Category'
 import {RelatedProjectForSoftware} from '~/types/Project'
 import {CommunitiesOfSoftware} from '~/components/software/edit/communities/apiSoftwareCommunities'
+import {
+  CategoriesForSoftware,
+  CategoryForSoftwareIds,
+  KeywordForSoftware,
+  LicenseForSoftware,
+  RepositoryInfo,
+  SoftwareItem,
+  SoftwareOverviewItemProps
+} from '~/types/SoftwareTypes'
 import {extractCountFromHeader} from './extractCountFromHeader'
 import {createJsonHeaders, getBaseUrl} from './fetchHelpers'
 
@@ -209,6 +217,26 @@ export async function getCategoriesForSoftware(software_id: string, token?: stri
     logger(`getCategoriesForSoftware: ${e?.message}`, 'error')
   }
   return []
+}
+
+export async function getCategoryForSoftwareIds(software_id: string, token?: string): Promise<CategoryForSoftwareIds> {
+  try {
+    const url = prepareQueryURL('/category_for_software', {software_id: `eq.${software_id}`, select: 'category_id'})
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: createJsonHeaders(token)
+    })
+    if (resp.status === 200) {
+      const data = await resp.json()
+      logger(`getCategoriesForSoftwareIds response: ${JSON.stringify(data)}`)
+      return new Set(data.map((entry: any) => entry.category_id))
+    } else if (resp.status === 404) {
+      logger(`getCategoriesForSoftwareIds: 404 [${url}]`, 'error')
+    }
+  } catch (e: any) {
+    logger(`getCategoriesForSoftwareIds: ${e?.message}`, 'error')
+  }
+  return new Set()
 }
 
 export async function addCategoryToSoftware(softwareId: string, categoryId: CategoryID, token: string) {


### PR DESCRIPTION
## Consolidate category types and use MUI

Changes proposed in this pull request:

* Remove the redundant types `CategoryTreeLevel` and `CategoryTree` and use `TreeNode<CategoryEntry>` instead
* Use MUI components for the category selector on the software edit page

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin
* Create some highlighted categories
* Edit software pages to add and remove categories to them, there should be no errors and the visual state should update immediately
* Check the software view page to see if it's still rendered correctly (nothing should be visually changed here)


Closes #1236

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
