### PR TITLE
Fix delete functions

### DIFF
--- a/database/106-project-views.sql
+++ b/database/106-project-views.sql
@@ -26,6 +26,7 @@ BEGIN
 		RAISE EXCEPTION USING MESSAGE = 'You are not allowed to delete this project';
 	END IF;
 
+	DELETE FROM category_for_project WHERE category_for_project.project_id = delete_project.id;
 	DELETE FROM impact_for_project WHERE impact_for_project.project = delete_project.id;
 	DELETE FROM invite_maintainer_for_project WHERE invite_maintainer_for_project.project = delete_project.id;
 	DELETE FROM keyword_for_project WHERE keyword_for_project.project = delete_project.id;
@@ -36,6 +37,7 @@ BEGIN
 	DELETE FROM research_domain_for_project WHERE research_domain_for_project.project = delete_project.id;
 	DELETE FROM software_for_project WHERE software_for_project.project = delete_project.id;
 	DELETE FROM team_member WHERE team_member.project = delete_project.id;
+	DELETE FROM testimonial_for_project WHERE testimonial_for_project.project = delete_project.id;
 	DELETE FROM url_for_project WHERE url_for_project.project = delete_project.id;
 
 	DELETE FROM project WHERE project.id = delete_project.id;


### PR DESCRIPTION
## Fix delete functions

### Changes proposed in this pull request

* Fix the delete functions for projects and organisations to adapt to testimonials and categories
* This also fixes a bug that didn't allow organisations with multiple research units to be deleted

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin, deleting software, projects and organisations should always work without errors
* Create an organisation with multiple research units, deleting the parent should also work (this also deletes the research units)

Closes #1334

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
