### PR TITLE
Restrict MIME types for image table

### DIFF
--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -889,46 +889,10 @@ function mimeTypeFromFileName(fileName) {
 	if (fileName.endsWith('.png')) {
 		return 'image/png';
 	} else if (fileName.endsWith('.jpg') || fileName.endsWith('.jpeg')) {
-		return 'image/jpg';
+		return 'image/jpeg';
 	} else if (fileName.endsWith('.svg')) {
 		return 'image/svg+xml';
 	} else return null;
-}
-
-// returns the IDs of the images after they have been posted to the database
-async function downloadAndGetImages(urlGenerator, amount) {
-	const imageAsBase64Promises = [];
-	const timeOuts = [];
-	for (let index = 0; index < amount; index++) {
-		const url = urlGenerator();
-		imageAsBase64Promises.push(
-			Promise.race([
-				fetch(url)
-					.then(resp => {
-						clearTimeout(timeOuts[index]);
-						return resp.arrayBuffer();
-					})
-					.then(ab => Buffer.from(ab))
-					.then(bf => bf.toString('base64')),
-				new Promise((res, rej) => (timeOuts[index] = setTimeout(res, 3000))).then(() => {
-					console.warn('Timeout for ' + url + ', skipping');
-					return null;
-				}),
-			]),
-		);
-	}
-	const imagesAsBase64 = await Promise.all(imageAsBase64Promises);
-
-	const imagesWithoutNulls = imagesAsBase64
-		.filter(img => img !== null)
-		.map(base64 => {
-			return {data: base64, mime_type: 'image/jpeg'};
-		});
-
-	const resp = await postToBackend('/image?select=id', imagesWithoutNulls);
-	const idsAsObjects = await resp.json();
-	const ids = idsAsObjects.map(idAsObject => idAsObject.id);
-	return ids;
 }
 
 async function postAccountsToBackend(amount = 100) {

--- a/database/003-create-image-table.sql
+++ b/database/003-create-image-table.sql
@@ -13,7 +13,17 @@ CREATE TABLE image (
 	id VARCHAR(40) PRIMARY KEY,
 	data VARCHAR(2750000) NOT NULL,
 	mime_type VARCHAR(100) NOT NULL,
-	created_at TIMESTAMPTZ NOT NULL
+	created_at TIMESTAMPTZ NOT NULL,
+
+	CONSTRAINT image_valid_mime_type CHECK (mime_type IN (
+		'image/avif',
+		'image/gif',
+		'image/jpeg',
+		'image/png',
+		'image/svg+xml',
+		'image/webp',
+		'image/x-icon'
+	))
 );
 
 CREATE FUNCTION sanitise_insert_image() RETURNS TRIGGER LANGUAGE plpgsql AS

--- a/frontend/components/form/ControlledImageInput.tsx
+++ b/frontend/components/form/ControlledImageInput.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -14,7 +15,7 @@ import {UseFormSetValue} from 'react-hook-form'
 import {useSession} from '~/auth'
 import {deleteImage, getImageUrl} from '~/utils/editImage'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import {handleFileUpload} from '~/utils/handleFileUpload'
+import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
 
 export type FormInputsForImage={
   logo_id: string|null
@@ -108,7 +109,7 @@ export default function ControlledImageInput({name,logo_b64,logo_id,setValue}:Im
         ref={imgInputRef}
         id="upload-avatar-image"
         type="file"
-        accept="image/*"
+        accept={allowedImageMimeTypes}
         onChange={onFileUpload}
         style={{display:'none'}}
       />

--- a/frontend/components/news/edit/AutosaveNewsImage.tsx
+++ b/frontend/components/news/edit/AutosaveNewsImage.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
@@ -15,7 +15,7 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import {useFormContext} from 'react-hook-form'
 
 import {useSession} from '~/auth'
-import {handleFileUpload} from '~/utils/handleFileUpload'
+import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
 import {deleteImage,getImageUrl,upsertImage} from '~/utils/editImage'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import ImageWithPlaceholder from '~/components/layout/ImageWithPlaceholder'
@@ -199,7 +199,7 @@ export default function AutosaveNewsImage() {
       <input
         id="upload-article-image"
         type="file"
-        accept="image/*"
+        accept={allowedImageMimeTypes}
         onChange={onFileUpload}
         style={{display:'none'}}
       />

--- a/frontend/components/organisation/units/ResearchUnitModal.tsx
+++ b/frontend/components/organisation/units/ResearchUnitModal.tsx
@@ -2,8 +2,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,6 +30,7 @@ import {deleteImage, getImageUrl} from '~/utils/editImage'
 import logger from '../../../utils/logger'
 import {getSlugFromString} from '../../../utils/getSlugFromString'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
+import {allowedImageMimeTypes} from '~/utils/handleFileUpload'
 
 
 type EditOrganisationModalProps = {
@@ -219,7 +221,7 @@ export default function ResearchUnitModal({
               <input
                 id="upload-avatar-image-modal"
                 type="file"
-                accept="image/*"
+                accept={allowedImageMimeTypes}
                 onChange={handleFileUpload}
                 style={{display:'none'}}
               />

--- a/frontend/components/person/AvatarOptions.tsx
+++ b/frontend/components/person/AvatarOptions.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,6 +13,7 @@ import IconButton from '@mui/material/IconButton'
 
 import {getImageUrl} from '~/utils/editImage'
 import {getDisplayInitials, getDisplayName} from '~/utils/getDisplayName'
+import {allowedImageMimeTypes} from '~/utils/handleFileUpload'
 
 type AvatarOptionsProps = {
   given_names: string
@@ -57,7 +59,7 @@ export default function AvatarOptions(props: AvatarOptionsProps) {
           data-testid="upload-avatar-input"
           id="upload-avatar-image"
           type="file"
-          accept="image/*"
+          accept={allowedImageMimeTypes}
           onChange={onFileUpload}
           style={{display:'none'}}
         />

--- a/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
@@ -22,7 +22,7 @@ import {projectInformation as config} from './config'
 import {patchProjectTable} from './patchProjectInfo'
 import {upsertImage,deleteImage} from '~/utils/editImage'
 import {ChangeEvent} from 'react'
-import {handleFileUpload} from '~/utils/handleFileUpload'
+import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
 
 export default function AutosaveProjectImage() {
   const {token} = useSession()
@@ -214,7 +214,7 @@ export default function AutosaveProjectImage() {
       <input
         id="upload-avatar-image"
         type="file"
-        accept="image/*"
+        accept={allowedImageMimeTypes}
         onChange={onFileUpload}
         style={{display:'none'}}
       />

--- a/frontend/components/projects/edit/team/EditTeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/EditTeamMemberModal.tsx
@@ -2,9 +2,10 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,7 +29,7 @@ import ControlledSwitch from '~/components/form/ControlledSwitch'
 import ContributorAvatar from '~/components/software/ContributorAvatar'
 import {cfgTeamMembers as config} from './config'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
-import {handleFileUpload} from '~/utils/handleFileUpload'
+import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
 import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
 import {patchTeamMember, postTeamMember} from './editTeamMembers'
 import {getPropsFromObject} from '~/utils/getPropsFromObject'
@@ -237,7 +238,7 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
                 data-testid="upload-avatar-input"
                 id="upload-avatar-image"
                 type="file"
-                accept="image/*"
+                accept={allowedImageMimeTypes}
                 onChange={onFileUpload}
                 style={{display:'none'}}
               />

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -2,9 +2,10 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,7 +29,7 @@ import ContributorAvatar from '../../ContributorAvatar'
 import {contributorInformation as config} from '../editSoftwareConfig'
 import {getDisplayInitials, getDisplayName} from '../../../../utils/getDisplayName'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
-import {handleFileUpload} from '~/utils/handleFileUpload'
+import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
 import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
 import {patchContributor, postContributor} from '~/utils/editContributors'
 import {getPropsFromObject} from '~/utils/getPropsFromObject'
@@ -237,7 +238,7 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
                 data-testid="upload-avatar-input"
                 id="upload-avatar-image"
                 type="file"
-                accept="image/*"
+                accept={allowedImageMimeTypes}
                 onChange={onFileUpload}
                 style={{display:'none'}}
               />

--- a/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
@@ -17,7 +17,7 @@ import {useFormContext} from 'react-hook-form'
 import {softwareInformation as config} from '../editSoftwareConfig'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import ImageWithPlaceholder from '~/components/layout/ImageWithPlaceholder'
-import {handleFileUpload} from '~/utils/handleFileUpload'
+import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
 import {useSession} from '~/auth'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {EditSoftwareItem} from '~/types/SoftwareTypes'
@@ -173,7 +173,7 @@ export default function AutosaveSoftwareLogo() {
       <input
         id="upload-software-logo"
         type="file"
-        accept="image/*"
+        accept={allowedImageMimeTypes}
         onChange={onFileUpload}
         style={{display:'none'}}
       />

--- a/frontend/utils/handleFileUpload.ts
+++ b/frontend/utils/handleFileUpload.ts
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +17,8 @@ type HandleFileUploadResponse = {
 
 // max file size ~ 2MB
 export const maxFileSize = 2097152
+
+export const allowedImageMimeTypes: string = 'image/avif,image/gif,image/jpeg,image/png,image/svg+xml,image/webp,image/x-icon'
 
 export function handleFileUpload({target}: { target: any }): Promise<HandleFileUploadResponse>{
   return new Promise((res, rej) => {
@@ -77,7 +80,7 @@ export function showDialogAndGetFile(): Promise<HandleFileUploadResponse> {
       input.id = id
       input.type = 'file'
       input.name = 'file-input-element'
-      input.accept = 'image/*'
+      input.accept = allowedImageMimeTypes
       input.onchange = (e) => {
         // call file upload function
         handleFileUpload(e)


### PR DESCRIPTION
## Restrict MIME types for image table

Changes proposed in this pull request:

* Restrict the allowed MIME types in the `image` table
* Adapt the frontend to show, by default, only allowed files when choosing an image
* Adapt the data generation script
* Remove an unused function from the data generation script

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin
* Upload some images in various places
* By default, the upload window will only show accepted files
* If you try to upload a non-accepted file, it should fail with an error

**Note**: you might have the non-existing MIME type `image/jpg` in the database. Before applying this in production, you should run the following SQL query:

```sql
UPDATE IMAGE SET mime_type = 'image/jpeg' WHERE mime_type = 'image/jpg';
```

Closes #1241

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
