### PR TITLE
Support repository urls ending with .git

### DIFF
--- a/documentation/docs/01-users/05-adding-software.md
+++ b/documentation/docs/01-users/05-adding-software.md
@@ -87,6 +87,11 @@ The software logo is shown on the software page and in the software card (see ex
 
 - A **Source code repository URL** of the software. This link will show up as a repository icon on the software page and will be used to harvest information about the software development activity, which will be shown as a graph. At the moment we support [GitHub](https://github.com/), [GitLab](https://about.gitlab.com/) and have limited support for [Bitbucket](https://bitbucket.org/product/). The platform is automatically detected from the http domain, but can be changed manually.
 
+  The RSD supports URLs starting with https that point to the repository website, or to the actual git repository, for example:
+
+  * `https://github.com/research-software-directory/RSD-as-a-service` (website)
+  * `https://github.com/research-software-directory/RSD-as-a-service.git` (git repository)
+
 - A **Getting started URL** which refers to webpage with more information about the software. This is shown as the "Get started" button on the software page.
 
 ### Software DOI

--- a/frontend/components/software/edit/links/AutosaveRepositoryUrl.tsx
+++ b/frontend/components/software/edit/links/AutosaveRepositoryUrl.tsx
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -251,7 +251,7 @@ export default function AutosaveRepositoryUrl() {
             useNull: true,
             defaultValue: scraping_disabled_reason,
             helperTextMessage: config.repository_url.help(repository_url),
-            helperTextCnt: `${repository_url?.length || 0}/200`,
+            helperTextCnt: `${scraping_disabled_reason?.length || 0}/200`,
             disabled: user?.role !== 'rsd_admin',
           }}
           control={control}

--- a/frontend/components/software/edit/links/SoftwareLinksInfo.tsx
+++ b/frontend/components/software/edit/links/SoftwareLinksInfo.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
@@ -29,7 +30,7 @@ export default function SoftwareLinksInfo({reorderedCategories}: SoftwareLinksIn
       On this page you can provide links and metadata to better describe your software. Some of this metadata can be imported automatically.
 
       <p className="py-2"><strong>Software URLs</strong></p>
-      <p>Providing the URL of the source code repository of the software allows the RSD show a link to the source code on the software page, and automatically harvest information about the development activity.</p>
+      <p>Providing the URL of the source code repository of the software allows the RSD show a link to the source code on the software page, and automatically harvest information about the development activity. The RSD supports https URLs pointing to the git repository, or to the website of the repository.</p>
       <p className="py-2">The getting started URL can be used to link to a webpage describing how to install and use the software. This link will be prominently shown on the top of the software page.</p>
 
       <p className="py-2"><strong>Software DOI</strong></p>

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GithubScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GithubScraper.java
@@ -1,7 +1,7 @@
+// SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,13 +28,16 @@ import java.util.regex.Pattern;
 public class GithubScraper implements GitScraper {
 
 	private final String BASE_API_URL = "https://api.github.com";
-	private final String organisation;
-	private final String repo;
+	public final String organisation;
+	public final String repo;
 	private static final Pattern LINK_PATTERN = Pattern.compile("<([^>]+page=(\\d+)[^>]*)>; rel=\"([^\"]+)\"");
 	public static final Pattern GITHUB_URL_PATTERN = Pattern.compile("^https?://github\\.com/([^\\s/]+)/([^\\s/]+)/?$");
 
 	private GithubScraper(String organisation, String repo) {
 		this.organisation = Objects.requireNonNull(organisation);
+		if (repo.endsWith(".git")) {
+			repo = repo.substring(0, repo.length() - 4);
+		}
 		this.repo = Objects.requireNonNull(repo);
 	}
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitlabScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitlabScraper.java
@@ -1,7 +1,7 @@
+// SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -35,6 +35,9 @@ public class GitlabScraper implements GitScraper {
 	 */
 	public GitlabScraper(String gitLabApiUrl, String projectPath) {
 		this.projectPath = projectPath;
+		if (this.projectPath.endsWith(".git")) {
+			this.projectPath = this.projectPath.substring(0, this.projectPath.length() - 4);
+		}
 		this.apiUri = gitLabApiUrl + "/v4";
 	}
 

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScaperIT.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScaperIT.java
@@ -1,4 +1,6 @@
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperIT.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperIT.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-public class GithubScaperIT {
+public class GithubScraperIT {
 
 	private final String githubUrlPrefix = "https://github.com/";
 	private final String repo = "research-software-directory/RSD-as-a-service";

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperTest.java
@@ -1,7 +1,7 @@
+// SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,6 +17,7 @@ public class GithubScraperTest {
 
 	private final String githubUrlPrefix = "https://github.com/";
 	private final String repo = "research-software-directory/RSD-as-a-service";
+	private final String repoGit = "research-software-directory/RSD-as-a-service.git";
 	private final String repoEmpty = "cmeessen/empty";
 	private final String repoNonEx = "research-software-directory/does-not-exist";
 
@@ -59,5 +60,11 @@ public class GithubScraperTest {
 
 		Optional<GithubScraper> scraper3 = GithubScraper.create(githubUrlPrefix + "org-only/");
 		Assertions.assertTrue(scraper3.isEmpty());
+	}
+
+	@Test
+	void givenGitRepoUrl_whenCreatingScraper_thenRemoveGitSuffix() {
+		Optional<GithubScraper> scraper = GithubScraper.create(githubUrlPrefix + repoGit);
+		Assertions.assertEquals(repo, scraper.get().organisation + "/" + scraper.get().repo);
 	}
 }

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GitlabScraperIT.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GitlabScraperIT.java
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
Fixes #1244 

Changes proposed in this pull request:

* scrapers recognise repository urls that end with `.git` and scrape them
* adds a sentence to the UI stating which URLs are supported
* update user documentation
* adds tests for the scrapers (disabled)
* rename GithubScaperTestIT to GithubSc**r**aperTestIT
* fix bug where `scraping_disabled_reason` text field shows number of characters of `repository_url`

How to test:

* ```
  docker compose down --volumes && docker compose build --parallel && docker compose up
  ```
* create four software entries with the following repository URLs (or those of you choice) and set them visible:
  * `https://github.com/research-software-directory/RSD-as-a-service.git`
  * `https://github.com/research-software-directory/RSD-as-a-service`
  * `https://codebase.helmholtz.cloud/research-software-directory/RSD-as-a-service.git`
  * `https://codebase.helmholtz.cloud/research-software-directory/RSD-as-a-service`
* wait for the scrapers to run or force them with:
  ```
  docker compose run scrapers /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits
  ```
* verify that the software entries display the scraped information

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
