### PR TITLE
fix: prevent crashes by filtering out null auth providers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,7 @@
 # If you experience any problems, remove the special characters from the values or place them in quotes (' or ").
 ################ WARNING ################
 
-# .env.local is consumed by frontent (Next)
+# .env.local is consumed by frontend (Next)
 # see https://nextjs.org/docs/basic-features/environment-variables
 
 # .env is consumed by docker-compose.yml

--- a/frontend/pages/api/fe/auth/azure.ts
+++ b/frontend/pages/api/fe/auth/azure.ts
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
@@ -27,7 +27,7 @@ export async function azureRedirectProps() {
   const wellknownUrl = process.env.AZURE_WELL_KNOWN_URL ?? null
   if (wellknownUrl) {
     // get (cached) authorisation endpoint from wellknown url
-    const authorization_endpoint = await getAuthEndpoint(wellknownUrl,'azure')
+    const authorization_endpoint = await getAuthEndpoint(wellknownUrl, 'azure')
     if (authorization_endpoint) {
       // construct all props needed for redirectUrl
       const props: RedirectToProps = {
@@ -52,7 +52,7 @@ export async function azureRedirectProps() {
 }
 
 export async function azureInfo() {
-  // extract all props from env and wellknow endpoint
+  // extract all props from env and wellknown endpoint
   const redirectProps = await azureRedirectProps()
   if (redirectProps) {
     // create return url and the name to use in login button
@@ -72,7 +72,7 @@ export default async function handler(
   res: NextApiResponse<Data>
 ) {
   try {
-    // extract all props from env and wellknow endpoint
+    // extract all props from env and wellknown endpoint
     // and create return url and the name to use in login button
     const loginInfo = await azureInfo()
     if (loginInfo) {

--- a/frontend/pages/api/fe/auth/helmholtzid.ts
+++ b/frontend/pages/api/fe/auth/helmholtzid.ts
@@ -4,7 +4,8 @@
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +24,7 @@ import {Provider, ApiError} from '.'
 type Data = Provider | ApiError
 
 const claims = {
-  id_token:{
+  id_token: {
     schac_home_organization: null,
     name: null,
     email: null
@@ -35,7 +36,7 @@ async function helmholtzRedirectProps() {
   const wellknownUrl = process.env.HELMHOLTZID_WELL_KNOWN_URL ?? null
   if (wellknownUrl) {
     // get (cached) authorisation endpoint from wellknown url
-    const authorization_endpoint = await getAuthEndpoint(wellknownUrl,'helmholtzid')
+    const authorization_endpoint = await getAuthEndpoint(wellknownUrl, 'helmholtzid')
     if (authorization_endpoint) {
       // construct all props needed for redirectUrl
       // use default values if env not provided
@@ -61,7 +62,7 @@ async function helmholtzRedirectProps() {
 }
 
 export async function helmholtzInfo() {
-  // extract all props from env and wellknow endpoint
+  // extract all props from env and wellknown endpoint
   const redirectProps = await helmholtzRedirectProps()
   if (redirectProps) {
     // create return url and the name to use in login button
@@ -83,7 +84,7 @@ export default async function handler(
   res: NextApiResponse<Data>
 ) {
   try {
-    // extract all props from env and wellknow endpoint
+    // extract all props from env and wellknown endpoint
     // and create return url and the name to use in login button
     const loginInfo = await helmholtzInfo()
     if (loginInfo) {

--- a/frontend/pages/api/fe/auth/index.ts
+++ b/frontend/pages/api/fe/auth/index.ts
@@ -62,14 +62,14 @@ async function getRedirectInfo(provider: string) {
   }
 }
 
-async function getProvidersInfo(){
+async function getProvidersInfo() {
   // extract list of providers, default value surfconext
   const strProviders = process.env.RSD_AUTH_PROVIDERS || 'surfconext'
   // split providers to array on ;
   const providers = strProviders.split(';')
 
   // add all requests
-  const promises: Promise<Provider|null>[] = []
+  const promises: Promise<Provider | null>[] = []
   providers.forEach(provider => {
     promises.push(
       getRedirectInfo(provider)
@@ -80,8 +80,8 @@ async function getProvidersInfo(){
   // filter null responses (if any)
   const info: Provider[] = []
   resp.forEach(item => {
-    if (item.status === 'fulfilled') {
-      info.push(item.value as Provider)
+    if (item.status === 'fulfilled' && item.value !== null) {
+      info.push(item.value)
     }
   })
   return info

--- a/frontend/pages/api/fe/auth/orcid.ts
+++ b/frontend/pages/api/fe/auth/orcid.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
@@ -23,12 +23,12 @@ import {Provider, ApiError} from '.'
 type Data = Provider | ApiError
 
 export async function orcidRedirectProps() {
-  try{
+  try {
     // extract well known url from env
     const wellknownUrl = process.env.ORCID_WELL_KNOWN_URL ?? null
     if (wellknownUrl) {
       // get (cached) authorisation endpoint from wellknown url
-      const authorization_endpoint = await getAuthEndpoint(wellknownUrl,'orcid') ?? null
+      const authorization_endpoint = await getAuthEndpoint(wellknownUrl, 'orcid') ?? null
       if (authorization_endpoint) {
         // construct all props needed for redirectUrl
         const props: RedirectToProps = {
@@ -50,14 +50,14 @@ export async function orcidRedirectProps() {
       logger(`orcidRedirectProps: ${message}`, 'error')
       return null
     }
-  }catch(e:any){
+  } catch (e: any) {
     logger(`orcidRedirectProps: ${e.message}`, 'error')
     return null
   }
 }
 
 export async function orcidInfo() {
-  // extract all props from env and wellknow endpoint
+  // extract all props from env and wellknown endpoint
   const redirectProps = await orcidRedirectProps()
   if (redirectProps) {
     // create return url and the name to use in login button
@@ -80,7 +80,7 @@ export default async function handler(
   res: NextApiResponse<Data>
 ) {
   try {
-    // extract all props from env and wellknow endpoint
+    // extract all props from env and wellknown endpoint
     // and create return url and the name to use in login button
     const loginInfo = await orcidInfo()
     if (loginInfo) {

--- a/frontend/pages/api/fe/auth/surfconext.ts
+++ b/frontend/pages/api/fe/auth/surfconext.ts
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
@@ -23,7 +23,7 @@ import {Provider, ApiError} from '.'
 type Data = Provider | ApiError
 
 const claims = {
-  id_token:{
+  id_token: {
     schac_home_organization: null,
     name: null,
     email: null
@@ -35,7 +35,7 @@ export async function surfconextRedirectProps() {
   const wellknownUrl = process.env.SURFCONEXT_WELL_KNOWN_URL ?? null
   if (wellknownUrl) {
     // get (cached) authorisation endpoint from wellknown url
-    const authorization_endpoint = await getAuthEndpoint(wellknownUrl,'surfconext') ?? null
+    const authorization_endpoint = await getAuthEndpoint(wellknownUrl, 'surfconext') ?? null
     if (authorization_endpoint) {
       // construct all props needed for redirectUrl
       const props: RedirectToProps = {
@@ -60,7 +60,7 @@ export async function surfconextRedirectProps() {
 }
 
 export async function surfconextInfo() {
-  // extract all props from env and wellknow endpoint
+  // extract all props from env and wellknown endpoint
   const redirectProps = await surfconextRedirectProps()
   if (redirectProps) {
     // create return url and the name to use in login button
@@ -81,7 +81,7 @@ export default async function handler(
   res: NextApiResponse<Data>
 ) {
   try {
-    // extract all props from env and wellknow endpoint
+    // extract all props from env and wellknown endpoint
     // and create return url and the name to use in login button
     const loginInfo = await surfconextInfo()
     if (loginInfo) {


### PR DESCRIPTION
## Prevent crashes when auth provider down

### Changes proposed in this pull request

* Do an extra null check to prevent crashes when an auth provider is down

### How to test

* Have LinkedIn auth properly setup in your `.env`
* Simulate LinkedIn being down by adding `120.0.0.1 www.linkedin.com` to `/etc/hosts`
* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Visit http://localhost/, because of the line in `/etc/hosts`, wait 10 seconds
* Click on Sign in, the LinkedIn option should not be there
* Remove the line from `/etc/hosts`
* Restart the RSD and refresh the page
* LinkedIn should be back as a signing in option
* (Optional): try this out with other auth providers as well

**Note:** In order to get this fix out, I skipped the "greying out" part I suggested in #1367.

Closes #1367

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
