### PR TITLE
1350 category overview database

### DIFF
--- a/backend-postgrest/Dockerfile
+++ b/backend-postgrest/Dockerfile
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgrest/postgrest:v12.2.2
+FROM postgrest/postgrest:v12.2.3

--- a/database/014-create-keyword-and-category.sql
+++ b/database/014-create-keyword-and-category.sql
@@ -233,6 +233,7 @@ $$;
 -- includes organisation, community and general categories
 -- Note! to filter specific categories of an community or organisation use join with community table
 
+-- if you ever change this table, then software_of_category() needs to be changed as well
 CREATE TABLE category_for_software (
 	software_id UUID REFERENCES software (id),
 	category_id UUID REFERENCES category (id),
@@ -260,6 +261,8 @@ $$;
 
 -- TABLE FOR project categories
 -- currently used only for organisation categories
+
+-- if you ever change this table, then projects_of_category() needs to be changed as well
 CREATE TABLE category_for_project (
 	project_id UUID REFERENCES project (id),
 	category_id UUID REFERENCES category (id),
@@ -297,4 +300,30 @@ $$
 			)
 			ELSE '[]'::json
 		END AS result
+$$;
+
+
+CREATE FUNCTION software_of_category()
+RETURNS SETOF category_for_software
+LANGUAGE SQL STABLE AS
+$$
+SELECT DISTINCT software.id, category_path.id
+FROM software
+INNER JOIN category_for_software
+	ON software.id = category_for_software.software_id
+INNER JOIN category_path(category_for_software.category_id)
+	ON TRUE;
+$$;
+
+
+CREATE FUNCTION projects_of_category()
+RETURNS SETOF category_for_project
+LANGUAGE SQL STABLE AS
+$$
+SELECT DISTINCT project.id, category_path.id
+FROM project
+INNER JOIN category_for_project
+	ON project.id = category_for_project.project_id
+INNER JOIN category_path(category_for_project.category_id)
+	ON TRUE;
 $$;

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgres:15.7
+FROM postgres:15.9
 RUN chmod a+rwx /docker-entrypoint-initdb.d
 COPY --chown=postgres:postgres *.sh /docker-entrypoint-initdb.d/
 COPY --chown=postgres:postgres *.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:2.5.0
+    image: rsd/database:2.6.0
     ports:
       # enable connection from outside (development mode)
       - "5432:5432"


### PR DESCRIPTION
## Backend functions for software and project overviews per category

### Changes proposed in this pull request

* Upgrade Postgres from 15.7 to 15.9
* Upgrade PostgREST from v12.2.2 to v12.2.3
* Add database functions that show all categories of software and projects (including categories that are not assigned directly but are a parent of an assigned category)

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin, create an organisation, add three levels of categories
* Create a project, publish it, add the organiation, add its lowest level category
* On http://localhost/api/v1/category_for_project?select=*,project(title),category(short_name,name), you should see only one entry
* On http://localhost/api/v1/rpc/projects_of_category?select=*,project(title),category(short_name,name) you should see three entries, as the parents of the category are also shown
* Do the same with a software page, the URLs to check are http://localhost/api/v1/category_for_software?select=*,software(brand_name),category(short_name,name) and http://localhost/api/v1/rpc/software_of_category?select=*,software(brand_name),category(short_name,name) respectively
* Now we will use a populated RSD:
* `docker compose down --volumes && docker compose up --scale data-generation=1`
* http://localhost/api/v1/rpc/projects_of_category and http://localhost/api/v1/rpc/software_of_category should take about half a second to load.
* We should maybe disable [JIT](https://www.postgresql.org/docs/15/jit.html), because those endpoints are faster when JIT is disabled (run `ALTER DATABASE "rsd-db" SET JIT = OFF;` or use the value of `POSTGRES_DB` in your `.env` and then run `docker compose kill -s SIGUSR1 backend`)

Implements the first step of #1350

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
