### PR TITLE
fix: optimise GitLab commit history scraper

### DIFF
--- a/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -7,7 +7,10 @@
 
 package nl.esciencecenter;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
@@ -35,14 +38,14 @@ public class AuthenticationIntegrationTest {
 
 		String expectedMessage = "You need to agree to our Terms of Service and the Privacy Statement before proceeding. Please open your user profile settings to agree.";
 		RestAssured.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"slug\": \"test-slug-user\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}")
-				.when()
-				.post("software")
-				.then()
-				.statusCode(400)
-				.body(CoreMatchers.containsString(expectedMessage));
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"slug\": \"test-slug-user\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}")
+			.when()
+			.post("software")
+			.then()
+			.statusCode(400)
+			.body(CoreMatchers.containsString(expectedMessage));
 	}
 
 	@Test
@@ -50,38 +53,38 @@ public class AuthenticationIntegrationTest {
 		User user = User.create(false);
 
 		RestAssured.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"agree_terms\": true, \"notice_privacy_statement\": true}")
-				.when()
-				.patch("account?id=eq." + user.accountId)
-				.then()
-				.statusCode(204);
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"agree_terms\": true, \"notice_privacy_statement\": true}")
+			.when()
+			.patch("account?id=eq." + user.accountId)
+			.then()
+			.statusCode(204);
 
 		String slug = Commons.createUUID();
 		RestAssured.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}"
-						.formatted(slug))
-				.when()
-				.post("software")
-				.then()
-				.statusCode(201);
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}"
+				.formatted(slug))
+			.when()
+			.post("software")
+			.then()
+			.statusCode(201);
 
 		String getStartedUrl = "https://www.example.com";
 		String patchedGetStartedUrl = RestAssured.given()
-				.header(user.authHeader)
-				.header(Commons.requestEntry)
-				.contentType(ContentType.JSON)
-				.body("{\"get_started_url\": \"%s\"}".formatted(getStartedUrl))
-				.when()
-				.patch("software?select=get_started_url&slug=eq." + slug)
-				.then()
-				.statusCode(200)
-				.extract()
-				.jsonPath()
-				.getString("[0].get_started_url");
+			.header(user.authHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body("{\"get_started_url\": \"%s\"}".formatted(getStartedUrl))
+			.when()
+			.patch("software?select=get_started_url&slug=eq." + slug)
+			.then()
+			.statusCode(200)
+			.extract()
+			.jsonPath()
+			.getString("[0].get_started_url");
 		Assertions.assertEquals(getStartedUrl, patchedGetStartedUrl);
 	}
 
@@ -89,97 +92,97 @@ public class AuthenticationIntegrationTest {
 	void givenUserWhoAgreedOnTerms_whenEditingSoftwareNotMaintainer_thenNowAllowed() {
 		String slug = Commons.createUUID();
 		RestAssured.given()
-				.header(SetupAllTests.adminAuthHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}"
-						.formatted(slug))
-				.when()
-				.post("software")
-				.then()
-				.statusCode(201);
+			.header(SetupAllTests.adminAuthHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}"
+				.formatted(slug))
+			.when()
+			.post("software")
+			.then()
+			.statusCode(201);
 
 		User user = User.create(false);
 
 		RestAssured.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"agree_terms\": true, \"notice_privacy_statement\": true}")
-				.when()
-				.patch("account?id=eq." + user.accountId)
-				.then()
-				.statusCode(204);
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"agree_terms\": true, \"notice_privacy_statement\": true}")
+			.when()
+			.patch("account?id=eq." + user.accountId)
+			.then()
+			.statusCode(204);
 
 		String getStartedUrl = "https://www.example.com";
 		List response = RestAssured.given()
-				.header(user.authHeader)
-				.header(new Header("Prefer", "return=representation"))
-				.contentType(ContentType.JSON)
-				.body("{\"get_started_url\": \"%s\"}".formatted(getStartedUrl))
-				.when()
-				.patch("software?select=get_started_url&slug=eq." + slug)
-				.then()
-				.statusCode(200)
-				.extract()
-				.body()
-				.as(List.class);
+			.header(user.authHeader)
+			.header(new Header("Prefer", "return=representation"))
+			.contentType(ContentType.JSON)
+			.body("{\"get_started_url\": \"%s\"}".formatted(getStartedUrl))
+			.when()
+			.patch("software?select=get_started_url&slug=eq." + slug)
+			.then()
+			.statusCode(200)
+			.extract()
+			.body()
+			.as(List.class);
 		Assertions.assertTrue(response.isEmpty());
 	}
 
 	@Test
 	void givenUnauthenticatedUser_whenViewingTables_thenSuccess() {
 		RestAssured
-				.when()
-				.get("software")
-				.then()
-				.statusCode(200);
+			.when()
+			.get("software")
+			.then()
+			.statusCode(200);
 
 		RestAssured
-				.when()
-				.get("project")
-				.then()
-				.statusCode(200);
+			.when()
+			.get("project")
+			.then()
+			.statusCode(200);
 	}
 
 	@Test
 	void givenUnauthenticatedUser_whenViewingUnpublishedSoftware_thenNothingReturned() {
 		String slug = Commons.createUUID();
 		RestAssured.given()
-				.header(SetupAllTests.adminAuthHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": false, \"short_statement\": \"Test software for testing\"}"
-						.formatted(slug))
-				.when()
-				.post("software")
-				.then()
-				.statusCode(201);
+			.header(SetupAllTests.adminAuthHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": false, \"short_statement\": \"Test software for testing\"}"
+				.formatted(slug))
+			.when()
+			.post("software")
+			.then()
+			.statusCode(201);
 
 		List response = RestAssured.when()
-				.get("software?slug=eq." + slug)
-				.then()
-				.statusCode(200)
-				.extract()
-				.body()
-				.as(List.class);
+			.get("software?slug=eq." + slug)
+			.then()
+			.statusCode(200)
+			.extract()
+			.body()
+			.as(List.class);
 		Assertions.assertTrue(response.isEmpty());
 	}
 
 	@Test
 	void givenUnauthenticatedUser_whenEditingAnyTable_thenNotAllowed() {
 		RestAssured.given()
-				.contentType(ContentType.JSON)
-				.body("{\"short_statement\": \"invalid statement\"}")
-				.when()
-				.patch("software")
-				.then()
-				.statusCode(401);
+			.contentType(ContentType.JSON)
+			.body("{\"short_statement\": \"invalid statement\"}")
+			.when()
+			.patch("software")
+			.then()
+			.statusCode(401);
 
 		RestAssured.given()
-				.contentType(ContentType.JSON)
-				.body("{\"subtitle\": \"invalid subtitle\"}")
-				.when()
-				.patch("project")
-				.then()
-				.statusCode(401);
+			.contentType(ContentType.JSON)
+			.body("{\"subtitle\": \"invalid subtitle\"}")
+			.when()
+			.patch("project")
+			.then()
+			.statusCode(401);
 	}
 
 	/*
@@ -191,23 +194,23 @@ public class AuthenticationIntegrationTest {
 	@Test
 	void givenUnauthenticatedUser_createCategory() {
 		requestCreateDummyCategory(null)
-				.then()
-				.statusCode(401);
+			.then()
+			.statusCode(401);
 
 	}
 
 	@Test
 	void givenAuthenticatedUser_createCategory() {
 		requestCreateDummyCategory(User.create().authHeader)
-				.then()
-				.statusCode(403);
+			.then()
+			.statusCode(403);
 	}
 
 	@Test
 	void givenAdmin_createCategory() {
 		requestCreateDummyCategory(SetupAllTests.adminAuthHeader)
-				.then()
-				.statusCode(201);
+			.then()
+			.statusCode(201);
 	}
 
 	@Test
@@ -217,8 +220,8 @@ public class AuthenticationIntegrationTest {
 		User user = User.create();
 		String softwareId = user.createSoftware("Software 1");
 		requestAddCategoryForSoftware(user, softwareId, categoryId)
-				.then()
-				.statusCode(201);
+			.then()
+			.statusCode(201);
 	}
 
 	@Test
@@ -230,8 +233,8 @@ public class AuthenticationIntegrationTest {
 
 		User user2 = User.create();
 		requestAddCategoryForSoftware(user2, softwareId, categoryId)
-				.then()
-				.statusCode(403);
+			.then()
+			.statusCode(403);
 	}
 
 	@Test
@@ -244,19 +247,28 @@ public class AuthenticationIntegrationTest {
 		addCategoryForSoftware(user, softwareId, catIds[0]);
 		addCategoryForSoftware(user, softwareId, catIds[1]);
 
-		JsonObject obj = new JsonObject();
-		obj.addProperty("software_id", softwareId);
+		String response = RestAssured
+			.get("/rpc/category_paths_by_software_expanded?software_id=" + softwareId)
+			.then()
+			.contentType(ContentType.JSON)
+			.extract()
+			.asString();
 
-		RestAssured.given()
-				.contentType(ContentType.JSON)
-				.body(obj.toString())
-				.when()
-				.post("/rpc/category_paths_by_software_expanded")
-				.then()
-				.contentType(ContentType.JSON)
-				// check if category IDs appear in proper location of result (=CategoryPath[])
-				.body("[0][1].id", CoreMatchers.equalTo(catIds[0]))
-				.body("[1][1].id", CoreMatchers.equalTo(catIds[1]));
+		// check if category IDs appear in proper location of result (=CategoryPath[])
+		JsonArray jsonArray = JsonParser.parseString(response).getAsJsonArray();
+		Assertions.assertEquals(jsonArray.size(), 2);
+		for (JsonElement jsonElement : jsonArray) {
+			JsonArray categoryPath = jsonElement.getAsJsonArray();
+			String shortName = categoryPath.get(1).getAsJsonObject().getAsJsonPrimitive("short_name").getAsString();
+			String id = categoryPath.get(1).getAsJsonObject().getAsJsonPrimitive("id").getAsString();
+			if (shortName.startsWith("sub category 1.1")) {
+				Assertions.assertEquals(id, catIds[0]);
+			} else if (shortName.startsWith("sub category 1.2")) {
+				Assertions.assertEquals(id, catIds[1]);
+			} else {
+				Assertions.fail("Category paths are incorrect");
+			}
+		}
 	}
 
 	@Test
@@ -270,14 +282,14 @@ public class AuthenticationIntegrationTest {
 		obj.addProperty("parent", catId3);
 
 		RestAssured.given()
-				.header(SetupAllTests.adminAuthHeader)
-				.contentType(ContentType.JSON)
-				.body(obj.toString())
-				.when()
-				.patch("category?id=eq." + catId1)
-				.then()
-				.statusCode(400)
-				.body("message", Matchers.containsStringIgnoringCase("cycle detected"));
+			.header(SetupAllTests.adminAuthHeader)
+			.contentType(ContentType.JSON)
+			.body(obj.toString())
+			.when()
+			.patch("category?id=eq." + catId1)
+			.then()
+			.statusCode(400)
+			.body("message", Matchers.containsStringIgnoringCase("cycle detected"));
 	}
 
 	String[] createCategoryTreeExample1() {
@@ -304,17 +316,17 @@ public class AuthenticationIntegrationTest {
 		obj.addProperty("parent", parentId);
 
 		return RestAssured.given()
-				.header(SetupAllTests.adminAuthHeader)
-				.header(Commons.requestEntry)
-				.contentType(ContentType.JSON)
-				.body(obj.toString())
-				.when()
-				.post("category")
-				.then()
-				.statusCode(201)
-				.extract()
-				.jsonPath()
-				.getString("[0].id");
+			.header(SetupAllTests.adminAuthHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body(obj.toString())
+			.when()
+			.post("category")
+			.then()
+			.statusCode(201)
+			.extract()
+			.jsonPath()
+			.getString("[0].id");
 	}
 
 	String createUniqueCategory(String name, String short_name, String parentId) {
@@ -323,8 +335,8 @@ public class AuthenticationIntegrationTest {
 
 	void addCategoryForSoftware(User user, String softwareId, String categoryId) {
 		requestAddCategoryForSoftware(user, softwareId, categoryId)
-				.then()
-				.statusCode(201);
+			.then()
+			.statusCode(201);
 	}
 
 	Response requestAddCategoryForSoftware(User user, String softwareId, String categoryId) {
@@ -334,11 +346,11 @@ public class AuthenticationIntegrationTest {
 		obj.addProperty("category_id", categoryId);
 
 		return RestAssured.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body(obj.toString())
-				.when()
-				.post("category_for_software");
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body(obj.toString())
+			.when()
+			.post("category_for_software");
 	}
 
 	Response requestCreateDummyCategory(Header authHeader) {
@@ -354,9 +366,9 @@ public class AuthenticationIntegrationTest {
 			request.header(authHeader);
 		}
 		return request
-				.contentType(ContentType.JSON)
-				.body(obj.toString())
-				.when()
-				.post("category");
+			.contentType(ContentType.JSON)
+			.body(obj.toString())
+			.when()
+			.post("category");
 	}
 }

--- a/database/014-create-keyword-and-category.sql
+++ b/database/014-create-keyword-and-category.sql
@@ -1,9 +1,9 @@
 -- SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 - 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 -- SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+-- SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 -- SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
--- SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -195,6 +195,7 @@ RETURNS TABLE (
 	id UUID,
 	parent UUID,
 	community UUID,
+	organisation UUID,
 	short_name VARCHAR,
 	name VARCHAR,
 	properties JSONB,
@@ -215,7 +216,7 @@ $$
 	-- 2. How a table row "type" could be used here Now we have to list all columns of `category` explicitly
 	--    I want to have something like `* without 'r_index'` to be independent from modifications of `category`
 	-- 3. Maybe this could be improved by using SEARCH keyword.
-	SELECT id, parent, community, short_name, name, properties, provenance_iri
+	SELECT id, parent, community, organisation, short_name, name, properties, provenance_iri
 	FROM cat_path
 	ORDER BY r_index DESC;
 $$;
@@ -249,7 +250,12 @@ LANGUAGE SQL STABLE AS
 $$
 	WITH
 		cat_ids AS
-		(SELECT category_id FROM category_for_software AS c4s WHERE c4s.software_id = category_paths_by_software_expanded.software_id),
+		(SELECT
+			category_id
+			FROM
+			category_for_software AS c4s
+			WHERE c4s.software_id = category_paths_by_software_expanded.software_id
+		),
 	paths AS
 		(SELECT category_path_expanded(category_id) AS path FROM cat_ids)
 	SELECT

--- a/database/014-create-keyword-and-category.sql
+++ b/database/014-create-keyword-and-category.sql
@@ -1,4 +1,4 @@
--- SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 - 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 -- SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -221,14 +221,6 @@ $$
 	ORDER BY r_index DESC;
 $$;
 
--- returns a list of `category` entries traversing from the tree root to entry with `category_id`
-CREATE FUNCTION category_path_expanded(category_id UUID)
-RETURNS JSON
-LANGUAGE SQL STABLE AS
-$$
-	SELECT json_agg(row_to_json) AS path FROM (SELECT row_to_json(category_path(category_id))) AS cats;
-$$;
-
 
 -- TABLE FOR software categories
 -- includes organisation, community and general categories
@@ -243,27 +235,6 @@ CREATE TABLE category_for_software (
 
 CREATE INDEX category_for_software_category_id_idx ON category_for_software(category_id);
 
--- RPC for software page to show all software categories
-CREATE FUNCTION category_paths_by_software_expanded(software_id UUID)
-RETURNS JSON
-LANGUAGE SQL STABLE AS
-$$
-	WITH
-		cat_ids AS
-		(SELECT
-			category_id
-			FROM
-			category_for_software AS c4s
-			WHERE c4s.software_id = category_paths_by_software_expanded.software_id
-		),
-	paths AS
-		(SELECT category_path_expanded(category_id) AS path FROM cat_ids)
-	SELECT
-		CASE WHEN EXISTS(SELECT 1 FROM cat_ids) THEN (SELECT json_agg(path) FROM paths)
-		ELSE '[]'::json
-		END AS result
-$$;
-
 
 -- TABLE FOR project categories
 -- currently used only for organisation categories
@@ -276,37 +247,6 @@ CREATE TABLE category_for_project (
 );
 
 CREATE INDEX category_for_project_category_id_idx ON category_for_project(category_id);
-
--- RPC for project page to show all project categories
-CREATE FUNCTION category_paths_by_project_expanded(project_id UUID)
-RETURNS JSON
-LANGUAGE SQL STABLE AS
-$$
-	WITH
-		cat_ids AS
-		(SELECT
-			category_id
-		FROM
-			category_for_project
-		WHERE
-			category_for_project.project_id = category_paths_by_project_expanded.project_id
-		),
-		paths AS
-		(
-			SELECT
-				category_path_expanded(category_id) AS path
-			FROM cat_ids
-		)
-	SELECT
-		CASE
-			WHEN EXISTS(
-				SELECT 1 FROM cat_ids
-			) THEN (
-				SELECT json_agg(path) FROM paths
-			)
-			ELSE '[]'::json
-		END AS result
-$$;
 
 
 CREATE FUNCTION software_of_category()

--- a/database/104-software-views.sql
+++ b/database/104-software-views.sql
@@ -215,18 +215,16 @@ $$
 	SELECT
 		category_for_software.software_id AS software,
 		ARRAY_AGG(
-			DISTINCT category.short_name
-			ORDER BY category.short_name
+			DISTINCT category_path.short_name
+			ORDER BY category_path.short_name
 		) AS category
 	FROM
 		category_for_software
 	INNER JOIN
-		category ON category.id = category_for_software.category_id
-	INNER JOIN
-		category_path(category.id) ON TRUE
+		category_path(category_for_software.category_id) ON TRUE
 	WHERE
 	-- FILTER FOR GLOBAL CATEGORIES
-		category.community IS NULL AND category.organisation IS NULL
+		category_path.community IS NULL AND category_path.organisation IS NULL
 	GROUP BY
 		category_for_software.software_id;
 $$;

--- a/database/104-software-views.sql
+++ b/database/104-software-views.sql
@@ -215,13 +215,15 @@ $$
 	SELECT
 		category_for_software.software_id AS software,
 		ARRAY_AGG(
-			category.short_name
-			ORDER BY short_name
+			DISTINCT category.short_name
+			ORDER BY category.short_name
 		) AS category
 	FROM
 		category_for_software
 	INNER JOIN
 		category ON category.id = category_for_software.category_id
+	INNER JOIN
+		category_path(category.id) ON TRUE
 	WHERE
 	-- FILTER FOR GLOBAL CATEGORIES
 		category.community IS NULL AND category.organisation IS NULL

--- a/database/108-community-views.sql
+++ b/database/108-community-views.sql
@@ -219,15 +219,15 @@ $$
 	SELECT
 		category_for_software.software_id AS software,
 		ARRAY_AGG(
-			category.short_name
-			ORDER BY short_name
+			DISTINCT category_path.short_name
+			ORDER BY category_path.short_name
 		) AS category
 	FROM
 		category_for_software
 	INNER JOIN
-		category ON category.id = category_for_software.category_id
+		category_path(category_for_software.category_id) ON TRUE
 	WHERE
-		category.community = community_id
+		category_path.community = community_id
 	GROUP BY
 		category_for_software.software_id;
 $$;

--- a/database/113-organisation-views.sql
+++ b/database/113-organisation-views.sql
@@ -58,13 +58,15 @@ $$
 	SELECT
 		category_for_project.project_id AS project,
 		ARRAY_AGG(
-			category.short_name
-			ORDER BY short_name
+			DISTINCT category_path.short_name
+			ORDER BY category_path.short_name
 		) AS category
 	FROM
 		category_for_project
 	INNER JOIN
 		category ON category.id = category_for_project.category_id
+	INNER JOIN
+		category_path(category.id) ON TRUE
 	WHERE
 		category.organisation = organisation_id
 	GROUP BY
@@ -436,13 +438,15 @@ $$
 	SELECT
 		category_for_software.software_id AS software,
 		ARRAY_AGG(
-			category.short_name
-			ORDER BY short_name
+			DISTINCT category.short_name
+			ORDER BY category.short_name
 		) AS category
 	FROM
 		category_for_software
 	INNER JOIN
 		category ON category.id = category_for_software.category_id
+	INNER JOIN
+		category_path(category.id) ON TRUE
 	WHERE
 		category.organisation = organisation_id
 	GROUP BY

--- a/database/113-organisation-views.sql
+++ b/database/113-organisation-views.sql
@@ -64,11 +64,9 @@ $$
 	FROM
 		category_for_project
 	INNER JOIN
-		category ON category.id = category_for_project.category_id
-	INNER JOIN
-		category_path(category.id) ON TRUE
+		category_path(category_for_project.category_id) ON TRUE
 	WHERE
-		category.organisation = organisation_id
+		category_path.organisation = organisation_id
 	GROUP BY
 		category_for_project.project_id;
 $$;
@@ -438,17 +436,15 @@ $$
 	SELECT
 		category_for_software.software_id AS software,
 		ARRAY_AGG(
-			DISTINCT category.short_name
-			ORDER BY category.short_name
+			DISTINCT category_path.short_name
+			ORDER BY category_path.short_name
 		) AS category
 	FROM
 		category_for_software
 	INNER JOIN
-		category ON category.id = category_for_software.category_id
-	INNER JOIN
-		category_path(category.id) ON TRUE
+		category_path(category_for_software.category_id) ON TRUE
 	WHERE
-		category.organisation = organisation_id
+		category_path.organisation = organisation_id
 	GROUP BY
 		category_for_software.software_id;
 $$;

--- a/database/114-keyword-category-views.sql
+++ b/database/114-keyword-category-views.sql
@@ -1,0 +1,74 @@
+-- SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+CREATE FUNCTION category_for_software_status(software_id UUID, category_id UUID)
+	RETURNS VARCHAR
+	LANGUAGE SQL
+	STABLE
+AS
+$$
+WITH
+	category_data AS (SELECT organisation, community FROM category WHERE category.id = category_id)
+SELECT
+	CASE
+		WHEN (SELECT organisation FROM category_data) IS NULL AND (SELECT community FROM category_data) IS NULL THEN 'global'
+		WHEN (SELECT organisation FROM category_data AS organisation_id) IS NOT NULL THEN (SELECT status FROM software_for_organisation WHERE software_for_organisation.software = software_id AND software_for_organisation.organisation = (SELECT organisation FROM category_data AS organisation_id))::VARCHAR
+		WHEN (SELECT community FROM category_data) IS NOT NULL THEN (SELECT status FROM software_for_community WHERE software_for_community.software = software_id AND software_for_community.community = (SELECT community FROM category_data))::VARCHAR
+		ELSE 'other'
+		END
+$$;
+
+
+-- RPC for software page to show all software categories
+CREATE FUNCTION category_paths_by_software_expanded(software_id UUID)
+	RETURNS JSONB
+	LANGUAGE SQL STABLE AS
+$$
+SELECT COALESCE(jsonb_agg(paths.content),  jsonb_build_array())::JSONB FROM (
+	SELECT ARRAY_AGG(rows) AS content FROM (
+		SELECT category_for_software.category_id, category_path.*, category_for_software_status AS status
+		FROM category_for_software
+		INNER JOIN category_path(category_for_software.category_id) ON TRUE
+		INNER JOIN category_for_software_status(category_paths_by_software_expanded.software_id, category_path.id) ON TRUE
+		WHERE category_for_software.software_id = category_paths_by_software_expanded.software_id
+	) AS rows
+	GROUP BY rows.category_id
+) AS paths
+$$;
+
+
+CREATE FUNCTION category_for_project_status(project_id UUID, category_id UUID)
+	RETURNS VARCHAR
+	LANGUAGE SQL
+	STABLE
+AS
+$$
+WITH
+	category_data AS (SELECT organisation FROM category WHERE category.id = category_id)
+SELECT
+	CASE
+		WHEN (SELECT organisation FROM category_data) IS NULL THEN 'global'
+		WHEN (SELECT organisation FROM category_data AS organisation_id) IS NOT NULL THEN (SELECT status FROM project_for_organisation WHERE project_for_organisation.project = project_id AND project_for_organisation.organisation = (SELECT organisation FROM category_data AS organisation_id))::VARCHAR
+		ELSE 'other'
+		END
+$$;
+
+
+-- RPC for project page to show all project categories
+CREATE FUNCTION category_paths_by_project_expanded(project_id UUID)
+	RETURNS JSONB
+	LANGUAGE SQL STABLE AS
+$$
+SELECT COALESCE(jsonb_agg(paths.content),  jsonb_build_array())::JSONB FROM (
+	SELECT ARRAY_AGG(rows) AS content FROM (
+		SELECT category_for_project.category_id, category_path.*, category_for_project_status AS status
+		FROM category_for_project
+		INNER JOIN category_path(category_for_project.category_id) ON TRUE
+		INNER JOIN category_for_project_status(category_paths_by_project_expanded.project_id, category_path.id) ON TRUE
+		WHERE category_for_project.project_id = category_paths_by_project_expanded.project_id
+	) AS rows
+	GROUP BY rows.category_id
+) AS paths
+$$;

--- a/documentation/docs/01-users/05-adding-software.md
+++ b/documentation/docs/01-users/05-adding-software.md
@@ -253,6 +253,8 @@ Here, you can see all the people who can maintain this software page. You can al
 
 Here you can find the information about the background services that RSD offers and their last status.
 
+You can clear the data that the scrapers collected by clicking on the delete icons next to the individual services. This is useful for example if you changed your default branch or rebased your git commit history.
+
 :::tip
 Please check this section from time to time to confirm that information you provided is correct and that RSD background services are able to use provided information in the proper way.
 :::

--- a/frontend/__tests__/ProjectItem.test.tsx
+++ b/frontend/__tests__/ProjectItem.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -40,7 +40,11 @@ const mockedProps: ProjectPageProps = {
   impact: apiMentions as MentionItemProps[],
   team: apiContributors,
   relatedProjects: apiRelatedProjects as RelatedProject[],
-  relatedSoftware: apiRelatedSoftware as any
+  relatedSoftware: apiRelatedSoftware as any,
+  testimonials:[],
+  categories:[],
+  orgMaintainer:[],
+  comMaintainer:[]
 }
 
 describe('pages/projects/[slug]/index.tsx', () => {

--- a/frontend/__tests__/__mocks__/softwareIndexData.js
+++ b/frontend/__tests__/__mocks__/softwareIndexData.js
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
@@ -50,7 +50,10 @@ const softwarePageData = {
   relatedTools: apiRelatedSoftware,
   relatedProjects: apiRelatedProjects,
   isMaintainer: false,
-  organisations: apiOrganisationsOfSoftware
+  organisations: apiOrganisationsOfSoftware,
+  categories:[],
+  orgMaintainer:[],
+  comMaintainer:[]
 }
 
 export default softwarePageData

--- a/frontend/auth/permissions/isMaintainerOfCommunity.ts
+++ b/frontend/auth/permissions/isMaintainerOfCommunity.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -63,7 +63,7 @@ export async function isMaintainerOfCommunity({community, account, token}: isCom
 }
 
 export async function getCommunitiesOfMaintainer({token}:
-  {token: string}) {
+  {token?: string}) {
   try {
     // without token api request is not needed
     if (!token) return []

--- a/frontend/auth/permissions/isMaintainerOfOrganisation.ts
+++ b/frontend/auth/permissions/isMaintainerOfOrganisation.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -69,7 +69,7 @@ export async function isMaintainerOfOrganisation({organisation, account, token}:
 }
 
 export async function getMaintainerOrganisations({token}:
-  {token: string}) {
+  {token?: string}) {
   try {
     // without token api request is not needed
     if (!token) return []

--- a/frontend/components/cards/StatusBanner.tsx
+++ b/frontend/components/cards/StatusBanner.tsx
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {Status} from '~/types/Organisation'
+import {OrganisationStatus} from '~/types/Organisation'
 
 type StatusBannerProps = {
-  status: Status
+  status: OrganisationStatus
   is_featured: boolean
   is_published: boolean
   width?: string

--- a/frontend/components/category/CategoriesDialogBody.tsx
+++ b/frontend/components/category/CategoriesDialogBody.tsx
@@ -32,8 +32,8 @@ export default function CategoriesDialogBody({
   function isSelected(node: TreeNode<CategoryEntry>) {
     const val = node.getValue()
 
-    // directly selected
-    if (selectedCategoryIds.has(val.id)) return true
+    // directly selected child item
+    if (selectedCategoryIds.has(val.id) && val.parent!==null) return true
 
     // any of children selected?
     const found = node.children().find(item=>{
@@ -51,6 +51,15 @@ export default function CategoriesDialogBody({
         },0)
       }
       return true
+    }
+    // if top level item is in selected list BUT no children selected
+    // WE NEED TO REMOVE TOP LEVEL ITEM because it is not selectable
+    if (val.parent===null && selectedCategoryIds.has(val.id)){
+      selectedCategoryIds.delete(val.id)
+      // update state at the end of cycle to avoid render error
+      setTimeout(()=>{
+        setSelectedCategoryIds(new Set(selectedCategoryIds))
+      },0)
     }
     // none of children selected either
     return false

--- a/frontend/components/category/CategoryChipFilter.tsx
+++ b/frontend/components/category/CategoryChipFilter.tsx
@@ -3,22 +3,102 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {Fragment} from 'react'
+import {Fragment, useEffect, useState} from 'react'
+import {useRouter} from 'next/router'
+
+import {buildFilterUrl, ssrSoftwareUrl} from '~/utils/postgrestUrl'
 import {CategoryEntry} from '~/types/Category'
 import {TreeNode} from '~/types/TreeNode'
 import TagChipFilter from '~/components/layout/TagChipFilter'
+import {getCommunitySlug, getOrganisationSlug} from './apiCategories'
+
+function useFilterUrl({category,organisation,community}:{
+  category:string,organisation:string|null,community:string|null,
+}){
+  const [loading, setLoading] = useState(true)
+  const [url, setUrl] = useState<string>()
+  const router = useRouter()
+  // extract tab from the pathname
+  const tab = router.pathname.split('/')[1]
+
+  useEffect(()=>{
+    if (category && tab){
+      // GLOBAL category - software overview page
+      if(community===null && organisation===null){
+        const url = ssrSoftwareUrl({categories: [category]})
+        setUrl(url)
+        setLoading(false)
+      }
+      // ORGANISATION category
+      if (organisation!==null){
+        getOrganisationSlug(organisation).then(rsd_path=>{
+          if (rsd_path){
+            // build URL for organisation filter
+            const url = `/organisations${buildFilterUrl({categories: [category]},rsd_path)}&tab=${tab}`
+            setUrl(url)
+          }
+          setLoading(false)
+        })
+      }
+      // COMMUNITIES category
+      if (community!==null){
+        getCommunitySlug(community).then(slug=>{
+          if (slug){
+            // build URL for community filter
+            const url = `/communities${buildFilterUrl({categories: [category]},`${slug}/${tab}`)}`
+            setUrl(url)
+          }
+          setLoading(false)
+        })
+      }
+    }
+  },[category,organisation,community,tab])
+
+  return {
+    loading,
+    url
+  }
+}
+
+function CategoryChipItem({cat}:{cat:CategoryEntry}){
+  // construct filter url
+  const {loading,url} = useFilterUrl({
+    category: cat.short_name,
+    organisation: cat.organisation,
+    community: cat.community
+  })
+
+  return (
+    <TagChipFilter
+      key={cat.id}
+      title={cat.name}
+      label={cat.short_name}
+      capitalize={false}
+      url={url}
+      loading={loading}
+    />
+  )
+}
 
 export function CategoryChipFilter({nodes}:{nodes:TreeNode<CategoryEntry>[]}){
   return nodes.map(node=>{
     const cat = node.getValue()
     const children = node.children()
+
+    // console.group("CategoryChipFilter")
+    // console.log("cat...",cat)
+    // console.log("url...",url)
+    // console.groupEnd()
+
     return (
       <Fragment key={cat.id}>
-        {/* Do not capitalize category labels */}
-        <TagChipFilter key={cat.id} title={cat.name} label={cat.short_name} capitalize={false} />
+        <CategoryChipItem
+          key={cat.id}
+          cat={cat}
+        />
         <CategoryChipFilter nodes={children} />
       </Fragment>
     )
+
   })
 }
-

--- a/frontend/components/category/CategoryChipFilter.tsx
+++ b/frontend/components/category/CategoryChipFilter.tsx
@@ -29,7 +29,7 @@ function useFilterUrl(cat:CategoryEntry){
         setLoading(false)
       }
       // ORGANISATION category
-      if (organisation!==null){
+      if (organisation){
         getOrganisationSlug(organisation).then(rsd_path=>{
           if (rsd_path){
             // build URL for organisation filter
@@ -38,24 +38,27 @@ function useFilterUrl(cat:CategoryEntry){
           }
           setLoading(false)
         })
-      }
-      // COMMUNITIES category
-      if (community!==null){
+      } else if (community){
+        // COMMUNITIES category
         getCommunitySlug(community).then(slug=>{
           if (slug){
             // build URL for community filter
-            let url = `/communities${buildFilterUrl({categories: [short_name]},`${slug}/${tab}`)}`
+            let view = `${slug}/${tab}`
             if (status==='pending'){
               // pending software is on requests tab
-              url = `/communities${buildFilterUrl({categories: [short_name]},`${slug}/requests`)}`
+              view = `${slug}/requests`
             }else if (status==='rejected'){
-              url = `/communities${buildFilterUrl({categories: [short_name]},`${slug}/rejected`)}`
+              view = `${slug}/rejected`
             }
+            const url = `/communities${buildFilterUrl({categories: [short_name]},view)}`
             // update url
             setUrl(url)
           }
           setLoading(false)
         })
+      }else{
+        // no URL
+        setLoading(false)
       }
     }
   },[short_name,organisation,community,tab,status])
@@ -66,7 +69,7 @@ function useFilterUrl(cat:CategoryEntry){
   }
 }
 
-function CategoryChipItem({cat}:{cat:CategoryEntry}){
+function CategoryChipItem({cat}:Readonly<{cat:CategoryEntry}>){
   // construct filter url
   const {loading,url} = useFilterUrl(cat)
 

--- a/frontend/components/category/CategoryList.tsx
+++ b/frontend/components/category/CategoryList.tsx
@@ -50,16 +50,15 @@ function CategoryContent({
     <ListItemButton
       onClick={onSelect}
     >
-      {cat.parent!==null ?
-        <ListItemIcon>
-          <Checkbox
-            edge="start"
-            disableRipple
-            checked={isSelected}
-          />
-        </ListItemIcon>
-        : null
-      }
+
+      <ListItemIcon>
+        <Checkbox
+          edge="start"
+          disableRipple
+          checked={isSelected}
+        />
+      </ListItemIcon>
+
       <ListItemText
         // alias Label
         primary={cat.short_name}

--- a/frontend/components/category/CategoryStatus.tsx
+++ b/frontend/components/category/CategoryStatus.tsx
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {CategoryEntry} from '~/types/Category'
+
+export default function CategoryStatus({category}:{category:CategoryEntry}){
+  switch(category.status){
+    case 'pending':
+      return (
+        <span
+          title = "Pending approval"
+          className='bg-warning text-warning-content py-1 px-2 uppercase text-sm'
+        >
+          pending
+        </span>
+      )
+    case 'rejected':
+    case 'rejected_by_origin':
+    case 'rejected_by_relation':
+      return <span className='bg-error text-warning-content py-1 px-2 uppercase text-sm'>rejected</span>
+    default:
+      return null
+  }
+}

--- a/frontend/components/category/CategoryStatus.tsx
+++ b/frontend/components/category/CategoryStatus.tsx
@@ -5,7 +5,7 @@
 
 import {CategoryEntry} from '~/types/Category'
 
-export default function CategoryStatus({category}:{category:CategoryEntry}){
+export default function CategoryStatus({category}:Readonly<{category:CategoryEntry}>){
   switch(category.status){
     case 'pending':
       return (

--- a/frontend/components/category/CategoryTable.tsx
+++ b/frontend/components/category/CategoryTable.tsx
@@ -1,13 +1,16 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Link from 'next/link'
+import SearchIcon from '@mui/icons-material/Search'
 import {CategoryEntry} from '~/types/Category'
 import {TreeNode} from '~/types/TreeNode'
+import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
 
 export function calcTreeLevelDepth(tree: TreeNode<CategoryEntry>): number {
 
@@ -28,9 +31,9 @@ export const CategoryTable = ({tree}: CategoryTableProps) => {
   const levelLables = category.properties.tree_level_labels
   const depth = calcTreeLevelDepth(tree)
   return (
-    <div className={`grid grid-cols-${depth} border-y-2`}>
+    <div className={`grid grid-cols-${depth} border-y`}>
       {levelLables &&
-        <div className={`grid grid-cols-subgrid col-span-${depth} border-b-2`}>
+        <div className={`grid grid-cols-subgrid col-span-${depth} border-b`}>
           {levelLables.map(label =>
             <div className="px-3 py-2" key={label}><b>{label}</b></div>
           )}
@@ -49,19 +52,29 @@ const Block = ({tree, depth}: BlockProps) => {
   const depth2 = depth - 1
   return tree.map((node, index) => {
     const category = node.getValue()
-
     const children = node.children()
-    const border = (index != tree.length-1) ? 'border-b-2' : ''
-    return <div key={category.id} className={`grid grid-cols-subgrid col-span-${depth} ${border}`}>
-      <div className="px-3 py-2">
-        {category.name}
-      </div>
-      {depth2 > 0 &&
+    const border = (index != tree.length-1) ? 'border-b' : ''
+    const url = ssrSoftwareUrl({categories: [category.short_name]})
+    return (
+      <div key={category.id} className={`grid grid-cols-subgrid col-span-${depth} ${border}`}>
+        {url ?
+          <Link href={url}>
+            <div className="px-3 py-2">
+              <span>{category.name}</span> <SearchIcon />
+            </div>
+          </Link>
+          :
+          <div className="px-3 py-2">
+            {category.name}
+          </div>
+        }
+        {depth2 > 0 &&
         <div className={`grid grid-cols-subgrid col-span-${depth2}`}>
           <Block tree={children} depth={depth2} />
         </div>
-      }
-    </div>
+        }
+      </div>
+    )
   })
 }
 

--- a/frontend/components/category/CategoryTree.tsx
+++ b/frontend/components/category/CategoryTree.tsx
@@ -6,11 +6,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Link from 'next/link'
 import CancelIcon from '@mui/icons-material/Cancel'
 import Tooltip from '@mui/material/Tooltip'
 import IconButton from '@mui/material/IconButton'
 import {CategoryEntry} from '~/types/Category'
 import {TreeNode} from '~/types/TreeNode'
+import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
 
 export type CategoryTreeLevelProps = {
   items: TreeNode<CategoryEntry>[]
@@ -40,12 +42,15 @@ const TreeLevel = ({items, showLongNames, onRemoveHandler}: TreeLevelProps) => {
       {items.map((item) => {
         const category = item.getValue()
         const children = item.children()
+        const url = ssrSoftwareUrl({categories: [category.short_name]})
         return (
-          <li key={category.id}>
+          <li key={category.id} >
             <div className='flex flex-row justify-between items-start'>
-              <Tooltip title={showLongNames ? category.short_name : category.name} placement='left'>
-                <span className='pb-1'>{showLongNames ? category.name : category.short_name}</span>
-              </Tooltip>
+              <Link href={url}>
+                <Tooltip title={showLongNames ? category.short_name : category.name} placement='left'>
+                  <span className='pb-1'>{showLongNames ? category.name : category.short_name}</span>
+                </Tooltip>
+              </Link>
               { onRemoveHandler && children.length === 0 ?
 				          <IconButton sx={{top: '-0.25rem'}} data-id={category.id} size='small'onClick={onRemoveHandler}>
                   <CancelIcon fontSize='small'/>

--- a/frontend/components/category/apiCategories.ts
+++ b/frontend/components/category/apiCategories.ts
@@ -1,12 +1,13 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {CategoryEntry} from '~/types/Category'
 import {getBaseUrl} from '~/utils/fetchHelpers'
 import {TreeNode} from '~/types/TreeNode'
+import logger from '~/utils/logger'
 
 type LoadCategoryProps={
   community?: string | null,
@@ -92,4 +93,50 @@ export function categoryEntriesToRoots(categoriesArr: CategoryEntry[]): TreeNode
   }
 
   return result
+}
+
+export async function getOrganisationSlug(id:string){
+  try{
+    const url=`${getBaseUrl()}/rpc/organisation_route?id=${id}`
+
+    const resp = await fetch(url)
+
+    if (resp.ok){
+      const data:any = await resp.json()
+      if (data[0]?.rsd_path){
+        return data[0].rsd_path
+      }
+      return undefined
+    }
+
+    logger(`getOrganisationSlug ${resp.status}: ${resp.statusText}`)
+    return undefined
+
+  }catch(e:any){
+    logger(`getOrganisationSlug: ${e?.message}`,'error')
+    return undefined
+  }
+}
+
+export async function getCommunitySlug(id:string){
+  try{
+    const url=`${getBaseUrl()}/community?id=eq.${id}&select=slug`
+
+    const resp = await fetch(url)
+
+    if (resp.ok){
+      const data:any = await resp.json()
+      if (data[0]?.slug){
+        return data[0].slug
+      }
+      return undefined
+    }
+
+    logger(`getCommunitySlug ${resp.status}: ${resp.statusText}`)
+    return undefined
+
+  }catch(e:any){
+    logger(`getCommunitySlug: ${e?.message}`,'error')
+    return undefined
+  }
 }

--- a/frontend/components/category/useCategoriesFilter.tsx
+++ b/frontend/components/category/useCategoriesFilter.tsx
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {CategoryEntry, CategoryPath} from '~/types/Category'
+
+type UseCategoriesProps = {
+  categories: CategoryPath[]
+  isMaintainer: boolean
+  orgMaintainer: string[],
+  comMaintainer: string[]
+}
+
+function categoryFilter({root,isMaintainer,orgMaintainer,comMaintainer}:{
+  root:CategoryEntry,isMaintainer:boolean,orgMaintainer:string[],comMaintainer:string[]
+}){
+  switch (true){
+    // OK categories to show to all
+    case root?.status == 'global':
+    case root?.status == 'other':
+    case root?.status == 'approved':
+      return true
+    // maintainer sees all
+    case isMaintainer:
+      return true
+    // organisation maintainer sees all organisation categories
+    case root?.organisation && orgMaintainer.includes(root?.organisation):
+      return true
+    // community maintainer sees all community categories
+    case root?.community && comMaintainer.includes(root?.community):
+      return true
+    default:
+      // otherwise do not show category tree
+      return false
+  }
+}
+
+export function useSoftwareCategoriesFilter({
+  categories=[],isMaintainer,orgMaintainer=[],comMaintainer=[]
+}:UseCategoriesProps){
+  const [highlightedCategories, setHighlightedCategories] = useState<CategoryPath[]>([])
+  const [softwareCategories, setSoftwareCategories] = useState<CategoryPath[]>([])
+
+  useEffect(()=>{
+    let abort = false
+    const highlights:CategoryPath[] =[]
+    const software:CategoryPath[] = []
+
+    categories?.forEach(path=>{
+      const root = path[0]
+      // highlighted categories
+      if (root?.properties.is_highlight){
+        highlights.push(path)
+      } else if (categoryFilter({root,isMaintainer,orgMaintainer,comMaintainer})){
+        software.push(path)
+      }
+    })
+    // skip on abort
+    if (abort) return
+    // update state
+    setHighlightedCategories(highlights)
+    setSoftwareCategories(software)
+
+    return ()=>{abort=true}
+  },[categories,isMaintainer,orgMaintainer,comMaintainer])
+
+  return [
+    highlightedCategories,
+    softwareCategories
+  ]
+}
+
+export function useProjectCategoriesFilter({categories=[],isMaintainer,orgMaintainer=[],comMaintainer=[]}:UseCategoriesProps){
+  const [filteredCategories, setFilteredCategories] = useState<CategoryPath[]>([])
+
+  useEffect(()=>{
+    let abort = false
+    const projects:CategoryPath[] = categories?.filter(path=>{
+      return categoryFilter({root:path[0],isMaintainer,orgMaintainer,comMaintainer})
+    })
+    // skip on abort
+    if (abort) return
+    // update state
+    setFilteredCategories(projects)
+
+    return ()=>{abort=true}
+  },[categories,isMaintainer,orgMaintainer,comMaintainer])
+
+  return filteredCategories
+}

--- a/frontend/components/communities/software/filters/apiCommunitySoftwareFilters.ts
+++ b/frontend/components/communities/software/filters/apiCommunitySoftwareFilters.ts
@@ -121,7 +121,7 @@ export async function comSoftwareLicensesFilter({token,...params}: CommunitySoft
 
 export async function comSoftwareCategoriesFilter({token,...params}: CommunitySoftwareFilterProps) {
   try {
-    const query = 'rpc/com_software_categories_filter?order=category'
+    const query = 'rpc/com_software_categories_filter?order=category_cnt.desc,category'
     const url = `${getBaseUrl()}/${query}`
     const filter = buildCommunitySoftwareFilter(params)
 

--- a/frontend/components/layout/ContentLoader.tsx
+++ b/frontend/components/layout/ContentLoader.tsx
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import ContentInTheMiddle from './ContentInTheMiddle'
 import CircularProgress from '@mui/material/CircularProgress'
+import ContentInTheMiddle from './ContentInTheMiddle'
 
 export default function ContentLoader() {
   return (

--- a/frontend/components/layout/TagChipFilter.tsx
+++ b/frontend/components/layout/TagChipFilter.tsx
@@ -5,23 +5,43 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Link from 'next/link'
 import Chip from '@mui/material/Chip'
 import SearchIcon from '@mui/icons-material/Search'
-import Link from 'next/link'
+import CircularProgress from '@mui/material/CircularProgress'
 
 type TagChipFilterProps=Readonly<{
   label: string,
   url?:string ,
   title?: string
   capitalize?: boolean
+  loading?: boolean
 }>
 
 export default function TagChipFilter({
   url, label,
-  title, capitalize=true
+  title, capitalize=true,
+  loading
 }:TagChipFilterProps){
   // if no label no chip
   if (!label) return null
+
+  if (loading) return (
+    <Chip
+      title={title ? title : label}
+      label={label}
+      icon={<div><CircularProgress size={16} /></div>}
+      sx={{
+        maxWidth: '19rem',
+        borderRadius: '0.125rem',
+        textTransform: capitalize ? 'capitalize' : 'none',
+        '& .MuiChip-icon': {
+          order: 1,
+          margin:'0.5rem',
+        }
+      }}
+    />
+  )
 
   // simple chip without link
   if (!url) return (

--- a/frontend/components/layout/TagChipFilter.tsx
+++ b/frontend/components/layout/TagChipFilter.tsx
@@ -28,7 +28,7 @@ export default function TagChipFilter({
 
   if (loading) return (
     <Chip
-      title={title ? title : label}
+      title={title ?? label}
       label={label}
       icon={<div><CircularProgress size={16} /></div>}
       sx={{
@@ -46,7 +46,7 @@ export default function TagChipFilter({
   // simple chip without link
   if (!url) return (
     <Chip
-      title={title ? title : label}
+      title={title ?? label}
       label={label}
       sx={{
         maxWidth: '19rem',

--- a/frontend/components/organisation/projects/useAdminMenuOptions.tsx
+++ b/frontend/components/organisation/projects/useAdminMenuOptions.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,11 +10,11 @@ import Check from '@mui/icons-material/Check'
 import UndoIcon from '@mui/icons-material/Undo'
 
 import {IconBtnMenuOption} from '~/components/menu/IconBtnMenuOnAction'
-import {Status} from '~/types/Organisation'
+import {OrganisationStatus} from '~/types/Organisation'
 import {ProjectMenuAction} from './card/useProjectCardActions'
 
 type AdminMenuOptionsProps = {
-  status: Status
+  status: OrganisationStatus
   is_published: boolean
   is_featured: boolean
   target: 'project'| 'software'

--- a/frontend/components/projects/ProjectCategories.tsx
+++ b/frontend/components/projects/ProjectCategories.tsx
@@ -8,6 +8,7 @@ import {useCategoryTree} from '~/components/category/useCategoryTree'
 import SidebarSection from '~/components/layout/SidebarSection'
 import SidebarTitle from '~/components/layout/SidebarTitle'
 import {CategoryChipFilter} from '~/components/category/CategoryChipFilter'
+import CategoryStatus from '../category/CategoryStatus'
 
 export default function ProjectCategories({categories}:{categories:CategoryPath[]}) {
   const tree = useCategoryTree(categories)
@@ -26,7 +27,11 @@ export default function ProjectCategories({categories}:{categories:CategoryPath[
     if (children.length > 0){
       return (
         <SidebarSection key={category.id}>
-          <SidebarTitle title={category.name}>{category.short_name}</SidebarTitle>
+          <SidebarTitle title={category.name}>
+            <span className="mr-2">{category.short_name}</span>
+            {/* show status if not not approved/global/other */}
+            <CategoryStatus category={category} />
+          </SidebarTitle>
           <div className="flex flex-wrap gap-2">
             <CategoryChipFilter nodes={children} />
           </div>

--- a/frontend/components/projects/edit/related-projects/RelatedProjectList.tsx
+++ b/frontend/components/projects/edit/related-projects/RelatedProjectList.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,14 +19,14 @@ import LockIcon from '@mui/icons-material/Lock'
 
 import {maxText} from '~/utils/maxText'
 import {getImageUrl} from '~/utils/editImage'
-import {Status} from '~/types/Organisation'
+import {OrganisationStatus} from '~/types/Organisation'
 
 type RelatedProjectProps = {
   slug: string
   title: string
   subtitle: string | null
   image_id: string | null
-  status: Status
+  status: OrganisationStatus
 }
 
 type ProjectListProps = {

--- a/frontend/components/projects/edit/related-projects/index.tsx
+++ b/frontend/components/projects/edit/related-projects/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,7 @@ import {addRelatedProject, deleteRelatedProject} from '~/utils/editProject'
 import {sortOnStrProp} from '~/utils/sortFn'
 import {extractErrorMessages} from '~/utils/fetchHelpers'
 import {ProjectStatusKey, RelatedProjectForProject, SearchProject} from '~/types/Project'
-import {Status} from '~/types/Organisation'
+import {OrganisationStatus} from '~/types/Organisation'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import EditSection from '~/components/layout/EditSection'
@@ -61,7 +61,7 @@ export default function RelatedProjectsForProject() {
     // debugger
     if (find.length === 0) {
       // default status is set to approved without validation
-      const status:Status = 'approved'
+      const status:OrganisationStatus = 'approved'
       // append(selected)
       const resp = await addRelatedProject({
         origin: project.id,

--- a/frontend/components/projects/edit/related-software/RelatedSoftwareList.tsx
+++ b/frontend/components/projects/edit/related-software/RelatedSoftwareList.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,14 +18,14 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import LockIcon from '@mui/icons-material/Lock'
 
 import {maxText} from '~/utils/maxText'
-import {Status} from '~/types/Organisation'
+import {OrganisationStatus} from '~/types/Organisation'
 
 type SoftwareItem = {
   id: string
   slug: string
   brand_name: string
   short_statement: string
-  status: Status
+  status: OrganisationStatus
 }
 
 type SoftwareListProps = {

--- a/frontend/components/projects/edit/related-software/index.tsx
+++ b/frontend/components/projects/edit/related-software/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +12,7 @@ import {getRelatedSoftwareForProject} from '~/utils/getProjects'
 import {addRelatedSoftware, deleteRelatedSoftware} from '~/utils/editProject'
 import {sortOnStrProp} from '~/utils/sortFn'
 import {RelatedSoftwareOfProject, SearchSoftware} from '~/types/SoftwareTypes'
-import {Status} from '~/types/Organisation'
+import {OrganisationStatus} from '~/types/Organisation'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import EditSection from '~/components/layout/EditSection'
@@ -57,7 +57,7 @@ export default function RelatedSoftwareForProject() {
     // debugger
     if (find.length === 0) {
       // default status is set to approved without validation
-      const status:Status = 'approved'
+      const status:OrganisationStatus = 'approved'
       // add selected item to related software
       const resp = await addRelatedSoftware({
         project: project.id,

--- a/frontend/components/software/CategoriesSection.tsx
+++ b/frontend/components/software/CategoriesSection.tsx
@@ -1,8 +1,8 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,14 +20,15 @@ export default function CategoriesSection({categories}: CategoriesSectionProps) 
 
   return tree.map(node => {
     const category = node.getValue()
-
     const children = node.children()
 
     return (
-      <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]" key={category.id}>
+      <PageContainer
+        key={category.id}
+        className="py-12 px-4 lg:grid lg:grid-cols-[1fr,4fr]">
         <h2
           data-testid="software-categories-section-title"
-          className="pb-8 text-[2rem] text-primary">
+          className="pb-8 pr-4 text-[2rem] text-primary">
           {category.name}
         </h2>
         {/* Display as table and on small screens as bullet point list  */}

--- a/frontend/components/software/CategoriesSidebar.tsx
+++ b/frontend/components/software/CategoriesSidebar.tsx
@@ -9,6 +9,8 @@ import SidebarTitle from '~/components/layout/SidebarTitle'
 import {CategoryChipFilter} from '~/components/category/CategoryChipFilter'
 import {useCategoryTree} from '~/components/category/useCategoryTree'
 import CategoryIcon from '~/components/category/CategoryIcon'
+import CategoryStatus from '../category/CategoryStatus'
+
 
 export default function CategoriesSidebar({categories}:{categories:CategoryPath[]}) {
   const tree = useCategoryTree(categories)
@@ -33,6 +35,8 @@ export default function CategoriesSidebar({categories}:{categories:CategoryPath[
           >
             <span><CategoryIcon name={category.properties.icon} /></span>
             <span>{category.short_name}</span>
+            {/* show status if not not approved/global/other */}
+            <CategoryStatus category={category} />
           </SidebarTitle>
           <div className="flex flex-wrap gap-2">
             <CategoryChipFilter nodes={children} />

--- a/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
+++ b/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
@@ -30,6 +30,7 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
   const [_, setAssociatedCategories] = useState<Set<string>>(associatedCategoryIds)
   const {token} = useSession()
   const selectedNodes: TreeNode<CategoryEntry>[] = []
+
   for (const root of reorderedCategories.all) {
     const rootSelectedSubTree= root.subTreeWhereLeavesSatisfy(value => associatedCategoryIds.has(value.id))
     if (rootSelectedSubTree !== null) {

--- a/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
+++ b/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -50,7 +50,8 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
         allow_projects: false,
         short_name: '',
         properties: {subtitle: config.categories.subtitle},
-        provenance_iri: null
+        provenance_iri: null,
+        status: 'global'
       }
     )
     for (const generalRoot of reorderedCategories.general) {

--- a/frontend/components/software/edit/related-projects/index.tsx
+++ b/frontend/components/software/edit/related-projects/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,7 @@ import {useSession} from '~/auth'
 import {getRelatedProjectsForSoftware} from '~/utils/getSoftware'
 import {addRelatedSoftware, deleteRelatedSoftware} from '~/utils/editProject'
 import {sortOnStrProp} from '~/utils/sortFn'
-import {Status} from '~/types/Organisation'
+import {OrganisationStatus} from '~/types/Organisation'
 import {SearchProject} from '~/types/Project'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import FindRelatedProject from '~/components/projects/edit/related-projects/FindRelatedProject'
@@ -58,7 +58,7 @@ export default function RelatedProjectsForSoftware() {
     // debugger
     if (find.length === 0) {
       // default status of relation between software and project is approved
-      const status:Status = 'approved'
+      const status:OrganisationStatus = 'approved'
       // append(selected)
       const resp = await addRelatedSoftware({
         software: software.id ?? '',

--- a/frontend/components/software/edit/related-software/index.tsx
+++ b/frontend/components/software/edit/related-software/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,7 @@ import {useSession} from '~/auth'
 import {sortOnStrProp} from '~/utils/sortFn'
 import {addRelatedSoftware, deleteRelatedSoftware, getRelatedSoftwareForSoftware} from '~/utils/editRelatedSoftware'
 import {RelatedSoftwareOfSoftware, SearchSoftware} from '~/types/SoftwareTypes'
-import {Status} from '~/types/Organisation'
+import {OrganisationStatus} from '~/types/Organisation'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import FindRelatedSoftware from '~/components/projects/edit/related-software/FindRelatedSoftware'
 import RelatedSoftwareList from '~/components/projects/edit/related-software/RelatedSoftwareList'
@@ -44,7 +44,7 @@ export default function RelatedSoftwareForSoftware() {
             brand_name: item.brand_name,
             short_statement: item.short_statement,
             updated_at: item.updated_at ?? undefined,
-            status: 'approved' as Status
+            status: 'approved' as OrganisationStatus
           }
         }).sort((a, b) => sortOnStrProp(a, b, 'brand_name'))
 
@@ -78,7 +78,7 @@ export default function RelatedSoftwareForSoftware() {
         const newList = [
           ...relatedSoftware, {
             ...selected,
-            status: 'approved' as Status
+            status: 'approved' as OrganisationStatus
           }
 
         ].sort((a, b) => sortOnStrProp(a, b, 'brand_name'))

--- a/frontend/components/software/edit/services/SoftwareRepoServices.tsx
+++ b/frontend/components/software/edit/services/SoftwareRepoServices.tsx
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -30,7 +33,8 @@ export default function SoftwareRepoServices() {
             scraped_at: services ? services[service.props.scraped_at] : null,
             last_error: services ? services[service.props.last_error] : null,
             url: services ? services[service.props.url] : null,
-            platform: services ? services['code_platform'] : null
+            platform: services ? services['code_platform'] : null,
+            dbprops: service.dbprops
           }
           return (
             <ServiceInfoListItem key={service.name} scraping_disabled_reason={null} {...props} />

--- a/frontend/components/software/edit/services/SoftwareRepoServices.tsx
+++ b/frontend/components/software/edit/services/SoftwareRepoServices.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -16,7 +16,7 @@ import {ServiceInfoListItem} from './ServiceInfoListItem'
 
 
 export default function SoftwareRepoServices() {
-  const {loading,services} = useSoftwareServices()
+  const {loading,services,loadServices} = useSoftwareServices()
 
   if (loading) return <ContentLoader />
 
@@ -37,12 +37,15 @@ export default function SoftwareRepoServices() {
             dbprops: service.dbprops
           }
           return (
-            <ServiceInfoListItem key={service.name} scraping_disabled_reason={null} {...props} />
+            <ServiceInfoListItem
+              key={service.name}
+              scraping_disabled_reason={null}
+              onClear={()=>loadServices(false)}
+              {...props}
+            />
           )
         })}
       </List>
     </>
-
   )
-
 }

--- a/frontend/components/software/edit/services/apiSoftwareServices.tsx
+++ b/frontend/components/software/edit/services/apiSoftwareServices.tsx
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -158,5 +161,38 @@ export function useSoftwareServices(){
   return {
     loading,
     services
+  }
+}
+
+export async function deleteServiceDataFromDb({dbprops, software, token}:
+  {dbprops:string[], software: string, token:string}){
+  try {
+    const query = `repository_url?software=eq.${software}`
+    const url = `${getBaseUrl()}/${query}`
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        ...createJsonHeaders(token),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(
+        dbprops.reduce((acc, dbprop) => ({...acc, [dbprop]: null}), {})
+      )
+    })
+    if (resp.status === 204) {
+      const formattedProps = dbprops
+        .map((str, index) => (index === 0 ? str.replace(/_/g, ' ').replace(/^./, c => c.toUpperCase()) : str.replace(/_/g, ' ')))
+        .join(', ')
+      return {
+        status: 204,
+        message: `${formattedProps} cleared from database.`
+      }
+    }
+  } catch (e: any) {
+    logger(`deleteServiceDataFromDb: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
   }
 }

--- a/frontend/components/software/edit/services/config.ts
+++ b/frontend/components/software/edit/services/config.ts
@@ -1,5 +1,8 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,21 +15,25 @@ type ServiceListProps={
     scraped_at: keyof SoftwareServices,
     last_error: keyof SoftwareServices,
     url: keyof SoftwareServices
-  }
+  },
+  dbprops: string[]
 }
 
 export const repoServiceList:ServiceListProps[]=[{
   name: 'Commit history',
   desc: 'Information is extracted from the repository api (github/gitlab)',
-  props:{scraped_at:'commit_history_scraped_at',last_error:'commit_history_last_error',url:'url'}
+  props:{scraped_at:'commit_history_scraped_at',last_error:'commit_history_last_error',url:'url'},
+  dbprops: ['commit_history']
 },{
   name: 'Programming languages',
   desc: 'Information is extracted from the repository api (github/gitlab)',
-  props:{scraped_at:'languages_scraped_at',last_error:'languages_last_error',url:'url'}
+  props:{scraped_at:'languages_scraped_at',last_error:'languages_last_error',url:'url'},
+  dbprops: ['languages']
 },{
   name: 'Repository statistics',
   desc: 'Information is extracted from the repository api (github/gitlab)',
-  props:{scraped_at:'basic_data_scraped_at',last_error:'basic_data_last_error',url:'url'}
+  props:{scraped_at:'basic_data_scraped_at',last_error:'basic_data_last_error',url:'url'},
+  dbprops: ['star_count', 'fork_count', 'open_issue_count', 'contributor_count']
 }]
 
 

--- a/frontend/components/software/edit/services/config.ts
+++ b/frontend/components/software/edit/services/config.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
@@ -23,17 +23,17 @@ export const repoServiceList:ServiceListProps[]=[{
   name: 'Commit history',
   desc: 'Information is extracted from the repository api (github/gitlab)',
   props:{scraped_at:'commit_history_scraped_at',last_error:'commit_history_last_error',url:'url'},
-  dbprops: ['commit_history']
+  dbprops: ['commit_history','commit_history_scraped_at']
 },{
   name: 'Programming languages',
   desc: 'Information is extracted from the repository api (github/gitlab)',
   props:{scraped_at:'languages_scraped_at',last_error:'languages_last_error',url:'url'},
-  dbprops: ['languages']
+  dbprops: ['languages','languages_scraped_at']
 },{
   name: 'Repository statistics',
   desc: 'Information is extracted from the repository api (github/gitlab)',
   props:{scraped_at:'basic_data_scraped_at',last_error:'basic_data_last_error',url:'url'},
-  dbprops: ['star_count', 'fork_count', 'open_issue_count', 'contributor_count']
+  dbprops: ['star_count', 'fork_count', 'open_issue_count', 'contributor_count','basic_data_scraped_at']
 }]
 
 

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.
+// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/frontend/pages/software/[slug]/index.tsx
+++ b/frontend/pages/software/[slug]/index.tsx
@@ -2,9 +2,9 @@
 // SPDX-FileCopyrightText: 2021 - 2024 dv4all
 // SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -99,14 +99,14 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
     mentions, testimonials, contributors,
     relatedSoftware, relatedProjects, isMaintainer,
     slug, organisations, referencePapers, packages,
-    communities
+    communities, categories
   } = props
 
   const [highlightedCategories, otherCategories] = useMemo(() => {
     const highlightedCategories: CategoryPath[] = []
     const otherCategories: CategoryPath[] = []
 
-    for (const path of (props.categories || [])) {
+    for (const path of (categories || [])) {
       if (path[0].properties.is_highlight) {
         highlightedCategories.push(path)
       } else {
@@ -114,7 +114,7 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
       }
     }
     return [highlightedCategories, otherCategories]
-  }, [props.categories])
+  }, [categories])
 
   useEffect(() => {
     const contact = contributors.filter(item => item.is_contact_person)
@@ -127,7 +127,10 @@ export default function SoftwareIndexPage(props:SoftwareIndexData) {
   if (!software?.brand_name){
     return <NoContent />
   }
-  // console.log('SoftwareIndexPage...communities...', communities)
+  // console.group('SoftwareIndexPage')
+  // console.log('otherCategories...', otherCategories)
+  // console.log('categories...', categories)
+  // console.groupEnd()
   return (
     <>
       {/* Page Head meta tags */}

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -18,7 +18,7 @@
       "limit": 5,
       "description": null
     },
-    "modules":["software","projects","organisations"]
+    "modules":["software","projects","organisations","communities"]
   },
   "links": [
     {

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -18,7 +18,7 @@
       "limit": 5,
       "description": null
     },
-    "modules":["software","projects","organisations","communities"]
+    "modules":["software","projects","organisations"]
   },
   "links": [
     {

--- a/frontend/types/Category.ts
+++ b/frontend/types/Category.ts
@@ -7,6 +7,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {MuiIconName} from '~/components/category/CategoryIcon'
+import {CommunityRequestStatus} from '~/components/communities/software/apiCommunitySoftware'
+import {OrganisationStatus} from './Organisation'
 
 export type CategoryProperties = {
   icon?: MuiIconName
@@ -29,6 +31,8 @@ export type CategoryEntry = {
   name: string
   properties: CategoryProperties
   provenance_iri: string | null
+  // values: global, other + organisation and community acceptance statuses
+  status: 'global' | 'other' | CommunityRequestStatus | OrganisationStatus
 }
 
 

--- a/frontend/types/Organisation.ts
+++ b/frontend/types/Organisation.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -9,7 +9,7 @@
 import {ProjectStatusKey} from './Project'
 
 // based on ENUMS defined in 012-inter-relation-tables.sql
-export type Status = 'rejected_by_origin' | 'rejected_by_relation' | 'approved'
+export type OrganisationStatus = 'rejected_by_origin' | 'rejected_by_relation' | 'approved'
 export type OrganisationRole = 'participating' | 'funding' | 'hosting'
 export type OrganisationSource = 'RSD' | 'ROR' | 'MANUAL'
 
@@ -79,7 +79,7 @@ export type EditOrganisation = SearchOrganisation & {
   logo_b64: string | null
   logo_mime_type: string | null
   // source?: OrganisationSource
-  status?: Status
+  status?: OrganisationStatus
   // only maintainers can edit values
   canEdit?: boolean
   // used for children to have complete rsd_path
@@ -103,7 +103,7 @@ export type PatchOrganisation = {
 export type SoftwareForOrganisation = {
   software: string,
   organisation: string,
-  status: Status,
+  status: OrganisationStatus,
   position: number|null
 }
 
@@ -120,7 +120,7 @@ export type OrganisationsForSoftware={
   website: string | null
   rsd_path: string
   logo_id: string | null
-  status: Status
+  status: OrganisationStatus
   software: string
 }
 
@@ -156,7 +156,7 @@ export type SoftwareOfOrganisation = {
   is_published: boolean
   updated_at: string
   is_featured: boolean
-  status: Status
+  status: OrganisationStatus
   keywords: string[],
   prog_lang: string[],
   licenses: string,
@@ -178,7 +178,7 @@ export type ProjectOfOrganisation = {
   image_contain: boolean
   image_id: string | null
   // organisation: string
-  status: Status
+  status: OrganisationStatus
   keywords: string[] | null
   research_domain: string[] | null
   impact_cnt: number | null

--- a/frontend/types/Project.ts
+++ b/frontend/types/Project.ts
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {SearchOrganisation, OrganisationRole, Status} from './Organisation'
+import {SearchOrganisation, OrganisationRole, OrganisationStatus} from './Organisation'
 import {Person} from './Contributor'
 
 export type NewProject = {
@@ -73,7 +73,7 @@ export type OrganisationsOfProject = {
   website: string | null
   rsd_path: string
   logo_id: string | null
-  status: Status
+  status: OrganisationStatus
   role: OrganisationRole
   project: string
   parent: string | null
@@ -97,7 +97,7 @@ export type SearchProject = {
   slug: string
   title: string
   subtitle: string | null
-  status: Status
+  status: OrganisationStatus
   image_id: string | null
 }
 

--- a/frontend/types/SoftwareTypes.ts
+++ b/frontend/types/SoftwareTypes.ts
@@ -16,7 +16,7 @@
 
 import {AutocompleteOption} from './AutocompleteOptions'
 import {CategoryPath} from './Category'
-import {Status} from './Organisation'
+import {OrganisationStatus} from './Organisation'
 
 export type CodePlatform = 'github' | 'gitlab' | 'bitbucket' | 'other'
 
@@ -139,6 +139,7 @@ export type KeywordForSoftware = {
   pos?: number
 }
 
+// NOTE: why not use CategoryPath[]?
 export type CategoriesForSoftware = CategoryPath[]
 
 export type CategoryForSoftwareIds = Set<string>
@@ -201,12 +202,12 @@ export type SearchSoftware = {
 export type RelatedSoftwareOfSoftware = SearchSoftware & {
   is_featured?: boolean
   updated_at?: string
-  status: Status
+  status: OrganisationStatus
 }
 
 export type RelatedSoftwareOfProject = SearchSoftware & {
   project: string
-  status: Status
+  status: OrganisationStatus
 }
 
 

--- a/frontend/utils/editProject.ts
+++ b/frontend/utils/editProject.ts
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,7 @@ import {createJsonHeaders, extractReturnMessage} from './fetchHelpers'
 import {
   NewProject, ProjectLink, ResearchDomainForProject
 } from '~/types/Project'
-import {colForCreate, EditOrganisation, OrganisationRole, Status} from '~/types/Organisation'
+import {colForCreate, EditOrganisation, OrganisationRole, OrganisationStatus} from '~/types/Organisation'
 import {createOrganisation} from './editOrganisation'
 import {getPropsFromObject} from './getPropsFromObject'
 
@@ -448,7 +448,7 @@ export async function createMaintainerLink({project,account,token}:{project:stri
 }
 
 export async function addRelatedSoftware({project,software,status,token}: {
-  project: string, software: string, status: Status, token: string
+  project: string, software: string, status: OrganisationStatus, token: string
 }) {
   const url = '/api/v1/software_for_project'
 
@@ -485,7 +485,7 @@ export async function deleteRelatedSoftware({project, software, token}: {
 }
 
 export async function addRelatedProject({origin, relation, status, token}: {
-  origin: string, relation: string, status: Status, token: string
+  origin: string, relation: string, status: OrganisationStatus, token: string
 }) {
   const url = '/api/v1/project_for_project'
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicRepositoryDataWithHistory.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicRepositoryDataWithHistory.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper.git;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+public record BasicRepositoryDataWithHistory(UUID software, String url, ZonedDateTime commitHistoryScrapedAt, CommitsPerWeek commitsPerWeek) {
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeek.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeek.java
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,6 +15,7 @@ import com.google.gson.JsonSerializer;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.Period;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -26,11 +29,15 @@ import java.util.TreeMap;
  */
 public class CommitsPerWeek {
 
-	final SortedMap<Instant, Long> data = new TreeMap<>();
+	private final SortedMap<Instant, Long> data = new TreeMap<>();
 	static final Gson gson = new GsonBuilder()
 			.enableComplexMapKeySerialization()
 			.registerTypeAdapter(Instant.class, (JsonSerializer<Instant>) (src, typeOfSrc, context) -> new JsonPrimitive(src.getEpochSecond()))
 			.create();
+
+	SortedMap<Instant, Long> getData() {
+		return new TreeMap<>(data);
+	}
 
 	public void addCommits(ZonedDateTime zonedDateTime, long count) {
 		ZonedDateTime utcTime = zonedDateTime.withZoneSameInstant(ZoneOffset.UTC);
@@ -41,6 +48,15 @@ public class CommitsPerWeek {
 	public void addCommits(Instant instant, long count) {
 		ZonedDateTime utcTime = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC);
 		addCommits(utcTime, count);
+	}
+
+	public ZonedDateTime popLatestTimestamp() {
+		if (this.data.size() > 0) {
+			Instant lastTimeStamp = this.data.lastKey();
+			this.data.remove(lastTimeStamp);
+			return ZonedDateTime.ofInstant(lastTimeStamp, ZoneId.systemDefault());
+		}
+		return null;
 	}
 
 	/**

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeekTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeekTest.java
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,11 +24,12 @@ class CommitsPerWeekTest {
 	@Test
 	void givenInstance_whenValidOperations_thenCorrectResults() {
 		CommitsPerWeek commitsPerWeek = new CommitsPerWeek();
-		Map<Instant, Long> underlyingMap = commitsPerWeek.data;
+		Map<Instant, Long> underlyingMap;
 
 		Instant sundayMidnight1 = Instant.ofEpochSecond(1670716800);
 		commitsPerWeek.addCommits(sundayMidnight1, 10);
 
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(1, underlyingMap.size());
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight1));
 		Assertions.assertEquals(10, underlyingMap.get(sundayMidnight1));
@@ -34,6 +37,7 @@ class CommitsPerWeekTest {
 
 		commitsPerWeek.addCommits(sundayMidnight1, 20);
 
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(1, underlyingMap.size());
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight1));
 		Assertions.assertEquals(30, underlyingMap.get(sundayMidnight1));
@@ -43,6 +47,7 @@ class CommitsPerWeekTest {
 			.plus(Duration.ofSeconds(12345));
 		commitsPerWeek.addCommits(smallTimeAfterSundayMidnight1, 10);
 
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(1, underlyingMap.size());
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight1));
 		Assertions.assertEquals(40, underlyingMap.get(sundayMidnight1));
@@ -51,6 +56,7 @@ class CommitsPerWeekTest {
 		Instant sundayMidnight2 = sundayMidnight1.plus(Period.ofWeeks(5));
 		commitsPerWeek.addCommits(sundayMidnight2, 5);
 
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(2, underlyingMap.size());
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight2));
 		Assertions.assertEquals(5, underlyingMap.get(sundayMidnight2));
@@ -58,6 +64,7 @@ class CommitsPerWeekTest {
 
 
 		commitsPerWeek.addMissingZeros();
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(6, underlyingMap.size());
 		Assertions.assertEquals(0, underlyingMap.get(sundayMidnight1.plus(Period.ofWeeks(1))));
 		Assertions.assertEquals(0, underlyingMap.get(sundayMidnight1.plus(Period.ofWeeks(2))));


### PR DESCRIPTION
Fixes #777

Changes proposed in this pull request:

* optimise gitlab scrapers so that they do not scrape the entire commit history every time they run
* scraper uses `commit_history_scraped_at` to start checking for new commits
* the commit history could become incorrect if
  * there are commits between finishing scraping and writing the timestamp to the database
  * if the entire commit history was rewritten
* added delete buttons to reset scraped metadata (commit history, programming languages, repository statistics)

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up`
* login and create a new software that uses a gitlab repository url, e.g.
  ```
  https://codebase.helmholtz.cloud/research-software-directory/RSD-as-a-service
  ```
* publish the software entry
* start the commit scrapers
  ```
  docker compose exec scrapers /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits
  ```
* the first time the scraping will take a while until it is finished
* rerun the commit scrapers, this time the scraping should stop 

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
