### PR TITLE
Remove `null` from TreeNode

### DIFF
--- a/frontend/components/category/CategoriesWithHeadlines.tsx
+++ b/frontend/components/category/CategoriesWithHeadlines.tsx
@@ -20,9 +20,6 @@ export const CategoriesWithHeadlines = ({categories}: CategoriesWithHeadlinesPro
 
   return tree.map(node => {
     const category = node.getValue()
-    if (category === null) {
-      return null
-    }
     const children = node.children()
 
     return <React.Fragment key={category.short_name}>

--- a/frontend/components/category/CategoryEditTree.tsx
+++ b/frontend/components/category/CategoryEditTree.tsx
@@ -67,11 +67,11 @@ export default function CategoryEditTree({roots, community, title, onMutation}:C
         />
         }
         {roots.length > 0 ?
-          roots.filter(node => node.getValue() !== null)
+          roots
             .map(node => {
               return (
                 <CategoryEditTreeNode
-                  key={node.getValue()!.id}
+                  key={node.getValue().id}
                   node={node}
                   community={community}
                   onDelete={onDeleteChild}

--- a/frontend/components/category/CategoryEditTreeNode.tsx
+++ b/frontend/components/category/CategoryEditTreeNode.tsx
@@ -170,11 +170,10 @@ export default function CategoryEditTreeNode({node, community, onDelete, onMutat
         }
         {node.childrenCount() > 0 && <Collapse in={expandChildren}>
           {node.children()
-            .filter(child => child.getValue() !== null)
             .map(child => {
               return (
                 <CategoryEditTreeNode
-                  key={child.getValue()?.id}
+                  key={child.getValue().id}
                   node={child}
                   community={community}
                   onDelete={onDeleteChild}

--- a/frontend/components/category/CategoryTable.tsx
+++ b/frontend/components/category/CategoryTable.tsx
@@ -1,5 +1,7 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,9 +14,6 @@ export type CategoryTableProps = Readonly<{
 }>
 export const CategoryTable = ({tree}: CategoryTableProps) => {
   const category = tree.getValue()
-  if (category === null) {
-    return null
-  }
 
   const children = tree.children()
   const levelLables = category.properties.tree_level_labels
@@ -41,9 +40,6 @@ const Block = ({tree, depth}: BlockProps) => {
   const depth2 = depth - 1
   return tree.map((node, index) => {
     const category = node.getValue()
-    if (category === null) {
-      return null
-    }
 
     const children = node.children()
     const border = (index != tree.length-1) ? 'border-b-2' : ''

--- a/frontend/components/category/CategoryTree.tsx
+++ b/frontend/components/category/CategoryTree.tsx
@@ -38,9 +38,6 @@ const TreeLevel = ({items, showLongNames, onRemoveHandler}: TreeLevelProps) => {
   return <ul className={'list-disc list-outside pl-6'}>
     {items.map((item) => {
       const category = item.getValue()
-      if (category === null) {
-        return null
-      }
 
       const children = item.children()
       return (

--- a/frontend/components/category/apiCategories.test.ts
+++ b/frontend/components/category/apiCategories.test.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {CategoryEntry} from '~/types/Category'
+import {categoryEntriesToRoots} from '~/components/category/apiCategories'
+import {TreeNode} from '~/types/TreeNode'
+import {shuffle} from '~/utils/jest/utils'
+
+it('generates the category tree correctly', () => {
+  const grandChild1: CategoryEntry = {id: 'grandChild1', parent: 'child1', short_name: '', name: '', community: null, provenance_iri: null, properties: {}}
+  const grandChild2: CategoryEntry = {id: 'grandChild2', parent: 'child1', short_name: '', name: '', community: null, provenance_iri: null, properties: {}}
+  const grandChild3: CategoryEntry = {id: 'grandChild3', parent: 'child2', short_name: '', name: '', community: null, provenance_iri: null, properties: {}}
+  const grandChild4: CategoryEntry = {id: 'grandChild4', parent: 'child2', short_name: '', name: '', community: null, provenance_iri: null, properties: {}}
+  const child1: CategoryEntry = {id: 'child1', parent: 'parent', short_name: '', name: '', community: null, provenance_iri: null, properties: {}}
+  const child2: CategoryEntry = {id: 'child2', parent: 'parent', short_name: '', name: '', community: null, provenance_iri: null, properties: {}}
+  const parent: CategoryEntry = {id: 'parent', parent: null, short_name: '', name: '', community: null, provenance_iri: null, properties: {}}
+
+  const entries = [
+    parent,
+    child1,
+    child2,
+    grandChild1,
+    grandChild2,
+    grandChild3,
+    grandChild4,
+  ]
+
+  shuffle(entries)
+
+  const tree: TreeNode<CategoryEntry>[] = categoryEntriesToRoots(entries)
+  expect(tree.length).toEqual(1)
+  const parentRoot = tree[0]
+  expect(parentRoot.getValue().id).toEqual('parent')
+  expect(parentRoot.childrenCount()).toEqual(2)
+
+  parentRoot.sortRecursively((ce1, ce2) => ce1.id.localeCompare(ce2.id))
+  const children = parentRoot.children()
+  expect(children.length).toEqual(2)
+  expect(children[0].getValue().id).toEqual('child1')
+  expect(children[1].getValue().id).toEqual('child2')
+
+  const grandChildren1 = children[0].children()
+  expect(grandChildren1.length).toEqual(2)
+  expect(grandChildren1[0].getValue().id).toEqual('grandChild1')
+  expect(grandChildren1[1].getValue().id).toEqual('grandChild2')
+
+  const grandChildren2 = children[1].children()
+  expect(grandChildren2.length).toEqual(2)
+  expect(grandChildren2[0].getValue().id).toEqual('grandChild3')
+  expect(grandChildren2[1].getValue().id).toEqual('grandChild4')
+})

--- a/frontend/components/category/apiCategories.ts
+++ b/frontend/components/category/apiCategories.ts
@@ -58,8 +58,6 @@ export function categoryEntriesToRoots(categoriesArr: CategoryEntry[]): TreeNode
     } else {
       idToNode.get(parentId)!.addChild(node)
     }
-
-
   }
 
   const result: TreeNode<CategoryEntry>[] = []

--- a/frontend/components/category/apiCategories.ts
+++ b/frontend/components/category/apiCategories.ts
@@ -25,17 +25,23 @@ export async function loadCategoryRoots(community: string | null): Promise<TreeN
 }
 
 export function categoryEntriesToRoots(categoriesArr: CategoryEntry[]): TreeNode<CategoryEntry>[] {
-  const map: Map<CategoryID, TreeNode<CategoryEntry>> = new Map()
+  const idToNode: Map<CategoryID, TreeNode<CategoryEntry>> = new Map()
+  const idToChildren: Map<CategoryID, TreeNode<CategoryEntry>[]> = new Map()
 
   for (const cat of categoriesArr) {
     const id = cat.id
-    let node
+    let node: TreeNode<CategoryEntry>
 
-    if (!map.has(id)) {
+    if (!idToNode.has(id)) {
       node = new TreeNode<CategoryEntry>(cat)
-      map.set(id, node)
+      idToNode.set(id, node)
+      if (idToChildren.has(id)) {
+        for (const child of idToChildren.get(id)!) {
+          node.addChild(child)
+        }
+      }
     } else {
-      node = map.get(id) as TreeNode<CategoryEntry>
+      node = idToNode.get(id) as TreeNode<CategoryEntry>
       node.setValue(cat)
     }
 
@@ -44,17 +50,22 @@ export function categoryEntriesToRoots(categoriesArr: CategoryEntry[]): TreeNode
     }
 
     const parentId = cat.parent
-    if (!map.has(parentId)) {
-      map.set(parentId, new TreeNode<CategoryEntry>(null))
+    if (!idToNode.has(parentId)) {
+      if (!idToChildren.has(parentId)) {
+        idToChildren.set(parentId, [])
+      }
+      idToChildren.get(parentId)!.push(node)
+    } else {
+      idToNode.get(parentId)!.addChild(node)
     }
 
-    map.get(parentId)!.addChild(node)
+
   }
 
   const result: TreeNode<CategoryEntry>[] = []
 
-  for (const node of map.values()) {
-    if (node.getValue()!.parent === null) {
+  for (const node of idToNode.values()) {
+    if (node.getValue().parent === null) {
       result.push(node)
     }
   }

--- a/frontend/components/form/AutosaveControlledMarkdown.test.tsx
+++ b/frontend/components/form/AutosaveControlledMarkdown.test.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -52,13 +54,14 @@ it('renders component with text input', () => {
   // render component
   const {container} = render(<WithAllContexts {...mockProps} />)
   // get reference to input
-  const textarea = container.querySelector('#markdown-textarea')
+  const textArea = container.querySelector('#markdown-textarea')
+  expect(textArea).not.toBeNull()
   // check exists
-  expect(textarea).toBeInTheDocument()
+  expect(textArea).toBeInTheDocument()
   // fill in text input
-  fireEvent.change(textarea, {target: {value: testInput}})
+  fireEvent.change(textArea!, {target: {value: testInput}})
   // fire on blur action to trigger save
-  fireEvent.blur(textarea)
+  fireEvent.blur(textArea!)
   // assert save action took place
   expect(mockPatchFn).toBeCalledTimes(1)
   expect(mockPatchFn).toBeCalledWith(expectedSave)

--- a/frontend/components/software/CategoriesSection.tsx
+++ b/frontend/components/software/CategoriesSection.tsx
@@ -19,9 +19,6 @@ export default function CategoriesSection({categories}: CategoriesSectionProps) 
 
   return tree.map(node => {
     const category = node.getValue()
-    if (category === null) {
-      return null
-    }
 
     const children = node.children()
 

--- a/frontend/components/software/TreeSelect.tsx
+++ b/frontend/components/software/TreeSelect.tsx
@@ -37,9 +37,6 @@ export function RecursivelyGenerateItems<T>({
 }: RecursiveTreeSelectProps<T>) {
   return nodes.map(node => {
     const val = node.getValue()
-    if (val === null) {
-      return null
-    }
 
     const key = keyExtractor(val)
     const text = textExtractor(val)

--- a/frontend/components/software/edit/communities/CommunityAddCategoriesDialog.tsx
+++ b/frontend/components/software/edit/communities/CommunityAddCategoriesDialog.tsx
@@ -51,7 +51,7 @@ export default function CommunityAddCategoriesDialog({
 
   function isSelected(node: TreeNode<CategoryEntry>) {
     const val = node.getValue()
-    return val === null ? false : selectedCategoryIds.has(val.id)
+    return selectedCategoryIds.has(val.id)
   }
 
   function textExtractor(value: CategoryEntry) {
@@ -64,9 +64,6 @@ export default function CommunityAddCategoriesDialog({
 
   function onSelect(node: TreeNode<CategoryEntry>) {
     const val = node.getValue()
-    if (val === null) {
-      return
-    }
     if (selectedCategoryIds.has(val.id)) {
       selectedCategoryIds.delete(val.id)
     } else {
@@ -88,7 +85,7 @@ export default function CommunityAddCategoriesDialog({
         for (const root of roots) {
           root.forEach(node => {
             if (node.children().length === 0) {
-              leaveIds.add(node.getValue()!.id)
+              leaveIds.add(node.getValue().id)
             }
           })
         }

--- a/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
+++ b/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
@@ -67,9 +67,6 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
 
   function addOrDeleteCategory(node: TreeNode<CategoryEntry>): void {
     const val = node.getValue()
-    if (val === null) {
-      return
-    }
 
     const categoryId = val.id
     if (associatedCategoryIds.has(categoryId)) {
@@ -86,16 +83,16 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
   function extractSelectedRoots(root: TreeNode<CategoryEntry>): TreeNode<CategoryEntry>[] {
     const result: TreeNode<CategoryEntry>[] = []
 
-    if (root.getValue()!.properties.is_highlight) {
+    if (root.getValue().properties.is_highlight) {
       for (const selectedRoot of selectedNodes) {
-        if (root.getValue()!.id === selectedRoot.getValue()!.id) {
+        if (root.getValue().id === selectedRoot.getValue().id) {
           result.push(selectedRoot)
           break
         }
       }
     } else {
       for (const selectedRoot of selectedNodes) {
-        if (root.children().some(entry => entry.getValue()?.id === selectedRoot.getValue()!.id)) {
+        if (root.children().some(entry => entry.getValue().id === selectedRoot.getValue().id)) {
           result.push(selectedRoot)
         }
       }
@@ -108,9 +105,6 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
     <>
       {availableCategoriesTree.map(root => {
         const rootValue = root.getValue()
-        if (rootValue === null) {
-          return null
-        }
         const children = root.children()
 
         return (
@@ -127,7 +121,7 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
               onSelect={node => addOrDeleteCategory(node)}
               isSelected={node => {
                 const val = node.getValue()
-                return val === null ? false : associatedCategoryIds.has(val.id)
+                return associatedCategoryIds.has(val.id)
               }}
             />
 

--- a/frontend/components/software/edit/links/SoftwareLinksInfo.tsx
+++ b/frontend/components/software/edit/links/SoftwareLinksInfo.tsx
@@ -60,7 +60,7 @@ function generateHelpOnCategories(reorderedCategories: ReorderedCategories) {
   const items = []
 
   for (const treeLevel of reorderedCategories.highlighted) {
-    const category: CategoryEntry = treeLevel.getValue()!
+    const category: CategoryEntry = treeLevel.getValue()
     if (category.properties.is_highlight && category.properties.description) {
       items.push([category.name, category.properties.description])
     }

--- a/frontend/types/TreeNode.ts
+++ b/frontend/types/TreeNode.ts
@@ -5,9 +5,9 @@
 
 export class TreeNode<T> {
   #children: Set<TreeNode<T>> = new Set()
-  #value: T | null
+  #value: T
 
-  constructor(value: T | null) {
+  constructor(value: T) {
     this.#value = value
   }
 
@@ -23,11 +23,11 @@ export class TreeNode<T> {
     return this.#children.size
   }
 
-  getValue() {
+  getValue(): T {
     return this.#value
   }
 
-  setValue(value: T | null) {
+  setValue(value: T) {
     this.#value = value
   }
 
@@ -44,7 +44,7 @@ export class TreeNode<T> {
 
   subTreeWhereLeavesSatisfy(predicate: (value: T) => boolean): TreeNode<T> | null {
     if (this.#children.size === 0) {
-      return (this.#value === null || !(predicate(this.#value)) ? null : new TreeNode<T>(this.#value))
+      return predicate(this.#value) ? new TreeNode<T>(this.#value) : null
     }
 
     const newNode = new TreeNode<T>(this.#value)
@@ -60,7 +60,7 @@ export class TreeNode<T> {
 
   sortRecursively(comparator: (val1: T, val2: T) => number) {
     const childrenArray = this.children()
-    childrenArray.sort((n1, n2) => comparator(n1.#value!, n2.#value!))
+    childrenArray.sort((n1, n2) => comparator(n1.#value, n2.#value))
     this.#children = new Set(childrenArray)
     for (const child of this.#children) {
       child.sortRecursively(comparator)

--- a/frontend/utils/categories.ts
+++ b/frontend/utils/categories.ts
@@ -10,10 +10,8 @@ import {CategoryEntry, CategoryPath} from '~/types/Category'
 import {categoryEntriesToRoots, loadCategoryRoots} from '~/components/category/apiCategories'
 import {TreeNode} from '~/types/TreeNode'
 
-export const leaf = <T>(list: T[]) => list[list.length - 1]
-
 const compareCategoryEntry = (p1: CategoryEntry, p2: CategoryEntry) => p1.name.localeCompare(p2.name)
-const compareCategoryTreeNode = (p1: TreeNode<CategoryEntry>, p2: TreeNode<CategoryEntry>) => compareCategoryEntry(p1.getValue()!, p2.getValue()!)
+const compareCategoryTreeNode = (p1: TreeNode<CategoryEntry>, p2: TreeNode<CategoryEntry>) => compareCategoryEntry(p1.getValue(), p2.getValue())
 
 
 export const categoryTreeNodesSort = (trees: TreeNode<CategoryEntry>[]) => {
@@ -57,7 +55,7 @@ export function reorderCategories(categoryRoots: TreeNode<CategoryEntry>[]): Reo
   const general: TreeNode<CategoryEntry>[] = []
 
   for (const root of all) {
-    if (root.getValue()!.properties.is_highlight) {
+    if (root.getValue().properties.is_highlight) {
       highlighted.push(root)
     } else {
       general.push(root)
@@ -81,7 +79,7 @@ function rootsToPaths(roots: TreeNode<CategoryEntry>[]): CategoryPath[] {
   const resultStack: CategoryPath[] = []
   for (const root of roots) {
     treeNodeStack.push(root)
-    resultStack.push([root.getValue()!])
+    resultStack.push([root.getValue()])
   }
 
   while (treeNodeStack.length > 0) {
@@ -94,7 +92,7 @@ function rootsToPaths(roots: TreeNode<CategoryEntry>[]): CategoryPath[] {
 
     for (const child of node.children()) {
       treeNodeStack.push(child)
-      resultStack.push([...path, child.getValue()!])
+      resultStack.push([...path, child.getValue()])
     }
   }
 

--- a/frontend/utils/jest/utils.js
+++ b/frontend/utils/jest/utils.js
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle#The_modern_algorithm
+export function shuffle(arr) {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const randomIndex = Math.floor(Math.random() * (i + 1));
+    [arr[i], arr[randomIndex]] = [arr[randomIndex], arr[i]]
+  }
+}


### PR DESCRIPTION
## Remove `null` from TreeNode

Changes proposed in this pull request:

* Force the TreeNode values to be non-null and adapt the calling code
* Add a test to check if `categoryEntriesToRoots` works correctly
* Fixed the type in an existing, not-related test

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin
* Check if categories still work correctly everywhere

Closes #1242

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests