### PR TITLE
1253 communities redirect

### DIFF
--- a/frontend/components/communities/context/index.tsx
+++ b/frontend/components/communities/context/index.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {PropsWithChildren, createContext, useCallback, useContext, useState} from 'react'
+import {PropsWithChildren, createContext, useCallback, useContext, useEffect, useState} from 'react'
 import {EditCommunityProps} from '~/components/communities/apiCommunities'
 
 type UpdateCommunityProps = {
@@ -40,6 +41,10 @@ const CommunityContext = createContext<CommunityContextProps>({
 export function CommunityProvider({community:initCommunity,isMaintainer:initMaintainer,...props}:any){
   const [community, setCommunity] = useState(initCommunity)
   const [isMaintainer] = useState<boolean>(initMaintainer ?? false)
+
+  useEffect(() => {
+    setCommunity(initCommunity)
+  }, [initCommunity])
 
   const updateCommunity = useCallback(({key,value}:UpdateCommunityProps)=>{
     if (community){

--- a/frontend/components/communities/metadata/CommunityLogo.tsx
+++ b/frontend/components/communities/metadata/CommunityLogo.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useState} from 'react'
+import {useEffect, useState} from 'react'
 
 import {useSession} from '~/auth'
 import {deleteImage,getImageUrl,upsertImage} from '~/utils/editImage'
@@ -29,6 +30,10 @@ export default function CommunityLogo({id,name,logo_id,isMaintainer}:CommunityLo
   const {showErrorMessage} = useSnackbar()
   // currently shown image
   const [logo, setLogo] = useState<string|null>(logo_id)
+
+  useEffect(() => {
+    setLogo(logo_id)
+  }, [logo_id])
 
   // console.group('CommunityLogo')
   // console.log('id...', id)

--- a/frontend/components/organisation/metadata/OrganisationLogo.tsx
+++ b/frontend/components/organisation/metadata/OrganisationLogo.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -40,9 +41,12 @@ export default function OrganisationLogo({isMaintainer}:OrganisationLogoProps) {
   // console.groupEnd()
 
   // Update logo when new value
-  // received from parent
+  // received from parent,
+  // can be null, indicating no logo exists for the org
   useEffect(() => {
-    if (logo_id) setLogo(logo_id)
+    if (logo_id !== undefined) {
+      setLogo(logo_id)
+    }
   },[logo_id])
 
   async function addLogo({data, mime_type}: ImageDataProps) {

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {NextResponse} from 'next/server'
+import type {NextRequest} from 'next/server'
+
+export function middleware(request: NextRequest) {
+  return NextResponse.redirect(request.url + '/software')
+}
+
+export const config = {
+  matcher: '/communities/:path/',
+}

--- a/frontend/next.config.js
+++ b/frontend/next.config.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
@@ -36,17 +36,6 @@ module.exports = {
         source: '/:path*',
         headers: securityHeaders,
       },
-    ]
-  },
-
-  async redirects() {
-    return [
-      // default community redirect to software page
-      {
-        source: '/communities/:slug',
-        destination: '/communities/:slug/software',
-        permanent: true,
-      }
     ]
   },
 


### PR DESCRIPTION
## Various frontend fixes

Changes proposed in this pull request:

* Visiting a community from the global search bar doesn't trigger a full page reload anymore
* Switching between organisations using the global search bar now always shows the correct (maybe missing) logo
* Switching between communities using the global search bar now always shows the correct metadata and (maybe missing) logo

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Switch between various organisations through the global search bar, the correct logo should always be shown, also when the organisation doesn't have a logo
* Do the same for communities, also look at the short description

Closes #1253

Closes #1254

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
