### PR TITLE
fix: mention form validation

### DIFF
--- a/frontend/components/admin/mentions/MentionsOverviewList.tsx
+++ b/frontend/components/admin/mentions/MentionsOverviewList.tsx
@@ -74,14 +74,17 @@ export default function MentionsOverviewList({list, onUpdate}: { list: MentionIt
           )
         })}
       </List>
-      <EditMentionModal
-        title={mentionToEdit?.id as string ?? 'undefined'}
-        open={modalOpen}
-        pos={undefined} //why does this exist?
-        item={mentionToEdit}
-        onCancel={() => setModalOpen(false)}
-        onSubmit={({data}) => {updateMention(data)}}
-      />
+      {modalOpen ?
+        <EditMentionModal
+          title={mentionToEdit?.id as string ?? 'undefined'}
+          open={modalOpen}
+          pos={undefined} //why does this exist?
+          item={mentionToEdit}
+          onCancel={() => setModalOpen(false)}
+          onSubmit={({data}) => {updateMention(data)}}
+        />
+        : null
+      }
     </>
   )
 };

--- a/frontend/components/mention/MentionEditSection.tsx
+++ b/frontend/components/mention/MentionEditSection.tsx
@@ -85,35 +85,41 @@ export default function MentionEditSection() {
     return (
       <>
         {/* modal as external part of the section */}
-        <EditMentionModal
-          title={settings.editModalTitle}
-          open={editModal.open}
-          pos={editModal.pos}
-          item={editModal.item}
-          onCancel={closeEditModal}
-          onSubmit={(props)=>onSubmit(props.data)}
-        />
-        <ConfirmDeleteModal
-          open={confirmModal.open}
-          title={settings.confirmDeleteModalTitle}
-          body={
-            <p>Are you sure you want to remove <strong>
-              <SanitizedMathMLBox
-                component="span"
-                rawHtml={confirmModal?.item?.title ?? 'this item'}
-              />
-            </strong>?</p>
-          }
-          onCancel={() => {
-          // cancel confirm by removing item
-            confirmDelete()
-          }}
-          onDelete={() => {
-            if (confirmModal?.item) onDelete(confirmModal?.item)
-            // hide modal by removing confirm item
-            confirmDelete()
-          }}
-        />
+        {editModal.open ?
+          <EditMentionModal
+            title={settings.editModalTitle}
+            open={editModal.open}
+            pos={editModal.pos}
+            item={editModal.item}
+            onCancel={closeEditModal}
+            onSubmit={(props)=>onSubmit(props.data)}
+          />
+          : null
+        }{
+          confirmModal.open ?
+            <ConfirmDeleteModal
+              open={confirmModal.open}
+              title={settings.confirmDeleteModalTitle}
+              body={
+                <p>Are you sure you want to remove <strong>
+                  <SanitizedMathMLBox
+                    component="span"
+                    rawHtml={confirmModal?.item?.title ?? 'this item'}
+                  />
+                </strong>?</p>
+              }
+              onCancel={() => {
+                // cancel confirm by removing item
+                confirmDelete()
+              }}
+              onDelete={() => {
+                if (confirmModal?.item) onDelete(confirmModal?.item)
+                // hide modal by removing confirm item
+                confirmDelete()
+              }}
+            />
+            : null
+        }
       </>
     )
   }


### PR DESCRIPTION
# Fix mention form validation when changing type

Closes #1304 

Changes proposed in this pull request:
* The modals are conditionally rendered in order to properly load initial form data for editing
* When changing mention type from highlight to other type the rules are improved (required is set to false)
* Manually remove highlight specific error from the error object after type is changed

How to test:
* `make start` to build and generate test data
* login as rsd admin and try to manually create or edit mentions
* When using `highlight` mention type you will need to provide image_url before save button is enabled (form is valid)
* Try changing the mention type from highlight to other types. You should be able to save mention without image_url (save button should be enabled)

## Edit mention modal
![image](https://github.com/user-attachments/assets/47724eeb-ad5b-4706-a6e6-e5de9f6707ae)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
