### PR TITLE
fix: add missing centres

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzIdLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzIdLogin.java
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2023 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -51,7 +51,7 @@ public class HelmholtzIdLogin implements Login {
 
 	// See https://hifis.net/doc/helmholtz-aai/list-of-vos/#vos-representing-helmholtz-centres
 	private static final Collection<String> knownHgfOrganisations = Set.of(
-			"AWI", "CISPA", "DESY", "DKFZ", "DLR", "DZNE", "FZJ", "GEOMAR", "GFZ", "GSI", "hereon", "HMGU", "HZB", "KIT", "MDC", "UFZ"
+			"AWI", "CISPA", "DESY", "DKFZ", "DLR", "DZNE", "FZJ", "GEOMAR", "GFZ", "GSI", "hereon", "HMGU", "HZB", "HZDR", "HZI", "KIT", "MDC", "UFZ"
 	);
 
 	public HelmholtzIdLogin(String code, String redirectUrl) {


### PR DESCRIPTION
# Adds missing VOs from HelmholtzID

Changes proposed in this pull request:

* adds two missing VOs to the list of known Helmholtz VOs

How to test:

* `docker compose build` should build without errors

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
