### PR TITLE
fix: software mentions counts on homepage

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -749,6 +749,7 @@ $$;
 -- TOTAL COUNTS FOR HOMEPAGE
 -- software_cnt, project_cnt, organisation_cnt
 -- this rpc returns json object instead of array
+-- DEPENDS on RPC mentions_by_software (104-software-views.sql)
 CREATE FUNCTION homepage_counts(
 	OUT software_cnt BIGINT,
 	OUT open_software_cnt BIGINT,
@@ -759,18 +760,18 @@ CREATE FUNCTION homepage_counts(
 ) LANGUAGE plpgsql STABLE AS
 $$
 BEGIN
-	SELECT COUNT(id) FROM software INTO software_cnt;
-	SELECT COUNT(id) FROM software WHERE NOT closed_source INTO open_software_cnt;
-	SELECT COUNT(id) FROM project INTO project_cnt;
+	SELECT COUNT(*) FROM software INTO software_cnt;
+	SELECT COUNT(*) FROM software WHERE NOT closed_source INTO open_software_cnt;
+	SELECT COUNT(*) FROM project INTO project_cnt;
 	SELECT
-		COUNT(id) AS organisation_cnt
+		COUNT(*) AS organisation_cnt
 	FROM
 		organisations_overview(TRUE)
 	WHERE
 		organisations_overview.parent IS NULL AND organisations_overview.score>0
 	INTO organisation_cnt;
 	SELECT COUNT(DISTINCT(orcid,given_names,family_names)) FROM contributor INTO contributor_cnt;
-	SELECT COUNT(mention) FROM mention_for_software INTO software_mention_cnt;
+	SELECT COUNT(*) FROM mentions_by_software() INTO software_mention_cnt;
 END
 $$;
 


### PR DESCRIPTION
# Improve mention count on homepage

Closes #1326

Changes proposed in this pull request:
* Improve  homepage_counts RPC to use  mentions_by_software RPC for software mentions count
* We count unique combination of mention and software id's. In other words, if multiple software packages (registered in RSD) are referenced from one paper we count this reference multiple times (for each software registered in RSD).

How to test:
* Easier to validate is to start without test data. `docker compose build && docker compose up`
* Login and create 2 software packages and 1 project
* In the first software package in reference papers use this DOI 10.1186/s13321-017-0220-4
* In the second software package in reference papers use this DOI 10.5194/gmd-7-267-2014
* In the project output use this DOI 10.5194/gmd-10-3167-2017
* Let the scrapers run and collect the citations (wait 15 minutes or more).
* Navigate to home page and check homepage stats. It should show **555 software mentions**
    *  10.1186/s13321-017-0220-4 produces 461 software mentions
    *  10.5194/gmd-7-267-2014 produces 16 software mentions
    *  10.1016/j.softx.2020.100549 produces 14 software mentions
    *  10.1016/j.future.2018.08.004 produces 64 software mentions

## Example software overview 
![image](https://github.com/user-attachments/assets/42664558-0f39-4a12-a014-4358031331ef)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
