### PR TITLE
Redirect to "My software" after sign in from home page

### DIFF
--- a/frontend/auth/locationCookie.test.ts
+++ b/frontend/auth/locationCookie.test.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -50,7 +51,7 @@ it('ignores these paths', () => {
 it('when root write cookie to redirect to software', () => {
   // should ignore this path
   window.location.pathname = '/'
-  const expectedCookie = 'rsd_pathname=http://localhost/software?order=mention_cnt;path=/auth;SameSite=None;Secure'
+  const expectedCookie = 'rsd_pathname=http://localhost/user/software;path=/auth;SameSite=None;Secure'
   document.cookie = ''
   // call function
   saveLocationCookie()

--- a/frontend/auth/locationCookie.ts
+++ b/frontend/auth/locationCookie.ts
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 //
@@ -22,7 +22,7 @@ export function saveLocationCookie() {
       break
     case '/':
       // root is send to /software
-      document.cookie = `rsd_pathname=${location.href}software?order=mention_cnt;path=/auth;SameSite=None;Secure`
+      document.cookie = `rsd_pathname=${location.href}user/software;path=/auth;SameSite=None;Secure`
       break
     default:
       // write simple browser cookie


### PR DESCRIPTION
## Redirect to "My software" after sign in from home page

Changes proposed in this pull request:

* When signing in from the home page, you are redirected to "My software" istead of the global software overview page

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in from the home page
* You should be at "My software", not the the global software overview page
* When signing in from another page, you should still be redirected back to that page

Closes #1257

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
