### PR TITLE
Option to disallow package manager harvesting

### DIFF
--- a/database/005-create-relations-for-software.sql
+++ b/database/005-create-relations-for-software.sql
@@ -65,9 +65,11 @@ CREATE TABLE package_manager (
 	download_count BIGINT,
 	download_count_last_error VARCHAR(500),
 	download_count_scraped_at TIMESTAMPTZ,
+	download_count_scraping_disabled_reason VARCHAR(200),
 	reverse_dependency_count INTEGER,
 	reverse_dependency_count_last_error VARCHAR(500),
 	reverse_dependency_count_scraped_at TIMESTAMPTZ,
+	reverse_dependency_count_scraping_disabled_reason VARCHAR(200),
 	position INTEGER,
 	created_at TIMESTAMPTZ NOT NULL,
 	updated_at TIMESTAMPTZ NOT NULL

--- a/documentation/docs/03-rsd-instance/03-administration.md
+++ b/documentation/docs/03-rsd-instance/03-administration.md
@@ -3,8 +3,8 @@
 This section describes administration options available in the RSD.
 
 :::tip
-To be able to log in as RSD administrator you first need to define a list of rsd admin users in the .env file.
-See [Login as rsd administrator in the getting started section](/rsd-instance/getting-started/#log-in-as-rsd-administrator).
+To be able to log in as an RSD administrator, you first need to grant an existing user admin privileges in the database.
+See [Log in as rsd administrator in the getting started section](/rsd-instance/getting-started/#log-in-as-rsd-administrator).
 :::
 
 ## Public pages
@@ -65,7 +65,7 @@ You can add, search and delete ORCIDs from the RSD. Use the bulk import button t
 
 ## RSD users
 
-This section shows all RSD users who logged in to RSD at least once. You can search for users, assign the administrator role (rsd_admin) or delete user accounts.
+This section shows all RSD users who logged in to RSD at least once. You can search for users, assign the administrator role (`rsd_admin`) or delete user accounts.
 
 :::danger
 
@@ -93,7 +93,7 @@ Use the search box to find organisations in the ROR database. This is the prefer
 
 ### Define organisation primary maintainer
 
-The primary maintainer of an organisation is defined by an RSD administrator. You need to provide the user id in the general settings section. The user id is unique, and it is automatically created by RSD after a user is logged in for the first time.
+The primary maintainer of an organisation is defined by an RSD administrator. You need to provide the user ID in the general settings section. The user ID is unique, and it is automatically created by RSD after a user is logged in for the first time.
 
 ![animation](img/organisation-maintainers-primary-invite.gif)
 
@@ -140,7 +140,7 @@ Only RSD administrators can create communities.
 
 ### Add community
 
-To create new community use "Add" button. Provide name, short description and logo in the modal.
+To create new community use "Add" button. Provide a name, short description and logo in the modal.
 
 ### Edit community
 
@@ -205,6 +205,26 @@ This section is used to show public announcements to all users of the RSD. It is
 
 ![animation](img/admin-announcement.gif)
 
+## Software
+
+### Slug
+
+When editing a software page, the **slug** of the page (called **RSD path**) can be changed by admins under the **Description** tab.
+
+### Disable Git harvesting
+
+If you want to disable the harvesting of a Git repo, you can do so by providing a reason under the **Links & metadata** tab. Page maintainers will be able to see if and why the harvesting is disabled under the **Background services** tab.
+
+### Disable package manager harvesting
+
+If you want to disable the harvesting of a package manager, you can do so by providing a reason under the **Package managers** tab. Page maintainers will be able to see if and why the harvesting is disabled under the **Background services** tab.
+
+## Project
+
+### Slug
+
+When editing a project page, the **slug** of the page (called **RSD path**) can be changed by admins under the **Project details** tab.
+
 ## News
 
 RSD administrators are able to create news items. The additional option "Add news" will appear in the "+" menu at the top right of the page header.
@@ -232,7 +252,7 @@ After news item is created you will be redirected to edit news item page. Here y
 - Publication date is shown in the header of the news title. It can be changed at any time. Note that changing the publication title also changes public url of the news item.
 - First uploaded image is used in the news card.
 - Using "Copy link" button you can copy the Markdown syntax to the clipboard and the paste the link at the desired location of the body.
-- Using "Delete" button will delete image and the Markdown link syntax from the news body.
+- Using "Delete" button will delete the image and the Markdown link syntax from the news body.
 
 :::
 

--- a/frontend/components/software/edit/package-managers/apiPackageManager.ts
+++ b/frontend/components/software/edit/package-managers/apiPackageManager.ts
@@ -9,10 +9,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import logger from '~/utils/logger'
-import {
-  createJsonHeaders, extractErrorMessages,
-  extractReturnMessage, getBaseUrl
-} from '~/utils/fetchHelpers'
+import {createJsonHeaders, extractErrorMessages, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
 
 export type PackageManagerSettings={
   name: string,
@@ -126,7 +123,7 @@ export type NewPackageManager = {
   id: string|null
   software: string,
   url: string,
-  package_manager: PackageManagerTypes|null,
+  package_manager: PackageManagerTypes | null,
   position: number
 }
 
@@ -138,11 +135,13 @@ export type PackageManager = NewPackageManager & {
   id: string,
   download_count: number | null,
   download_count_scraped_at: string | null,
+  download_count_scraping_disabled_reason: string | null,
   reverse_dependency_count: number | null,
-  reverse_dependency_count_scraped_at: string | null
+  reverse_dependency_count_scraped_at: string | null,
+  reverse_dependency_count_scraping_disabled_reason: string | null,
 }
 
-export async function getPackageManagers({software, token}: { software: string, token?: string }) {
+export async function getPackageManagers({software, token}: { software: string, token?: string }): Promise<PackageManager[]> {
   try {
     const query = `software=eq.${software}&order=position.asc,package_manager.asc`
     const url = `${getBaseUrl()}/package_manager?${query}`
@@ -156,8 +155,7 @@ export async function getPackageManagers({software, token}: { software: string, 
     })
 
     if (resp.status === 200) {
-      const json:PackageManager[] = await resp.json()
-      return json
+      return await resp.json()
     }
     logger(`getPackageManagers...${resp.status} ${resp.statusText}`,'warn')
     return []

--- a/frontend/components/software/edit/services/PackageManagerServices.tsx
+++ b/frontend/components/software/edit/services/PackageManagerServices.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -35,6 +36,7 @@ export default function PackageManagerServices() {
                     last_error={service.download_count_last_error}
                     url={service.url}
                     platform={null}
+                    scraping_disabled_reason={service.download_count_scraping_disabled_reason}
                   />
                   : null
                 }
@@ -46,6 +48,7 @@ export default function PackageManagerServices() {
                     last_error={service.reverse_dependency_count_last_error}
                     url={service.url}
                     platform={null}
+                    scraping_disabled_reason={service.reverse_dependency_count_scraping_disabled_reason}
                   />
                   : null
                 }

--- a/frontend/components/software/edit/services/ServiceInfoListItem.tsx
+++ b/frontend/components/software/edit/services/ServiceInfoListItem.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,14 +16,15 @@ import DoDisturbOnIcon from '@mui/icons-material/DoDisturbOn'
 import {CodePlatform} from '~/types/SoftwareTypes'
 
 type ServiceInfoListItemProps={
-  title:string
-  scraped_at: string|null
-  last_error: string|null
-  url: string|null
-  platform: CodePlatform|null
+  readonly title:string
+  readonly scraped_at: string|null
+  readonly last_error: string|null
+  readonly url: string|null
+  readonly platform: CodePlatform|null
+  readonly scraping_disabled_reason: string|null
 }
 
-export function ServiceInfoListItem({title,scraped_at,last_error,url,platform}:ServiceInfoListItemProps){
+export function ServiceInfoListItem({title,scraped_at,last_error,url,platform,scraping_disabled_reason}:ServiceInfoListItemProps){
   let status:'error'|'success'|'not_active'|'scheduled'|'not_supported' = 'not_active'
 
   // set service status
@@ -38,6 +40,7 @@ export function ServiceInfoListItem({title,scraped_at,last_error,url,platform}:S
   if (status==='not_active') color='warning.main'
 
   function getStatusIcon(){
+    if (scraping_disabled_reason !== null) return <DoDisturbOnIcon sx={{width:'2.5rem',height:'2.5rem'}} />
     if (status === 'error') return <ErrorIcon sx={{width:'2.5rem',height:'2.5rem'}} />
     if (status === 'success') return <CheckCircleIcon sx={{width:'2.5rem',height:'2.5rem'}} />
     if (status === 'scheduled') return <ScheduleIcon sx={{width:'2.5rem',height:'2.5rem'}} />
@@ -46,6 +49,10 @@ export function ServiceInfoListItem({title,scraped_at,last_error,url,platform}:S
   }
 
   function getStatusMsg(){
+    if (scraping_disabled_reason !== null) {
+      return (<span className="text-error">{`This harvester was disabled by the admins for the following reason: ${scraping_disabled_reason}`}</span>)
+    }
+
     if (last_error) return (
       <span className="text-error">{last_error}</span>
     )

--- a/frontend/components/software/edit/services/SoftwareRepoServices.tsx
+++ b/frontend/components/software/edit/services/SoftwareRepoServices.tsx
@@ -33,7 +33,7 @@ export default function SoftwareRepoServices() {
             platform: services ? services['code_platform'] : null
           }
           return (
-            <ServiceInfoListItem key={service.name} {...props} />
+            <ServiceInfoListItem key={service.name} scraping_disabled_reason={null} {...props} />
           )
         })}
       </List>

--- a/frontend/components/software/edit/services/apiSoftwareServices.tsx
+++ b/frontend/components/software/edit/services/apiSoftwareServices.tsx
@@ -31,8 +31,10 @@ export type PackageManagerService = {
   package_manager: PackageManagerTypes,
 	download_count_scraped_at: string|null,
 	download_count_last_error: string|null,
+  download_count_scraping_disabled_reason: string|null,
 	reverse_dependency_count_scraped_at: string|null,
-	reverse_dependency_count_last_error: string|null
+	reverse_dependency_count_last_error: string|null,
+  reverse_dependency_count_scraping_disabled_reason: string|null,
 }
 
 async function getSoftwareServices(id:string,token:string){
@@ -61,7 +63,7 @@ async function getSoftwareServices(id:string,token:string){
 
 async function getPackageManagerServices(id:string,token:string){
   try{
-    const select='select=software,url,package_manager,download_count_scraped_at,download_count_last_error,reverse_dependency_count_scraped_at,reverse_dependency_count_last_error'
+    const select='select=software,url,package_manager,download_count_scraped_at,download_count_last_error,download_count_scraping_disabled_reason,reverse_dependency_count_scraped_at,reverse_dependency_count_last_error,reverse_dependency_count_scraping_disabled_reason'
     const query = `${select}&software=eq.${id}&order=position`
     const url = `${getBaseUrl()}/package_manager?${query}`
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
@@ -27,7 +27,7 @@ public class PostgrestConnector {
 	}
 
 	public Collection<BasicPackageManagerData> oldestDownloadCounts(int limit) {
-		String filter = "or=(package_manager.eq.dockerhub)";
+		String filter = "download_count_scraping_disabled_reason=is.null&or=(package_manager.eq.dockerhub)";
 		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=id,url,package_manager&order=download_count_scraped_at.asc.nullsfirst&limit=" + limit
 				+ "&" + Utils.atLeastOneHourAgoFilter("download_count_scraped_at")
 		);
@@ -35,7 +35,7 @@ public class PostgrestConnector {
 	}
 
 	public Collection<BasicPackageManagerData> oldestReverseDependencyCounts(int limit) {
-		String filter = "or=(package_manager.eq.anaconda,package_manager.eq.cran,package_manager.eq.crates,package_manager.eq.golang,package_manager.eq.maven,package_manager.eq.npm,package_manager.eq.pypi,package_manager.eq.sonatype)";
+		String filter = "reverse_dependency_count_scraping_disabled_reason=is.null&or=(package_manager.eq.anaconda,package_manager.eq.cran,package_manager.eq.crates,package_manager.eq.golang,package_manager.eq.maven,package_manager.eq.npm,package_manager.eq.pypi,package_manager.eq.sonatype)";
 		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=id,url,package_manager&order=reverse_dependency_count_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("reverse_dependency_count_scraped_at"));
 		return parseBasicJsonData(data);
 	}


### PR DESCRIPTION
## Option to disallow package manager harvesting

Changes proposed in this pull request:

* Admins can disable the harvesting of specific package managers statistics by supplying a reason as to why it is disabled
* Page maintainer can see if and why a harvester is disabled on the `Background services` tab
* Add documentation on this

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin
* Create a software page, publish it and add some package managers
* Disable those package managers
* Check that the reason is visible on the `Background services` tab
* Run the harvesters: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.package_manager.MainPackageManager`
* Check that the `*_updated_at` fields are still `null` at http://localhost/api/v1/package_manager
* Enable harvesting again by removing the reasons
* Run the harvesters again
* Check that the applicable `*_updated_at` fields are now set
* Check out the new documentation under http://localhost/documentation/rsd-instance/administration/#software

Closes #1117

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [ ] Tests
