### PR TITLE
448 delete software, project, organisation, community from RSD

### DIFF
--- a/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.util.List;
 
 @ExtendWith({SetupAllTests.class})
-
 public class AuthenticationIntegrationTest {
 
 	@Test

--- a/backend-tests/src/test/java/nl/esciencecenter/UserDeletingItemsIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/UserDeletingItemsIntegrationTest.java
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({SetupAllTests.class})
+public class UserDeletingItemsIntegrationTest {
+
+	@Test
+	void givenAnonymousUser_whenCallingSoftwareDeleteEndpoint_thenErrorReturned() {
+		String softwareSlug = Commons.createUUID();
+		String softwareId = RestAssured
+				.given()
+				.header(SetupAllTests.adminAuthHeader)
+				.header(Commons.requestEntry)
+				.contentType(ContentType.JSON)
+				.body("{\"slug\":  \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug))
+				.when()
+				.post("software")
+				.then()
+				.statusCode(201)
+				.extract()
+				.jsonPath()
+				.getString("[0].id");
+
+		String errorMessage = RestAssured
+				.given()
+				.contentType(ContentType.JSON)
+				.body("{\"id\": \"%s\"}".formatted(softwareId))
+				.when()
+				.post("rpc/delete_software")
+				.then()
+				.statusCode(400)
+				.extract()
+				.jsonPath()
+				.getString("message");
+
+		Assertions.assertEquals("You are not allowed to delete this software", errorMessage);
+	}
+
+	@Test
+	void givenRegularUser_whenCallingSoftwareDeleteEndpoint_thenErrorReturned() {
+		User user = User.create(true);
+
+		String softwareSlug = Commons.createUUID();
+		String softwareId = RestAssured
+				.given()
+				.header(user.authHeader)
+				.header(Commons.requestEntry)
+				.contentType(ContentType.JSON)
+				.body("{\"slug\":  \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug))
+				.when()
+				.post("software")
+				.then()
+				.statusCode(201)
+				.extract()
+				.jsonPath()
+				.getString("[0].id");
+
+		String errorMessage = RestAssured
+				.given()
+				.header(user.authHeader)
+				.contentType(ContentType.JSON)
+				.body("{\"id\": \"%s\"}".formatted(softwareId))
+				.when()
+				.post("rpc/delete_software")
+				.then()
+				.statusCode(400)
+				.extract()
+				.jsonPath()
+				.getString("message");
+
+		Assertions.assertEquals("You are not allowed to delete this software", errorMessage);
+	}
+
+	@Test
+	void givenRegularUser_whenCallingProjectDeleteEndpoint_thenErrorReturned() {
+		User user = User.create(true);
+
+		String projectSlug = Commons.createUUID();
+		String projectId = RestAssured
+				.given()
+				.header(user.authHeader)
+				.header(Commons.requestEntry)
+				.contentType(ContentType.JSON)
+				.body("{\"slug\":  \"%s\", \"is_published\": true, \"title\": \"test project\"}".formatted(projectSlug))
+				.when()
+				.post("project")
+				.then()
+				.statusCode(201)
+				.extract()
+				.jsonPath()
+				.getString("[0].id");
+
+		String errorMessage = RestAssured
+				.given()
+				.header(user.authHeader)
+				.contentType(ContentType.JSON)
+				.body("{\"id\": \"%s\"}".formatted(projectId))
+				.when()
+				.post("rpc/delete_project")
+				.then()
+				.statusCode(400)
+				.extract()
+				.jsonPath()
+				.getString("message");
+
+		Assertions.assertEquals("You are not allowed to delete this project", errorMessage);
+	}
+
+
+	@Test
+	void givenRegularUser_whenCallingOrganisationDeleteEndpoint_thenErrorReturned() {
+		User user = User.create(true);
+
+		String organisationSlug = Commons.createUUID();
+		String organisationId = RestAssured
+				.given()
+				.header(user.authHeader)
+				.header(Commons.requestEntry)
+				.contentType(ContentType.JSON)
+				.body("{\"slug\":  \"%s\", \"name\": \"test organisation\"}".formatted(organisationSlug))
+				.when()
+				.post("organisation")
+				.then()
+				.statusCode(201)
+				.extract()
+				.jsonPath()
+				.getString("[0].id");
+
+		String errorMessage = RestAssured
+				.given()
+				.header(user.authHeader)
+				.contentType(ContentType.JSON)
+				.body("{\"id\": \"%s\"}".formatted(organisationId))
+				.when()
+				.post("rpc/delete_organisation")
+				.then()
+				.statusCode(400)
+				.extract()
+				.jsonPath()
+				.getString("message");
+
+		Assertions.assertEquals("You are not allowed to delete this organisation", errorMessage);
+	}
+
+	@Test
+	void givenRegularUser_whenCallingCommunityDeleteEndpoint_thenErrorReturned() {
+		String communitySlug = Commons.createUUID();
+		String communityId = RestAssured
+				.given()
+				.header(SetupAllTests.adminAuthHeader)
+				.header(Commons.requestEntry)
+				.contentType(ContentType.JSON)
+				.body("{\"slug\":  \"%s\", \"name\": \"test community\"}".formatted(communitySlug))
+				.when()
+				.post("community")
+				.then()
+				.statusCode(201)
+				.extract()
+				.jsonPath()
+				.getString("[0].id");
+
+		User user = User.create(true);
+		String errorMessage = RestAssured
+				.given()
+				.header(user.authHeader)
+				.contentType(ContentType.JSON)
+				.body("{\"id\": \"%s\"}".formatted(communityId))
+				.when()
+				.post("rpc/delete_community")
+				.then()
+				.statusCode(400)
+				.extract()
+				.jsonPath()
+				.getString("message");
+
+		Assertions.assertEquals("You are not allowed to delete this community", errorMessage);
+	}
+}

--- a/database/005-create-relations-for-software.sql
+++ b/database/005-create-relations-for-software.sql
@@ -61,7 +61,7 @@ CREATE TYPE package_manager_type AS ENUM (
 
 CREATE TABLE package_manager (
 	id UUID PRIMARY KEY,
-	software UUID references software (id) NOT NULL,
+	software UUID REFERENCES software (id) NOT NULL,
 	url VARCHAR(200) NOT NULL CHECK (url ~ '^https?://'),
 	package_manager package_manager_type NOT NULL DEFAULT 'other',
 	download_count BIGINT,
@@ -108,7 +108,7 @@ CREATE TRIGGER sanitise_update_package_manager BEFORE UPDATE ON package_manager 
 
 CREATE TABLE license_for_software (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	software UUID references software (id) NOT NULL,
+	software UUID REFERENCES software (id) NOT NULL,
 	license VARCHAR(100) NOT NULL,
 	name VARCHAR(200) NULL,
 	reference VARCHAR(200) NULL CHECK (reference ~ '^https?://'),
@@ -147,7 +147,7 @@ CREATE TRIGGER sanitise_update_license_for_software BEFORE UPDATE ON license_for
 
 CREATE TABLE contributor (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	software UUID references software (id) NOT NULL,
+	software UUID REFERENCES software (id) NOT NULL,
 	is_contact_person BOOLEAN NOT NULL DEFAULT FALSE,
 	email_address VARCHAR(200),
 	family_names VARCHAR(200) NOT NULL,

--- a/database/007-create-relations-for-projects.sql
+++ b/database/007-create-relations-for-projects.sql
@@ -7,7 +7,7 @@
 
 CREATE TABLE team_member (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	project UUID references project (id) NOT NULL,
+	project UUID REFERENCES project (id) NOT NULL,
 	is_contact_person BOOLEAN NOT NULL DEFAULT FALSE,
 	email_address VARCHAR(200),
 	family_names VARCHAR(200) NOT NULL,

--- a/database/009-create-keyword-and-category.sql
+++ b/database/009-create-keyword-and-category.sql
@@ -37,16 +37,16 @@ CREATE TRIGGER sanitise_update_keyword BEFORE UPDATE ON keyword FOR EACH ROW EXE
 
 
 CREATE TABLE keyword_for_software (
-	software UUID references software (id),
-	keyword UUID references keyword (id),
+	software UUID REFERENCES software (id),
+	keyword UUID REFERENCES keyword (id),
 	PRIMARY KEY (software, keyword)
 );
 
 CREATE INDEX keyword_for_software_keyword_idx ON keyword_for_software(keyword);
 
 CREATE TABLE keyword_for_project (
-	project UUID references project (id),
-	keyword UUID references keyword (id),
+	project UUID REFERENCES project (id),
+	keyword UUID REFERENCES keyword (id),
 	PRIMARY KEY (project, keyword)
 );
 
@@ -103,8 +103,8 @@ CREATE INDEX category_community_idx ON category(community);
 
 
 CREATE TABLE category_for_software (
-	software_id UUID references software (id),
-	category_id UUID references category (id),
+	software_id UUID REFERENCES software (id),
+	category_id UUID REFERENCES category (id),
 	PRIMARY KEY (software_id, category_id)
 );
 

--- a/database/023-news.sql
+++ b/database/023-news.sql
@@ -1,5 +1,6 @@
 -- SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 -- SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -53,7 +54,7 @@ CREATE TRIGGER sanitise_update_news BEFORE UPDATE ON news FOR EACH ROW EXECUTE P
 -- IMAGES FOR NEWS items
 CREATE TABLE image_for_news (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
-	news UUID references news (id) NOT NULL,
+	news UUID REFERENCES news (id) NOT NULL,
 	image_id VARCHAR(40) REFERENCES image(id) NOT NULL,
 	position VARCHAR(25) DEFAULT 'card',
 	created_at TIMESTAMPTZ NOT NULL,

--- a/database/104-software-views.sql
+++ b/database/104-software-views.sql
@@ -37,6 +37,7 @@ BEGIN
 	DELETE FROM mention_for_software WHERE mention_for_software.software = delete_software.id;
 	DELETE FROM package_manager WHERE package_manager.software = delete_software.id;
 	DELETE FROM reference_paper_for_software WHERE reference_paper_for_software.software = delete_software.id;
+	DELETE FROM release_version WHERE release_version.release_id = delete_software.id;
 	DELETE FROM release WHERE release.software = delete_software.id;
 	DELETE FROM repository_url WHERE repository_url.software = delete_software.id;
 	DELETE FROM software_for_community WHERE software_for_community.software = delete_software.id;

--- a/frontend/components/admin/AdminNav.tsx
+++ b/frontend/components/admin/AdminNav.tsx
@@ -28,6 +28,8 @@ import BugReportIcon from '@mui/icons-material/BugReport'
 import ReceiptLongIcon from '@mui/icons-material/ReceiptLong'
 import Diversity3Icon from '@mui/icons-material/Diversity3'
 import CategoryIcon from '@mui/icons-material/Category'
+import TerminalIcon from '@mui/icons-material/Terminal'
+import ListAltIcon from '@mui/icons-material/ListAlt'
 
 import {editMenuItemButtonSx} from '~/config/menuItems'
 
@@ -61,6 +63,18 @@ export const adminPages = {
     subtitle: '',
     icon: <AccountCircleIcon />,
     path: '/admin/rsd-contributors',
+  },
+  software: {
+    title: 'Software',
+    subtitle: '',
+    icon: <TerminalIcon />,
+    path: '/admin/software',
+  },
+  projects: {
+    title: 'Projects',
+    subtitle: '',
+    icon: <ListAltIcon />,
+    path: '/admin/projects',
   },
   organisations: {
     title: 'Organisations',

--- a/frontend/components/admin/communities/CommunityList.tsx
+++ b/frontend/components/admin/communities/CommunityList.tsx
@@ -27,9 +27,9 @@ export default function CommunityList({communities,loading,page,onDeleteItem}:Or
     open: false
   })
 
-  if (loading && !page) return <ContentLoader />
+  if (loading && !page) return <div className="py-6"><ContentLoader /></div>
 
-  if (communities.length===0) return <NoCommunityAlert />
+  if (communities.length===0) return <div className="py-6"><NoCommunityAlert /></div>
 
   return (
     <>

--- a/frontend/components/admin/communities/CommunityList.tsx
+++ b/frontend/components/admin/communities/CommunityList.tsx
@@ -8,16 +8,12 @@
 import {useState} from 'react'
 import List from '@mui/material/List'
 
-import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
 import ContentLoader from '~/components/layout/ContentLoader'
 import {CommunityListProps} from '~/components/communities/apiCommunities'
 import CommunityListItem from './CommunityListItem'
 import NoCommunityAlert from './NoCommunityAlert'
+import RemoveCommunityModal, {CommunityModalProps} from './RemoveCommunityModal'
 
-type DeleteOrganisationModal = {
-  open: boolean,
-  item?: CommunityListProps
-}
 
 type OrganisationsAdminListProps = {
   communities: CommunityListProps[]
@@ -27,7 +23,7 @@ type OrganisationsAdminListProps = {
 }
 
 export default function CommunityList({communities,loading,page,onDeleteItem}:OrganisationsAdminListProps) {
-  const [modal, setModal] = useState<DeleteOrganisationModal>({
+  const [modal, setModal] = useState<CommunityModalProps>({
     open: false
   })
 
@@ -55,29 +51,25 @@ export default function CommunityList({communities,loading,page,onDeleteItem}:Or
           })
         }
       </List>
-      <ConfirmDeleteModal
-        open={modal.open}
-        title="Remove community"
-        body={
-          <>
-            <p>
-              Are you sure you want to delete community <strong>{modal?.item?.name}</strong>?
-            </p>
-          </>
-        }
-        onCancel={() => {
-          setModal({
-            open: false
-          })
-        }}
-        onDelete={() => {
-          // call remove method if id present
-          if (modal.item && modal.item?.id) onDeleteItem(modal.item?.id,modal.item?.logo_id)
-          setModal({
-            open: false
-          })
-        }}
-      />
+      {
+        modal.open ?
+          <RemoveCommunityModal
+            item = {modal.item}
+            onCancel={() => {
+              setModal({
+                open: false
+              })
+            }}
+            onDelete={() => {
+            // call remove method if id present
+              if (modal.item && modal.item?.id) onDeleteItem(modal.item?.id,modal.item?.logo_id)
+              setModal({
+                open: false
+              })
+            }}
+          />
+          : null
+      }
     </>
   )
 }

--- a/frontend/components/admin/communities/CommunityListItem.tsx
+++ b/frontend/components/admin/communities/CommunityListItem.tsx
@@ -5,8 +5,6 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useRouter} from 'next/router'
-
 import IconButton from '@mui/material/IconButton'
 import ListItem from '@mui/material/ListItem'
 import DeleteIcon from '@mui/icons-material/Delete'
@@ -25,18 +23,6 @@ type OrganisationItemProps = {
 }
 
 export default function CommunityListItem({item, onDelete}: OrganisationItemProps) {
-
-  function isDeletedDisabled(){
-    // if any of software in community
-    if (item.software_cnt && item?.software_cnt > 0 ) return true
-    if (item.rejected_cnt && item?.rejected_cnt > 0 ) return true
-    if (item.pending_cnt && item?.pending_cnt > 0 ) return true
-    // if keywords are defined
-    if (item.keywords && item.keywords?.length > 0 ) return true
-    // otherwise it can be deleted
-    return false
-  }
-
   return (
     <ListItem
       data-testid="admin-community-item"
@@ -53,7 +39,7 @@ export default function CommunityListItem({item, onDelete}: OrganisationItemProp
             <EditIcon />
           </IconButton>
           <IconButton
-            disabled={isDeletedDisabled()}
+            // disabled={isDeletedDisabled()}
             edge="end"
             aria-label="delete"
             onClick={() => {

--- a/frontend/components/admin/communities/CommunityListItem.tsx
+++ b/frontend/components/admin/communities/CommunityListItem.tsx
@@ -5,10 +5,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Link from 'next/link'
+
 import IconButton from '@mui/material/IconButton'
 import ListItem from '@mui/material/ListItem'
 import DeleteIcon from '@mui/icons-material/Delete'
-import EditIcon from '@mui/icons-material/Edit'
 import ListItemText from '@mui/material/ListItemText'
 import ListItemAvatar from '@mui/material/ListItemAvatar'
 import Avatar from '@mui/material/Avatar'
@@ -16,6 +17,7 @@ import Avatar from '@mui/material/Avatar'
 import {getImageUrl} from '~/utils/editImage'
 import {CommunityListProps} from '~/components/communities/apiCommunities'
 import config from './config'
+
 
 type OrganisationItemProps = {
   item: CommunityListProps,
@@ -29,65 +31,66 @@ export default function CommunityListItem({item, onDelete}: OrganisationItemProp
       key={item.id}
       secondaryAction={
         <>
-          {/* onEdit we open community settings */}
           <IconButton
-            edge="end"
-            aria-label="edit"
-            sx={{marginRight: '1rem'}}
-            href={`/${config.rsdRootPath}/${item.slug}/settings`}
-          >
-            <EditIcon />
-          </IconButton>
-          <IconButton
-            // disabled={isDeletedDisabled()}
+            title="Delete community"
             edge="end"
             aria-label="delete"
             onClick={() => {
               onDelete()
             }}
+            sx={{margin: '0rem'}}
           >
             <DeleteIcon />
           </IconButton>
         </>
       }
+      className="transition shadow-sm border bg-base-100 rounded hover:shadow-lg"
       sx={{
         // this makes space for buttons
-        paddingRight:'6.5rem',
+        padding:'0.5rem 4.5rem 0.5rem 1rem',
+        margin: '0.5rem 0rem'
       }}
     >
-      <ListItemAvatar>
-        <Avatar
-          alt={item.name ?? ''}
-          src={getImageUrl(item.logo_id) ?? undefined}
-          sx={{
-            width: '4rem',
-            height: '4rem',
-            fontSize: '1.5rem',
-            marginRight: '1rem',
-            '& img': {
-              height:'auto'
-            }
-          }}
-          variant="square"
-        >
-          {item.name.slice(0,3)}
-        </Avatar>
-      </ListItemAvatar>
-      <ListItemText
-        primary={item.name}
-        secondary={
-          <>
-            <span>{item.short_description}</span>
-            <br/>
-            <span className="flex gap-2">
-              <span>Software: {item.software_cnt ?? 0}</span>
-              <span>Pending requests: {item.pending_cnt ?? 0}</span>
-              <span>Rejected requests: {item.rejected_cnt ?? 0}</span>
-              <span>Keywords: {item.keywords?.length ?? 0}</span>
-            </span>
-          </>
-        }
-      />
+      {/* open community settings for edit */}
+      <Link
+        title="Click to edit community settings"
+        href={`/${config.rsdRootPath}/${item.slug}/settings`}
+        className="flex-1 flex justify-center items-center hover:text-inherit"
+      >
+        <ListItemAvatar>
+          <Avatar
+            alt={item.name ?? ''}
+            src={getImageUrl(item.logo_id) ?? undefined}
+            sx={{
+              width: '4rem',
+              height: '4rem',
+              fontSize: '1.5rem',
+              marginRight: '1rem',
+              '& img': {
+                height:'auto'
+              }
+            }}
+            variant="square"
+          >
+            {item.name.slice(0,3)}
+          </Avatar>
+        </ListItemAvatar>
+        <ListItemText
+          primary={item.name}
+          secondary={
+            <>
+              <span>{item.short_description}</span>
+              <br/>
+              <span className="flex gap-2">
+                <span>Software: {item.software_cnt ?? 0}</span>
+                <span>Pending requests: {item.pending_cnt ?? 0}</span>
+                <span>Rejected requests: {item.rejected_cnt ?? 0}</span>
+                <span>Keywords: {item.keywords?.length ?? 0}</span>
+              </span>
+            </>
+          }
+        />
+      </Link>
     </ListItem>
   )
 }

--- a/frontend/components/admin/communities/NoCommunityAlert.tsx
+++ b/frontend/components/admin/communities/NoCommunityAlert.tsx
@@ -8,9 +8,7 @@ import AlertTitle from '@mui/material/AlertTitle'
 
 export default function NoCommunityAlert() {
   return (
-    <Alert severity="warning"
-      sx={{marginTop: '0.5rem'}}
-    >
+    <Alert severity="warning">
       <AlertTitle sx={{fontWeight:500}}>No communities defined</AlertTitle>
       To add community to RSD <strong>use Add button on the right</strong>.
     </Alert>

--- a/frontend/components/admin/communities/RemoveCommunityModal.tsx
+++ b/frontend/components/admin/communities/RemoveCommunityModal.tsx
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+import TextField from '@mui/material/TextField'
+
+import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
+import {CommunityListProps} from '~/components/communities/apiCommunities'
+
+export type CommunityModalProps={
+  open: boolean
+  item?: CommunityListProps
+}
+
+type RemoveCommunityModalProps={
+  item?: CommunityListProps
+  onCancel: ()=>void
+  onDelete: ()=>void
+}
+
+export default function RemoveCommunityModal({item,onCancel,onDelete}:RemoveCommunityModalProps) {
+  const [confirmation,setConfirmation] = useState<string>('')
+  return (
+    <ConfirmDeleteModal
+      open={true}
+      title="Delete community"
+      removeDisabled={item?.name!==confirmation}
+      body={
+        <>
+          <p>
+            Are you sure you want to delete this community?
+          </p>
+          <p className="py-4">
+            <strong>{item?.name}</strong>
+          </p>
+          <TextField
+            label="Name of the community to delete"
+            helperText={
+              <span>Type the community name exactly as shown above.</span>
+            }
+            value = {confirmation}
+            onChange={({target})=>setConfirmation(target.value)}
+            sx={{
+              width: '100%',
+              margin: '1rem 0rem'
+            }}
+          />
+          <p className="text-error text-base">
+            This will remove community from all related RSD entries too!
+          </p>
+        </>
+      }
+      onCancel={onCancel}
+      onDelete={onDelete}
+    />
+  )
+}

--- a/frontend/components/admin/communities/apiCommunities.ts
+++ b/frontend/components/admin/communities/apiCommunities.ts
@@ -3,8 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
+import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
 
 export type Community={
   id?:string,
@@ -76,14 +76,16 @@ export async function addCommunity({data,token}:{data:Community,token:string}) {
 
 export async function deleteCommunityById({id,token}:{id:string,token:string}) {
   try {
-    const query = `community?id=eq.${id}`
-    const url = `/api/v1/${query}`
+    const url = `${getBaseUrl()}/rpc/delete_community`
 
     const resp = await fetch(url,{
-      method: 'DELETE',
+      method: 'POST',
       headers: {
         ...createJsonHeaders(token)
-      }
+      },
+      body: JSON.stringify({
+        id
+      })
     })
     return extractReturnMessage(resp, '')
   } catch (e: any) {

--- a/frontend/components/admin/communities/index.tsx
+++ b/frontend/components/admin/communities/index.tsx
@@ -35,7 +35,7 @@ export default function AdminCommunities() {
             <Searchbox />
             <Pagination />
           </div>
-          <div className="pt-6">
+          <div className="pt-2">
             <CommunityList
               communities={communities}
               loading={loading}

--- a/frontend/components/admin/communities/index.tsx
+++ b/frontend/components/admin/communities/index.tsx
@@ -35,12 +35,14 @@ export default function AdminCommunities() {
             <Searchbox />
             <Pagination />
           </div>
-          <CommunityList
-            communities={communities}
-            loading={loading}
-            page={page}
-            onDeleteItem={deleteCommunity}
-          />
+          <div className="pt-6">
+            <CommunityList
+              communities={communities}
+              loading={loading}
+              page={page}
+              onDeleteItem={deleteCommunity}
+            />
+          </div>
         </div>
         <div className="flex items-start justify-end">
           <Button

--- a/frontend/components/admin/communities/useAdminCommunities.tsx
+++ b/frontend/components/admin/communities/useAdminCommunities.tsx
@@ -3,24 +3,25 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useSession} from '~/auth'
-import useSnackbar from '~/components/snackbar/useSnackbar'
-import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
-import {addCommunity as addCommunityToRsd, deleteCommunityById} from './apiCommunities'
 import {useCallback, useEffect, useState} from 'react'
-import {EditCommunityProps} from './AddCommunityModal'
+
+import {useSession} from '~/auth'
+import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
 import {deleteImage, upsertImage} from '~/utils/editImage'
+import useSnackbar from '~/components/snackbar/useSnackbar'
 import {CommunityListProps, getCommunityList} from '~/components/communities/apiCommunities'
+import {addCommunity as addCommunityToRsd, deleteCommunityById} from './apiCommunities'
+import {EditCommunityProps} from './AddCommunityModal'
 
 export function useAdminCommunities(){
   const {token} = useSession()
-  const {showErrorMessage} = useSnackbar()
+  const {showErrorMessage, showSuccessMessage} = useSnackbar()
   const {searchFor, page, rows, setCount} = usePaginationWithSearch('Find community by name')
   const [communities, setCommunities] = useState<CommunityListProps[]>([])
   const [loading, setLoading] = useState(true)
 
   const loadCommunities = useCallback(async() => {
-    setLoading(true)
+    // setLoading(true)
     const {communities, count} = await getCommunityList({
       token,
       searchFor,
@@ -105,6 +106,8 @@ export function useAdminCommunities(){
       }
       // reload list
       loadCommunities()
+      // confirm deletion
+      showSuccessMessage('Community deleted from RSD')
     }
   // we do not include showErrorMessage in order to avoid loop
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/components/admin/organisations/OrganisationItem.test.tsx
+++ b/frontend/components/admin/organisations/OrganisationItem.test.tsx
@@ -37,14 +37,12 @@ it('renders organisation item', () => {
       onDelete = {mockOnDelete}
     />
   )
-
   // organisation name
   screen.getByText(mockOrganisationItem.name)
-  // edit icon button
-  screen.getByTestId('EditIcon')
   // delete icon button
   screen.getByTestId('DeleteIcon')
-  // screen.debug()
+  // edit link
+  screen.getByRole<HTMLLinkElement>('link')
 })
 
 it('can DELETE organisation with zero software and projects', () => {
@@ -107,6 +105,6 @@ it('can EDIT organisation with software or projects', () => {
   )
 
   // edit link
-  const editBtn = screen.getByRole<HTMLLinkElement>('link',{name:'edit'})
+  const editBtn = screen.getByRole<HTMLLinkElement>('link')
   expect(editBtn.href).toEqual(editLink)
 })

--- a/frontend/components/admin/organisations/OrganisationItem.test.tsx
+++ b/frontend/components/admin/organisations/OrganisationItem.test.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -48,7 +48,7 @@ it('renders organisation item', () => {
 })
 
 it('can DELETE organisation with zero software and projects', () => {
-  // ensuren zero counts
+  // ensure zero counts
   mockOrganisationItem.software_cnt = 0
   mockOrganisationItem.project_cnt=0
 
@@ -69,10 +69,10 @@ it('can DELETE organisation with zero software and projects', () => {
   // screen.debug(deleteBtn)
 })
 
-it('canNOT DELETE organisation with software or projects', () => {
+it('can DELETE organisation with software or projects', () => {
   // ensuren zero counts
   mockOrganisationItem.software_cnt = 1
-  mockOrganisationItem.project_cnt = 0
+  mockOrganisationItem.project_cnt = 1
 
   render(
     <OrganisationItem
@@ -83,11 +83,11 @@ it('canNOT DELETE organisation with software or projects', () => {
 
   // delete icon button
   const deleteBtn = screen.getByRole('button',{name:'delete'})
-  expect(deleteBtn).toBeDisabled()
+  // expect(deleteBtn).toBeDisabled()
 
   // check calling
   fireEvent.click(deleteBtn)
-  expect(mockOnDelete).toBeCalledTimes(0)
+  expect(mockOnDelete).toBeCalledTimes(1)
 
   // screen.debug(deleteBtn)
 })

--- a/frontend/components/admin/organisations/OrganisationItem.tsx
+++ b/frontend/components/admin/organisations/OrganisationItem.tsx
@@ -1,11 +1,9 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
-
-import {useRouter} from 'next/router'
 
 import IconButton from '@mui/material/IconButton'
 import ListItem from '@mui/material/ListItem'
@@ -24,7 +22,6 @@ type OrganisationItemProps = {
 }
 
 export default function OrganisationItem({item, onDelete}: OrganisationItemProps) {
-  const router = useRouter()
   return (
     <ListItem
       data-testid="admin-organisation-item"
@@ -41,7 +38,7 @@ export default function OrganisationItem({item, onDelete}: OrganisationItemProps
             <EditIcon />
           </IconButton>
           <IconButton
-            disabled={item.software_cnt > 0 || item.project_cnt > 0}
+            // disabled={item.software_cnt > 0 || item.project_cnt > 0}
             edge="end"
             aria-label="delete"
             onClick={() => {
@@ -55,6 +52,7 @@ export default function OrganisationItem({item, onDelete}: OrganisationItemProps
       sx={{
         // this makes space for buttons
         paddingRight:'6.5rem',
+        paddingLeft: '0'
       }}
     >
       <ListItemAvatar>

--- a/frontend/components/admin/organisations/OrganisationItem.tsx
+++ b/frontend/components/admin/organisations/OrganisationItem.tsx
@@ -5,6 +5,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Link from 'next/link'
+
 import IconButton from '@mui/material/IconButton'
 import ListItem from '@mui/material/ListItem'
 import DeleteIcon from '@mui/icons-material/Delete'
@@ -15,6 +17,7 @@ import ListItemText from '@mui/material/ListItemText'
 import ListItemAvatar from '@mui/material/ListItemAvatar'
 import Avatar from '@mui/material/Avatar'
 import {getImageUrl} from '~/utils/editImage'
+
 
 type OrganisationItemProps = {
   item: OrganisationList,
@@ -28,60 +31,61 @@ export default function OrganisationItem({item, onDelete}: OrganisationItemProps
       key={item.id}
       secondaryAction={
         <>
-          {/* onEdit we open organisation settings */}
           <IconButton
-            edge="end"
-            aria-label="edit"
-            sx={{marginRight: '1rem'}}
-            href={`/organisations/${item.rsd_path}?tab=settings`}
-          >
-            <EditIcon />
-          </IconButton>
-          <IconButton
-            // disabled={item.software_cnt > 0 || item.project_cnt > 0}
+            title="Delete organisation"
             edge="end"
             aria-label="delete"
             onClick={() => {
               onDelete()
             }}
+            sx={{margin: '0rem'}}
           >
             <DeleteIcon />
           </IconButton>
         </>
       }
+      className="transition shadow-sm border bg-base-100 rounded hover:shadow-lg"
       sx={{
         // this makes space for buttons
-        paddingRight:'6.5rem',
-        paddingLeft: '0'
+        padding:'0.5rem 4.5rem 0.5rem 1rem',
+        margin: '0.5rem 0rem'
       }}
     >
-      <ListItemAvatar>
-        <Avatar
-          alt={item.name ?? ''}
-          src={getImageUrl(item.logo_id) ?? undefined}
-          sx={{
-            width: '4rem',
-            height: '4rem',
-            fontSize: '1.5rem',
-            marginRight: '1rem',
-            '& img': {
-              height:'auto'
-            }
-          }}
-          variant="square"
-        >
-          {item.name.slice(0,3)}
-        </Avatar>
-      </ListItemAvatar>
-      <ListItemText
-        primary={item.name}
-        secondary={
-          <>
-            <span>Software: {item.software_cnt ?? 0}</span>
-            <span className="ml-4">Projects: {item.project_cnt ?? 0}</span>
-          </>
-        }
-      />
+      {/* open organisation settings for edit */}
+      <Link
+        data-test-id="edit-organisation"
+        title="Click to edit organisation settings"
+        href={`/organisations/${item.rsd_path}?tab=settings`}
+        className="flex-1 flex justify-center items-center hover:text-inherit"
+      >
+        <ListItemAvatar>
+          <Avatar
+            alt={item.name ?? ''}
+            src={getImageUrl(item.logo_id) ?? undefined}
+            sx={{
+              width: '4rem',
+              height: '4rem',
+              fontSize: '1.5rem',
+              marginRight: '1rem',
+              '& img': {
+                height:'auto'
+              }
+            }}
+            variant="square"
+          >
+            {item.name.slice(0,3)}
+          </Avatar>
+        </ListItemAvatar>
+        <ListItemText
+          primary={item.name}
+          secondary={
+            <>
+              <span>Software: {item.software_cnt ?? 0}</span>
+              <span className="ml-4">Projects: {item.project_cnt ?? 0}</span>
+            </>
+          }
+        />
+      </Link>
     </ListItem>
   )
 }

--- a/frontend/components/admin/organisations/OrganisationsAdminList.test.tsx
+++ b/frontend/components/admin/organisations/OrganisationsAdminList.test.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,8 @@ const mockOnDelete = jest.fn()
 const mockProps = {
   loading: true,
   organisations: mockOrganisationList as any,
-  onDeleteOrganisation: mockOnDelete
+  onDeleteOrganisation: mockOnDelete,
+  page: 0
 }
 
 

--- a/frontend/components/admin/organisations/OrganisationsAdminList.tsx
+++ b/frontend/components/admin/organisations/OrganisationsAdminList.tsx
@@ -27,7 +27,7 @@ export default function OrganisationsAdminList({organisations,loading,page,onDel
     open: false
   })
 
-  if (loading && !page) return <ContentLoader />
+  if (loading && !page) return <div className="py-6"><ContentLoader /></div>
 
   if (organisations.length === 0){
     return (
@@ -83,37 +83,6 @@ export default function OrganisationsAdminList({organisations,loading,page,onDel
         />
         : null
       }
-      {/* <ConfirmDeleteModal
-        open={modal.open}
-        title="Remove organisation"
-        body={
-          <>
-            <p>
-              Are you sure you want to delete this organisation?
-            </p>
-            <p className="py-4">
-              <strong>{modal?.organisation?.name}</strong>
-            </p>
-            <p>
-              This will remove organisation from all related RSD entries too!
-            </p>
-          </>
-        }
-        onCancel={() => {
-          setModal({
-            open: false
-          })
-        }}
-        onDelete={() => {
-          onDeleteOrganisation({
-            uuid: modal?.organisation?.id ?? '',
-            logo_id: modal?.organisation?.logo_id ?? null
-          })
-          setModal({
-            open: false
-          })
-        }}
-      /> */}
     </>
   )
 }

--- a/frontend/components/admin/organisations/OrganisationsAdminList.tsx
+++ b/frontend/components/admin/organisations/OrganisationsAdminList.tsx
@@ -7,18 +7,13 @@
 
 import {useState} from 'react'
 import List from '@mui/material/List'
-
-import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
-import ContentLoader from '~/components/layout/ContentLoader'
-import {OrganisationList} from '~/types/Organisation'
-import {RemoveOrganisationProps} from './apiOrganisation'
-import OrganisationItem from './OrganisationItem'
 import Alert from '@mui/material/Alert'
 
-type DeleteOrganisationModal = {
-  open: boolean,
-  organisation?: OrganisationList
-}
+import {OrganisationList} from '~/types/Organisation'
+import ContentLoader from '~/components/layout/ContentLoader'
+import {RemoveOrganisationProps} from './apiOrganisation'
+import OrganisationItem from './OrganisationItem'
+import RemoveOrganisationModal, {OrganisationModalProps} from './RemoveOrganisationModal'
 
 type OrganisationsAdminListProps = {
   organisations: OrganisationList[]
@@ -28,7 +23,7 @@ type OrganisationsAdminListProps = {
 }
 
 export default function OrganisationsAdminList({organisations,loading,page,onDeleteOrganisation}:OrganisationsAdminListProps) {
-  const [modal, setModal] = useState<DeleteOrganisationModal>({
+  const [modal, setModal] = useState<OrganisationModalProps>({
     open: false
   })
 
@@ -36,7 +31,7 @@ export default function OrganisationsAdminList({organisations,loading,page,onDel
 
   if (organisations.length === 0){
     return (
-      <Alert severity="info" sx={{margin:'1.5rem 0rem'}}>
+      <Alert severity="info">
         No organisation to show.
       </Alert>
     )
@@ -46,7 +41,7 @@ export default function OrganisationsAdminList({organisations,loading,page,onDel
     if (organisation) {
       setModal({
         open: true,
-        organisation
+        item: organisation
       })
     }
   }
@@ -68,13 +63,39 @@ export default function OrganisationsAdminList({organisations,loading,page,onDel
           })
         }
       </List>
-      <ConfirmDeleteModal
+      {modal?.open ?
+        <RemoveOrganisationModal
+          item = {modal?.item}
+          onCancel={() => {
+            setModal({
+              open: false
+            })
+          }}
+          onDelete={() => {
+            onDeleteOrganisation({
+              uuid: modal?.item?.id ?? '',
+              logo_id: modal?.item?.logo_id ?? null
+            })
+            setModal({
+              open: false
+            })
+          }}
+        />
+        : null
+      }
+      {/* <ConfirmDeleteModal
         open={modal.open}
         title="Remove organisation"
         body={
           <>
             <p>
-              Are you sure you want to delete organisation <strong>{modal?.organisation?.name}</strong>?
+              Are you sure you want to delete this organisation?
+            </p>
+            <p className="py-4">
+              <strong>{modal?.organisation?.name}</strong>
+            </p>
+            <p>
+              This will remove organisation from all related RSD entries too!
             </p>
           </>
         }
@@ -92,7 +113,7 @@ export default function OrganisationsAdminList({organisations,loading,page,onDel
             open: false
           })
         }}
-      />
+      /> */}
     </>
   )
 }

--- a/frontend/components/admin/organisations/RemoveOrganisationModal.tsx
+++ b/frontend/components/admin/organisations/RemoveOrganisationModal.tsx
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+import TextField from '@mui/material/TextField'
+
+import {OrganisationList} from '~/types/Organisation'
+import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
+
+export type OrganisationModalProps={
+  open: boolean
+  item?: OrganisationList
+}
+
+type RemoveOrganisationModalProps={
+  item?: OrganisationList
+  onCancel: ()=>void
+  onDelete: ()=>void
+}
+
+export default function RemoveOrganisationModal({item,onCancel,onDelete}:RemoveOrganisationModalProps) {
+  const [confirmation,setConfirmation] = useState<string>('')
+  return (
+    <ConfirmDeleteModal
+      open={true}
+      title="Delete organisation"
+      removeDisabled={item?.name!==confirmation}
+      body={
+        <>
+          <p>
+            Are you sure you want to delete this organisation?
+          </p>
+          <p className="py-4">
+            <strong>{item?.name}</strong>
+          </p>
+          <TextField
+            label="Name of the organisation to delete"
+            helperText={
+              <span>Type the organisation name exactly as shown above.</span>
+            }
+            value = {confirmation}
+            onChange={({target})=>setConfirmation(target.value)}
+            sx={{
+              width: '100%',
+              margin: '1rem 0rem'
+            }}
+          />
+          <p className="text-error text-base">
+            This will remove organisation from all related RSD entries too!
+          </p>
+        </>
+      }
+      onCancel={onCancel}
+      onDelete={onDelete}
+    />
+  )
+}

--- a/frontend/components/admin/organisations/apiOrganisation.tsx
+++ b/frontend/components/admin/organisations/apiOrganisation.tsx
@@ -87,7 +87,7 @@ export function useOrganisations(token: string) {
   const [loading, setLoading] = useState(true)
 
   const loadOrganisations = useCallback(async() => {
-    setLoading(true)
+    // setLoading(true)
     const {organisations, count} = await getOrganisations({
       token,
       searchFor,
@@ -164,9 +164,11 @@ export function useOrganisations(token: string) {
     })
     if (resp.status !== 200) {
       showErrorMessage(`Failed to remove organisation. ${resp.message}`)
+    }else{
+      showSuccessMessage('Organisation deleted from RSD!')
+      // reload organisations
+      loadOrganisations()
     }
-    // reload organisations
-    loadOrganisations()
   }
 
   return {

--- a/frontend/components/admin/organisations/apiOrganisation.tsx
+++ b/frontend/components/admin/organisations/apiOrganisation.tsx
@@ -35,7 +35,7 @@ async function getOrganisations({page, rows, token, searchFor, orderBy}: getOrga
   try {
     // NOTE 1! selectList need to include all colums used in filtering
     // NOTE 2! ensure selectList uses identical props as defined in OrganisationList type
-    const selectList = 'id,parent,name,website,is_tenant,rsd_path,logo_id,ror_id,software_cnt,project_cnt,score'
+    const selectList = 'id,parent,name,website,is_tenant,rsd_path,logo_id,ror_id,software_cnt,project_cnt'
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
       query+=`&or=(name.ilike.*${searchFor}*,website.ilike.*${searchFor}*,ror_id.ilike.*${searchFor}*)`
@@ -43,7 +43,7 @@ async function getOrganisations({page, rows, token, searchFor, orderBy}: getOrga
     if (orderBy) {
       query+=`&order=${orderBy}`
     } else {
-      query+='&order=score.asc,name.asc'
+      query+='&order=name.asc'
     }
     // complete url
     const url = `${getBaseUrl()}/rpc/organisations_overview?select=${selectList}&parent=is.null?${query}`

--- a/frontend/components/admin/organisations/index.tsx
+++ b/frontend/components/admin/organisations/index.tsx
@@ -27,12 +27,14 @@ export default function OrganisationsAdminPage() {
           <Searchbox />
           <Pagination />
         </div>
-        <OrganisationsAdminList
-          page={page}
-          loading={loading}
-          organisations={organisations}
-          onDeleteOrganisation={removeOrganisation}
-        />
+        <div className="pt-6">
+          <OrganisationsAdminList
+            page={page}
+            loading={loading}
+            organisations={organisations}
+            onDeleteOrganisation={removeOrganisation}
+          />
+        </div>
       </div>
       <AddOrganisation onAddOrganisationToRsd={addOrganisation} />
     </section>

--- a/frontend/components/admin/organisations/index.tsx
+++ b/frontend/components/admin/organisations/index.tsx
@@ -27,7 +27,7 @@ export default function OrganisationsAdminPage() {
           <Searchbox />
           <Pagination />
         </div>
-        <div className="pt-6">
+        <div className="pt-1">
           <OrganisationsAdminList
             page={page}
             loading={loading}

--- a/frontend/components/admin/projects/AdminProjectListItem.tsx
+++ b/frontend/components/admin/projects/AdminProjectListItem.tsx
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+import IconButton from '@mui/material/IconButton'
+import DeleteIcon from '@mui/icons-material/Delete'
+
+import {ProjectListItem} from '~/types/Project'
+import OverviewListItem from '~/components/software/overview/list/OverviewListItem'
+import ProjectListItemContent from '~/components/projects/overview/list/ProjectListItemContent'
+import StatusBanner from '~/components/cards/StatusBanner'
+
+type ProjectListItemProps = {
+  project:ProjectListItem
+  onDelete: ()=>void
+}
+
+export default function AdminProjectListItem({project,onDelete}:ProjectListItemProps) {
+  return (
+    <OverviewListItem>
+      {/* standard project list item with link */}
+      <Link
+        data-testid="project-grid-card"
+        href={`/project/${project.slug}`}
+        className="flex-1 flex hover:text-inherit"
+      >
+        <ProjectListItemContent
+          statusBanner={
+            <StatusBanner
+              status={'approved'}
+              is_featured={false}
+              is_published={project.is_published}
+              width='auto'
+              borderRadius='0.125rem'
+            />
+          }
+          {...project}
+        />
+      </Link>
+
+      {/* admin menu */}
+      <div className="flex w-12 ml-4">
+        <IconButton
+          title = "Delete project"
+          edge="end"
+          aria-label="delete"
+          onClick={onDelete}
+        >
+          <DeleteIcon />
+        </IconButton>
+      </div>
+    </OverviewListItem>
+  )
+}

--- a/frontend/components/admin/projects/AdminProjectListItem.tsx
+++ b/frontend/components/admin/projects/AdminProjectListItem.tsx
@@ -23,7 +23,8 @@ export default function AdminProjectListItem({project,onDelete}:ProjectListItemP
       {/* standard project list item with link */}
       <Link
         data-testid="project-grid-card"
-        href={`/project/${project.slug}`}
+        title="Click to edit project"
+        href={`/projects/${project.slug}/edit/information`}
         className="flex-1 flex hover:text-inherit"
       >
         <ProjectListItemContent
@@ -41,12 +42,13 @@ export default function AdminProjectListItem({project,onDelete}:ProjectListItemP
       </Link>
 
       {/* admin menu */}
-      <div className="flex w-12 ml-4">
+      <div className="flex mr-4">
         <IconButton
           title = "Delete project"
           edge="end"
           aria-label="delete"
           onClick={onDelete}
+          sx={{margin: '0rem'}}
         >
           <DeleteIcon />
         </IconButton>

--- a/frontend/components/admin/projects/AdminProjectsList.tsx
+++ b/frontend/components/admin/projects/AdminProjectsList.tsx
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+import Alert from '@mui/material/Alert'
+
+import ContentLoader from '~/components/layout/ContentLoader'
+import ProjectOverviewList from '~/components/projects/overview/list/ProjectOverviewList'
+import useAdminProjects from './useAdminProjects'
+import AdminProjectListItem from './AdminProjectListItem'
+import RemoveProjectModal, {ProjectModalProps} from './RemoveProjectModal'
+
+export default function AdminProjectList() {
+  const {projects,loading,page,deleteProject} = useAdminProjects()
+  const [modal,setModal] = useState<ProjectModalProps>({
+    open:false
+  })
+
+  if (loading && !page) return <ContentLoader />
+
+  if (projects.length===0) return (
+    <Alert severity="info">
+      No software to show.
+    </Alert>
+  )
+
+  return (
+    <>
+      <ProjectOverviewList>
+        {projects.map(item=>{
+          return (
+            <AdminProjectListItem
+              key={item.id}
+              project={item}
+              onDelete={()=>{
+                setModal({
+                  open: true,
+                  item
+                })
+              }}
+            />
+          )
+        })}
+      </ProjectOverviewList>
+      {
+        modal.open ?
+          <RemoveProjectModal
+            item = {modal.item}
+            onCancel={() => {
+              setModal({
+                open: false
+              })
+            }}
+            onDelete={() => {
+              // call remove method if id present
+              if (modal.item) deleteProject(modal.item)
+              setModal({
+                open: false
+              })
+            }}
+          />
+          : null
+      }
+    </>
+  )
+}

--- a/frontend/components/admin/projects/RemoveProjectModal.tsx
+++ b/frontend/components/admin/projects/RemoveProjectModal.tsx
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+import TextField from '@mui/material/TextField'
+
+import {ProjectListItem} from '~/types/Project'
+import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
+
+export type ProjectModalProps={
+  open: boolean
+  item?: ProjectListItem
+}
+
+type RemoveProjectModalProps={
+  item?: ProjectListItem
+  onCancel: ()=>void
+  onDelete: ()=>void
+}
+
+export default function RemoveProjectModal({item,onCancel,onDelete}:RemoveProjectModalProps) {
+  const [confirmation,setConfirmation] = useState<string>('')
+  return (
+    <ConfirmDeleteModal
+      open={true}
+      title="Delete project"
+      removeDisabled={item?.title!==confirmation}
+      body={
+        <>
+          <p>
+            Are you sure you want to delete this project?
+          </p>
+          <p className="py-4">
+            <strong>{item?.title}</strong>
+          </p>
+          <TextField
+            label="Name of the project to delete"
+            helperText={
+              <span>Type the project name exactly as shown above.</span>
+            }
+            value = {confirmation}
+            onChange={({target})=>setConfirmation(target.value)}
+            sx={{
+              width: '100%',
+              margin: '1rem 0rem'
+            }}
+          />
+          <p className="text-error text-base">
+            This will remove all data related to this project from RSD!
+          </p>
+        </>
+      }
+      onCancel={onCancel}
+      onDelete={onDelete}
+    />
+  )
+}

--- a/frontend/components/admin/projects/apiAdminProjects.ts
+++ b/frontend/components/admin/projects/apiAdminProjects.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
+import {getProjectList} from '~/utils/getProjects'
+import {projectListUrl} from '~/utils/postgrestUrl'
+
+export type GetProjectListParams={
+  page: number,
+  rows: number,
+  token?: string
+  searchFor?:string,
+  orderBy?:string,
+}
+
+export async function getProjectItems({page,rows,searchFor,orderBy,token}:GetProjectListParams){
+
+  const url = projectListUrl({
+    baseUrl: getBaseUrl(),
+    search: searchFor,
+    order: orderBy,
+    limit: rows,
+    offset: page * rows
+  })
+
+  const resp = getProjectList({url,token})
+
+  return resp
+}
+
+type DeleteProjectProps={
+  id:string,
+  token:string
+}
+
+export async function deleteProjectById({id,token}:DeleteProjectProps){
+  try{
+    const url=`${getBaseUrl()}/rpc/delete_project`
+
+    // DELETE project using POST method!!!
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token)
+      },
+      body:JSON.stringify({
+        id
+      })
+    })
+
+    return extractReturnMessage(resp, '')
+
+  }catch(e:any){
+    logger(`deleteProjectById: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}

--- a/frontend/components/admin/projects/index.tsx
+++ b/frontend/components/admin/projects/index.tsx
@@ -14,7 +14,7 @@ export default function AdminProjects() {
         <Searchbox />
         <Pagination />
       </div>
-      <div className="pt-6">
+      <div className="pt-4">
         <AdminProjectsList/>
       </div>
     </section>

--- a/frontend/components/admin/projects/index.tsx
+++ b/frontend/components/admin/projects/index.tsx
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Pagination from '~/components/pagination/Pagination'
+import Searchbox from '~/components/search/Searchbox'
+import AdminProjectsList from './AdminProjectsList'
+
+export default function AdminProjects() {
+  return (
+    <section className="flex-1">
+      <div className="flex flex-wrap items-center justify-end">
+        <Searchbox />
+        <Pagination />
+      </div>
+      <div className="pt-6">
+        <AdminProjectsList/>
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/admin/projects/useAdminProjects.tsx
+++ b/frontend/components/admin/projects/useAdminProjects.tsx
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useCallback, useEffect, useState} from 'react'
+
+import {useSession} from '~/auth'
+import {ProjectListItem} from '~/types/Project'
+import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
+import {deleteImage} from '~/utils/editImage'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {deleteProjectById, getProjectItems, GetProjectListParams} from './apiAdminProjects'
+
+// always use this order for admin list: not published first and smaller update date (not updated recently)
+const orderBy = 'is_published, updated_at, title'
+
+export default function useAdminProjects(){
+  const {token} = useSession()
+  const {showErrorMessage,showSuccessMessage} = useSnackbar()
+  const {searchFor, page, rows, setCount} = usePaginationWithSearch('Find project by title or slug')
+  const [projects, setProjects] = useState<ProjectListItem[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const getProjects = useCallback(async({searchFor,page,rows,token}:GetProjectListParams)=>{
+    const resp = await getProjectItems({
+      searchFor,page,rows,orderBy,token
+    })
+    // set record count
+    setCount(resp?.count ?? 0)
+    // set software items
+    setProjects(resp.data)
+    // set loaded done
+    setLoading(false)
+    // debugger
+  // exclude setCount to avoid endless loop
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[searchFor,page,rows,token])
+
+  const deleteProject = useCallback(async(project:ProjectListItem)=>{
+    if (token){
+      const resp = await deleteProjectById({
+        id:project.id,
+        token
+      })
+      // debugger
+      if (resp.status!==200){
+        showErrorMessage(`Failed to remove project item. ${resp.message}`)
+      } else {
+        // reload software to first page
+        getProjects({
+          searchFor,
+          orderBy,
+          page,
+          rows,
+          token
+        })
+        // try to remove image
+        if (project.image_id){
+          deleteImage({
+            id:project.image_id,
+            token
+          })
+        }
+      }
+      showSuccessMessage(`${project.title} deleted from RSD`)
+    }else{
+      showErrorMessage('Failed to remove project. You need to login first')
+    }
+  // ignore showErrorMessage dependency
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[searchFor,page,rows,token])
+
+  useEffect(()=>{
+    if (token){
+      getProjects({searchFor,page,rows,token})
+    }
+  },[searchFor,page,rows,token,getProjects])
+
+  return {
+    page,
+    projects,
+    loading,
+    deleteProject
+  }
+}

--- a/frontend/components/admin/projects/useAdminProjects.tsx
+++ b/frontend/components/admin/projects/useAdminProjects.tsx
@@ -13,7 +13,7 @@ import useSnackbar from '~/components/snackbar/useSnackbar'
 import {deleteProjectById, getProjectItems, GetProjectListParams} from './apiAdminProjects'
 
 // always use this order for admin list: not published first and smaller update date (not updated recently)
-const orderBy = 'is_published, updated_at, title'
+const orderBy = 'is_published,updated_at,title'
 
 export default function useAdminProjects(){
   const {token} = useSession()

--- a/frontend/components/admin/software/AdminSoftwareList.tsx
+++ b/frontend/components/admin/software/AdminSoftwareList.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+
+import Alert from '@mui/material/Alert'
+
+import ContentLoader from '~/components/layout/ContentLoader'
+import SoftwareOverviewList from '~/components/software/overview/list/SoftwareOverviewList'
+import AdminSoftwareListItem from './AdminSoftwareListItem'
+import {useAdminSoftware} from './useAdminSoftware'
+import RemoveSoftwareModal, {SoftwareModalProps} from './RemoveSoftwareModal'
+
+export default function AdminSoftwareList() {
+  const {software,loading,page,deleteSoftware} = useAdminSoftware()
+  const [modal,setModal] = useState<SoftwareModalProps>({
+    open:false
+  })
+
+  if (loading && !page) return <ContentLoader />
+
+  if (software.length===0) return (
+    <Alert severity="info">
+      No software to show.
+    </Alert>
+  )
+
+  return (
+    <>
+      <SoftwareOverviewList>
+        {software.map(item=>{
+          return (
+            <AdminSoftwareListItem
+              key={item.id}
+              software={item}
+              onDelete={()=>{
+                setModal({
+                  open: true,
+                  item
+                })
+              }}
+            />
+          )
+        })}
+      </SoftwareOverviewList>
+      {
+        modal.open ?
+          <RemoveSoftwareModal
+            item = {modal.item}
+            onCancel={() => {
+              setModal({
+                open: false
+              })
+            }}
+            onDelete={() => {
+              // call delete method if id present
+              if (modal.item) deleteSoftware(modal.item)
+              setModal({
+                open: false
+              })
+            }}
+          />
+          : null
+      }
+    </>
+  )
+}

--- a/frontend/components/admin/software/AdminSoftwareListItem.tsx
+++ b/frontend/components/admin/software/AdminSoftwareListItem.tsx
@@ -23,7 +23,8 @@ export default function AdminSoftwareListItem({software,onDelete}:SoftwareListIt
       {/* standard software list item with link */}
       <Link
         data-testid="software-grid-card"
-        href={`/software/${software.slug}`}
+        title="Click to edit software"
+        href={`/software/${software.slug}/edit/information`}
         className="flex-1 flex hover:text-inherit"
       >
         <SoftwareListItemContent
@@ -41,12 +42,13 @@ export default function AdminSoftwareListItem({software,onDelete}:SoftwareListIt
       </Link>
 
       {/* admin menu */}
-      <div className="flex w-12 ml-4">
+      <div className="flex mx-4">
         <IconButton
           title = "Delete software"
           edge="end"
           aria-label="delete"
           onClick={onDelete}
+          sx={{margin: '0rem'}}
         >
           <DeleteIcon />
         </IconButton>

--- a/frontend/components/admin/software/AdminSoftwareListItem.tsx
+++ b/frontend/components/admin/software/AdminSoftwareListItem.tsx
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+import IconButton from '@mui/material/IconButton'
+import DeleteIcon from '@mui/icons-material/Delete'
+
+import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
+import OverviewListItem from '~/components/software/overview/list/OverviewListItem'
+import SoftwareListItemContent from '~/components/software/overview/list/SoftwareListItemContent'
+import StatusBanner from '~/components/cards/StatusBanner'
+
+type SoftwareListItemProps = {
+  software:SoftwareOverviewItemProps
+  onDelete: ()=>void
+}
+
+export default function AdminSoftwareListItem({software,onDelete}:SoftwareListItemProps) {
+  return (
+    <OverviewListItem>
+      {/* standard software list item with link */}
+      <Link
+        data-testid="software-grid-card"
+        href={`/software/${software.slug}`}
+        className="flex-1 flex hover:text-inherit"
+      >
+        <SoftwareListItemContent
+          statusBanner={
+            <StatusBanner
+              status={'approved'}
+              is_featured={false}
+              is_published={software.is_published}
+              width='auto'
+              borderRadius='0.125rem'
+            />
+          }
+          {...software}
+        />
+      </Link>
+
+      {/* admin menu */}
+      <div className="flex w-12 ml-4">
+        <IconButton
+          title = "Delete software"
+          edge="end"
+          aria-label="delete"
+          onClick={onDelete}
+        >
+          <DeleteIcon />
+        </IconButton>
+      </div>
+    </OverviewListItem>
+  )
+}

--- a/frontend/components/admin/software/RemoveSoftwareModal.tsx
+++ b/frontend/components/admin/software/RemoveSoftwareModal.tsx
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useState} from 'react'
+import TextField from '@mui/material/TextField'
+
+import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
+import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
+
+export type SoftwareModalProps={
+  open: boolean
+  item?: SoftwareOverviewItemProps
+}
+
+type RemoveSoftwareModalProps={
+  item?: SoftwareOverviewItemProps
+  onCancel: ()=>void
+  onDelete: ()=>void
+}
+
+export default function RemoveSoftwareModal({item,onCancel,onDelete}:RemoveSoftwareModalProps) {
+  const [confirmation,setConfirmation] = useState<string>('')
+  return (
+    <ConfirmDeleteModal
+      open={true}
+      title="Delete software"
+      removeDisabled={item?.brand_name!==confirmation}
+      body={
+        <>
+          <p>
+            Are you sure you want to delete this software?
+          </p>
+          <p className="py-4">
+            <strong>{item?.brand_name}</strong>
+          </p>
+          <TextField
+            label="Name of the software to delete"
+            helperText={
+              <span>Type the software name exactly as shown above.</span>
+            }
+            value = {confirmation}
+            onChange={({target})=>setConfirmation(target.value)}
+            sx={{
+              width: '100%',
+              margin: '1rem 0rem'
+            }}
+          />
+          <p className="text-error text-base">
+            This will remove all data related to this software from RSD!
+          </p>
+        </>
+      }
+      onCancel={onCancel}
+      onDelete={onDelete}
+    />
+  )
+}

--- a/frontend/components/admin/software/apiAdminSoftware.ts
+++ b/frontend/components/admin/software/apiAdminSoftware.ts
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
+import {getSoftwareList} from '~/utils/getSoftware'
+import {softwareListUrl} from '~/utils/postgrestUrl'
+
+export type GetSoftwareListParams={
+  page: number,
+  rows: number,
+  token?: string
+  searchFor?:string,
+  orderBy?:string,
+}
+
+export async function getSoftwareItems({page,rows,searchFor,orderBy,token}:GetSoftwareListParams){
+
+  const url = softwareListUrl({
+    baseUrl: getBaseUrl(),
+    search: searchFor,
+    order: orderBy,
+    limit: rows,
+    offset: page * rows
+  })
+
+  const resp = getSoftwareList({url,token})
+
+  return resp
+}
+
+type DeleteSoftwareProps={
+  id:string,
+  token:string
+}
+
+export async function deleteSoftwareById({id,token}:DeleteSoftwareProps){
+  try{
+    const url=`${getBaseUrl()}/rpc/delete_software`
+
+    // DELETE software using POST method!!!
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: {
+        ...createJsonHeaders(token)
+      },
+      body:JSON.stringify({
+        id
+      })
+    })
+
+    return extractReturnMessage(resp, '')
+
+  }catch(e:any){
+    logger(`deleteSoftware: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
+  }
+}

--- a/frontend/components/admin/software/index.tsx
+++ b/frontend/components/admin/software/index.tsx
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Pagination from '~/components/pagination/Pagination'
+import Searchbox from '~/components/search/Searchbox'
+import SoftwareList from './AdminSoftwareList'
+
+export default function AdminSoftware() {
+  return (
+    <section className="flex-1">
+      <div className="flex flex-wrap items-center justify-end">
+        <Searchbox />
+        <Pagination />
+      </div>
+      <div className="pt-6">
+        <SoftwareList/>
+      </div>
+    </section>
+  )
+}

--- a/frontend/components/admin/software/index.tsx
+++ b/frontend/components/admin/software/index.tsx
@@ -14,7 +14,7 @@ export default function AdminSoftware() {
         <Searchbox />
         <Pagination />
       </div>
-      <div className="pt-6">
+      <div className="pt-4">
         <SoftwareList/>
       </div>
     </section>

--- a/frontend/components/admin/software/useAdminSoftware.tsx
+++ b/frontend/components/admin/software/useAdminSoftware.tsx
@@ -13,7 +13,7 @@ import useSnackbar from '~/components/snackbar/useSnackbar'
 import {deleteSoftwareById, getSoftwareItems, GetSoftwareListParams} from './apiAdminSoftware'
 
 // always use this order for admin list: not published first and smaller update date (not updated recently)
-const orderBy = 'is_published, updated_at, brand_name'
+const orderBy = 'is_published,updated_at,brand_name'
 
 export function useAdminSoftware(){
   const {token} = useSession()

--- a/frontend/components/admin/software/useAdminSoftware.tsx
+++ b/frontend/components/admin/software/useAdminSoftware.tsx
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useCallback, useEffect, useState} from 'react'
+
+import {useSession} from '~/auth'
+import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
+import {deleteImage} from '~/utils/editImage'
+import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {deleteSoftwareById, getSoftwareItems, GetSoftwareListParams} from './apiAdminSoftware'
+
+// always use this order for admin list: not published first and smaller update date (not updated recently)
+const orderBy = 'is_published, updated_at, brand_name'
+
+export function useAdminSoftware(){
+  const {token} = useSession()
+  const {showErrorMessage, showSuccessMessage} = useSnackbar()
+  const {searchFor, page, rows, setCount} = usePaginationWithSearch('Find software by name, slug, keyword')
+  const [software, setSoftware] = useState<SoftwareOverviewItemProps[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const getSoftware = useCallback(async({searchFor,page,rows,token}:GetSoftwareListParams)=>{
+    const resp = await getSoftwareItems({
+      searchFor,page,rows,orderBy,token
+    })
+    // set record count
+    setCount(resp?.count ?? 0)
+    // set software items
+    setSoftware(resp.data)
+    // set loaded done
+    setLoading(false)
+    // debugger
+  // exclude setCount to avoid endless loop
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[searchFor,page,rows,token])
+
+  const deleteSoftware = useCallback(async(software:SoftwareOverviewItemProps)=>{
+    if (token){
+      const resp = await deleteSoftwareById({
+        id:software.id,
+        token
+      })
+      // debugger
+      if (resp.status!==200){
+        showErrorMessage(`Failed to remove software item. ${resp.message}`)
+      } else {
+        // reload software to first page
+        getSoftware({
+          searchFor,
+          orderBy,
+          page,
+          rows,
+          token
+        })
+        // try to remove image
+        if (software.image_id){
+          deleteImage({
+            id:software.image_id,
+            token
+          })
+        }
+        showSuccessMessage(`${software.brand_name} deleted from RSD`)
+      }
+    }else{
+      showErrorMessage('Failed to remove software item. You need to login first')
+    }
+  // ignore showErrorMessage dependency
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  },[searchFor,page,rows,token])
+
+  useEffect(()=>{
+    if (token){
+      getSoftware({searchFor,page,rows,token})
+    }
+  },[searchFor,page,rows,token,getSoftware])
+
+  return {
+    page,
+    software,
+    loading,
+    deleteSoftware
+  }
+}

--- a/frontend/components/layout/ConfirmDeleteModal.tsx
+++ b/frontend/components/layout/ConfirmDeleteModal.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,20 +18,25 @@ import WarningIcon from '@mui/icons-material/Warning'
 type ConfirmDeleteModalProps = {
   open: boolean,
   title: string,
-  body: JSX.Element,
+  body: JSX.Element | JSX.Element[],
   onCancel: () => void,
-  onDelete: () => void
+  onDelete: () => void,
+  // when passed it is used to require additional confirmation
+  // to enable delete button
+  removeDisabled?: boolean
 }
+
 
 export default function ConfirmDeleteModal({
   open = false, title = 'Remove',
   body = <p>Are you sure you want to remove <strong>this item</strong>?</p>,
-  onCancel, onDelete}: ConfirmDeleteModalProps
+  onCancel, onDelete, removeDisabled = false
+}: ConfirmDeleteModalProps
 ) {
   const smallScreen = useMediaQuery('(max-width:600px)')
-  // console.group('DeleteContributorModal')
+  // console.group('ConfirmDeleteModal')
   // console.log('open...', open)
-  // console.log('contributor...', displayName)
+  // console.log('actions...', actions)
   // console.groupEnd()
   return (
     <Dialog
@@ -66,6 +71,7 @@ export default function ConfirmDeleteModal({
       <DialogActions sx={{
         padding: '1rem 1.5rem',
       }}>
+
         <Button
           onClick={onCancel}
           color="secondary"
@@ -73,9 +79,10 @@ export default function ConfirmDeleteModal({
             marginRight: '1rem',
           }}
         >
-            Cancel
+          Cancel
         </Button>
         <Button
+          disabled={removeDisabled}
           type="button"
           variant="contained"
           color="error"
@@ -84,10 +91,9 @@ export default function ConfirmDeleteModal({
           }
           onClick={onDelete}
         >
-            Remove
+          Remove
         </Button>
       </DialogActions>
-
     </Dialog>
   )
 }

--- a/frontend/pages/admin/projects.tsx
+++ b/frontend/pages/admin/projects.tsx
@@ -13,9 +13,10 @@ import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
 import {adminPages} from '~/components/admin/AdminNav'
 import {SearchProvider} from '~/components/search/SearchContext'
 import {PaginationProvider} from '~/components/pagination/PaginationContext'
-import AdminCommunities from '~/components/admin/communities'
+import AdminProjects from '~/components/admin/projects'
 
-const pageTitle = `${adminPages['communities'].title} | Admin page | ${app.title}`
+
+const pageTitle = `${adminPages['projects'].title} | Admin page | ${app.title}`
 
 const pagination = {
   count: 0,
@@ -25,8 +26,7 @@ const pagination = {
   labelRowsPerPage:'Per page'
 }
 
-
-export default function AdminCommunitiesPage() {
+export default function AdminSoftwarePage() {
   // use page rows from user settings
   const {rsd_page_rows} = useUserSettings()
   pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
@@ -36,40 +36,13 @@ export default function AdminCommunitiesPage() {
       <Head>
         <title>{pageTitle}</title>
       </Head>
-      <AdminPageWithNav title={adminPages['communities'].title}>
+      <AdminPageWithNav title={adminPages['projects'].title}>
         <SearchProvider>
           <PaginationProvider pagination={pagination}>
-            <AdminCommunities />
+            <AdminProjects />
           </PaginationProvider>
         </SearchProvider>
       </AdminPageWithNav>
     </DefaultLayout>
   )
 }
-
-// see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
-// export async function getServerSideProps(context:GetServerSidePropsContext) {
-//   try{
-//     const {req} = context
-//     const token = req?.cookies['rsd_token']
-
-//     // get links to all pages server side
-//     const resp = await getCommunities({
-//       page: 0,
-//       rows: 12,
-//       token: token ?? ''
-//     })
-
-//     return {
-//       // passed to the page component as props
-//       props: {
-//         count: resp?.count,
-//         communities: resp.communities
-//       },
-//     }
-//   }catch(e){
-//     return {
-//       notFound: true,
-//     }
-//   }
-// }

--- a/frontend/pages/admin/software-highlights.tsx
+++ b/frontend/pages/admin/software-highlights.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -13,7 +13,7 @@ import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
 import {adminPages} from '~/components/admin/AdminNav'
 import AdminSoftwareHighlight from '~/components/admin/software-highlights/index'
 
-const pageTitle = `${adminPages['organisations'].title} | Admin page | ${app.title}`
+const pageTitle = `${adminPages['softwareHighlights'].title} | Admin page | ${app.title}`
 
 export default function AdminSoftwareHighlightsPage() {
 

--- a/frontend/pages/admin/software.tsx
+++ b/frontend/pages/admin/software.tsx
@@ -13,9 +13,9 @@ import AdminPageWithNav from '~/components/admin/AdminPageWithNav'
 import {adminPages} from '~/components/admin/AdminNav'
 import {SearchProvider} from '~/components/search/SearchContext'
 import {PaginationProvider} from '~/components/pagination/PaginationContext'
-import AdminCommunities from '~/components/admin/communities'
+import AdminSoftware from '~/components/admin/software'
 
-const pageTitle = `${adminPages['communities'].title} | Admin page | ${app.title}`
+const pageTitle = `${adminPages['software'].title} | Admin page | ${app.title}`
 
 const pagination = {
   count: 0,
@@ -25,8 +25,7 @@ const pagination = {
   labelRowsPerPage:'Per page'
 }
 
-
-export default function AdminCommunitiesPage() {
+export default function AdminSoftwarePage() {
   // use page rows from user settings
   const {rsd_page_rows} = useUserSettings()
   pagination.rows = rsd_page_rows ?? rowsPerPageOptions[0]
@@ -36,40 +35,13 @@ export default function AdminCommunitiesPage() {
       <Head>
         <title>{pageTitle}</title>
       </Head>
-      <AdminPageWithNav title={adminPages['communities'].title}>
+      <AdminPageWithNav title={adminPages['software'].title}>
         <SearchProvider>
           <PaginationProvider pagination={pagination}>
-            <AdminCommunities />
+            <AdminSoftware />
           </PaginationProvider>
         </SearchProvider>
       </AdminPageWithNav>
     </DefaultLayout>
   )
 }
-
-// see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
-// export async function getServerSideProps(context:GetServerSidePropsContext) {
-//   try{
-//     const {req} = context
-//     const token = req?.cookies['rsd_token']
-
-//     // get links to all pages server side
-//     const resp = await getCommunities({
-//       page: 0,
-//       rows: 12,
-//       token: token ?? ''
-//     })
-
-//     return {
-//       // passed to the page component as props
-//       props: {
-//         count: resp?.count,
-//         communities: resp.communities
-//       },
-//     }
-//   }catch(e){
-//     return {
-//       notFound: true,
-//     }
-//   }
-// }

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -220,15 +220,17 @@ export async function deleteOrganisation({uuid,logo_id, token}:
   { uuid: string, logo_id: string|null, token: string }) {
   try {
     // delete organisation
-    const url = `/api/v1/organisation?id=eq.${uuid}`
+    const url = `${getBaseUrl()}/rpc/delete_organisation`
     const resp = await fetch(url, {
-      method: 'DELETE',
+      method: 'POST',
       headers: {
         ...createJsonHeaders(token)
-      }
+      },
+      body:JSON.stringify({
+        id: uuid
+      })
     })
     if ([200, 204].includes(resp.status) === true && logo_id) {
-      //try to remove image
       // try to remove old image
       // but don't wait for results
       const del = await deleteImage({


### PR DESCRIPTION
# Admin can delete software,project,organisation & community from RSD

Closes #488

Changes proposed in this pull request:
* RSD admin can delete software, project, organisation and community from admin page
* We also try to remove images (logo/project image) from RSD
* Order on software is not published, not updated
* Order on projects is not published, not updated
* Click on item to open it for edit (instead of using edit button)

How to test:
* `make start` to build app and generate test data
* login as rsd admin
* navigate to admin pages
* navigate to software and try to remove a software item. Conform the item is deleted.
* navigate to project page and try to remove project. Confirm the item is removed.
* navigate to organisations page and try to remove organisation. Confirm that organisation is removed (it is also removed from software and project pages)
* navigate to community page and remove community. Confirm the community is removed

## Example delete software
![image](https://github.com/user-attachments/assets/bf706868-c353-4b03-8c04-d6eac74e3060)

## Example delete project
![image](https://github.com/user-attachments/assets/1578540f-e969-4e32-a413-a9ba29954f00)

## Example delete organisation
![image](https://github.com/user-attachments/assets/1228c158-3bcf-41f2-af1c-1bb1beef126b)

## Example delete community
![image](https://github.com/user-attachments/assets/e5c3d4a6-3cbd-4ac1-9958-3ca7d1a2e5bc)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
