### PR TITLE
fix: allow for escaped slash in DOI

### DIFF
--- a/frontend/components/software/edit/mentions/utils.ts
+++ b/frontend/components/software/edit/mentions/utils.ts
@@ -6,7 +6,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-const DOI_REGEX = /10(\.\w+)+\/\S+/
+const DOI_REGEX = /(10(\.\w+)+)(\/|%2F)(\S+)/i
 export const DOI_REGEX_STRICT = /^10(\.\w+)+\/\S+$/
 const OPENALEX_ID_REGEX = /https:\/\/openalex\.org\/([WwAaSsIiCcPpFf]\d{3,13})/
 
@@ -18,7 +18,7 @@ export function extractSearchTerm(query: string): SearchTermInfo{
 
   const doiRegexMatch = DOI_REGEX.exec(query)
   if (doiRegexMatch != null) {
-    return {term: doiRegexMatch[0], type: 'doi'}
+    return {term: doiRegexMatch[1] + '/' + doiRegexMatch[4], type: 'doi'}
   }
   const openalexRegexMatch = OPENALEX_ID_REGEX.exec(query)
   if (openalexRegexMatch != null) {


### PR DESCRIPTION
## Allow for escaped slash in DOI

### Changes proposed in this pull request

* When entering a DOI, allow for the first forward slash to be URL encoded (`%2F`)

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, create a software or project page
* When searching anywhere for the DOI `10.1186%2Fs40537-019-0194-3` (or `https://doi.org/10.1186%2Fs40537-019-0194-3`) using regular search or bulk import, a result should be found. The same when using the unescaped DOI `10.1186/s40537-019-0194-3`.
* Try out other DOIs from #808 to see if they still work

Closes #1309

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
