### PR TITLE
1247 image upload

### DIFF
--- a/frontend/components/form/ControlledImageInput.tsx
+++ b/frontend/components/form/ControlledImageInput.tsx
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEvent, useRef} from 'react'
+import {ChangeEvent} from 'react'
 
 import Avatar from '@mui/material/Avatar'
 import Button from '@mui/material/Button'
@@ -15,7 +15,8 @@ import {UseFormSetValue} from 'react-hook-form'
 import {useSession} from '~/auth'
 import {deleteImage, getImageUrl} from '~/utils/editImage'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
+import {handleFileUpload} from '~/utils/handleFileUpload'
+import ImageInput from './ImageInput'
 
 export type FormInputsForImage={
   logo_id: string|null
@@ -33,7 +34,6 @@ type ImageInputProps={
 export default function ControlledImageInput({name,logo_b64,logo_id,setValue}:ImageInputProps) {
   const {token} = useSession()
   const {showWarningMessage,showErrorMessage} = useSnackbar()
-  const imgInputRef = useRef<HTMLInputElement>(null)
 
   async function onFileUpload(e:ChangeEvent<HTMLInputElement>|undefined) {
     if (typeof e !== 'undefined') {
@@ -76,10 +76,6 @@ export default function ControlledImageInput({name,logo_b64,logo_id,setValue}:Im
     setValue('logo_id', null)
     setValue('logo_b64', null)
     setValue('logo_mime_type', null, {shouldDirty: true})
-    // remove image value from input
-    if (imgInputRef.current){
-      imgInputRef.current.value = ''
-    }
   }
 
   return (
@@ -105,13 +101,9 @@ export default function ControlledImageInput({name,logo_b64,logo_id,setValue}:Im
           {name ? name.slice(0,3) : ''}
         </Avatar>
       </label>
-      <input
-        ref={imgInputRef}
+      <ImageInput
         id="upload-avatar-image"
-        type="file"
-        accept={allowedImageMimeTypes}
         onChange={onFileUpload}
-        style={{display:'none'}}
       />
       <div className="flex pt-4">
         <Button

--- a/frontend/components/form/ImageInput.tsx
+++ b/frontend/components/form/ImageInput.tsx
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {InputHTMLAttributes} from 'react'
+import {allowedImageMimeTypes} from '~/utils/handleFileUpload'
+
+type ImageInputProps = Omit<InputHTMLAttributes<HTMLInputElement>,'accept'|'style'|'type'>
+
+export default function ImageInput(props:Readonly<ImageInputProps>) {
+  return (
+    <input
+      id="image-input"
+      type="file"
+      style={{display:'none'}}
+      accept={allowedImageMimeTypes}
+      {...props}
+    />
+  )
+}

--- a/frontend/components/news/edit/AutosaveNewsImage.tsx
+++ b/frontend/components/news/edit/AutosaveNewsImage.tsx
@@ -15,7 +15,7 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import {useFormContext} from 'react-hook-form'
 
 import {useSession} from '~/auth'
-import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
+import {handleFileUpload} from '~/utils/handleFileUpload'
 import {deleteImage,getImageUrl,upsertImage} from '~/utils/editImage'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import ImageWithPlaceholder from '~/components/layout/ImageWithPlaceholder'
@@ -23,6 +23,7 @@ import useSnackbar from '~/components/snackbar/useSnackbar'
 import CopyToClipboard from '~/components/layout/CopyToClipboard'
 import {NewsImageProps,NewsItem,addNewsImage,deleteNewsImage} from '../apiNews'
 import {newsConfig as config} from './config'
+import ImageInput from '~/components/form/ImageInput'
 
 type UploadedImageProps={
   imgUrl: string|null,
@@ -196,12 +197,9 @@ export default function AutosaveNewsImage() {
         />
       </label>
 
-      <input
+      <ImageInput
         id="upload-article-image"
-        type="file"
-        accept={allowedImageMimeTypes}
         onChange={onFileUpload}
-        style={{display:'none'}}
       />
     </>
   )

--- a/frontend/components/organisation/apiOrganisations.ts
+++ b/frontend/components/organisation/apiOrganisations.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -173,7 +173,7 @@ export async function getOrganisationById({uuid,token,isMaintainer=false}:
 
 export async function getOrganisationChildren({uuid, token}:
   { uuid: string, token: string}) {
-  const selectList = 'name,primary_maintainer,slug,website,logo_id'
+  const selectList = 'id,name,primary_maintainer,slug,website,logo_id,is_tenant,parent'
   const query = `organisation?parent=eq.${uuid}&order=name.asc&select=${selectList}`
   let url = `${getBaseUrl()}/${query}`
 

--- a/frontend/components/person/AvatarOptions.tsx
+++ b/frontend/components/person/AvatarOptions.tsx
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -13,7 +13,7 @@ import IconButton from '@mui/material/IconButton'
 
 import {getImageUrl} from '~/utils/editImage'
 import {getDisplayInitials, getDisplayName} from '~/utils/getDisplayName'
-import {allowedImageMimeTypes} from '~/utils/handleFileUpload'
+import ImageInput from '~/components/form/ImageInput'
 
 type AvatarOptionsProps = {
   given_names: string
@@ -55,13 +55,10 @@ export default function AvatarOptions(props: AvatarOptionsProps) {
             {getDisplayInitials({given_names, family_names}) ?? ''}
           </Avatar>
         </label>
-        <input
+        <ImageInput
           data-testid="upload-avatar-input"
           id="upload-avatar-image"
-          type="file"
-          accept={allowedImageMimeTypes}
           onChange={onFileUpload}
-          style={{display:'none'}}
         />
       </div>
       <div>

--- a/frontend/components/person/AvatarOptionsPerson.tsx
+++ b/frontend/components/person/AvatarOptionsPerson.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -27,7 +27,7 @@ export type AvatarOptionsProps = {
   setValue: UseFormSetValue<RequiredAvatarProps>
 }
 
-export default function AvatarOptionsContributor(props: AvatarOptionsProps) {
+export default function AvatarOptionsPerson(props: AvatarOptionsProps) {
   const {showWarningMessage, showErrorMessage} = useSnackbar()
   const {setValue, avatar_options, watch} = props
   const [avatar_id, avatar_b64] = watch(['avatar_id', 'avatar_b64'])

--- a/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
@@ -22,7 +22,8 @@ import {projectInformation as config} from './config'
 import {patchProjectTable} from './patchProjectInfo'
 import {upsertImage,deleteImage} from '~/utils/editImage'
 import {ChangeEvent} from 'react'
-import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
+import {handleFileUpload} from '~/utils/handleFileUpload'
+import ImageInput from '~/components/form/ImageInput'
 
 export default function AutosaveProjectImage() {
   const {token} = useSession()
@@ -211,12 +212,9 @@ export default function AutosaveProjectImage() {
         />
       </label>
 
-      <input
+      <ImageInput
         id="upload-avatar-image"
-        type="file"
-        accept={allowedImageMimeTypes}
         onChange={onFileUpload}
-        style={{display:'none'}}
       />
 
       {renderImageAttributes()}

--- a/frontend/components/projects/edit/team/EditTeamMemberModal.tsx
+++ b/frontend/components/projects/edit/team/EditTeamMemberModal.tsx
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
@@ -29,11 +29,12 @@ import ControlledSwitch from '~/components/form/ControlledSwitch'
 import ContributorAvatar from '~/components/software/ContributorAvatar'
 import {cfgTeamMembers as config} from './config'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
-import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
+import {handleFileUpload} from '~/utils/handleFileUpload'
 import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
 import {patchTeamMember, postTeamMember} from './editTeamMembers'
 import {getPropsFromObject} from '~/utils/getPropsFromObject'
 import {TeamMemberProps} from '~/types/Contributor'
+import ImageInput from '~/components/form/ImageInput'
 
 type TeamMemberModalProps = {
   open: boolean,
@@ -234,13 +235,10 @@ export default function TeamMemberModal({open, onCancel, onSubmit, member, pos}:
                   displayInitials={getDisplayInitials(member ?? {}) ?? ''}
                 />
               </label>
-              <input
+              <ImageInput
                 data-testid="upload-avatar-input"
                 id="upload-avatar-image"
-                type="file"
-                accept={allowedImageMimeTypes}
                 onChange={onFileUpload}
-                style={{display:'none'}}
               />
               <div className="flex pt-4">
                 <Button

--- a/frontend/components/software/edit/contributors/EditContributorModal.tsx
+++ b/frontend/components/software/edit/contributors/EditContributorModal.tsx
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
@@ -21,18 +21,19 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import {useForm} from 'react-hook-form'
 
 import {useSession} from '~/auth'
-import useSnackbar from '../../../snackbar/useSnackbar'
-import {Contributor, ContributorProps, SaveContributor} from '../../../../types/Contributor'
-import ControlledTextField from '../../../form/ControlledTextField'
-import ControlledSwitch from '../../../form/ControlledSwitch'
-import ContributorAvatar from '../../ContributorAvatar'
-import {contributorInformation as config} from '../editSoftwareConfig'
-import {getDisplayInitials, getDisplayName} from '../../../../utils/getDisplayName'
-import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
-import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
+import {Contributor, ContributorProps, SaveContributor} from '~/types/Contributor'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {getDisplayInitials, getDisplayName} from '~/utils/getDisplayName'
 import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
 import {patchContributor, postContributor} from '~/utils/editContributors'
 import {getPropsFromObject} from '~/utils/getPropsFromObject'
+import {handleFileUpload} from '~/utils/handleFileUpload'
+import ControlledTextField from '~/components/form/ControlledTextField'
+import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
+import ControlledSwitch from '~/components/form/ControlledSwitch'
+import ImageInput from '~/components/form/ImageInput'
+import ContributorAvatar from '../../ContributorAvatar'
+import {contributorInformation as config} from '../editSoftwareConfig'
 
 type EditContributorModalProps = {
   open: boolean,
@@ -234,13 +235,10 @@ export default function EditContributorModal({open, onCancel, onSubmit, contribu
                   displayInitials={getDisplayInitials(contributor ?? {}) ?? ''}
                 />
               </label>
-              <input
+              <ImageInput
                 data-testid="upload-avatar-input"
                 id="upload-avatar-image"
-                type="file"
-                accept={allowedImageMimeTypes}
                 onChange={onFileUpload}
-                style={{display:'none'}}
               />
               <div className="flex pt-4">
                 <Button

--- a/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
@@ -14,14 +14,15 @@ import Button from '@mui/material/Button'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {useFormContext} from 'react-hook-form'
 
-import {softwareInformation as config} from '../editSoftwareConfig'
+import {useSession} from '~/auth'
+import {EditSoftwareItem} from '~/types/SoftwareTypes'
+import {handleFileUpload} from '~/utils/handleFileUpload'
+import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import ImageWithPlaceholder from '~/components/layout/ImageWithPlaceholder'
-import {allowedImageMimeTypes, handleFileUpload} from '~/utils/handleFileUpload'
-import {useSession} from '~/auth'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import {EditSoftwareItem} from '~/types/SoftwareTypes'
-import {deleteImage, getImageUrl, upsertImage} from '~/utils/editImage'
+import ImageInput from '~/components/form/ImageInput'
+import {softwareInformation as config} from '../editSoftwareConfig'
 import {patchSoftwareTable} from './patchSoftwareTable'
 
 export default function AutosaveSoftwareLogo() {
@@ -170,12 +171,9 @@ export default function AutosaveSoftwareLogo() {
         />
       </label>
 
-      <input
+      <ImageInput
         id="upload-software-logo"
-        type="file"
-        accept={allowedImageMimeTypes}
         onChange={onFileUpload}
-        style={{display:'none'}}
       />
 
       {renderImageAttributes()}

--- a/frontend/utils/handleFileUpload.ts
+++ b/frontend/utils/handleFileUpload.ts
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -75,9 +75,8 @@ export function handleFileUpload({target}: { target: any }): Promise<HandleFileU
 export function showDialogAndGetFile(): Promise<HandleFileUploadResponse> {
   return new Promise((res, rej) => {
     try {
-      const id = 'handle-input-and-file-upload-element'
       const input = document.createElement('input')
-      input.id = id
+      input.id = 'handle-file-upload-element'
       input.type = 'file'
       input.name = 'file-input-element'
       input.accept = allowedImageMimeTypes
@@ -86,6 +85,11 @@ export function showDialogAndGetFile(): Promise<HandleFileUploadResponse> {
         handleFileUpload(e)
           .then(resp => res(resp))
           .catch(err=>rej(err))
+          .finally(()=>{
+            // remove input element
+            // after file upload
+            input.remove()
+          })
       }
       // click on input element
       input.click()


### PR DESCRIPTION
# Refactor image upload

Closes #1247 

Changes proposed in this pull request:
* Create ImageInput component to be used in all other component for image upload
* Fixed organisation unit failed updates (after changing values from the parent organisation)   

How to test:
* `make start` to build and create test data
* login as rsd admin and test all image uploads:
* Software:
  * upload software logo
  * add/edit contributor
  * add/edit organisation
* Project
  * upload body image
  * edit team member
  * add organisation and upload logo
* Organisation
  * add/edit logo
  * add/edit research unit (error fixed)
* News: add/edit news images
* Administration:
  * add/edit organisation image
  * ads/edit community image
   

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
