### PR TITLE
Select accessibility and logo size

### DIFF
--- a/frontend/components/software/AboutPackageManagers.tsx
+++ b/frontend/components/software/AboutPackageManagers.tsx
@@ -19,15 +19,16 @@ function PackageManagerItem({item}:{item:PackageManager}){
     const info = packageManagerSettings[item.package_manager ?? 'other']
     const link = new URL(item.url)
     return (
-      <a href={item.url} target="_blank">
+      <a href={item.url} target="_blank" rel="noreferrer">
         <LogoAvatar
           name={link.hostname}
           src={info.icon ?? undefined}
           sx={{
-            height: '4rem',
-            width: '4rem',
-            fontSize: '1.5rem',
-            // borderRadius: '0.25rem',
+            width: 'auto',
+            height: '3rem',
+            fontSize: '3rem',
+            // add 2 pixel margin to align it with same logo in source code
+            margin:'0.125rem',
             '& img': {
               // fit icon into area
               objectFit: 'scale-down'
@@ -51,7 +52,7 @@ export default function AboutPackageManagers({packages}:AboutPackageManagersProp
           </span>
           <span className="text-primary pl-2">Packages</span>
         </div>
-        <div className="flex gap-4 flex-wrap">
+        <div className="flex gap-4 flex-wrap py-2">
           {packages.map(item=><PackageManagerItem key={item.id} item={item} />)}
         </div>
       </>

--- a/frontend/components/software/AboutSourceCode.tsx
+++ b/frontend/components/software/AboutSourceCode.tsx
@@ -1,12 +1,14 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import GitHubIcon from '@mui/icons-material/GitHub'
 import FolderOpenIcon from '@mui/icons-material/FolderOpen'
 import {CodePlatform} from '~/types/SoftwareTypes'
-import GitlabIcon from '../../assets/logos/gitlab-icon-rgb.svg'
+import GitlabIcon from '~/assets/logos/gitlab-icon-rgb.svg'
 
 
 export default function AboutSourceCode({repository,platform}: { repository: string | null, platform: CodePlatform}) {
@@ -18,24 +20,33 @@ export default function AboutSourceCode({repository,platform}: { repository: str
     switch (platform) {
       case 'github':
         return (
-          <a key={repository} href={repository ?? ''} title="Github repository" target="_blank" rel="noreferrer">
+          <a key={repository} href={repository ?? ''}
+            title="Github repository" target="_blank" rel="noreferrer"
+            className="hover:text-base-content"
+          >
             <GitHubIcon sx={{
-              width: '3rem',
-              height: '3rem'
+              width: '3.25rem',
+              height: '3.25rem'
             }} />
           </a>
         )
       case 'gitlab':
         return (
-          <a key={repository} href={repository ?? ''} title="Gitlab repository" target="_blank" rel="noreferrer">
+          <a key={repository} href={repository ?? ''}
+            title="Gitlab repository" target="_blank" rel="noreferrer"
+            className="hover:text-base-content"
+          >
             <GitlabIcon
-              className="w-[3rem]"
+              className="w-[3rem] h-[3rem]"
             />
           </a>
         )
       default:
         return (
-          <a key={repository} href={repository ?? ''} title="Repository" target="_blank" rel="noreferrer">
+          <a key={repository} href={repository ?? ''}
+            title="Repository" target="_blank" rel="noreferrer"
+            className="hover:text-base-content"
+          >
             <FolderOpenIcon sx={{
               width: '3rem',
               height: '3rem',

--- a/frontend/components/software/overview/search/SelectRows.tsx
+++ b/frontend/components/software/overview/search/SelectRows.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -8,9 +8,11 @@
 import FormControl from '@mui/material/FormControl'
 import Select from '@mui/material/Select'
 import MenuItem from '@mui/material/MenuItem'
+import InputLabel from '@mui/material/InputLabel'
 
-import {setDocumentCookie} from '../../../../utils/userSettings'
+import {setDocumentCookie} from '~/utils/userSettings'
 import {rowsPerPageOptions} from '~/config/pagination'
+
 
 type SelectRowsProps = {
   rows: number
@@ -35,9 +37,11 @@ export default function SelectRows({rows, handleQueryChange}: SelectRowsProps) {
       }}
       title={`Show ${rows} items on page`}
     >
+      {/* need to add it for accessibility - Lighthouse audit */}
+      <InputLabel id="select-items" className="opacity-0">Items</InputLabel>
       <Select
         id="select-rows"
-        labelId="select-rows-label"
+        labelId="select-items"
         variant="outlined"
         value={rows}
         // label="Items"


### PR DESCRIPTION
# Improve accessibility

Closes #1375 
Closes #1373

Changes proposed in this pull request:
* Add aria label to select number of items on the overview pages
* Made logos of the same size. Note! The logo height is set to 3rem. This is best we can do due to various logo ratios.  
* Remove on hover color on source code logos

How to test:
* `make start` to build and generate test data
*  visit software overview page and run Lighthouse audit, accessibility section (check accessiblity) - see image below
*  edit software page, add github as repository and package manager


## Accessibility
![image](https://github.com/user-attachments/assets/075877e2-4ad1-4872-8a2b-b07e5c52b63f)

## Expected score
![image](https://github.com/user-attachments/assets/746010b4-941e-4ef5-bd15-23bb9b99cd1e)

## Example logos
![image](https://github.com/user-attachments/assets/8b702f48-390d-4fc0-994d-d5989c14af7a)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
