### PR TITLE
Don't show categories dropdown when there are no categories

### DIFF
--- a/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
+++ b/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
@@ -49,10 +49,15 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
       generalCategories.addChild(generalRoot)
     }
 
-    const result = [
-      ...reorderedCategories.highlighted,
-      generalCategories
-    ]
+    // prevent the dropdown from being there if there are no global categories
+    const result = generalCategories.childrenCount() > 0
+      ?
+      [
+        ...reorderedCategories.highlighted,
+        generalCategories
+      ]
+      :
+      reorderedCategories.highlighted
 
     categoryTreeNodesSort(result)
 
@@ -112,7 +117,7 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
             <EditSectionTitle
               title={rootValue.name}
               subtitle={rootValue.properties.subtitle}
-              className="py-4"
+              className="font-medium py-4"
             />
             <TreeSelect
               roots={children}

--- a/frontend/components/software/edit/links/EditSoftwareMetadataInputs.tsx
+++ b/frontend/components/software/edit/links/EditSoftwareMetadataInputs.tsx
@@ -22,7 +22,7 @@ import AutosaveSoftwareCategories from './AutosaveSoftwareCategories'
 import AutosaveSoftwareKeywords from './AutosaveSoftwareKeywords'
 import AutosaveSoftwareLicenses from './AutosaveSoftwareLicenses'
 import SoftwareLinksInfo from './SoftwareLinksInfo'
-import {useReorderedCategories} from '~/utils/categories'
+import {ReorderedCategories, useReorderedCategories} from '~/utils/categories'
 
 export default function EditSoftwareMetadataInputs() {
   // use form context to interact with form data
@@ -30,7 +30,7 @@ export default function EditSoftwareMetadataInputs() {
   // watch form data changes
   const [id, get_started_url, categoryForSoftwareIds] = watch(['id', 'get_started_url', 'categoryForSoftwareIds'])
 
-  const reorderedCategories = useReorderedCategories(null)
+  const reorderedCategories: ReorderedCategories = useReorderedCategories(null)
 
   // console.group('EditSoftwareMetadataInputs')
   // console.log('editSoftware...', editSoftware)


### PR DESCRIPTION
## Don't show categories dropdown when there are no categories

Changes proposed in this pull request:

* Don't show the categories dropdown when there are no categories to choose from
* Fix the font weight as described in #1251

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin
* Create a software page, go to the **Links & metadata** tab
* There should be no dropdown for the categories
* Add some categories as admin
* The dropdown should be there
* Mix and match with regular/highlighted categories being present or not and check if the drowdown(s) are as expected

Closes #1251

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
