### PR TITLE
Auth refresh check admin

### DIFF
--- a/authentication/README.md
+++ b/authentication/README.md
@@ -28,7 +28,8 @@ extra_hosts:
   - "host.docker.internal:host-gateway"
 ```
 2. In `nginx.conf`, replace `server auth:7000;` with `server host.docker.internal:7000;`
-3. (Optionally) allow TCP traffic on port 7000 of your firewall if logging in seems to hang forever or if you get `504 Gateway Timeout` responses.
+3. (Optional) For refreshing your tokens to work, set `RSD_AUTH_URL=http://nginx/auth` in your `.env`.
+4. (Optional) Allow TCP traffic on port 7000 of your firewall if signing in seems to hang forever or if you get `504 Gateway Timeout` responses.
 
 Remember to undo these changes before committing!
 

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -34,7 +34,7 @@ SPDX-License-Identifier: Apache-2.0
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-dependency-plugin</artifactId>
-				<version>3.7.1</version>
+				<version>3.8.1</version>
 			</plugin>
 
 			<!-- https://mvnrepository.com/artifact/org.apache.maven.plugins/maven-assembly-plugin -->
@@ -101,21 +101,21 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>io.javalin</groupId>
 			<artifactId>javalin</artifactId>
-			<version>6.2.0</version>
+			<version>6.3.0</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.jetbrains/annotations -->
 		<dependency>
 			<groupId>org.jetbrains</groupId>
 			<artifactId>annotations</artifactId>
-			<version>24.1.0</version>
+			<version>26.0.1</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.slf4j/slf4j-simple -->
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-simple</artifactId>
-			<version>2.0.13</version>
+			<version>2.0.16</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.auth0/java-jwt -->
@@ -143,14 +143,14 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>slf4j-api</artifactId>
-			<version>2.0.13</version>
+			<version>2.0.16</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-classic -->
 		<dependency>
 			<groupId>ch.qos.logback</groupId>
 			<artifactId>logback-classic</artifactId>
-			<version>1.5.6</version>
+			<version>1.5.12</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.junit.jupiter/junit-jupiter -->

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.authentication;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+class PostgrestAccountTest {
+
+	@Test
+	void givenEmtpyArray_whenCheckingIfAdmin_thenFalseReturned() {
+		String emptyArray = "[]";
+		UUID adminUuid = UUID.randomUUID();
+
+		Assertions.assertFalse(PostgrestAccount.parseIsAdminResponse(adminUuid, emptyArray));
+	}
+
+	@Test
+	void givenResponseWithNullValue_whenCheckingIfAdmin_thenFalseReturned() {
+		String emptyArray = "[{\"account_id\": null}]";
+		UUID adminUuid = UUID.randomUUID();
+
+		Assertions.assertFalse(PostgrestAccount.parseIsAdminResponse(adminUuid, emptyArray));
+	}
+
+	@Test
+	void givenArrayOfSizeOneWithCorrectUuid_whenCheckingIfAdmin_thenTrueReturned() {
+		UUID adminUuid = UUID.randomUUID();
+		String successResponse = "[{\"account_id\": \"%s\"}]".formatted(adminUuid);
+
+		Assertions.assertTrue(PostgrestAccount.parseIsAdminResponse(adminUuid, successResponse));
+	}
+
+	@Test
+	void givenArrayOfSizeOneWithIncorrectUuid_whenCheckingIfAdmin_thenFalseReturned() {
+		UUID adminUuid = UUID.randomUUID();
+		String successResponse = "[{\"account_id\": \"%s\"}]".formatted(UUID.randomUUID());
+
+		Assertions.assertFalse(PostgrestAccount.parseIsAdminResponse(adminUuid, successResponse));
+	}
+
+	@Test
+	void givenArrayOfSizeTwoWithCorrectUuid_whenCheckingIfAdmin_thenFalseReturned() {
+		UUID adminUuid = UUID.randomUUID();
+		String wrongIdResponse = "[{\"account_id\": \"%s\"}, {\"account_id\": \"%s\"}]".formatted(adminUuid, UUID.randomUUID());
+
+		Assertions.assertFalse(PostgrestAccount.parseIsAdminResponse(adminUuid, wrongIdResponse));
+	}
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,7 @@ services:
 
   auth:
     build: ./authentication
-    image: rsd/auth:1.5.0
+    image: rsd/auth:1.6.0
     ports:
       - 5005:5005
     expose:


### PR DESCRIPTION
## Check admin status on JWT refresh

### Changes proposed in this pull request

* Check the database for admin status when refreshing JWT
* Upgrade some auth dependencies

### How to test

* To be able to test this, you need your cookies to expire in just slightly longer than 5 minutes (instead of an hour), so edit `JwtCreator.java` and set `ONE_HOUR_IN_MILLISECONDS` to `310_000L`
* Make sure to have `RSD_ENVIRONMENT=dev` in your `.env`
* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, you should be admin
* Run in the database `DELETE FROM admin_account;`; within 10 seconds, you should not be admin anymore
* Run in the database `INSERT INTO admin_account VALUES ('some-uuid');`, where you can find your UUID in your settings; within 10 seconds, you should be admin again
* Don't forget to `git restore .` afterwards

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [x] Tests
