### PR TITLE
Fix bulk import mentions from Crossref

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -130,6 +130,7 @@ services:
       - AZURE_LOGIN_PROMPT
       - AZURE_DISPLAY_NAME
       - AZURE_DESCRIPTION_HTML
+      - CROSSREF_CONTACT_EMAIL
     expose:
       - 3000
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,6 +142,7 @@ services:
       - AZURE_LOGIN_PROMPT
       - AZURE_DISPLAY_NAME
       - AZURE_DESCRIPTION_HTML
+      - CROSSREF_CONTACT_EMAIL
     expose:
       - 3000
     depends_on:

--- a/frontend/components/mention/ImportMentions/apiImportMentions.tsx
+++ b/frontend/components/mention/ImportMentions/apiImportMentions.tsx
@@ -41,6 +41,8 @@ export async function validateInputList(doiList: string[], mentions: MentionItem
 
   // create DOI list of valid entries eligible for futher processing
   const validDois: string[] = doiList
+    // filter out lines with white space only
+    .filter(input => input.trim().length > 0)
     // validate that input is of type="doi"
     .map(input => extractSearchTerm(input))
     // filter valid DOI type entries

--- a/frontend/components/mention/ImportMentions/apiImportMentions.tsx
+++ b/frontend/components/mention/ImportMentions/apiImportMentions.tsx
@@ -52,7 +52,7 @@ export async function validateInputList(doiList: string[], mentions: MentionItem
         // validate if not already included
         const found = mentions.find(mention => mention.doi?.toLowerCase() === doi)
         if (found) {
-          // flag item with DOI alredy processed
+          // flag item with DOI already processed
           mentionResultPerDoi.set(doi, {doi ,status: 'alreadyImported', include: false})
           return false
         }
@@ -87,7 +87,7 @@ export async function validateInputList(doiList: string[], mentions: MentionItem
 
   // DOI NOT IN RSD
   // valid dois not present in mentionResultPerDoi map at this point are not in RSD
-  const doisNotInDatabase: string[] = validDois.filter(entry => mentionResultPerDoi.has(entry)===false)
+  const doisNotInDatabase: string[] = validDois.filter(entry => !mentionResultPerDoi.has(entry))
 
   if (doisNotInDatabase.length > 0) {
     // getDoiRAList method

--- a/frontend/pages/api/fe/mention/crossref.ts
+++ b/frontend/pages/api/fe/mention/crossref.ts
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {NextApiRequest, NextApiResponse} from 'next'
+import {getCrossrefItemByDoi} from '~/utils/getCrossref'
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse) {
+  const doi = req.query.doi
+
+  if (doi === undefined || Array.isArray(doi)) {
+    res.status(400)
+    res.json({status: 400, message: 'please provide a valid DOI as doi query parameter'})
+  }
+
+  try {
+    const doiResponse = await getCrossrefItemByDoi(doi as string)
+    res.status(doiResponse.status)
+    res.json(doiResponse)
+  } catch (e: any) {
+    res.status(500)
+    res.json({status: 500, message: 'unknown error'})
+  }
+}

--- a/frontend/utils/getDOI.ts
+++ b/frontend/utils/getDOI.ts
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {MentionItemProps} from '~/types/Mention'
-import {crossrefItemToMentionItem, getCrossrefItemByDoi} from './getCrossref'
+import {crossrefItemToMentionItem} from './getCrossref'
 import {dataCiteGraphQLItemToMentionItem, getDataciteItemByDoiGraphQL, getDataciteItemsByDoiGraphQL} from './getDataCite'
 import logger from './logger'
 import {getOpenalexItemByDoi, getOpenalexItemsByDoi, openalexItemToMentionItem} from '~/utils/getOpenalex'

--- a/frontend/utils/getDOI.ts
+++ b/frontend/utils/getDOI.ts
@@ -75,7 +75,8 @@ export async function getUrlFromDoiOrg(doi: string) {
 
 
 async function getItemFromCrossref(doi: string) {
-  const resp = await getCrossrefItemByDoi(doi)
+  const mentionResponse = await fetch(`/api/fe/mention/crossref?doi=${doi}`)
+  const resp = await mentionResponse.json()
   // debugger
   if (resp.status === 200) {
     const mention = crossrefItemToMentionItem(resp.message)

--- a/frontend/utils/promisePool.test.ts
+++ b/frontend/utils/promisePool.test.ts
@@ -9,21 +9,15 @@ it('PromisePool class works correctly', async () => {
   const promisePool: PromisePool = new PromisePool(2)
   const messages: string[] = []
   await Promise.all([
-    promisePool.submit<string>(() => new Promise(res => {
-      res('first')
-    }))
+    promisePool.submit<string>(() => Promise.resolve('first'))
       .then(result => messages.push(result)),
     promisePool.submit<string>(() => new Promise(res => {
       setTimeout(() => res('fourth'), 200)
     }))
       .then(result => messages.push(result)),
-    promisePool.submit<string>(() => new Promise(res => {
-      res('second')
-    }))
+    promisePool.submit<string>(() => Promise.resolve('second'))
       .then(result => messages.push(result)),
-    promisePool.submit<string>(() => new Promise(res => {
-      res('third')
-    }))
+    promisePool.submit<string>(() => Promise.resolve('third'))
       .then(result => messages.push(result)),
   ])
 

--- a/frontend/utils/promisePool.test.ts
+++ b/frontend/utils/promisePool.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {PromisePool} from '~/utils/promisePool'
+
+it('PromisePool class works correctly', async () => {
+  const promisePool: PromisePool = new PromisePool(2)
+  const messages: string[] = []
+  await Promise.all([
+    promisePool.submit<string>(() => new Promise(res => {
+      res('first')
+    }))
+      .then(result => messages.push(result)),
+    promisePool.submit<string>(() => new Promise(res => {
+      setTimeout(() => res('fourth'), 200)
+    }))
+      .then(result => messages.push(result)),
+    promisePool.submit<string>(() => new Promise(res => {
+      res('second')
+    }))
+      .then(result => messages.push(result)),
+    promisePool.submit<string>(() => new Promise(res => {
+      res('third')
+    }))
+      .then(result => messages.push(result)),
+  ])
+
+  expect(messages).toEqual(['first', 'second', 'third', 'fourth'])
+})

--- a/frontend/utils/promisePool.ts
+++ b/frontend/utils/promisePool.ts
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export class PromisePool {
+  readonly size: number
+  #runningPromisesCounter: number = 0
+  #tasks: any[] = []
+
+  constructor(size: number) {
+    if (!Number.isInteger(size) || size <= 0) {
+      throw new Error('The size should be a positive integer')
+    }
+    this.size = size
+  }
+
+  async submit<T>(promiseProducer: () => Promise<T>): Promise<T> {
+    return new Promise((res, rej) => {
+      this.#tasks.push({res, rej, promiseProducer})
+      this.#tryNextTask()
+    })
+  }
+
+  #tryNextTask() {
+    if (this.#tasks.length === 0 || this.#runningPromisesCounter >= this.size) {
+      return
+    }
+
+    this.#runningPromisesCounter++
+    const {res, rej, promiseProducer} = this.#tasks.shift()
+    const task = promiseProducer()
+    task.then((result: any) => res(result))
+      .catch((error: any) => rej(error))
+      .finally(() => {
+        this.#runningPromisesCounter--
+        this.#tryNextTask()
+      })
+  }
+
+}


### PR DESCRIPTION
## Fix bulk import mentions from Crossref

Changes proposed in this pull request:

* Do requests to Crossref from the Next.js server instead of the browser, to that the polite pool (using email) can be used
* Use a promise pool (or semaphore) to limit the amount of parallel requests to Crossref.

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, create a software page
* Bulk add Crossref mentions to the page, using the examples from #808; this should work without error

Closes #1270

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests
