### PR TITLE
Deduplicate and test some authentication code

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OrcidLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OrcidLogin.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,6 @@ import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.StringJoiner;
 
 public class OrcidLogin implements Login {
 
@@ -60,27 +59,16 @@ public class OrcidLogin implements Login {
 	}
 
 	private String getTokensFromOrcidconext(Map<String, String> form) throws IOException, InterruptedException {
-		String body = formMapToxWwwFormUrlencoded(form);
 		URI tokenEndpoint = Utils.getTokenUrlFromWellKnownUrl(URI.create(Config.orcidWellknown()));
-		return postForm(tokenEndpoint, body);
-	}
-
-	private String formMapToxWwwFormUrlencoded(Map<String, String> form) {
-		StringJoiner x_www_form_urlencoded = new StringJoiner("&");
-		form.keySet().forEach(key -> x_www_form_urlencoded.add(key + "=" + form.get(key)));
-		return x_www_form_urlencoded.toString();
+		return postForm(tokenEndpoint, form);
 	}
 
 	private String extractIdToken(String response) {
 		return JsonParser.parseString(response).getAsJsonObject().getAsJsonPrimitive("id_token").getAsString();
 	}
 
-	private String postForm(URI uri, String json) throws IOException, InterruptedException {
-		HttpRequest request = HttpRequest.newBuilder()
-				.POST(HttpRequest.BodyPublishers.ofString(json))
-				.uri(uri)
-				.header("Content-Type", "application/x-www-form-urlencoded")
-				.build();
+	private String postForm(URI uri, Map<String, String> form) throws IOException, InterruptedException {
+		HttpRequest request = Utils.formToHttpRequest(uri, form);
 		try (HttpClient client = HttpClient.newHttpClient()) {
 			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 			if (response.statusCode() >= 300) {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2021 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2021 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
@@ -21,7 +21,6 @@ import java.net.http.HttpResponse;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
-import java.util.StringJoiner;
 
 public class SurfconextLogin implements Login {
 
@@ -59,27 +58,16 @@ public class SurfconextLogin implements Login {
 	}
 
 	private String getTokensFromSurfconext(Map<String, String> form) throws IOException, InterruptedException {
-		String body = formMapToxWwwFormUrlencoded(form);
 		URI tokenEndpoint = Utils.getTokenUrlFromWellKnownUrl(URI.create(Config.surfconextWellknown()));
-		return postForm(tokenEndpoint, body);
-	}
-
-	private String formMapToxWwwFormUrlencoded(Map<String, String> form) {
-		StringJoiner x_www_form_urlencoded = new StringJoiner("&");
-		form.keySet().forEach(key -> x_www_form_urlencoded.add(key + "=" + form.get(key)));
-		return x_www_form_urlencoded.toString();
+		return postForm(tokenEndpoint, form);
 	}
 
 	private String extractIdToken(String response) {
 		return JsonParser.parseString(response).getAsJsonObject().getAsJsonPrimitive("id_token").getAsString();
 	}
 
-	private String postForm(URI uri, String json) throws IOException, InterruptedException {
-		HttpRequest request = HttpRequest.newBuilder()
-				.POST(HttpRequest.BodyPublishers.ofString(json))
-				.uri(uri)
-				.header("Content-Type", "application/x-www-form-urlencoded")
-				.build();
+	private String postForm(URI uri, Map<String, String> form) throws IOException, InterruptedException {
+		HttpRequest request = Utils.formToHttpRequest(uri, form);
 		try (HttpClient client = HttpClient.newHttpClient()) {
 			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 			if (response.statusCode() >= 300) {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,8 +14,13 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.StringJoiner;
 
 public class Utils {
+
+	private Utils() {
+	}
 
 	public static URI getTokenUrlFromWellKnownUrl(URI wellKnownUrl) throws IOException, InterruptedException {
 		HttpRequest request = HttpRequest.newBuilder(wellKnownUrl).build();
@@ -26,10 +31,25 @@ public class Utils {
 		}
 	}
 
-	static URI extractTokenUrlFromWellKnownData(String jsonData) {
+	public static URI extractTokenUrlFromWellKnownData(String jsonData) {
 		JsonObject dataAsObject = JsonParser.parseString(jsonData).getAsJsonObject();
 		String tokenUrl = dataAsObject.getAsJsonPrimitive("token_endpoint").getAsString();
 		return URI.create(tokenUrl);
 	}
 
+	public static String formMapToxWwwFormUrlencoded(Map<String, String> form) {
+		StringJoiner x_www_form_urlencoded = new StringJoiner("&");
+		form.forEach((key, value) -> x_www_form_urlencoded.add(key + "=" + value));
+		return x_www_form_urlencoded.toString();
+	}
+
+	public static HttpRequest formToHttpRequest(URI uri, Map<String, String> form) {
+		String body = formMapToxWwwFormUrlencoded(form);
+
+		return HttpRequest.newBuilder()
+				.POST(HttpRequest.BodyPublishers.ofString(body))
+				.uri(uri)
+				.header("Content-Type", "application/x-www-form-urlencoded")
+				.build();
+	}
 }

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/UtilsTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/UtilsTest.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,6 +9,11 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 class UtilsTest {
 
@@ -76,4 +81,37 @@ class UtilsTest {
 		Assertions.assertThrows(ClassCastException.class, () -> Utils.extractTokenUrlFromWellKnownData(data));
 	}
 
+	@Test
+	void givenFormMap_whenConvertingToxWwwFormUrlencoded_thenCorrectResultReturned() {
+		Map<String, String> emptyForm = Map.of();
+		Assertions.assertEquals("", Utils.formMapToxWwwFormUrlencoded(emptyForm));
+
+		Map<String, String> singleEntryForm = Map.of("abc", "def");
+		Assertions.assertEquals("abc=def", Utils.formMapToxWwwFormUrlencoded(singleEntryForm));
+
+		// using a LinkedHashMap to ensure iteration order is insertion order
+		Map<String, String> multiEntryForm = new LinkedHashMap<>();
+		multiEntryForm.put("abc", "def");
+		multiEntryForm.put("123", "456");
+		Assertions.assertEquals("abc=def&123=456", Utils.formMapToxWwwFormUrlencoded(multiEntryForm));
+		multiEntryForm.put("key", "value");
+		Assertions.assertEquals("abc=def&123=456&key=value", Utils.formMapToxWwwFormUrlencoded(multiEntryForm));
+	}
+
+	@Test
+	void givenUriAndForm_whenConvertingToHttpRequest_thenCorrectResultReturned() {
+		URI uri = URI.create("https://www.example.com");
+		Map<String, String> form = Map.of("abc", "defgh");
+
+		HttpRequest request = Utils.formToHttpRequest(uri, form);
+
+		Assertions.assertEquals(uri, request.uri());
+		Assertions.assertEquals("POST", request.method());
+		HttpHeaders headers = request.headers();
+		List<String> contentTypeHeader = headers.allValues("Content-Type");
+		Assertions.assertEquals(1, contentTypeHeader.size());
+		Assertions.assertEquals("application/x-www-form-urlencoded", contentTypeHeader.getFirst());
+		int contentLength = Utils.formMapToxWwwFormUrlencoded(form).length();
+		Assertions.assertEquals(contentLength, request.bodyPublisher().orElseThrow().contentLength());
+	}
 }


### PR DESCRIPTION
## Deduplicate and test some authentication code

Changes proposed in this pull request:

* Deduplicate and test some of the code in the authentication module

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in through various methods, including SURFconect, Azure and ORCID (put your ORCID on the allowlist first as admin)


PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests
