### PR TITLE
fix: use additional validation for email and contact person switch

### DIFF
--- a/frontend/components/person/AggregatedPersonModal.tsx
+++ b/frontend/components/person/AggregatedPersonModal.tsx
@@ -3,6 +3,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {useEffect} from 'react'
+
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -60,7 +62,7 @@ export default function AggregatedPersonModal({
 }: AggregatedPersonModalProps) {
   const {loading, options} = useAggregatedPerson(person?.orcid)
   const smallScreen = useMediaQuery('(max-width:640px)')
-  const {handleSubmit, watch, formState, control, register, setValue} = useForm<FormPerson>({
+  const {handleSubmit, watch, formState, control, register, setValue, trigger} = useForm<FormPerson>({
     mode: 'onChange',
     defaultValues: {
       ...person,
@@ -72,6 +74,13 @@ export default function AggregatedPersonModal({
   // extract
   const {isValid, isDirty} = formState
   const formData = watch()
+
+  useEffect(()=>{
+    // when is_contact_person OR email_address changes
+    // we trigger additional validation on email because
+    // email is required for the contact person
+    trigger('email_address')
+  },[formData.email_address,formData.is_contact_person,trigger])
 
   // console.group('AggregatedPersonModal')
   // console.log('errors...', errors)


### PR DESCRIPTION
# Show email is required for contact person

Closes #1313

Changes proposed in this pull request:
*   Additional validation on email field is performed when contact person switch value changes

How to test:
* `make start` to build and generate test data
* login as rsd admin
* edit software or project contributors or team members
* try to set contact person flag to true when no email is provided, the email field should signal an error

## Example email error for contact person

![image](https://github.com/user-attachments/assets/44c7f8d3-5df4-46e9-9828-f38f47208f45)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
