### PR TITLE
chore: add plugin hostname to plugin configuration

### DIFF
--- a/frontend/config/RsdPluginContext.tsx
+++ b/frontend/config/RsdPluginContext.tsx
@@ -27,10 +27,9 @@ export const RsdPluginContext = createContext<{settings:PluginConfig[]}>({settin
 
 export default function PluginSettingsProvider(props: any) {
   const [settings, setSettings] = useState(props?.settings ?? [])
-  const value = useMemo(() => ({settings, setSettings}), [settings, setSettings])
 
   return <RsdPluginContext.Provider
-    value={value}
+    value={{settings, setSettings}}
     {...props}
   />
 }

--- a/frontend/config/getPlugins.ts
+++ b/frontend/config/getPlugins.ts
@@ -10,20 +10,9 @@ import {createJsonHeaders} from '~/utils/fetchHelpers'
 import {PluginConfig} from '~/config/RsdPluginContext'
 import {RsdPluginSettings} from './rsdSettingsReducer'
 
-function constructBackendUrl(pluginSettings: RsdPluginSettings) {
-  const {name, backend_hostname} = pluginSettings
-  if (process.env.NODE_ENV === 'development') {
-    return `http://localhost/plugin/${name}`
-  } else {
-    return `http://${backend_hostname}/plugin/${name}`
-  }
-}
-
 async function getPlugin({pluginSettings, token}:{pluginSettings: RsdPluginSettings, token?: string}){
-  const url = constructBackendUrl(pluginSettings) + '/api/config'
-  console.log(url)
   try {
-    const response = await fetch(url, {
+    const response = await fetch(pluginSettings.config_url, {
       headers: {
         ...createJsonHeaders(token)
       },
@@ -41,16 +30,16 @@ async function getPlugin({pluginSettings, token}:{pluginSettings: RsdPluginSetti
       })
       return config
     }
-    logger(`Failed to load plugin config from ${url}: ${response.status} ${response.statusText}`,'warn')
+    logger(`Failed to load plugin config from ${pluginSettings.config_url}: ${response.status} ${response.statusText}`,'warn')
     return []
 
   } catch (error) {
     if (error instanceof TypeError) {
       const message = error.message
       const cause = error.cause
-      logger(`Error loading plugin config from ${url}. Message: ${message}. Cause: ${cause}.`,'warn')
+      logger(`Error loading plugin config from ${pluginSettings.config_url}. Message: ${message}. Cause: ${cause}.`,'warn')
     } else {
-      logger(`Error loading plugin config from ${url}: ${error}`,'warn')
+      logger(`Error loading plugin config from ${pluginSettings.config_url}: ${error}`,'warn')
     }
     return []
   }

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -21,6 +21,11 @@ export type RsdSettingsState = {
 
 export type RsdModule= 'software'| 'projects' | 'organisations' | 'communities' | 'news' | 'user'
 
+export type RsdPluginSettings = {
+  name: string,
+  backend_hostname: string
+}
+
 export type RsdHost = {
   name: string,
   email: string,
@@ -41,7 +46,7 @@ export type RsdHost = {
     description?: string | null
   },
   modules?: RsdModule[],
-  plugins?: string[]
+  plugins?: RsdPluginSettings[]
 }
 
 export type CustomLink = {

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -23,7 +23,7 @@ export type RsdModule= 'software'| 'projects' | 'organisations' | 'communities' 
 
 export type RsdPluginSettings = {
   name: string,
-  backend_hostname: string
+  config_url: string
 }
 
 export type RsdHost = {


### PR DESCRIPTION
Fixes connection issues when running nextjs in a docker container.

Changes proposed in this pull request:

* changes the plugin settings in `frontend/public/data/settings.json` to also include the hostname of the plugin backend, which is required to make the requests inside the docker network

How to test:

* change plugins array in `settings.json` to:
```json
    "plugins": [
      {
        "name": "dummyplugin",
        "backend_hostname": "dummy-plugin-backend:8081"
      }
    ]
```
* build and run the application and verify that backend is reached by next

@dmijatovic please review this solution. I will update the documentation after you will have accepted.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
