### PR TITLE
Backend dependency upgrades

### DIFF
--- a/authentication/Dockerfile
+++ b/authentication/Dockerfile
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.9.5-eclipse-temurin-21 AS builder
+FROM maven:3.9.8-eclipse-temurin-21 AS builder
 WORKDIR /usr/mymaven
 RUN mkdir src
 COPY pom.xml .

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -32,7 +32,7 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.7.1</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin -->
@@ -61,14 +61,15 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M6</version>
+				<version>3.2.5</version>
 			</plugin>
 
 			<!-- https://docs.sonarcloud.io/enriching/test-coverage/java-test-coverage/ -->
+			<!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.10</version>
+				<version>0.8.12</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
@@ -98,7 +99,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>io.javalin</groupId>
 			<artifactId>javalin</artifactId>
-			<version>6.1.3</version>
+			<version>6.2.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
@@ -112,7 +113,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>2.0.9</version>
+			<version>2.0.13</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
@@ -126,7 +127,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.10.1</version>
+			<version>2.11.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.nimbusds/oauth2-oidc-sdk -->
@@ -140,7 +141,6 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>5.8.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -148,7 +148,6 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.8.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -156,7 +155,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.apache.maven.surefire</groupId>
 			<artifactId>surefire-junit-platform</artifactId>
-			<version>3.0.0-M6</version>
+			<version>3.2.5</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -172,14 +171,14 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>net.bytebuddy</groupId>
 			<artifactId>byte-buddy</artifactId>
-			<version>1.14.9</version>
+			<version>1.14.18</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/net.bytebuddy/byte-buddy-agent -->
 		<dependency>
 			<groupId>net.bytebuddy</groupId>
 			<artifactId>byte-buddy-agent</artifactId>
-			<version>1.14.9</version>
+			<version>1.14.18</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -187,10 +186,11 @@ SPDX-License-Identifier: Apache-2.0
 
 	<dependencyManagement>
 		<dependencies>
+			<!-- https://mvnrepository.com/artifact/org.junit/junit-bom -->
 			<dependency>
 				<groupId>org.junit</groupId>
 				<artifactId>junit-bom</artifactId>
-				<version>5.8.2</version>
+				<version>5.10.3</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>

--- a/backend-postgrest/Dockerfile
+++ b/backend-postgrest/Dockerfile
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgrest/postgrest:v12.0.2
+FROM postgrest/postgrest:v12.2.2

--- a/backend-tests/Dockerfile
+++ b/backend-tests/Dockerfile
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.9.5-eclipse-temurin-21
+FROM maven:3.9.8-eclipse-temurin-21
 WORKDIR /usr/mymaven
 RUN mkdir src
 COPY pom.xml .

--- a/backend-tests/pom.xml
+++ b/backend-tests/pom.xml
@@ -28,7 +28,7 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.7.1</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-surefire-plugin -->
@@ -50,14 +50,14 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-engine</artifactId>
-				<version>5.10.1</version>
+				<version>5.10.3</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.junit.platform/junit-platform-launcher -->
 			<plugin>
 				<groupId>org.junit.platform</groupId>
 				<artifactId>junit-platform-launcher</artifactId>
-				<version>1.10.1</version>
+				<version>1.10.3</version>
 			</plugin>
 		</plugins>
 	</build>
@@ -68,7 +68,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.10.1</version>
+			<version>2.11.0</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -83,7 +83,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>rest-assured</artifactId>
-			<version>5.4.0</version>
+			<version>5.5.0</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -91,7 +91,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-api</artifactId>
-			<version>5.10.1</version>
+			<version>5.10.3</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/codemeta/Dockerfile
+++ b/codemeta/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM golang:1.22.2-bookworm AS builder
+FROM golang:1.22.5-bookworm AS builder
 
 WORKDIR /usr/src/app
 COPY go.mod .

--- a/codemeta/template/overview.gohtml
+++ b/codemeta/template/overview.gohtml
@@ -3,7 +3,9 @@
 <head>
 	<meta charset="UTF-8">
 	<title>CodeMeta overview</title>
-	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2.0.3/css/pico.min.css">
+	<link rel="stylesheet" crossorigin="anonymous"
+		  integrity="sha256-UX1QXFbL3Q8J8D+FaNSZ66h7MsTUB5/2ZgX49wjIX7Y="
+		  href="https://cdn.jsdelivr.net/npm/@picocss/pico@2.0.6/css/pico.css">
 </head>
 <body class="container">
 <h1>

--- a/data-generation/Dockerfile
+++ b/data-generation/Dockerfile
@@ -1,9 +1,9 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM node:21.4.0-bullseye-slim
+FROM node:22.5.1-bullseye-slim
 WORKDIR /usr/app
 COPY ./package.json /usr/app
 RUN npm install

--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -455,7 +455,7 @@ function generateOrcids(amount = 50) {
 	const orcids = new Set();
 
 	while (orcids.size < amount) {
-		orcids.add(faker.helpers.replaceSymbolWithNumber('0000-000#-####-####'));
+		orcids.add(faker.helpers.replaceSymbols('0000-000#-####-####'));
 	}
 
 	return [...orcids];

--- a/data-generation/package-lock.json
+++ b/data-generation/package-lock.json
@@ -9,18 +9,18 @@
 			"version": "1.0.0",
 			"license": "ISC",
 			"dependencies": {
-				"@faker-js/faker": "8.3.1",
+				"@faker-js/faker": "8.4.1",
 				"jsonwebtoken": "9.0.2",
 				"wait-on": "7.2.0"
 			},
 			"devDependencies": {
-				"prettier": "3.2.5"
+				"prettier": "3.3.3"
 			}
 		},
 		"node_modules/@faker-js/faker": {
-			"version": "8.3.1",
-			"resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.3.1.tgz",
-			"integrity": "sha512-FdgpFxY6V6rLZE9mmIBb9hM0xpfvQOSNOLnzolzKwsE1DH+gC7lEKV1p1IbR0lAYyvYd5a4u3qWJzowUkw1bIw==",
+			"version": "8.4.1",
+			"resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-8.4.1.tgz",
+			"integrity": "sha512-XQ3cU+Q8Uqmrbf2e0cIC/QN43sTBSC8KF12u29Mb47tWrt2hAgBXSgpZMj4Ao8Uk0iJcU99QsOCaIL8934obCg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -267,9 +267,9 @@
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
 		"node_modules/prettier": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
-			"integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+			"integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"

--- a/data-generation/package.json
+++ b/data-generation/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@faker-js/faker": "8.3.1",
+		"@faker-js/faker": "8.4.1",
 		"jsonwebtoken": "9.0.2",
 		"wait-on": "7.2.0"
 	},
@@ -12,11 +12,9 @@
 		"format:check": "prettier --check .",
 		"format:fix": "prettier --write ."
 	},
-	"author": "",
-	"license": "ISC",
-	"description": "",
+	"description": "This module generates and stores fake data for the RSD for testing purposes",
 	"type": "module",
 	"devDependencies": {
-		"prettier": "3.2.5"
+		"prettier": "3.3.3"
 	}
 }

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgres:15.6
+FROM postgres:15.7
 RUN chmod a+rwx /docker-entrypoint-initdb.d
 COPY --chown=postgres:postgres *.sh /docker-entrypoint-initdb.d/
 COPY --chown=postgres:postgres *.sql /docker-entrypoint-initdb.d/

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -3,6 +3,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM nginx:1.25.4
+FROM nginx:1.26.1
 RUN apt-get update && apt-get install --yes certbot python3-certbot-nginx
 COPY nginx.conf /etc/nginx/conf.d/default.conf

--- a/scrapers/Dockerfile
+++ b/scrapers/Dockerfile
@@ -1,11 +1,11 @@
-# SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.9.5-eclipse-temurin-21 AS builder
+FROM maven:3.9.8-eclipse-temurin-21 AS builder
 WORKDIR /usr/mymaven
 RUN mkdir ./src
 COPY pom.xml .

--- a/scrapers/pom.xml
+++ b/scrapers/pom.xml
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.6.1</version>
+				<version>3.7.1</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin -->
@@ -63,14 +63,15 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>3.0.0-M6</version>
+				<version>3.2.5</version>
 			</plugin>
 
 			<!-- https://docs.sonarcloud.io/enriching/test-coverage/java-test-coverage/ -->
+			<!-- https://mvnrepository.com/artifact/org.jacoco/jacoco-maven-plugin -->
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.8.10</version>
+				<version>0.8.12</version>
 				<executions>
 					<execution>
 						<id>prepare-agent</id>
@@ -99,7 +100,7 @@ SPDX-License-Identifier: Apache-2.0
 			<dependency>
 				<groupId>org.junit</groupId>
 				<artifactId>junit-bom</artifactId>
-				<version>5.8.2</version>
+				<version>5.10.3</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -107,18 +108,18 @@ SPDX-License-Identifier: Apache-2.0
 	</dependencyManagement>
 
 	<dependencies>
-                <!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
+		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-api -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
-		        <artifactId>slf4j-api</artifactId>
-  	 	        <version>2.0.11</version>
+				<artifactId>slf4j-api</artifactId>
+				<version>2.0.13</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-classic -->
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.4.14</version>
+			<version>1.5.6</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
@@ -132,14 +133,13 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
-			<version>2.10.1</version>
+			<version>2.11.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>5.8.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -147,7 +147,6 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.junit.platform</groupId>
 			<artifactId>junit-platform-launcher</artifactId>
-			<version>1.8.2</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -155,7 +154,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.apache.maven.surefire</groupId>
 			<artifactId>surefire-junit-platform</artifactId>
-			<version>3.0.0-M6</version>
+			<version>3.2.5</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -170,13 +169,13 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.16.1</version>
+			<version>2.17.2</version>
 		</dependency>
 		<!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.dataformat/jackson-dataformat-yaml -->
 		<dependency>
 			<groupId>com.fasterxml.jackson.dataformat</groupId>
 			<artifactId>jackson-dataformat-yaml</artifactId>
-			<version>2.16.1</version>
+			<version>2.17.2</version>
 		</dependency>
 
 


### PR DESCRIPTION
## Backend dependency upgrades

Changes proposed in this pull request:

* Upgrade various dependencies used in the backend, including those described as in #1262

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Check if everything still works
* `docker compose down --volumes`
* `make run-backend-tests` should report 15 tests with 0 failures, errors or skipped

Closes #1262

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
