### PR TITLE
fix: show correct project counts on maintainer overview

### DIFF
--- a/database/106-project-views.sql
+++ b/database/106-project-views.sql
@@ -1,6 +1,6 @@
 -- SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
--- SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2023 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2023 dv4all
 --
@@ -893,7 +893,9 @@ CREATE FUNCTION projects_by_maintainer(maintainer_id UUID) RETURNS TABLE (
 	updated_at TIMESTAMPTZ,
 	is_published BOOLEAN,
 	image_contain BOOLEAN,
-	image_id VARCHAR
+	image_id VARCHAR,
+	impact_cnt INTEGER,
+	output_cnt INTEGER
 ) LANGUAGE sql STABLE AS
 $$
 	SELECT
@@ -906,11 +908,17 @@ $$
 		project.updated_at,
 		project.is_published,
 		project.image_contain,
-		project.image_id
+		project.image_id,
+		COALESCE(count_project_impact.impact_cnt, 0),
+		COALESCE(count_project_output.output_cnt, 0)
 	FROM
 		project
 	INNER JOIN
 		maintainer_for_project ON project.id = maintainer_for_project.project
+	LEFT JOIN
+		count_project_impact() ON count_project_impact.project = project.id
+	LEFT JOIN
+		count_project_output() ON count_project_output.project = project.id
 	LEFT JOIN
 		project_status() ON project.id=project_status.project
 	WHERE

--- a/frontend/pages/user/[section].tsx
+++ b/frontend/pages/user/[section].tsx
@@ -3,9 +3,9 @@
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -102,7 +102,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     // try to load menu item
     const sectionItem = userMenu.find(item=>item.id===section)
     if (typeof sectionItem == 'undefined') {
-      // 404 is section key does not exists
+      // 404 is section key does not exist
       return {
         notFound: true,
       }


### PR DESCRIPTION
## Fix project counts on maintainer overview

### Changes proposed in this pull request

* Change the `projects_by_maintainer` RPC to also include impact and output counts

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin, make yourself maintainer of a few projects
* Visit http://localhost/user/projects, the impact and output counts should be correct
* Create a new project with zero mentions
* This project should also be visible on http://localhost/user/projects

Closes #1369

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
