### PR TITLE
OpenAlex scraper bug fix

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -215,7 +215,7 @@ public class DataciteMentionRepository {
 	}
 
 	public Collection<ExternalMentionRecord> mentionData(Collection<Doi> dois) {
-		if (dois.isEmpty()) {
+		if (dois == null || dois.isEmpty()) {
 			return Collections.emptyList();
 		}
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
@@ -85,7 +85,8 @@ public class MainMentions {
 		try {
 			scrapedDataciteMentions = new DataciteMentionRepository().mentionData(dataciteDois);
 		} catch (RuntimeException e) {
-			Utils.saveExceptionInDatabase("DataCite mention scraper", "mention", null, e);
+			Exception exceptionToSave = new Exception("Failed scraping the following DataCite DOIs: " + dataciteDois, e);
+			Utils.saveExceptionInDatabase("DataCite mention scraper", "mention", null, exceptionToSave);
 		}
 		for (ExternalMentionRecord scrapedMention : scrapedDataciteMentions) {
 			Doi doi = scrapedMention.doi();
@@ -144,7 +145,8 @@ public class MainMentions {
 		try {
 			scrapedOpenalexMentions.addAll(openAlexConnector.mentionDataByDois(europeanPublicationsOfficeDois, email));
 		} catch (Exception e) {
-			Utils.saveExceptionInDatabase("OpenAlex mention scraper", "mention", null, e);
+			Exception exceptionToSave = new Exception("Failed scraping the following EPO DOIs: " + europeanPublicationsOfficeDois, e);
+			Utils.saveExceptionInDatabase("OpenAlex mention scraper", "mention", null, exceptionToSave);
 		}
 		Collection<OpenalexId> openalexIdsToScrape = mentionsToScrape
 				.stream()
@@ -154,7 +156,8 @@ public class MainMentions {
 		try {
 			scrapedOpenalexMentions.addAll(openAlexConnector.mentionDataByOpenalexIds(openalexIdsToScrape, email));
 		} catch (Exception e) {
-			Utils.saveExceptionInDatabase("OpenAlex mention scraper", "mention", null, e);
+			Exception exceptionToSave = new Exception("Failed scraping the following OpenAlex IDs: " + openalexIdsToScrape, e);
+			Utils.saveExceptionInDatabase("OpenAlex mention scraper", "mention", null, exceptionToSave);
 		}
 
 		for (ExternalMentionRecord scrapedMention : scrapedOpenalexMentions) {

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnectorTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnectorTest.java
@@ -11,8 +11,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.net.URI;
+import java.util.Collection;
+import java.util.Collections;
 
-public class OpenAlexCitationsTest {
+public class OpenAlexConnectorTest {
 
 	@Test
 	void givenLocationWithBackSlashes_whenExtractedAsLocation_thenSlashesUrlEncoded() {
@@ -26,5 +28,16 @@ public class OpenAlexCitationsTest {
 
 		Assertions.assertNotNull(result);
 		Assertions.assertEquals("https://www.example.com/path%5Cwith%5Cslash", result.toString());
+	}
+
+	@Test
+	void givenEmptyCollection_whenGettingData_thenEmptyCollectionReturned() {
+		OpenAlexConnector openAlexConnector = new OpenAlexConnector();
+
+		Collection<ExternalMentionRecord> doiMentions = Assertions.assertDoesNotThrow(() -> openAlexConnector.mentionDataByDois(Collections.emptyList(), null));
+		Assertions.assertTrue(doiMentions.isEmpty());
+
+		Collection<ExternalMentionRecord> openalexMentions = Assertions.assertDoesNotThrow(() -> openAlexConnector.mentionDataByOpenalexIds(Collections.emptyList(), null));
+		Assertions.assertTrue(openalexMentions.isEmpty());
 	}
 }


### PR DESCRIPTION
## OpenAlex scraper bug fix

### Changes proposed in this pull request

* When trying to scrape zero mentions, return immideately with an empty response to prevent errors later on
* Added tests to test this

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Now that there are no mentions, run the mentions scraper:
* `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainMentions`
* No errors should be reported
* Same for the citations scraper:
* `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations`


Closes #1317

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests
