### PR TITLE
Documentation on releases and workshops

### DIFF
--- a/documentation/docs/01-users/05-adding-software.md
+++ b/documentation/docs/01-users/05-adding-software.md
@@ -44,7 +44,7 @@ This example is code area
 
 |column 1| column 2| column 3|
 |-|-|-|
-|123242|234234|3
+|123242|234234|3|
 |some text here|34|x=23|
 
 ## Task list
@@ -75,7 +75,7 @@ When using a Document URL to point to a remote Markdown file on the GitHub, you 
 
 ### Logo
 
-The software logo is shown on the software page and in the software card (see example below). **You can upload an image up to 2MB of size**. Widely used image formats like JPG, JPEG, PNG, SVG etc. are supported. Use the **svg** format, if possible, because it scales better than other formats.
+The software logo is shown on the software page and in the software card (see example below). **You can upload an image up to 2MB of size**. Widely used image formats like JPG, JPEG, PNG, SVG etc. are supported. Use the **SVG** format, if possible, because it scales better than other formats.
 
 ![image](img/software-logo-card.webp)
 

--- a/documentation/docs/01-users/11-scrapers.md
+++ b/documentation/docs/01-users/11-scrapers.md
@@ -1,7 +1,7 @@
 # Data scrapers
 
 The RSD uses data scraper services to obtain and update various data. In this chapter, we explain these services.
-The scraper services are scheduled to run every 6 minutes on average. These services scrape the data from using various open API's, which might have a limit on the amount of data that can be scraped.
+The scraper services are scheduled to run every 6 minutes on average. These services scrape the data from using various open APIs, which might have a limit on the amount of data that can be scraped.
 
 :::warning
 The scraper services can only scrape information that is publicly available.
@@ -29,7 +29,9 @@ This service scrapes the contributor count from the repository of your software.
 
 ## Software releases
 
-The service scrapes information from Zenodo about registered software releases based on the concept DOI you provided to your software page.
+This service collects and stores all releases of your software page, if your software has a *[Concept DOI](https://support.zenodo.org/help/en-gb/1-upload-deposit/97-what-is-doi-versioning)*. The result is shown on the publicly facing software page as the "Cite this software" block.
+
+The releases are harvested from the [DataCite API](https://support.datacite.org/docs/api). We use the supplied concept DOI of the software to see if any *versions* exist of this software in the DataCite database. The best way to ensure that these links are stored in the DataCite database is to make use of the [GitHub and Zenodo integration](https://docs.github.com/en/repositories/archiving-a-github-repository/referencing-and-citing-content). This will make sure that every time you create a release of your software, an entry is created in [Zenodo](https://zenodo.org/) and that the link between the release and the concept DOI is created in the DataCite database.
 
 ## Citations
 

--- a/documentation/docs/01-users/11-scrapers.md.license
+++ b/documentation/docs/01-users/11-scrapers.md.license
@@ -1,5 +1,5 @@
+SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/documentation/docs/01-users/99-faq.md
+++ b/documentation/docs/01-users/99-faq.md
@@ -27,3 +27,11 @@ You can use the [GitHub discussions page](https://github.com/research-software-d
 ### Where can I request a new feature or report a bug?
 
 You can use the [GitHub issues page](https://github.com/research-software-directory/RSD-as-a-service/issues) for this.
+
+### Can I create a dedicated software page for a workshop about a software package?
+
+If your workshop has a dedicated Git repo, has releases and software examples (i.e. the workshop is similar to something that one can consider to be software), then you can go ahead and make a dedicated software page for your workshop. Please create a link, as *related software*, to the software page your workshop is about.
+
+If your workshop looks more like a static collection of files, e.g. a collection of slides, then please only add this as output to the software page of which the workshop is about.
+
+Please use your best judgement, and if you have any doubts, you can contact us.

--- a/documentation/docs/01-users/99-faq.md.license
+++ b/documentation/docs/01-users/99-faq.md.license
@@ -1,5 +1,6 @@
-SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 Jason Maassen (Netherlands eScience Center) <j.maassen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 
 SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
## Documentation on releases and workshops

### Changes proposed in this pull request

* Add more details on how software releases are harvested
* Add a FAQ entry on adding workshops as a software page
* Some other small fixes

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Read the new documentation on the "Data scrapers" and "Frequently Asked Questions" pages


Closes #1301
Closes #1307

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [ ] Tests
