### PR TITLE
feat: category filters

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -830,7 +830,6 @@ $$
 	GROUP BY research_domain_for_project.project;
 $$;
 
-
 -- Check whether user agreed on Terms of Service and read the Privacy Statement
 CREATE FUNCTION user_agreements_stored(account_id UUID) RETURNS BOOLEAN LANGUAGE sql STABLE AS
 $$

--- a/database/108-community-views.sql
+++ b/database/108-community-views.sql
@@ -1,6 +1,6 @@
--- SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+-- SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+-- SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -210,6 +210,32 @@ LEFT JOIN
 ;
 $$;
 
+-- CATEGORIES for software of specific community
+CREATE FUNCTION com_software_categories(community_id UUID) RETURNS TABLE(
+	software UUID,
+	category VARCHAR[],
+	category_text TEXT
+) LANGUAGE sql STABLE AS
+$$
+	SELECT
+		category_for_software.software_id AS software,
+		ARRAY_AGG(
+			category.short_name
+			ORDER BY short_name
+		) AS category,
+		STRING_AGG(
+			category.short_name || ' ' || category."name",' '
+			ORDER BY short_name
+		) AS category_text
+	FROM
+		category_for_software
+	INNER JOIN
+		category ON category.id = category_for_software.category_id
+	WHERE
+		category.community = community_id
+	GROUP BY
+		category_for_software.software_id;
+$$;
 
 -- SOFTWARE info by community
 -- we filter this view at least by community_id (uuid)
@@ -225,11 +251,11 @@ CREATE FUNCTION software_by_community(community_id UUID) RETURNS TABLE (
 	keywords CITEXT[],
 	prog_lang TEXT[],
 	licenses VARCHAR[],
+	categories VARCHAR[],
 	contributor_cnt BIGINT,
 	mention_cnt BIGINT
 ) LANGUAGE sql STABLE AS
 $$
-
 SELECT DISTINCT ON (software.id)
 	software.id,
 	software.slug,
@@ -242,6 +268,7 @@ SELECT DISTINCT ON (software.id)
 	keyword_filter_for_software.keywords,
 	prog_lang_filter_for_software.prog_lang,
 	license_filter_for_software.licenses,
+	com_software_categories.category AS categories,
 	count_software_contributors.contributor_cnt,
 	count_software_mentions.mention_cnt
 FROM
@@ -258,11 +285,12 @@ LEFT JOIN
 	prog_lang_filter_for_software() ON software.id=prog_lang_filter_for_software.software
 LEFT JOIN
 	license_filter_for_software() ON software.id=license_filter_for_software.software
+LEFT JOIN
+	com_software_categories(community_id) ON software.id=com_software_categories.software
 WHERE
 	software_for_community.community = community_id
 ;
 $$;
-
 
 -- SOFTWARE OF COMMUNITY LIST FOR SEARCH
 -- WITH keywords, programming languages and licenses for filtering
@@ -281,6 +309,7 @@ CREATE FUNCTION software_by_community_search(
 	keywords CITEXT[],
 	prog_lang TEXT[],
 	licenses VARCHAR[],
+	categories VARCHAR[],
 	contributor_cnt BIGINT,
 	mention_cnt BIGINT
 ) LANGUAGE sql STABLE AS
@@ -297,6 +326,7 @@ SELECT DISTINCT ON (software.id)
 	keyword_filter_for_software.keywords,
 	prog_lang_filter_for_software.prog_lang,
 	license_filter_for_software.licenses,
+	com_software_categories.category AS categories,
 	count_software_contributors.contributor_cnt,
 	count_software_mentions.mention_cnt
 FROM
@@ -313,6 +343,8 @@ LEFT JOIN
 	prog_lang_filter_for_software() ON software.id=prog_lang_filter_for_software.software
 LEFT JOIN
 	license_filter_for_software() ON software.id=license_filter_for_software.software
+LEFT JOIN
+	com_software_categories(community_id) ON software.id=com_software_categories.software
 WHERE
 	software_for_community.community = community_id AND (
 		software.brand_name ILIKE CONCAT('%', search, '%')
@@ -346,7 +378,6 @@ ORDER BY
 ;
 $$;
 
-
 -- REACTIVE KEYWORD FILTER WITH COUNTS FOR SOFTWARE
 -- PROVIDES AVAILABLE KEYWORDS FOR APPLIED FILTERS
 CREATE FUNCTION com_software_keywords_filter(
@@ -355,7 +386,8 @@ CREATE FUNCTION com_software_keywords_filter(
 	search_filter TEXT DEFAULT '',
 	keyword_filter CITEXT[] DEFAULT '{}',
 	prog_lang_filter TEXT[] DEFAULT '{}',
-	license_filter VARCHAR[] DEFAULT '{}'
+	license_filter VARCHAR[] DEFAULT '{}',
+	category_filter VARCHAR[] DEFAULT '{}'
 ) RETURNS TABLE (
 	keyword CITEXT,
 	keyword_cnt INTEGER
@@ -374,6 +406,8 @@ WHERE
 	COALESCE(prog_lang, '{}') @> prog_lang_filter
 	AND
 	COALESCE(licenses, '{}') @> license_filter
+	AND
+	COALESCE(categories, '{}') @> category_filter
 GROUP BY
 	keyword
 ;
@@ -387,7 +421,8 @@ CREATE FUNCTION com_software_languages_filter(
 	search_filter TEXT DEFAULT '',
 	keyword_filter CITEXT[] DEFAULT '{}',
 	prog_lang_filter TEXT[] DEFAULT '{}',
-	license_filter VARCHAR[] DEFAULT '{}'
+	license_filter VARCHAR[] DEFAULT '{}',
+	category_filter VARCHAR[] DEFAULT '{}'
 ) RETURNS TABLE (
 	prog_language TEXT,
 	prog_language_cnt INTEGER
@@ -406,6 +441,8 @@ WHERE
 	COALESCE(prog_lang, '{}') @> prog_lang_filter
 	AND
 	COALESCE(licenses, '{}') @> license_filter
+	AND
+	COALESCE(categories, '{}') @> category_filter
 GROUP BY
 	prog_language
 ;
@@ -419,7 +456,8 @@ CREATE FUNCTION com_software_licenses_filter(
 	search_filter TEXT DEFAULT '',
 	keyword_filter CITEXT[] DEFAULT '{}',
 	prog_lang_filter TEXT[] DEFAULT '{}',
-	license_filter VARCHAR[] DEFAULT '{}'
+	license_filter VARCHAR[] DEFAULT '{}',
+	category_filter VARCHAR[] DEFAULT '{}'
 ) RETURNS TABLE (
 	license VARCHAR,
 	license_cnt INTEGER
@@ -438,8 +476,45 @@ WHERE
 	COALESCE(prog_lang, '{}') @> prog_lang_filter
 	AND
 	COALESCE(licenses, '{}') @> license_filter
+	AND
+	COALESCE(categories, '{}') @> category_filter
 GROUP BY
 	license
+;
+$$;
+
+-- REACTIVE CATEGORIES FILTER WITH COUNTS FOR SOFTWARE
+-- PROVIDES AVAILABLE CATEGORIES FOR APPLIED FILTERS
+CREATE FUNCTION com_software_categories_filter(
+	community_id UUID,
+	software_status request_status DEFAULT 'approved',
+	search_filter TEXT DEFAULT '',
+	keyword_filter CITEXT[] DEFAULT '{}',
+	prog_lang_filter TEXT[] DEFAULT '{}',
+	license_filter VARCHAR[] DEFAULT '{}',
+	category_filter VARCHAR[] DEFAULT '{}'
+) RETURNS TABLE (
+	category VARCHAR,
+	category_cnt INTEGER
+) LANGUAGE sql STABLE AS
+$$
+SELECT
+	UNNEST(categories) AS category,
+	COUNT(id) AS category_cnt
+FROM
+	software_by_community_search(community_id,search_filter)
+WHERE
+	software_by_community_search.status = software_status
+	AND
+	COALESCE(keywords, '{}') @> keyword_filter
+	AND
+	COALESCE(prog_lang, '{}') @> prog_lang_filter
+	AND
+	COALESCE(licenses, '{}') @> license_filter
+	AND
+	COALESCE(categories, '{}') @> category_filter
+GROUP BY
+	category
 ;
 $$;
 

--- a/database/108-community-views.sql
+++ b/database/108-community-views.sql
@@ -500,7 +500,8 @@ CREATE FUNCTION com_software_categories_filter(
 $$
 SELECT
 	UNNEST(categories) AS category,
-	COUNT(id) AS category_cnt
+	-- count per software on unique software id
+	COUNT(DISTINCT(id)) AS category_cnt
 FROM
 	software_by_community_search(community_id,search_filter)
 WHERE

--- a/database/113-organisation-views.sql
+++ b/database/113-organisation-views.sql
@@ -410,7 +410,8 @@ CREATE FUNCTION org_project_categories_filter(
 $$
 SELECT
 	UNNEST(categories) AS category,
-	COUNT(id) AS category_cnt
+	-- count per project on unique project id
+	COUNT(DISTINCT(id)) AS category_cnt
 FROM
 	projects_by_organisation_search(organisation_id,search_filter)
 WHERE
@@ -719,7 +720,8 @@ CREATE FUNCTION org_software_categories_filter(
 $$
 SELECT
 	UNNEST(categories) AS category,
-	COUNT(id) AS category_cnt
+	-- count per software on unique software id
+	COUNT(DISTINCT(id)) AS category_cnt
 FROM
 	software_by_organisation_search(organisation_id,search_filter)
 WHERE

--- a/frontend/__tests__/OrganisationPage.test.tsx
+++ b/frontend/__tests__/OrganisationPage.test.tsx
@@ -29,6 +29,10 @@ jest.mock('~/components/GlobalSearchAutocomplete/useHasRemotes')
 // use DEFAULT MOCK for login providers list
 // required when AppHeader component is used
 jest.mock('~/auth/api/useLoginProviders')
+// mock project categories api
+jest.mock('~/components/organisation/projects/filters/useOrgProjectCategoriesList')
+// mock software categories api
+jest.mock('~/components/organisation/software/filters/useOrgSoftwareCategoriesList')
 
 const mockProps = {
   organisation: mockOrganisation as OrganisationForContext,

--- a/frontend/components/category/CategoryEditTreeNode.tsx
+++ b/frontend/components/category/CategoryEditTreeNode.tsx
@@ -118,7 +118,23 @@ export default function CategoryEditTreeNode({node, community, organisation, lab
           }}
           onClick={() => setExpandChildren(!expandChildren)}
         >
-          <ListItemText primary={categoryData.short_name} secondary={categoryData.name} />
+          <ListItemText
+            primary={categoryData.short_name}
+            secondary={
+              <>
+                <span>{categoryData.name}</span>
+                {/* only for top level item of organisation */}
+                {organisation && categoryData.parent===null ?
+                  <>
+                    <br/>
+                    <span className="pr-2">For software: {categoryData.allow_software ? 'Yes' : 'No'}</span>
+                    <span>For projects: {categoryData.allow_projects ? 'Yes' : 'No'}</span>
+                  </>
+                  : null
+                }
+              </>
+            }
+          />
           <ListItemSecondaryAction sx={{
             display: 'flex',
             gap:'0.25rem'

--- a/frontend/components/communities/software/filters/apiCommunitySoftwareFilters.ts
+++ b/frontend/components/communities/software/filters/apiCommunitySoftwareFilters.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,6 +9,7 @@ import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import {buildSoftwareFilter} from '~/components/software/overview/filters/softwareFiltersApi'
 import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
+import {CategoryOption} from '~/components/filter/CategoriesFilter'
 import {CommunityRequestStatus} from '../apiCommunitySoftware'
 
 export type CommunitySoftwareFilterProps = {
@@ -18,21 +19,17 @@ export type CommunitySoftwareFilterProps = {
   keywords?: string[] | null
   prog_lang?: string[] | null
   licenses?: string[] | null
+  categories?: string[] | null
   token?:string
 }
 
-export function buildCommunitySoftwareFilter({id, software_status, search, keywords, prog_lang, licenses}: CommunitySoftwareFilterProps) {
+export function buildCommunitySoftwareFilter({id, software_status, ...params}: CommunitySoftwareFilterProps) {
   const filter = {
     // additional organisation filter
     community_id: id,
     software_status,
     // add default software filter params
-    ...buildSoftwareFilter({
-      search,
-      keywords,
-      prog_lang,
-      licenses
-    })
+    ...buildSoftwareFilter(params)
   }
   // console.group('buildCommunitySoftwareFilter')
   // console.log('filter...', filter)
@@ -40,21 +37,12 @@ export function buildCommunitySoftwareFilter({id, software_status, search, keywo
   return filter
 }
 
-export async function comSoftwareKeywordsFilter({
-  id, software_status, search, keywords, prog_lang, licenses, token
-}: CommunitySoftwareFilterProps) {
+export async function comSoftwareKeywordsFilter({token,...params}: CommunitySoftwareFilterProps) {
   try {
 
     const query = 'rpc/com_software_keywords_filter?order=keyword'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildCommunitySoftwareFilter({
-      id,
-      software_status,
-      search,
-      keywords,
-      prog_lang,
-      licenses
-    })
+    const filter = buildCommunitySoftwareFilter(params)
 
     const resp = await fetch(url, {
       method: 'POST',
@@ -77,19 +65,11 @@ export async function comSoftwareKeywordsFilter({
   }
 }
 
-export async function comSoftwareLanguagesFilter({
-  id,software_status,search, keywords, prog_lang, licenses, token}: CommunitySoftwareFilterProps) {
+export async function comSoftwareLanguagesFilter({token,...params}: CommunitySoftwareFilterProps) {
   try {
     const query = 'rpc/com_software_languages_filter?order=prog_language'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildCommunitySoftwareFilter({
-      id,
-      software_status,
-      search,
-      keywords,
-      prog_lang,
-      licenses
-    })
+    const filter = buildCommunitySoftwareFilter(params)
 
     const resp = await fetch(url, {
       method: 'POST',
@@ -112,19 +92,11 @@ export async function comSoftwareLanguagesFilter({
   }
 }
 
-export async function comSoftwareLicensesFilter({
-  id,software_status,search, keywords, prog_lang, licenses, token}: CommunitySoftwareFilterProps) {
+export async function comSoftwareLicensesFilter({token,...params}: CommunitySoftwareFilterProps) {
   try {
     const query = 'rpc/com_software_licenses_filter?order=license'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildCommunitySoftwareFilter({
-      id,
-      software_status,
-      search,
-      keywords,
-      prog_lang,
-      licenses
-    })
+    const filter = buildCommunitySoftwareFilter(params)
 
     const resp = await fetch(url, {
       method: 'POST',
@@ -147,4 +119,29 @@ export async function comSoftwareLicensesFilter({
   }
 }
 
+export async function comSoftwareCategoriesFilter({token,...params}: CommunitySoftwareFilterProps) {
+  try {
+    const query = 'rpc/com_software_categories_filter?order=category'
+    const url = `${getBaseUrl()}/${query}`
+    const filter = buildCommunitySoftwareFilter(params)
 
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: createJsonHeaders(token),
+      // we pass params in the body of POST
+      body: JSON.stringify(filter)
+    })
+
+    if (resp.status === 200) {
+      const json: CategoryOption[] = await resp.json()
+      return json
+    }
+
+    logger(`comSoftwareCategoriesFilter: ${resp.status} ${resp.statusText}`, 'warn')
+    return []
+
+  } catch (e: any) {
+    logger(`comSoftwareCategoriesFilter: ${e?.message}`, 'error')
+    return []
+  }
+}

--- a/frontend/components/communities/software/filters/index.tsx
+++ b/frontend/components/communities/software/filters/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,29 +10,42 @@ import FilterHeader from '~/components/filter/FilterHeader'
 import KeywordsFilter, {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import LicensesFilter, {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 import ProgrammingLanguagesFilter, {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
+import CategoriesFilter, {CategoryOption} from '~/components/filter/CategoriesFilter'
 import useFilterQueryChange from '~/components/filter/useFilterQueryChange'
 
 import useSoftwareParams from '~/components/organisation/software/filters/useSoftwareParams'
 import OrderCommunitySoftwareBy from './OrderCommunitySoftwareBy'
+import useCommunityHasCategories from './useCommunityHasCategories'
 
 
 type CommunitySoftwareFiltersProps = {
   keywordsList: KeywordFilterOption[]
   languagesList: LanguagesFilterOption[]
   licensesList: LicensesFilterOption[]
+  categoryList: CategoryOption[]
 }
 
 export default function CommunitySoftwareFilters({
-  keywordsList,languagesList,licensesList
+  keywordsList,languagesList,licensesList,categoryList
 }:CommunitySoftwareFiltersProps) {
   const router = useRouter()
+  const hasCategories = useCommunityHasCategories()
   const {handleQueryChange} = useFilterQueryChange()
   // extract query params
-  const {filterCnt,keywords_json,prog_lang_json,licenses_json} = useSoftwareParams()
+  const {
+    filterCnt,keywords_json,prog_lang_json,
+    licenses_json,categories_json
+  } = useSoftwareParams()
   // decode query params
   const keywords = decodeJsonParam(keywords_json, [])
   const prog_lang = decodeJsonParam(prog_lang_json, [])
   const licenses= decodeJsonParam(licenses_json,[])
+  const categories= decodeJsonParam(categories_json,[])
+
+  // console.group('CommunitySoftwareFilters')
+  // console.log('hasCategories...', hasCategories)
+  // console.log('categoryList...', categoryList)
+  // console.groupEnd()
 
   // debugger
   function clearDisabled() {
@@ -83,6 +96,18 @@ export default function CommunitySoftwareFilters({
           handleQueryChange={handleQueryChange}
         />
       </div>
+
+      {hasCategories ?
+        <div>
+          <CategoriesFilter
+            title="Categories"
+            categories={categories}
+            categoryList={categoryList}
+            handleQueryChange={handleQueryChange}
+          />
+        </div>
+        :null
+      }
     </>
   )
 }

--- a/frontend/components/communities/software/filters/useCommunityHasCategories.tsx
+++ b/frontend/components/communities/software/filters/useCommunityHasCategories.tsx
@@ -1,0 +1,29 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {loadCategoryRoots} from '~/components/category/apiCategories'
+import {useCommunityContext} from '../../context'
+
+
+export default function useCommunityHasCategories(){
+  const {community:{id}} = useCommunityContext()
+  const [hasCategories, setHasCategories] = useState(false)
+
+  useEffect(()=>{
+    let abort = false
+
+    if (id){
+      loadCategoryRoots({community:id})
+        .then(roots=>{
+          if (abort) return
+          setHasCategories(roots.length > 0)
+        })
+    }
+    return ()=>{abort=true}
+  },[id])
+
+  return hasCategories
+}

--- a/frontend/components/communities/software/index.tsx
+++ b/frontend/components/communities/software/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +16,7 @@ import {useCommunityContext} from '~/components/communities/context'
 import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
 import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
+import {CategoryOption} from '~/components/filter/CategoriesFilter'
 import useFilterQueryChange from '~/components/filter/useFilterQueryChange'
 
 import CommunitySoftwareFilters from './filters'
@@ -32,11 +33,13 @@ type CommunitySoftwareProps={
   keywordsList: KeywordFilterOption[],
   languagesList: LanguagesFilterOption[],
   licensesList: LicensesFilterOption[],
+  categoryList: CategoryOption[]
 }
 
 export default function CommunitySoftware({
   software,count,page,rows,rsd_page_layout,
-  keywordsList, languagesList, licensesList
+  keywordsList, languagesList, licensesList,
+  categoryList
 }:CommunitySoftwareProps) {
   const smallScreen = useMediaQuery('(max-width:640px)')
   const {isMaintainer} = useCommunityContext()
@@ -66,6 +69,7 @@ export default function CommunitySoftware({
               keywordsList={keywordsList}
               languagesList={languagesList}
               licensesList={licensesList}
+              categoryList={categoryList}
             />
           </FiltersPanel>
         }
@@ -78,6 +82,7 @@ export default function CommunitySoftware({
             keywordsList={keywordsList}
             languagesList={languagesList}
             licensesList={licensesList}
+            categoryList={categoryList}
             smallScreen={smallScreen}
           />
           {/* software overview/content */}

--- a/frontend/components/communities/software/search/index.tsx
+++ b/frontend/components/communities/software/search/index.tsx
@@ -16,6 +16,7 @@ import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
 import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 import useFilterQueryChange from '~/components/filter/useFilterQueryChange'
+import {CategoryOption} from '~/components/filter/CategoriesFilter'
 import CommunitySoftwareFilters from '../filters/index'
 
 type SearchSoftwareSectionProps = {
@@ -23,6 +24,7 @@ type SearchSoftwareSectionProps = {
   keywordsList: KeywordFilterOption[],
   languagesList: LanguagesFilterOption[],
   licensesList: LicensesFilterOption[],
+  categoryList: CategoryOption[],
   smallScreen: boolean
   layout: ProjectLayoutType
   setView: (view:ProjectLayoutType) => void
@@ -30,7 +32,7 @@ type SearchSoftwareSectionProps = {
 
 export default function SearchCommunitySoftwareSection({
   count, layout, keywordsList, smallScreen,
-  languagesList, licensesList, setView
+  languagesList, licensesList, categoryList, setView
 }: SearchSoftwareSectionProps) {
   const {search,page,rows,filterCnt} = useSoftwareParams()
   const {handleQueryChange} = useFilterQueryChange()
@@ -86,6 +88,7 @@ export default function SearchCommunitySoftwareSection({
             keywordsList={keywordsList}
             languagesList={languagesList}
             licensesList={licensesList}
+            categoryList={categoryList}
           />
         </FiltersModal>
         : undefined

--- a/frontend/components/filter/CategoriesFilter.tsx
+++ b/frontend/components/filter/CategoriesFilter.tsx
@@ -65,9 +65,10 @@ export default function CategoriesFilter({categories,categoryList,handleQueryCha
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={(props, option) => (
+        // remove key from other props
+        renderOption={({key,...props}, option) => (
           <FilterOption
-            key={option.category}
+            key={key ?? option.category}
             props={props}
             label={option.category}
             count={option.category_cnt}

--- a/frontend/components/filter/CategoriesFilter.tsx
+++ b/frontend/components/filter/CategoriesFilter.tsx
@@ -1,0 +1,88 @@
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import Autocomplete from '@mui/material/Autocomplete'
+import TextField from '@mui/material/TextField'
+
+import FilterTitle from '~/components/filter/FilterTitle'
+import FilterOption from '~/components/filter/FilterOption'
+
+export type CategoryOption = {
+  category: string,
+  category_cnt: number
+}
+
+type CategoryFilterProps = Readonly<{
+  categories: string[],
+  categoryList: CategoryOption[]
+  handleQueryChange: (key: string, value: string | string[]) => void
+  title?: string
+}>
+
+export default function CategoriesFilter({categories,categoryList,handleQueryChange,title='Categories'}: CategoryFilterProps) {
+
+  const [selected, setSelected] = useState<CategoryOption[]>([])
+  const [options, setOptions] = useState<CategoryOption[]>(categoryList)
+
+  // console.group('CategoryFilter')
+  // console.log('categoryList...', categoryList)
+  // console.log('options...', options)
+  // console.groupEnd()
+
+  useEffect(() => {
+    if (categories.length > 0 && categoryList.length) {
+      const selectedCategories = categoryList.filter(option => {
+        return categories.includes(option.category)
+      })
+      setSelected(selectedCategories)
+    } else {
+      setSelected([])
+    }
+    setOptions(categoryList)
+  },[categories,categoryList])
+
+  return (
+    <>
+      <FilterTitle
+        title={title}
+        count={categoryList.length ?? ''}
+      />
+      <Autocomplete
+        className="mt-4"
+        value={selected}
+        size="small"
+        multiple
+        clearOnEscape
+        options={options}
+        getOptionLabel={(option) => (option.category)}
+        isOptionEqualToValue={(option, value) => {
+          return option.category === value.category
+        }}
+        defaultValue={[]}
+        filterSelectedOptions
+        renderOption={(props, option) => (
+          <FilterOption
+            key={option.category}
+            props={props}
+            label={option.category}
+            count={option.category_cnt}
+            capitalize={false}
+          />
+        )}
+        renderInput={(params) => (
+          <TextField {...params} placeholder={title} />
+        )}
+        onChange={(event, newValue) => {
+          // extract values into string[] for url query
+          const queryFilter = newValue.map(item => item.category)
+          handleQueryChange('categories', queryFilter)
+        }}
+      />
+    </>
+  )
+}

--- a/frontend/components/filter/FilterOption.test.tsx
+++ b/frontend/components/filter/FilterOption.test.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,16 @@ const mockProps = {
   // props: document.createAttribute('aria-label'),
   label: 'test label',
   count: 20,
-  capitalize: false
+  capitalize: false,
+  props:{
+    'tabIndex': -1,
+    'role': 'option',
+    'id': ':r1:-option-2',
+    'data-option-index': 2,
+    'aria-disabled': false,
+    'aria-selected': false,
+    'className': 'MuiAutocomplete-option'
+  }
 }
 
 it('renders filter option label', () => {

--- a/frontend/components/filter/FilterOption.tsx
+++ b/frontend/components/filter/FilterOption.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -14,9 +14,13 @@ type FilterOptionProps = {
   capitalize?: boolean
 }
 
-export default function FilterOption({props,label,count,capitalize=true}:FilterOptionProps) {
+export default function FilterOption({label,count,capitalize=true,props}:FilterOptionProps) {
+  // console.group('FilterOption')
+  // console.log('label...', label)
+  // console.log('props...', props)
+  // console.groupEnd()
   return (
-    <li className="flex w-full items-center content-between" {...props} >
+    <li className="flex w-full items-center content-between" {...props}>
       <div className={`text-sm flex-1 ${capitalize ? 'capitalize' :''}`}>
         {label}
       </div>

--- a/frontend/components/filter/KeywordsFilter.tsx
+++ b/frontend/components/filter/KeywordsFilter.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -78,9 +78,9 @@ export default function KeywordsFilter({keywords, keywordsList, handleQueryChang
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={(props, option) => (
+        renderOption={({key,...props}, option) => (
           <FilterOption
-            key={option.keyword}
+            key={key ?? option.keyword}
             props={props}
             label={option.keyword}
             count={option.keyword_cnt}

--- a/frontend/components/filter/LicensesFilter.tsx
+++ b/frontend/components/filter/LicensesFilter.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -59,9 +59,9 @@ export default function LicensesFilter({licenses, licensesList,handleQueryChange
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={(props, option) => (
+        renderOption={({key,...props}, option) => (
           <FilterOption
-            key={option.license}
+            key={key ?? option.license}
             props={props}
             label={option.license}
             count={option.license_cnt}

--- a/frontend/components/filter/OrganisationsFilter.tsx
+++ b/frontend/components/filter/OrganisationsFilter.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -67,9 +67,9 @@ export default function OrganisationFilter({
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={(props, option) => (
+        renderOption={({key,...props}, option) => (
           <FilterOption
-            key={option.organisation}
+            key={key ?? option.organisation}
             props={props}
             label={option.organisation}
             count={option.organisation_cnt}

--- a/frontend/components/filter/ProgrammingLanguagesFilter.tsx
+++ b/frontend/components/filter/ProgrammingLanguagesFilter.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -59,9 +59,9 @@ export default function ProgrammingLanguagesFilter({prog_lang,languagesList,hand
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={(props, option) => (
+        renderOption={({key, ...props}, option) => (
           <FilterOption
-            key={option.prog_language}
+            key={key ?? option.prog_language}
             props={props}
             label={option.prog_language}
             count={option.prog_language_cnt}

--- a/frontend/components/filter/ResearchDomainFilter.tsx
+++ b/frontend/components/filter/ResearchDomainFilter.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -66,9 +66,9 @@ export default function ResearchDomainFilter({domains, domainsList,handleQueryCh
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={(props, option) => (
+        renderOption={({key, ...props}, option) => (
           <FilterOption
-            key={option.domain}
+            key={key ?? option.domain}
             props={props}
             label={option.domain}
             count={option.domain_cnt}

--- a/frontend/components/organisation/apiOrganisations.ts
+++ b/frontend/components/organisation/apiOrganisations.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -265,6 +265,7 @@ export type OrganisationApiParams = {
   licenses?: string[] | null
   domains?: string[] | null
   organisations?: string[] | null
+  categories?: string[] | null
   order?: string
   page: number,
   rows: number,
@@ -274,7 +275,7 @@ export type OrganisationApiParams = {
 
 export async function getSoftwareForOrganisation({
   organisation, searchFor, keywords, prog_lang,
-  licenses, order, page, rows, token,
+  licenses, categories, order, page, rows, token,
   isMaintainer
 }: OrganisationApiParams) {
   try {
@@ -296,6 +297,7 @@ export async function getSoftwareForOrganisation({
       keywords,
       prog_lang,
       licenses,
+      categories,
       order,
       limit: rows,
       offset: page ? page * rows : undefined
@@ -346,7 +348,7 @@ export async function getSoftwareForOrganisation({
 export async function getProjectsForOrganisation({
   organisation, searchFor, keywords, domains,
   organisations, order, page, rows, token,
-  isMaintainer, project_status
+  isMaintainer, project_status, categories
 }: OrganisationApiParams) {
   try {
     // baseUrl
@@ -368,6 +370,7 @@ export async function getProjectsForOrganisation({
       keywords,
       domains,
       organisations,
+      categories,
       order,
       limit: rows,
       offset: page ? page * rows : undefined

--- a/frontend/components/organisation/projects/OrganisationProjectsIndex.test.tsx
+++ b/frontend/components/organisation/projects/OrganisationProjectsIndex.test.tsx
@@ -16,6 +16,8 @@ import mockProjects from './__mocks__/mockProjects.json'
 
 // mock user agreement call
 jest.mock('~/components/user/settings/useUserAgreements')
+// mock project categories api
+jest.mock('~/components/organisation/projects/filters/useOrgProjectCategoriesList')
 
 const mockProps = {
   organisation: mockOrganisation,

--- a/frontend/components/organisation/projects/filters/__mocks__/useOrgProjectCategoriesList.tsx
+++ b/frontend/components/organisation/projects/filters/__mocks__/useOrgProjectCategoriesList.tsx
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export default function useOrgProjectCategoriesList(){
+  return {
+    hasCategories:false,
+    categoryList:[]
+  }
+
+}

--- a/frontend/components/organisation/projects/filters/index.tsx
+++ b/frontend/components/organisation/projects/filters/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -11,6 +11,7 @@ import {decodeJsonParam} from '~/utils/extractQueryParam'
 import KeywordsFilter from '~/components/filter/KeywordsFilter'
 import ResearchDomainFilter from '~/components/filter/ResearchDomainFilter'
 import OrganisationsFilter from '~/components/filter/OrganisationsFilter'
+import CategoriesFilter from '~/components/filter/CategoriesFilter'
 import ProjectStatusFilter from '~/components/projects/overview/filters/ProjectStatusFilter'
 import useQueryChange from '../useQueryChange'
 import useProjectParams from '../useProjectParams'
@@ -19,18 +20,26 @@ import useOrgProjectKeywordsList from './useOrgProjectKeywordsList'
 import useOrgProjectDomainsFilter from './useOrgProjectDomainsList'
 import useOrgProjectOrganisationList from './useOrgProjectOrganisationsList'
 import useOrgProjectStatusList from './useOrgProjectStatusList'
+import useOrgProjectCategoriesList from './useOrgProjectCategoriesList'
 
 export default function OrgProjectFilters() {
   const {resetFilters, handleQueryChange} = useQueryChange()
-  const {project_status,filterCnt,keywords_json,domains_json,organisations_json} = useProjectParams()
+  const {project_status,filterCnt,keywords_json,domains_json,organisations_json,categories_json} = useProjectParams()
   const {keywordsList} = useOrgProjectKeywordsList()
   const {domainsList} = useOrgProjectDomainsFilter()
   const {organisationList} = useOrgProjectOrganisationList()
   const {statusList} = useOrgProjectStatusList()
+  const {hasCategories, categoryList} = useOrgProjectCategoriesList()
 
   const keywords = decodeJsonParam(keywords_json, [])
   const domains = decodeJsonParam(domains_json, [])
-  const organisations= decodeJsonParam(organisations_json,[])
+  const organisations = decodeJsonParam(organisations_json,[])
+  const categories = decodeJsonParam(categories_json,[])
+
+  // console.group('OrgProjectFilters')
+  // console.log('hasCategories...', hasCategories)
+  // console.log('categoryList...', categoryList)
+  // console.groupEnd()
 
   // debugger
   function clearDisabled() {
@@ -77,6 +86,18 @@ export default function OrgProjectFilters() {
           handleQueryChange={handleQueryChange}
         />
       </div>
+      {/* Custom organisation categories */}
+      {hasCategories ?
+        <div>
+          <CategoriesFilter
+            title="Categories"
+            categories={categories}
+            categoryList={categoryList}
+            handleQueryChange={handleQueryChange}
+          />
+        </div>
+        : null
+      }
     </>
   )
 }

--- a/frontend/components/organisation/projects/filters/useOrgProjectCategoriesList.tsx
+++ b/frontend/components/organisation/projects/filters/useOrgProjectCategoriesList.tsx
@@ -1,0 +1,117 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+
+import {useSession} from '~/auth'
+import logger from '~/utils/logger'
+import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import {decodeJsonParam} from '~/utils/extractQueryParam'
+import {loadCategoryRoots} from '~/components/category/apiCategories'
+import {CategoryOption} from '~/components/filter/CategoriesFilter'
+import useOrganisationContext from '~/components/organisation/context/useOrganisationContext'
+import useProjectParams from '../useProjectParams'
+import {buildOrgProjectFilter, OrgProjectFilterProps} from './useOrgProjectKeywordsList'
+
+async function orgProjectCategoriesFilter({token,...params}:OrgProjectFilterProps){
+  try {
+    const query = 'rpc/org_project_categories_filter?order=category_cnt.desc,category'
+    const url = `${getBaseUrl()}/${query}`
+    const filter = buildOrgProjectFilter(params)
+
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: createJsonHeaders(token),
+      // we pass params in the body of POST
+      body: JSON.stringify(filter)
+    })
+
+    if (resp.status === 200) {
+      const json: CategoryOption[] = await resp.json()
+      return json
+    }
+
+    logger(`orgProjectCategoriesFilter: ${resp.status} ${resp.statusText}`, 'warn')
+    return []
+
+  } catch (e: any) {
+    logger(`orgProjectCategoriesFilter: ${e?.message}`, 'error')
+    return []
+  }
+}
+
+
+function useOrgHasCategoriesFilter(id?:string){
+  const [hasCategories, setHasCategories] = useState(false)
+
+  useEffect(()=>{
+    let abort = false
+
+    if (id){
+      loadCategoryRoots({organisation:id})
+        .then(roots=>{
+          const categories = roots.filter(item=>item.getValue().allow_projects)
+          if (abort) return
+          setHasCategories(categories.length > 0)
+        })
+    }
+
+    return ()=>{abort=true}
+  },[id])
+
+  return hasCategories
+}
+
+
+export default function useOrgProjectCategoriesList(){
+  const {token} = useSession()
+  const {id} = useOrganisationContext()
+  const hasCategories = useOrgHasCategoriesFilter(id)
+  const {
+    search,project_status,keywords_json,
+    domains_json,organisations_json,categories_json
+  } = useProjectParams()
+  const [categoryList, setCategoryList] = useState<CategoryOption[]>([])
+
+  useEffect(()=>{
+    let abort = false
+
+    if (id) {
+      const keywords = decodeJsonParam(keywords_json, null)
+      const domains = decodeJsonParam(domains_json, null)
+      const organisations = decodeJsonParam(organisations_json, null)
+      const categories = decodeJsonParam(categories_json, null)
+
+      // get filter options
+      orgProjectCategoriesFilter({
+        id,
+        search,
+        keywords,
+        domains,
+        organisations,
+        project_status,
+        categories,
+        token
+      }).then(resp => {
+        // abort
+        if (abort) return
+        setCategoryList(resp)
+      })
+    }
+
+    return ()=>{abort=true}
+  },[
+    search, keywords_json,
+    domains_json, organisations_json,
+    project_status, categories_json,
+    id, token
+  ])
+
+  return {
+    hasCategories,
+    categoryList
+  }
+
+}

--- a/frontend/components/organisation/projects/filters/useOrgProjectDomainsList.tsx
+++ b/frontend/components/organisation/projects/filters/useOrgProjectDomainsList.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,13 +19,10 @@ import useProjectParams from '../useProjectParams'
 import {OrgProjectFilterProps, buildOrgProjectFilter} from './useOrgProjectKeywordsList'
 
 
-export async function orgProjectDomainsList({id,search,project_status,keywords,domains,organisations}: OrgProjectFilterProps) {
+export async function orgProjectDomainsList(params: OrgProjectFilterProps) {
   try {
     // get possible options
-    const domainsOptions = await orgProjectDomainsFilter({
-      id, search, project_status,
-      keywords, domains, organisations
-    })
+    const domainsOptions = await orgProjectDomainsFilter(params)
 
     if (domainsOptions.length > 0) {
       const keys = domainsOptions.map(item => item.domain)
@@ -46,18 +43,11 @@ export async function orgProjectDomainsList({id,search,project_status,keywords,d
   }
 }
 
-async function orgProjectDomainsFilter({id,search,project_status,keywords,domains,organisations}: OrgProjectFilterProps) {
+async function orgProjectDomainsFilter(params: OrgProjectFilterProps) {
   try {
     const query = 'rpc/org_project_domains_filter?order=domain'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildOrgProjectFilter({
-      id,
-      search,
-      keywords,
-      domains,
-      organisations,
-      project_status
-    })
+    const filter = buildOrgProjectFilter(params)
 
     // console.group('softwareKeywordsFilter')
     // console.log('filter...', JSON.stringify(filter))
@@ -87,7 +77,10 @@ async function orgProjectDomainsFilter({id,search,project_status,keywords,domain
 export default function useOrgProjectDomainsFilter(){
   const {token} = useSession()
   const {id} = useOrganisationContext()
-  const {search,project_status,keywords_json,domains_json,organisations_json} = useProjectParams()
+  const {
+    search,project_status,keywords_json,domains_json,
+    organisations_json,categories_json
+  } = useProjectParams()
   const [domainsList, setDomainsList] = useState<ResearchDomainOption[]>([])
 
   // console.group('useOrgProjectDomainsFilter')
@@ -105,6 +98,7 @@ export default function useOrgProjectDomainsFilter(){
       const keywords = decodeJsonParam(keywords_json,null)
       const domains = decodeJsonParam(domains_json, null)
       const organisations = decodeJsonParam(organisations_json, null)
+      const categories = decodeJsonParam(categories_json, null)
 
       // get filter options
       orgProjectDomainsList({
@@ -114,6 +108,7 @@ export default function useOrgProjectDomainsFilter(){
         domains,
         organisations,
         project_status,
+        categories,
         token
       }).then(resp => {
         // abort
@@ -128,7 +123,8 @@ export default function useOrgProjectDomainsFilter(){
   }, [
     search, keywords_json,
     domains_json, organisations_json,
-    id,token, project_status
+    project_status, categories_json,
+    id,token
   ])
 
   return {

--- a/frontend/components/organisation/projects/filters/useOrgProjectOrganisationsList.tsx
+++ b/frontend/components/organisation/projects/filters/useOrgProjectOrganisationsList.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,20 +14,11 @@ import useOrganisationContext from '../../context/useOrganisationContext'
 import useProjectParams from '../useProjectParams'
 import {OrgProjectFilterProps, buildOrgProjectFilter} from './useOrgProjectKeywordsList'
 
-export async function orgProjectOrganisationsFilter({
-  id,search,project_status,keywords,domains,organisations,token
-}: OrgProjectFilterProps) {
+export async function orgProjectOrganisationsFilter({token, ...params}: OrgProjectFilterProps) {
   try {
     const query = 'rpc/org_project_participating_organisations_filter?order=organisation'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildOrgProjectFilter({
-      id,
-      search,
-      keywords,
-      domains,
-      organisations,
-      project_status
-    })
+    const filter = buildOrgProjectFilter(params)
 
     // console.group('softwareKeywordsFilter')
     // console.log('filter...', JSON.stringify(filter))
@@ -58,7 +49,10 @@ export async function orgProjectOrganisationsFilter({
 export default function useOrgProjectOrganisationList() {
   const {token} = useSession()
   const {id} = useOrganisationContext()
-  const {search,project_status,keywords_json,domains_json,organisations_json} = useProjectParams()
+  const {
+    search,project_status,keywords_json,
+    domains_json,organisations_json,categories_json
+  } = useProjectParams()
   const [organisationList, setOrganisationList] = useState<OrganisationOption[]>([])
 
   // console.group('useOrgProjectOrganisationList')
@@ -76,6 +70,7 @@ export default function useOrgProjectOrganisationList() {
       const keywords = decodeJsonParam(keywords_json,null)
       const domains = decodeJsonParam(domains_json, null)
       const organisations = decodeJsonParam(organisations_json, null)
+      const categories = decodeJsonParam(categories_json, null)
 
       // get filter options
       orgProjectOrganisationsFilter({
@@ -85,6 +80,7 @@ export default function useOrgProjectOrganisationList() {
         domains,
         organisations,
         project_status,
+        categories,
         token
       }).then(resp => {
         // abort
@@ -99,7 +95,8 @@ export default function useOrgProjectOrganisationList() {
   }, [
     search, keywords_json,
     domains_json, organisations_json,
-    id,token,project_status
+    project_status, categories_json,
+    id, token
   ])
 
   return {

--- a/frontend/components/organisation/projects/filters/useOrgProjectStatusList.tsx
+++ b/frontend/components/organisation/projects/filters/useOrgProjectStatusList.tsx
@@ -1,17 +1,17 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useEffect, useState} from 'react'
 import {useSession} from '~/auth'
+import logger from '~/utils/logger'
+import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import {decodeJsonParam} from '~/utils/extractQueryParam'
+import {StatusFilterOption} from '~/components/projects/overview/filters/ProjectStatusFilter'
 import useOrganisationContext from '../../context/useOrganisationContext'
 import useProjectParams from '../useProjectParams'
-import {StatusFilterOption} from '~/components/projects/overview/filters/ProjectStatusFilter'
-import {decodeJsonParam} from '~/utils/extractQueryParam'
-import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
 import {buildOrgProjectFilter} from './useOrgProjectKeywordsList'
-import logger from '~/utils/logger'
 
 type OrgProjectStatusFilterProps = {
   id: string
@@ -19,25 +19,16 @@ type OrgProjectStatusFilterProps = {
   keywords?: string[] | null
   domains?: string[] | null
   organisations?: string[] | null
+  categories?: string[] | null
   token?:string
 }
 
 
-export async function orgProjectStatusFilter({
-  id, search, keywords,
-  domains, organisations, token
-}: OrgProjectStatusFilterProps) {
+export async function orgProjectStatusFilter({token, ...params}: OrgProjectStatusFilterProps) {
   try {
     const query = 'rpc/org_project_status_filter?order=project_status'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildOrgProjectFilter({
-      id,
-      search,
-      keywords,
-      domains,
-      organisations
-
-    })
+    const filter = buildOrgProjectFilter(params)
 
     const resp = await fetch(url, {
       method: 'POST',
@@ -64,7 +55,7 @@ export async function orgProjectStatusFilter({
 export default function useOrgProjectStatusList() {
   const {token} = useSession()
   const {id} = useOrganisationContext()
-  const {search,keywords_json,domains_json,organisations_json} = useProjectParams()
+  const {search,keywords_json,domains_json,organisations_json,categories_json} = useProjectParams()
   const [statusList, setStatusList] = useState<StatusFilterOption[]>([])
 
   // console.group('useOrgProjectStatusList')
@@ -82,6 +73,7 @@ export default function useOrgProjectStatusList() {
       const keywords = decodeJsonParam(keywords_json, null)
       const domains = decodeJsonParam(domains_json, null)
       const organisations = decodeJsonParam(organisations_json, null)
+      const categories = decodeJsonParam(categories_json, null)
 
       // get filter options
       orgProjectStatusFilter({
@@ -90,6 +82,7 @@ export default function useOrgProjectStatusList() {
         keywords,
         domains,
         organisations,
+        categories,
         token
       }).then(resp => {
         // abort
@@ -104,6 +97,7 @@ export default function useOrgProjectStatusList() {
   }, [
     search, keywords_json,
     domains_json, organisations_json,
+    categories_json,
     id,token
   ])
 

--- a/frontend/components/organisation/projects/useOrganisationProjects.tsx
+++ b/frontend/components/organisation/projects/useOrganisationProjects.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +24,10 @@ type State = {
 export default function useOrganisationProjects() {
   const {token} = useSession()
   const {id,isMaintainer} = useOrganisationContext()
-  const {search, keywords_json, domains_json, organisations_json, project_status, order, page, rows} = useProjectParams()
+  const {
+    search, keywords_json, domains_json, organisations_json,
+    project_status, categories_json, order, page, rows
+  } = useProjectParams()
   // we need to memo orderOptions array to avoid useEffect dependency loop
   const orderOptions = useMemo(()=>getProjectOrderOptions(isMaintainer),[isMaintainer])
 
@@ -40,7 +43,7 @@ export default function useOrganisationProjects() {
 
     async function getProjects() {
       if (id) {
-        // set loding done
+        // set loading start
         setLoading(true)
 
         if (order) {
@@ -52,12 +55,13 @@ export default function useOrganisationProjects() {
         }
 
         const projects: State = await getProjectsForOrganisation({
-          organisation:id,
+          organisation: id,
           searchFor: search ?? undefined,
           project_status: project_status ?? undefined,
           keywords: decodeJsonParam(keywords_json,null),
           domains: decodeJsonParam(domains_json,null),
           organisations: decodeJsonParam(organisations_json,null),
+          categories: decodeJsonParam(categories_json, null),
           order: orderBy ?? undefined,
           // api works with zero
           page:page ? page-1 : 0,
@@ -69,7 +73,7 @@ export default function useOrganisationProjects() {
         if (abort) return
         // set state
         setState(projects)
-        // set loding done
+        // set loading done
         setLoading(false)
       }
     }
@@ -84,7 +88,7 @@ export default function useOrganisationProjects() {
     search, keywords_json, domains_json,
     organisations_json, order, page, rows,
     id, token, isMaintainer, orderOptions,
-    project_status
+    project_status, categories_json
   ])
 
   return {

--- a/frontend/components/organisation/projects/useProjectParams.tsx
+++ b/frontend/components/organisation/projects/useProjectParams.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,7 +8,7 @@ import {getProjectsParams} from '~/utils/extractQueryParam'
 import {useUserSettings} from '../context/UserSettingsContext'
 
 export default function useProjectParams() {
-  // initalise router
+  // initialise router
   const router = useRouter()
   // get user preferences
   const {rsd_page_rows} = useUserSettings()
@@ -22,11 +22,12 @@ export default function useProjectParams() {
 
   function getFilterCount() {
     let count = 0
+    if (params?.search) count++
+    if (params?.project_status) count++
     if (params?.keywords_json) count++
     if (params?.domains_json) count++
     if (params?.organisations_json) count++
-    if (params?.search) count++
-    if (params?.project_status) count++
+    if (params?.categories_json) count++
     return count
   }
 

--- a/frontend/components/organisation/software/OrganisationSoftwareIndex.test.tsx
+++ b/frontend/components/organisation/software/OrganisationSoftwareIndex.test.tsx
@@ -14,12 +14,13 @@ import OrganisationSoftware from './index'
 import mockOrganisation from '../__mocks__/mockOrganisation'
 import mockSoftware from './__mocks__/mockSoftware.json'
 
+// mock software categories api
+jest.mock('~/components/organisation/software/filters/useOrgSoftwareCategoriesList')
 
 const mockProps = {
   organisation: mockOrganisation,
   isMaintainer: false
 }
-
 // MOCK getSoftwareForOrganisation
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mockUseOrganisationSoftware = jest.fn((props) => ({

--- a/frontend/components/organisation/software/filters/__mocks__/useOrgSoftwareCategoriesList.tsx
+++ b/frontend/components/organisation/software/filters/__mocks__/useOrgSoftwareCategoriesList.tsx
@@ -1,0 +1,11 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export default function useOrgSoftwareCategoriesList(){
+  return {
+    hasCategories: false,
+    categoryList: []
+  }
+}

--- a/frontend/components/organisation/software/filters/index.tsx
+++ b/frontend/components/organisation/software/filters/index.tsx
@@ -1,34 +1,42 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import FilterHeader from '~/components/filter/FilterHeader'
-
 import {decodeJsonParam} from '~/utils/extractQueryParam'
 import useQueryChange from '~/components/organisation/projects/useQueryChange'
 import KeywordsFilter from '~/components/filter/KeywordsFilter'
+import FilterHeader from '~/components/filter/FilterHeader'
 import ProgrammingLanguagesFilter from '~/components/filter/ProgrammingLanguagesFilter'
 import LicensesFilter from '~/components/filter/LicensesFilter'
+import CategoriesFilter from '~/components/filter/CategoriesFilter'
 
 import OrgOrderSoftwareBy from './OrgOrderSoftwareBy'
 import useSoftwareParams from './useSoftwareParams'
 import useOrgSoftwareKeywordsList from './useOrgSoftwareKeywordsList'
 import useOrgSoftwareLicensesList from './useOrgSoftwareLicensesList'
 import useOrgSoftwareLanguagesList from './useOrgSoftwareLanguagesList'
+import useOrgSoftwareCategoriesList from './useOrgSoftwareCategoriesList'
 
 export default function OrgSoftwareFilters() {
   const {resetFilters,handleQueryChange} = useQueryChange()
-  const {filterCnt,keywords_json,prog_lang_json,licenses_json} = useSoftwareParams()
+  const {filterCnt,keywords_json,prog_lang_json,licenses_json,categories_json} = useSoftwareParams()
   const {keywordsList} = useOrgSoftwareKeywordsList()
   const {languagesList} = useOrgSoftwareLanguagesList()
   const {licensesList} = useOrgSoftwareLicensesList()
+  const {hasCategories,categoryList} = useOrgSoftwareCategoriesList()
 
   const keywords = decodeJsonParam(keywords_json, [])
   const prog_lang = decodeJsonParam(prog_lang_json, [])
   const licenses= decodeJsonParam(licenses_json,[])
+  const categories = decodeJsonParam(categories_json,[])
+
+  // console.group('OrgSoftwareFilters')
+  // console.log('hasCategories...', hasCategories)
+  // console.log('categoryList...', categoryList)
+  // console.groupEnd()
 
   // debugger
   function clearDisabled() {
@@ -69,6 +77,18 @@ export default function OrgSoftwareFilters() {
           handleQueryChange={handleQueryChange}
         />
       </div>
+      {/* Custom organisation categories */}
+      {hasCategories ?
+        <div>
+          <CategoriesFilter
+            title="Categories"
+            categories={categories}
+            categoryList={categoryList}
+            handleQueryChange={handleQueryChange}
+          />
+        </div>
+        : null
+      }
     </>
   )
 }

--- a/frontend/components/organisation/software/filters/useOrgSoftwareCategoriesList.tsx
+++ b/frontend/components/organisation/software/filters/useOrgSoftwareCategoriesList.tsx
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+
+import {useSession} from '~/auth'
+import logger from '~/utils/logger'
+import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import {decodeJsonParam} from '~/utils/extractQueryParam'
+import {loadCategoryRoots} from '~/components/category/apiCategories'
+import {CategoryOption} from '~/components/filter/CategoriesFilter'
+import useOrganisationContext from '~/components/organisation/context/useOrganisationContext'
+import useSoftwareParams from './useSoftwareParams'
+import {buildOrgSoftwareFilter, OrgSoftwareFilterProps} from './useOrgSoftwareKeywordsList'
+
+async function orgSoftwareCategoriesFilter({token,...params}:OrgSoftwareFilterProps){
+  try {
+    const query = 'rpc/org_software_categories_filter?order=category_cnt.desc,category'
+    const url = `${getBaseUrl()}/${query}`
+    const filter = buildOrgSoftwareFilter(params)
+
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: createJsonHeaders(token),
+      // we pass params in the body of POST
+      body: JSON.stringify(filter)
+    })
+
+    if (resp.status === 200) {
+      const json: CategoryOption[] = await resp.json()
+      return json
+    }
+
+    logger(`orgSoftwareCategoriesFilter: ${resp.status} ${resp.statusText}`, 'warn')
+    return []
+
+  } catch (e: any) {
+    logger(`orgSoftwareCategoriesFilter: ${e?.message}`, 'error')
+    return []
+  }
+}
+
+
+function useOrgHasCategoriesFilter(id?:string){
+  const [hasCategories, setHasCategories] = useState(false)
+
+  useEffect(()=>{
+    let abort = false
+
+    if (id){
+      loadCategoryRoots({organisation:id})
+        .then(roots=>{
+          const categories = roots.filter(item=>item.getValue().allow_software)
+          if (abort) return
+          setHasCategories(categories.length > 0)
+        })
+    }
+
+    return ()=>{abort=true}
+  },[id])
+
+  return hasCategories
+}
+
+
+export default function useOrgSoftwareCategoriesList(){
+  const {token} = useSession()
+  const {id} = useOrganisationContext()
+  const hasCategories = useOrgHasCategoriesFilter(id)
+  const {
+    search,keywords_json,prog_lang_json,licenses_json,categories_json
+  } = useSoftwareParams()
+  const [categoryList, setCategoryList] = useState<CategoryOption[]>([])
+
+  useEffect(()=>{
+    let abort = false
+
+    if (id) {
+      const keywords = decodeJsonParam(keywords_json,null)
+      const prog_lang = decodeJsonParam(prog_lang_json, null)
+      const licenses = decodeJsonParam(licenses_json, null)
+      const categories = decodeJsonParam(categories_json, null)
+
+      // get filter options
+      orgSoftwareCategoriesFilter({
+        id,
+        search,
+        keywords,
+        prog_lang,
+        licenses,
+        categories,
+        token
+      }).then(resp => {
+        // abort
+        if (abort) return
+        setCategoryList(resp)
+      })
+    }
+
+    return ()=>{abort=true}
+  },[
+    search, keywords_json,
+    prog_lang_json, licenses_json,
+    categories_json,
+    id, token
+  ])
+
+  return {
+    hasCategories,
+    categoryList
+  }
+
+}

--- a/frontend/components/organisation/software/filters/useOrgSoftwareKeywordsList.tsx
+++ b/frontend/components/organisation/software/filters/useOrgSoftwareKeywordsList.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,9 +10,9 @@ import logger from '~/utils/logger'
 import {decodeJsonParam} from '~/utils/extractQueryParam'
 import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
 import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
+import {buildSoftwareFilter} from '~/components/software/overview/filters/softwareFiltersApi'
 import useOrganisationContext from '../../context/useOrganisationContext'
 import useSoftwareParams from './useSoftwareParams'
-import {buildSoftwareFilter} from '~/components/software/overview/filters/softwareFiltersApi'
 
 export type OrgSoftwareFilterProps = {
   id: string
@@ -20,20 +20,16 @@ export type OrgSoftwareFilterProps = {
   keywords?: string[] | null
   prog_lang?: string[] | null
   licenses?: string[] | null
+  categories?: string[] | null
   token?:string
 }
 
-export function buildOrgSoftwareFilter({id, search, keywords, prog_lang, licenses}: OrgSoftwareFilterProps) {
+export function buildOrgSoftwareFilter({id, ...params}: OrgSoftwareFilterProps) {
   const filter = {
     // additional organisation filter
     organisation_id: id,
     // add default software filter params
-    ...buildSoftwareFilter({
-      search,
-      keywords,
-      prog_lang,
-      licenses
-    })
+    ...buildSoftwareFilter(params)
   }
   // console.group('buildOrgProjectFilter')
   // console.log('filter...', filter)
@@ -41,18 +37,11 @@ export function buildOrgSoftwareFilter({id, search, keywords, prog_lang, license
   return filter
 }
 
-export async function orgSoftwareKeywordsFilter({
-  id,search, keywords, prog_lang, licenses, token}: OrgSoftwareFilterProps) {
+export async function orgSoftwareKeywordsFilter({token,...params}: OrgSoftwareFilterProps) {
   try {
     const query = 'rpc/org_software_keywords_filter?order=keyword'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildOrgSoftwareFilter({
-      id,
-      search,
-      keywords,
-      prog_lang,
-      licenses
-    })
+    const filter = buildOrgSoftwareFilter(params)
 
     const resp = await fetch(url, {
       method: 'POST',
@@ -79,7 +68,7 @@ export async function orgSoftwareKeywordsFilter({
 export default function useOrgSoftwareKeywordsList() {
   const {token} = useSession()
   const {id} = useOrganisationContext()
-  const {search,keywords_json,prog_lang_json,licenses_json} = useSoftwareParams()
+  const {search,keywords_json,prog_lang_json,licenses_json,categories_json} = useSoftwareParams()
   const [keywordsList, setKeywordsList] = useState<KeywordFilterOption[]>([])
 
   // console.group('useOrgSoftwareKeywordsList')
@@ -97,6 +86,7 @@ export default function useOrgSoftwareKeywordsList() {
       const keywords = decodeJsonParam(keywords_json,null)
       const prog_lang = decodeJsonParam(prog_lang_json, null)
       const licenses = decodeJsonParam(licenses_json, null)
+      const categories = decodeJsonParam(categories_json, null)
 
       // get filter options
       orgSoftwareKeywordsFilter({
@@ -105,6 +95,7 @@ export default function useOrgSoftwareKeywordsList() {
         keywords,
         prog_lang,
         licenses,
+        categories,
         token
       }).then(resp => {
         // abort
@@ -119,6 +110,7 @@ export default function useOrgSoftwareKeywordsList() {
   }, [
     search, keywords_json,
     prog_lang_json, licenses_json,
+    categories_json,
     id,token
   ])
 

--- a/frontend/components/organisation/software/filters/useOrgSoftwareLanguagesList.tsx
+++ b/frontend/components/organisation/software/filters/useOrgSoftwareLanguagesList.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,18 +14,11 @@ import useOrganisationContext from '../../context/useOrganisationContext'
 import useSoftwareParams from './useSoftwareParams'
 import {OrgSoftwareFilterProps, buildOrgSoftwareFilter} from './useOrgSoftwareKeywordsList'
 
-export async function orgSoftwareLanguagesFilter({
-  id,search, keywords, prog_lang, licenses, token}: OrgSoftwareFilterProps) {
+export async function orgSoftwareLanguagesFilter({token, ...params}: OrgSoftwareFilterProps) {
   try {
     const query = 'rpc/org_software_languages_filter?order=prog_language'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildOrgSoftwareFilter({
-      id,
-      search,
-      keywords,
-      prog_lang,
-      licenses
-    })
+    const filter = buildOrgSoftwareFilter(params)
 
     const resp = await fetch(url, {
       method: 'POST',
@@ -52,7 +45,7 @@ export async function orgSoftwareLanguagesFilter({
 export default function useOrgSoftwareLanguagesList() {
   const {token} = useSession()
   const {id} = useOrganisationContext()
-  const {search,keywords_json,prog_lang_json,licenses_json} = useSoftwareParams()
+  const {search,keywords_json,prog_lang_json,licenses_json,categories_json} = useSoftwareParams()
   const [languagesList, setLangList] = useState<LanguagesFilterOption[]>([])
 
   // console.group('useOrgSoftwareLanguagesList')
@@ -67,9 +60,10 @@ export default function useOrgSoftwareLanguagesList() {
   useEffect(() => {
     let abort = false
     if (id) {
-      const keywords = decodeJsonParam(keywords_json,null)
+      const keywords = decodeJsonParam(keywords_json, null)
       const prog_lang = decodeJsonParam(prog_lang_json, null)
       const licenses = decodeJsonParam(licenses_json, null)
+      const categories = decodeJsonParam(categories_json, null)
 
       // get filter options
       orgSoftwareLanguagesFilter({
@@ -78,6 +72,7 @@ export default function useOrgSoftwareLanguagesList() {
         keywords,
         prog_lang,
         licenses,
+        categories,
         token
       }).then(resp => {
         // abort
@@ -92,6 +87,7 @@ export default function useOrgSoftwareLanguagesList() {
   }, [
     search, keywords_json,
     prog_lang_json, licenses_json,
+    categories_json,
     id,token
   ])
 

--- a/frontend/components/organisation/software/filters/useOrgSoftwareLicensesList.tsx
+++ b/frontend/components/organisation/software/filters/useOrgSoftwareLicensesList.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,23 +9,16 @@ import {useSession} from '~/auth'
 import logger from '~/utils/logger'
 import {decodeJsonParam} from '~/utils/extractQueryParam'
 import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 import useOrganisationContext from '../../context/useOrganisationContext'
 import useSoftwareParams from './useSoftwareParams'
 import {OrgSoftwareFilterProps, buildOrgSoftwareFilter} from './useOrgSoftwareKeywordsList'
-import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 
-export async function orgSoftwareLicensesFilter({
-  id,search, keywords, prog_lang, licenses, token}: OrgSoftwareFilterProps) {
+export async function orgSoftwareLicensesFilter({token,...params}: OrgSoftwareFilterProps) {
   try {
     const query = 'rpc/org_software_licenses_filter?order=license'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildOrgSoftwareFilter({
-      id,
-      search,
-      keywords,
-      prog_lang,
-      licenses
-    })
+    const filter = buildOrgSoftwareFilter(params)
 
     const resp = await fetch(url, {
       method: 'POST',
@@ -52,7 +45,7 @@ export async function orgSoftwareLicensesFilter({
 export default function useOrgSoftwareLicensesList() {
   const {token} = useSession()
   const {id} = useOrganisationContext()
-  const {search,keywords_json,prog_lang_json,licenses_json} = useSoftwareParams()
+  const {search,keywords_json,prog_lang_json,licenses_json,categories_json} = useSoftwareParams()
   const [licensesList, setLicensesList] = useState<LicensesFilterOption[]>([])
 
   // console.group('useOrgSoftwareLicensesList')
@@ -67,9 +60,10 @@ export default function useOrgSoftwareLicensesList() {
   useEffect(() => {
     let abort = false
     if (id) {
-      const keywords = decodeJsonParam(keywords_json,null)
+      const keywords = decodeJsonParam(keywords_json, null)
       const prog_lang = decodeJsonParam(prog_lang_json, null)
       const licenses = decodeJsonParam(licenses_json, null)
+      const categories = decodeJsonParam(categories_json, null)
 
       // get filter options
       orgSoftwareLicensesFilter({
@@ -78,6 +72,7 @@ export default function useOrgSoftwareLicensesList() {
         keywords,
         prog_lang,
         licenses,
+        categories,
         token
       }).then(resp => {
         // abort
@@ -92,6 +87,7 @@ export default function useOrgSoftwareLicensesList() {
   }, [
     search, keywords_json,
     prog_lang_json, licenses_json,
+    categories_json,
     id,token
   ])
 

--- a/frontend/components/organisation/software/filters/useSoftwareParams.tsx
+++ b/frontend/components/organisation/software/filters/useSoftwareParams.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -25,6 +25,7 @@ export default function useSoftwareParams() {
     if (params?.keywords_json) count++
     if (params?.prog_lang_json) count++
     if (params?.licenses_json) count++
+    if (params?.categories_json) count++
     if (params?.search) count++
     return count
   }

--- a/frontend/components/organisation/software/useOrganisationSoftware.tsx
+++ b/frontend/components/organisation/software/useOrganisationSoftware.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +23,10 @@ type State = {
 export default function useOrganisationSoftware() {
   const {token} = useSession()
   const {id,isMaintainer} = useOrganisationContext()
-  const {search, keywords_json, prog_lang_json, licenses_json, order, page, rows} = useSoftwareParams()
+  const {
+    search, keywords_json, prog_lang_json, licenses_json,
+    categories_json, order, page, rows
+  } = useSoftwareParams()
   // we need to memo orderOptions array to avoid useEffect dependency loop
   const orderOptions = useMemo(()=>getSoftwareOrderOptions(isMaintainer),[isMaintainer])
 
@@ -41,7 +44,7 @@ export default function useOrganisationSoftware() {
 
     async function getSoftware() {
       if (id) {
-        // set loding done
+        // set loading done
         setLoading(true)
 
         if (order) {
@@ -58,6 +61,7 @@ export default function useOrganisationSoftware() {
           keywords: decodeJsonParam(keywords_json,null),
           prog_lang: decodeJsonParam(prog_lang_json,null),
           licenses: decodeJsonParam(licenses_json,null),
+          categories: decodeJsonParam(categories_json,null),
           order: orderBy ?? undefined,
           // api works with zero
           page:page ? page-1 : 0,
@@ -69,7 +73,7 @@ export default function useOrganisationSoftware() {
         if (abort) return
         // set state
         setState(software)
-        // set loding done
+        // set loading done
         setLoading(false)
       }
     }
@@ -86,7 +90,7 @@ export default function useOrganisationSoftware() {
 
   }, [
     search, keywords_json, prog_lang_json,
-    licenses_json, order, page, rows,
+    licenses_json, categories_json, order, page, rows,
     id, token, isMaintainer, orderOptions
   ])
 

--- a/frontend/components/projects/overview/filters/projectFiltersApi.ts
+++ b/frontend/components/projects/overview/filters/projectFiltersApi.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -36,6 +36,7 @@ export type ProjectFilterProps = {
   keywords?: string[] | null
   domains?: string[] | null
   organisations?: string[] | null
+  categories?: string[] | null
 }
 
 type ProjectFilterApiProps = {
@@ -44,9 +45,12 @@ type ProjectFilterApiProps = {
   keyword_filter?: string[]
   research_domain_filter?: string[]
   organisation_filter?: string[]
+  category_filter?: string[]
 }
 
-export function buildProjectFilter({search, keywords, domains, organisations, project_status}: ProjectFilterProps) {
+export function buildProjectFilter({
+  search, keywords, domains, organisations, project_status, categories
+}: ProjectFilterProps) {
   const filter: ProjectFilterApiProps = {}
   if (search) {
     filter['search_filter'] = search
@@ -63,6 +67,9 @@ export function buildProjectFilter({search, keywords, domains, organisations, pr
   if (project_status) {
     filter['status_filter'] = project_status
   }
+  if (categories) {
+    filter['category_filter'] = categories
+  }
   // console.group('buildProjectFilter')
   // console.log('filter...', filter)
   // console.groupEnd()
@@ -70,17 +77,11 @@ export function buildProjectFilter({search, keywords, domains, organisations, pr
 }
 
 
-export async function projectKeywordsFilter({search, keywords, domains, organisations,project_status}: ProjectFilterProps) {
+export async function projectKeywordsFilter(params: ProjectFilterProps) {
   try {
     const query = 'rpc/project_keywords_filter?order=keyword'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildProjectFilter({
-      search,
-      keywords,
-      domains,
-      organisations,
-      project_status
-    })
+    const filter = buildProjectFilter(params)
 
     // console.group('projectKeywordsFilter')
     // console.log('filter...', JSON.stringify(filter))
@@ -107,10 +108,10 @@ export async function projectKeywordsFilter({search, keywords, domains, organisa
   }
 }
 
-export async function projectDomainsFilter({search, keywords, domains, organisations, project_status}: ProjectFilterProps) {
+export async function projectDomainsFilter(params: ProjectFilterProps) {
   try {
     // get possible options
-    const domainsOptions = await getDomainsFilterList({search, keywords, domains, organisations, project_status})
+    const domainsOptions = await getDomainsFilterList(params)
 
     if (domainsOptions.length > 0) {
       const keys = domainsOptions.map(item => item.domain)
@@ -131,17 +132,11 @@ export async function projectDomainsFilter({search, keywords, domains, organisat
   }
 }
 
-export async function getDomainsFilterList({search, keywords, domains, organisations, project_status}: ProjectFilterProps) {
+export async function getDomainsFilterList(params: ProjectFilterProps) {
   try {
     const query = 'rpc/project_domains_filter?order=domain'
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildProjectFilter({
-      search,
-      keywords,
-      domains,
-      organisations,
-      project_status
-    })
+    const filter = buildProjectFilter(params)
 
     // console.group('softwareKeywordsFilter')
     // console.log('filter...', JSON.stringify(filter))

--- a/frontend/components/software/overview/filters/SoftwareFiltersModal.tsx
+++ b/frontend/components/software/overview/filters/SoftwareFiltersModal.tsx
@@ -15,21 +15,24 @@ import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
 import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 import {HostsFilterOption} from '~/components/filter/RsdHostFilter'
+import {CategoryOption} from '~/components/filter/CategoriesFilter'
 import SoftwareFilters from './index'
 
 type SoftwareFiltersModalProps = {
-  open: boolean,
+  open: boolean
   keywords?: string[]
-  keywordsList: KeywordFilterOption[],
-  prog_lang?: string[],
-  languagesList: LanguagesFilterOption[],
-  licenses?: string[],
-  licensesList: LicensesFilterOption[],
+  keywordsList: KeywordFilterOption[]
+  prog_lang?: string[]
+  languagesList: LanguagesFilterOption[]
+  licenses?: string[]
+  licensesList: LicensesFilterOption[]
+  categories: string[]
+  categoryList: CategoryOption[]
   rsd_host?: string
   hostsList?: HostsFilterOption[]
   hasRemotes?: boolean
-  order: string,
-  filterCnt: number,
+  order: string
+  filterCnt: number
   setModal:(open:boolean)=>void
 }
 
@@ -37,6 +40,7 @@ export default function SoftwareFiltersModal({
   open, keywords, keywordsList,
   prog_lang, languagesList,
   licenses, licensesList,
+  categories, categoryList,
   rsd_host, hostsList,
   hasRemotes, filterCnt, order,
   setModal
@@ -67,6 +71,8 @@ export default function SoftwareFiltersModal({
             languagesList={languagesList}
             licenses={licenses ?? []}
             licensesList={licensesList}
+            categories={categories ?? []}
+            categoryList={categoryList ?? []}
             rsd_host={rsd_host}
             hostsList={hostsList}
             orderBy={order ?? ''}

--- a/frontend/components/software/overview/filters/index.tsx
+++ b/frontend/components/software/overview/filters/index.tsx
@@ -14,8 +14,10 @@ import KeywordsFilter, {KeywordFilterOption} from '~/components/filter/KeywordsF
 import ProgrammingLanguagesFilter, {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
 import LicensesFilter, {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 import RsdSourceFilter, {HostsFilterOption} from '~/components/filter/RsdHostFilter'
+import CategoriesFilter, {CategoryOption} from '~/components/filter/CategoriesFilter'
 import useSoftwareOverviewParams from '../useSoftwareOverviewParams'
 import OrderSoftwareBy, {OrderHighlightsBy} from './OrderSoftwareBy'
+import useHasCategories from './useHasCategories'
 
 type SoftwareFilterProps = {
   keywords: string[]
@@ -24,6 +26,8 @@ type SoftwareFilterProps = {
   languagesList: LanguagesFilterOption[]
   licenses: string[]
   licensesList: LicensesFilterOption[]
+  categories: string[]
+  categoryList: CategoryOption[]
   orderBy: string,
   filterCnt: number,
   highlightsOnly?: boolean
@@ -33,24 +37,21 @@ type SoftwareFilterProps = {
 }
 
 export default function SoftwareFilters({
-  keywords,
-  keywordsList,
-  languages,
-  languagesList,
-  licenses,
-  licensesList,
-  rsd_host,
-  hostsList,
-  filterCnt,
-  orderBy,
+  keywords, keywordsList,
+  languages, languagesList,
+  licenses, licensesList,
+  categories, categoryList,
+  rsd_host, hostsList,
+  filterCnt, orderBy,
   highlightsOnly = false,
   hasRemotes = false
 }:SoftwareFilterProps) {
   const {resetFilters,handleQueryChange} = useSoftwareOverviewParams()
+  const hasCategories = useHasCategories()
 
   // console.group('SoftwareFilters')
-  // console.log('sources...', sources)
-  // console.log('hostsList...', hostsList)
+  // console.log('hasCategories...', hasCategories)
+  // console.log('categoryList...', categoryList)
   // console.groupEnd()
 
   function clearDisabled() {
@@ -95,6 +96,18 @@ export default function SoftwareFilters({
           handleQueryChange={handleQueryChange}
         />
       </div>
+      {/* Custom categories */}
+      {hasCategories ?
+        <div>
+          <CategoriesFilter
+            title="Categories"
+            categories={categories}
+            categoryList={categoryList}
+            handleQueryChange={handleQueryChange}
+          />
+        </div>
+        : null
+      }
       {/* RSD hosts list only if remotes are defined */}
       {hasRemotes ?
         <RsdSourceFilter

--- a/frontend/components/software/overview/filters/softwareFiltersApi.ts
+++ b/frontend/components/software/overview/filters/softwareFiltersApi.ts
@@ -13,6 +13,7 @@ import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
 import {HostsFilterOption} from '~/components/filter/RsdHostFilter'
+import {CategoryOption} from '~/components/filter/CategoriesFilter'
 
 type SoftwareFilterProps = {
   search?: string | null
@@ -186,6 +187,33 @@ export async function genericSoftwareLicensesFilter({rpc,...params}: GenericSoft
     return []
   }
 }
+
+export async function softwareCategoriesFilter(props: SoftwareFilterProps,rpcName:string='aggregated_software_categories_filter') {
+  try {
+    const query = `/rpc/${rpcName}?order=category_cnt.desc,category`
+    const url = `${getBaseUrl()}${query}`
+    const filter = buildSoftwareFilter(props)
+
+    const resp = await fetch(url, {
+      method: 'POST',
+      headers: createJsonHeaders(),
+      body: JSON.stringify(filter)
+    })
+
+    if (resp.status === 200) {
+      const json: CategoryOption[] = await resp.json()
+      return json
+    }
+
+    logger(`softwareCategoriesFilter: ${resp.status} ${resp.statusText}`, 'warn')
+    return []
+
+  } catch (e: any) {
+    logger(`softwareCategoriesFilter: ${e?.message}`, 'error')
+    return []
+  }
+}
+
 
 export async function softwareRsdHostsFilter(props: SoftwareFilterProps) {
   try {

--- a/frontend/components/software/overview/filters/softwareFiltersApi.ts
+++ b/frontend/components/software/overview/filters/softwareFiltersApi.ts
@@ -7,18 +7,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import logger from '~/utils/logger'
+import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
 import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
 import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
 import {HostsFilterOption} from '~/components/filter/RsdHostFilter'
-import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
-import logger from '~/utils/logger'
 
 type SoftwareFilterProps = {
   search?: string | null
   keywords?: string[] | null
   prog_lang?: string[] | null
   licenses?: string[] | null
+  categories?: string[] | null
   rsd_host?: string | null
 }
 
@@ -31,10 +32,13 @@ type SoftwareFilterApiProps = {
   keyword_filter?: string[]
   prog_lang_filter?: string[]
   license_filter?: string[]
+  category_filter?: string[]
   rsd_host_filter?: string | null
 }
 
-export function buildSoftwareFilter({search, keywords, prog_lang, licenses, rsd_host}: SoftwareFilterProps) {
+export function buildSoftwareFilter({
+  search, keywords, prog_lang, licenses, categories, rsd_host
+}: SoftwareFilterProps) {
   const filter: SoftwareFilterApiProps={}
   if (search) {
     filter['search_filter'] = search
@@ -47,6 +51,9 @@ export function buildSoftwareFilter({search, keywords, prog_lang, licenses, rsd_
   }
   if (licenses) {
     filter['license_filter'] = licenses
+  }
+  if (categories) {
+    filter['category_filter'] = categories
   }
   if (rsd_host) {
     if (rsd_host==='null') {
@@ -61,27 +68,21 @@ export function buildSoftwareFilter({search, keywords, prog_lang, licenses, rsd_
   return filter
 }
 
-export async function softwareKeywordsFilter({search, keywords, prog_lang, licenses, rsd_host}: SoftwareFilterProps) {
+export async function softwareKeywordsFilter(params: SoftwareFilterProps) {
   const rpc = 'aggregated_software_keywords_filter'
-  return genericSoftwareKeywordsFilter({search, keywords, prog_lang, licenses, rsd_host, rpc})
+  return genericSoftwareKeywordsFilter({...params,rpc})
 }
 
-export async function highlightKeywordsFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+export async function highlightKeywordsFilter(params: SoftwareFilterProps) {
   const rpc = 'highlight_keywords_filter'
-  return genericSoftwareKeywordsFilter({search, keywords, prog_lang, licenses, rpc})
+  return genericSoftwareKeywordsFilter({...params, rpc})
 }
 
-export async function genericSoftwareKeywordsFilter({search, keywords, prog_lang, licenses, rsd_host, rpc}: GenericSoftwareFilterProps) {
+export async function genericSoftwareKeywordsFilter({rpc, ...params}: GenericSoftwareFilterProps) {
   try {
     const query =`rpc/${rpc}?order=keyword`
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildSoftwareFilter({
-      search,
-      keywords,
-      prog_lang,
-      licenses,
-      rsd_host
-    })
+    const filter = buildSoftwareFilter(params)
 
     // console.group('softwareKeywordsFilter')
     // console.log('filter...', JSON.stringify(filter))
@@ -108,27 +109,21 @@ export async function genericSoftwareKeywordsFilter({search, keywords, prog_lang
   }
 }
 
-export async function softwareLanguagesFilter({search, keywords, prog_lang, licenses, rsd_host}: SoftwareFilterProps) {
+export async function softwareLanguagesFilter(params: SoftwareFilterProps) {
   const rpc = 'aggregated_software_languages_filter'
-  return genericSoftwareLanguagesFilter({search, keywords, prog_lang, licenses, rsd_host, rpc})
+  return genericSoftwareLanguagesFilter({...params, rpc})
 }
 
-export async function highlightLanguagesFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+export async function highlightLanguagesFilter(params: SoftwareFilterProps) {
   const rpc = 'highlight_languages_filter'
-  return genericSoftwareLanguagesFilter({search, keywords, prog_lang, licenses, rpc})
+  return genericSoftwareLanguagesFilter({...params, rpc})
 }
 
-export async function genericSoftwareLanguagesFilter({search, keywords, prog_lang, licenses, rsd_host, rpc}: GenericSoftwareFilterProps) {
+export async function genericSoftwareLanguagesFilter({rpc,...params}: GenericSoftwareFilterProps) {
   try {
     const query = `rpc/${rpc}?order=prog_language`
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildSoftwareFilter({
-      search,
-      keywords,
-      prog_lang,
-      licenses,
-      rsd_host
-    })
+    const filter = buildSoftwareFilter(params)
 
     // console.group('softwareLanguagesFilter')
     // console.log('filter...', JSON.stringify(filter))
@@ -155,28 +150,22 @@ export async function genericSoftwareLanguagesFilter({search, keywords, prog_lan
   }
 }
 
-export async function softwareLicensesFilter({search, keywords, prog_lang, licenses, rsd_host}: SoftwareFilterProps) {
+export async function softwareLicensesFilter(props: SoftwareFilterProps) {
   const rpc = 'aggregated_software_licenses_filter'
-  return genericSoftwareLicensesFilter({search, keywords, prog_lang, licenses, rsd_host, rpc})
+  return genericSoftwareLicensesFilter({...props, rpc})
 }
 
 
-export async function highlightLicensesFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+export async function highlightLicensesFilter(props: SoftwareFilterProps) {
   const rpc = 'highlight_licenses_filter'
-  return genericSoftwareLicensesFilter({search, keywords, prog_lang, licenses, rpc})
+  return genericSoftwareLicensesFilter({...props, rpc})
 }
 
-export async function genericSoftwareLicensesFilter({search, keywords, prog_lang, licenses, rsd_host, rpc}: GenericSoftwareFilterProps) {
+export async function genericSoftwareLicensesFilter({rpc,...params}: GenericSoftwareFilterProps) {
   try {
     const query = `rpc/${rpc}?order=license`
     const url = `${getBaseUrl()}/${query}`
-    const filter = buildSoftwareFilter({
-      search,
-      keywords,
-      prog_lang,
-      licenses,
-      rsd_host
-    })
+    const filter = buildSoftwareFilter(params)
 
     const resp = await fetch(url, {
       method: 'POST',
@@ -198,16 +187,11 @@ export async function genericSoftwareLicensesFilter({search, keywords, prog_lang
   }
 }
 
-export async function softwareRsdHostsFilter({search, keywords, prog_lang, licenses}: SoftwareFilterProps) {
+export async function softwareRsdHostsFilter(props: SoftwareFilterProps) {
   try {
     const query = 'aggregated_software_hosts_filter?order=rsd_host'
     const url = `${getBaseUrl()}/rpc/${query}`
-    const filter = buildSoftwareFilter({
-      search,
-      keywords,
-      prog_lang,
-      licenses
-    })
+    const filter = buildSoftwareFilter(props)
 
     const resp = await fetch(url, {
       method: 'POST',

--- a/frontend/components/software/overview/filters/useHasCategories.tsx
+++ b/frontend/components/software/overview/filters/useHasCategories.tsx
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {loadCategoryRoots} from '~/components/category/apiCategories'
+
+export default function useHasCategories() {
+  const [hasCategories, setHasCategories] = useState(false)
+
+  useEffect(()=>{
+    let abort = false
+
+    loadCategoryRoots({})
+      .then(roots=>{
+        if (abort) return
+        setHasCategories(roots.length > 0)
+      })
+
+    return ()=>{abort=true}
+  },[])
+
+  return hasCategories
+}

--- a/frontend/pages/communities/[slug]/rejected.tsx
+++ b/frontend/pages/communities/[slug]/rejected.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,33 +10,16 @@ import {getUserFromToken} from '~/auth'
 import {getUserSettings} from '~/utils/userSettings'
 import PageMeta from '~/components/seo/PageMeta'
 import CanonicalUrl from '~/components/seo/CanonicalUrl'
-import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
-import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
-import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
-import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
-import {EditCommunityProps, getCommunityBySlug} from '~/components/communities/apiCommunities'
+import {getCommunityBySlug} from '~/components/communities/apiCommunities'
 import CommunityPage from '~/components/communities/CommunityPage'
 import CommunitySoftware from '~/components/communities/software'
-import {SoftwareOfCommunity, ssrCommunitySoftwareProps} from '~/components/communities/software/apiCommunitySoftware'
-
-type CommunitySoftwareProps={
-  community: EditCommunityProps,
-  software: SoftwareOfCommunity[],
-  slug: string[],
-  isMaintainer: boolean,
-  rsd_page_rows: number,
-  rsd_page_layout: LayoutType,
-  count: number,
-  keywordsList: KeywordFilterOption[],
-  languagesList: LanguagesFilterOption[],
-  licensesList: LicensesFilterOption[],
-}
+import {ssrCommunitySoftwareProps} from '~/components/communities/software/apiCommunitySoftware'
+import {CommunitySoftwareProps} from './software'
 
 export default function CommunityRejectedSoftwarePage({
-  community,slug,isMaintainer,
-  rsd_page_rows, rsd_page_layout,
-  software, count, keywordsList,
-  languagesList, licensesList
+  community,slug,isMaintainer,rsd_page_rows,rsd_page_layout,
+  software, count, keywordsList, languagesList, licensesList,
+  categoryList
 }:CommunitySoftwareProps) {
 
   // console.group('CommunityRejectedSoftwarePage')
@@ -83,6 +66,7 @@ export default function CommunityRejectedSoftwarePage({
           keywordsList={keywordsList}
           languagesList={languagesList}
           licensesList={licensesList}
+          categoryList={categoryList}
         />
       </CommunityPage>
     </>
@@ -121,6 +105,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       keywordsList,
       languagesList,
       licensesList,
+      categoryList,
       // community with updated keywords
       community
     } = await ssrCommunitySoftwareProps({
@@ -145,7 +130,8 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
         software: software.data,
         keywordsList,
         languagesList,
-        licensesList
+        licensesList,
+        categoryList
       },
     }
   }catch{

--- a/frontend/pages/communities/[slug]/requests.tsx
+++ b/frontend/pages/communities/[slug]/requests.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,33 +10,29 @@ import {getUserFromToken} from '~/auth'
 import {getUserSettings} from '~/utils/userSettings'
 import PageMeta from '~/components/seo/PageMeta'
 import CanonicalUrl from '~/components/seo/CanonicalUrl'
-import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
-import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
-import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
-import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
-import {EditCommunityProps, getCommunityBySlug} from '~/components/communities/apiCommunities'
+import {getCommunityBySlug} from '~/components/communities/apiCommunities'
 import CommunityPage from '~/components/communities/CommunityPage'
 import CommunitySoftware from '~/components/communities/software'
-import {SoftwareOfCommunity, ssrCommunitySoftwareProps} from '~/components/communities/software/apiCommunitySoftware'
+import {ssrCommunitySoftwareProps} from '~/components/communities/software/apiCommunitySoftware'
+import {CommunitySoftwareProps} from './software'
 
-type CommunitySoftwareProps={
-  community: EditCommunityProps,
-  software: SoftwareOfCommunity[],
-  slug: string[],
-  isMaintainer: boolean,
-  rsd_page_rows: number,
-  rsd_page_layout: LayoutType,
-  count: number,
-  keywordsList: KeywordFilterOption[],
-  languagesList: LanguagesFilterOption[],
-  licensesList: LicensesFilterOption[],
-}
+// type CommunitySoftwareProps={
+//   community: EditCommunityProps,
+//   software: SoftwareOfCommunity[],
+//   slug: string[],
+//   isMaintainer: boolean,
+//   rsd_page_rows: number,
+//   rsd_page_layout: LayoutType,
+//   count: number,
+//   keywordsList: KeywordFilterOption[],
+//   languagesList: LanguagesFilterOption[],
+//   licensesList: LicensesFilterOption[],
+// }
 
 export default function RequestsToJoinCommunity({
-  community,slug,isMaintainer,
-  rsd_page_rows, rsd_page_layout,
-  software, count, keywordsList,
-  languagesList, licensesList
+  community,slug,isMaintainer,rsd_page_rows, rsd_page_layout,
+  software, count, keywordsList, languagesList, licensesList,
+  categoryList
 }:CommunitySoftwareProps) {
 
   // console.group('RequestsToJoinCommunity')
@@ -83,6 +79,7 @@ export default function RequestsToJoinCommunity({
           keywordsList={keywordsList}
           languagesList={languagesList}
           licensesList={licensesList}
+          categoryList={categoryList}
         />
       </CommunityPage>
     </>
@@ -121,6 +118,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       keywordsList,
       languagesList,
       licensesList,
+      categoryList,
       // community with updated keywords
       community
     } = await ssrCommunitySoftwareProps({
@@ -145,7 +143,8 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
         software: software.data,
         keywordsList,
         languagesList,
-        licensesList
+        licensesList,
+        categoryList
       },
     }
   }catch{

--- a/frontend/pages/communities/[slug]/software.tsx
+++ b/frontend/pages/communities/[slug]/software.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,13 +13,14 @@ import CanonicalUrl from '~/components/seo/CanonicalUrl'
 import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import {LanguagesFilterOption} from '~/components/filter/ProgrammingLanguagesFilter'
 import {LicensesFilterOption} from '~/components/filter/LicensesFilter'
+import {CategoryOption} from '~/components/filter/CategoriesFilter'
 import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
 import {EditCommunityProps, getCommunityBySlug} from '~/components/communities/apiCommunities'
 import CommunityPage from '~/components/communities/CommunityPage'
 import CommunitySoftware from '~/components/communities/software'
 import {SoftwareOfCommunity, ssrCommunitySoftwareProps} from '~/components/communities/software/apiCommunitySoftware'
 
-type CommunitySoftwareProps={
+export type CommunitySoftwareProps={
   community: EditCommunityProps,
   software: SoftwareOfCommunity[],
   slug: string[],
@@ -30,13 +31,13 @@ type CommunitySoftwareProps={
   keywordsList: KeywordFilterOption[],
   languagesList: LanguagesFilterOption[],
   licensesList: LicensesFilterOption[],
+  categoryList: CategoryOption[]
 }
 
 export default function CommunitySoftwarePage({
-  community,slug,isMaintainer,
-  rsd_page_rows, rsd_page_layout,
-  software, count, keywordsList,
-  languagesList, licensesList
+  community,slug,isMaintainer,rsd_page_rows,rsd_page_layout,
+  software, count, keywordsList,languagesList,licensesList,
+  categoryList
 }:CommunitySoftwareProps) {
 
   // console.group('CommunitySoftwarePage')
@@ -49,6 +50,7 @@ export default function CommunitySoftwarePage({
   // console.log('keywordsList....', keywordsList)
   // console.log('languagesList....', languagesList)
   // console.log('licensesList....', licensesList)
+  // console.log('categoryList....', categoryList)
   // console.groupEnd()
 
   function getMetaDescription() {
@@ -83,6 +85,7 @@ export default function CommunitySoftwarePage({
           keywordsList={keywordsList}
           languagesList={languagesList}
           licensesList={licensesList}
+          categoryList={categoryList}
         />
       </CommunityPage>
     </>
@@ -121,6 +124,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
       keywordsList,
       languagesList,
       licensesList,
+      categoryList,
       // community with updated keywords
       community
     } = await ssrCommunitySoftwareProps({
@@ -145,7 +149,8 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
         software: software.data,
         keywordsList,
         languagesList,
-        licensesList
+        licensesList,
+        categoryList
       },
     }
   }catch{

--- a/frontend/public/data/settings.json.license
+++ b/frontend/public/data/settings.json.license
@@ -1,7 +1,7 @@
 SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2022 - 2023 dv4all
-SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 
 SPDX-License-Identifier: Apache-2.0

--- a/frontend/utils/extractQueryParam.test.ts
+++ b/frontend/utils/extractQueryParam.test.ts
@@ -85,6 +85,7 @@ it('extracts ssrSoftwareParams from url query', () => {
     'keywords': '["BAM","FAIR Sofware"]',
     'prog_lang': '["Python","C++"]',
     'licenses': '["MIT","GPL-2.0-or-later"]',
+    'categories': '["Category 1","Category 2"]',
     'rsd_host': 'null',
     'order': 'test-order',
     'page': '0',
@@ -95,6 +96,7 @@ it('extracts ssrSoftwareParams from url query', () => {
     keywords: ['BAM', 'FAIR Sofware'],
     prog_lang: ['Python', 'C++'],
     licenses: ['MIT', 'GPL-2.0-or-later'],
+    categories: ['Category 1','Category 2'],
     // null value is string for localhost
     rsd_host: 'null',
     order: 'test-order',

--- a/frontend/utils/extractQueryParam.ts
+++ b/frontend/utils/extractQueryParam.ts
@@ -140,6 +140,7 @@ export type SoftwareParams = {
   keywords?: string[],
   prog_lang?: string[],
   licenses?: string[],
+  categories?: string[],
   rsd_host?: string,
   page?: number,
   rows?: number
@@ -188,12 +189,17 @@ export function ssrSoftwareParams(query: ParsedUrlQuery): SoftwareParams {
     castToType: 'json-encoded',
     defaultValue: null
   })
+  const categories:string[]|undefined = decodeQueryParam({
+    query,
+    param: 'categories',
+    castToType: 'json-encoded',
+    defaultValue: null
+  })
   const rsd_host:string|undefined = decodeQueryParam({
     query,
     param: 'rsd_host',
     defaultValue: undefined
   })
-
   const order:string = decodeQueryParam({
     query,
     param: 'order',
@@ -208,6 +214,7 @@ export function ssrSoftwareParams(query: ParsedUrlQuery): SoftwareParams {
     keywords,
     prog_lang,
     licenses,
+    categories,
     rsd_host,
     order,
     rows,

--- a/frontend/utils/extractQueryParam.ts
+++ b/frontend/utils/extractQueryParam.ts
@@ -361,6 +361,13 @@ export function getProjectsParams(query: ParsedUrlQuery) {
     param: 'organisations',
     defaultValue: null
   })
+  // string encoded array used to avoid
+  // useEffect change detection with string[]
+  const categories_json: string | null = decodeQueryParam({
+    query,
+    param: 'categories',
+    defaultValue: null
+  })
   const order: string | null = decodeQueryParam({
     query,
     param: 'order',
@@ -375,7 +382,8 @@ export function getProjectsParams(query: ParsedUrlQuery) {
     project_status,
     keywords_json,
     domains_json,
-    organisations_json
+    organisations_json,
+    categories_json
   }
 }
 
@@ -422,6 +430,13 @@ export function getSoftwareParams(query: ParsedUrlQuery) {
     param: 'licenses',
     defaultValue: null
   })
+  // string encoded array used to avoid
+  // useEffect change detection with string[]
+  const categories_json: string | null = decodeQueryParam({
+    query,
+    param: 'categories',
+    defaultValue: null
+  })
   const order: string | null = decodeQueryParam({
     query,
     param: 'order',
@@ -435,6 +450,7 @@ export function getSoftwareParams(query: ParsedUrlQuery) {
     page,
     keywords_json,
     prog_lang_json,
-    licenses_json
+    licenses_json,
+    categories_json
   }
 }

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -52,6 +52,7 @@ export type QueryParams={
   domains?:string[] | null,
   prog_lang?: string[] | null,
   licenses?: string[] | null,
+  categories?: string[] | null,
   rsd_host?: string,
   organisations?: string[] | null,
   project_status?: string | null,
@@ -94,7 +95,7 @@ export function buildFilterUrl(params: QueryParams, view:string) {
     search, order, keywords, domains,
     licenses, prog_lang, rsd_host,
     organisations, project_status,
-    rows, page
+    categories, rows, page
   } = params
   // console.log('buildFilterUrl...params...', params)
   const url = `/${view}?`
@@ -129,6 +130,12 @@ export function buildFilterUrl(params: QueryParams, view:string) {
     query,
     param: 'licenses',
     value: licenses
+  })
+  // categories
+  query = encodeUrlQuery({
+    query,
+    param: 'categories',
+    value: categories
   })
   // sources (rsd remote source)
   query = encodeUrlQuery({

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -35,6 +35,7 @@ type baseQueryStringProps = {
   licenses?: string[] | null,
   rsd_host?: string,
   organisations?: string[] | null,
+  categories?: string[] | null,
   order?: string,
   limit?: number,
   offset?: number
@@ -200,6 +201,7 @@ export function baseQueryString(props: baseQueryStringProps) {
     rsd_host,
     organisations,
     project_status,
+    categories,
     order,
     limit,
     offset
@@ -304,6 +306,21 @@ export function baseQueryString(props: baseQueryStringProps) {
       query = `${query}&participating_organisations=cs.%7B${organisationsAll}%7D`
     } else {
       query = `participating_organisations=cs.%7B${organisationsAll}%7D`
+    }
+  }
+  if (categories !== undefined &&
+    categories !== null &&
+    typeof categories === 'object') {
+    // sort and convert array to comma separated string
+    // we need to sort because search is on ARRAY field in pgSql
+    const categoriesAll = categories
+      .toSorted(localeSort)
+      .map((item: string) => `"${encodeURIComponent(item)}"`).join(',')
+    // use cs. command to find
+    if (query) {
+      query = `${query}&categories=cs.%7B${categoriesAll}%7D`
+    } else {
+      query = `categories=cs.%7B${categoriesAll}%7D`
     }
   }
   if (project_status !== undefined &&


### PR DESCRIPTION
# Category filters for software, organisation and communities

Closes #1350 
Closes #1399

Changes proposed in this pull request:
* Custom categories filter for software overview.
* Custom categories filter for software highlights.
* Custom categories filter for organisation projects. 
* Custom categories filter for organisation software.
* Custom categories filter for community software.
* Category filter is not shown if categories are not defined in organisation settings.
* Category filter is "dynamic" (as other filters); it  shows only the categories "applied" by software/projects. If no category is used the category filter is empty (shows No options).
* Category items in the filter are ordered by count, most used items are at the top of the list, then alphabetically. 

How to test:
* `make start` to build solution and generate test data
* Login as rsd admin in order to be able to manipulate organisation categories
* select one organisation from the list, one that has categories defined (see image 1)
* navigate to organisation settings, categories. 
* Enable all categories to be for software. This can be defined at the root level by selecting the switch for software.
* Navigate to software tab and confirm that Categories filter is shown. Note, the filter option can be empty if no software used any of the categories. If the filter is empty edit some of the software from the organisation list and add some categories. Confirm that selected categories are now shown in the category filter.
* Now change all categories to be for project and perform same operations and checks as with software.
* Next enable all categories to be for both software and project and confirm the filter is shown and works properly.
* Finally disable all organisation categories for both software and projects in organisation settings and confirm that category filters are not shown.
* enable communities in settings.json (add "communities" to modules array) and refresh page. The community menu option should be shown.
* Navigate to community overview page and select community that has custom categories defined. Confirm community filter is present and works properly.
* Navigate to community without custom categories. The community filter should not be shown.
* Navigate to software overview page. Validate that categories filter exists if the global categories are created.
* Navigate to software highlight overview page. Validate that categories filter is present if the global categories are created.

## Organisation categories (admin view)
![image](https://github.com/user-attachments/assets/e7186b3c-f752-4e13-9ff0-20a818ed43db)

## Organisation software with categories filter
![image](https://github.com/user-attachments/assets/bcdb5bf1-efdc-4163-967d-b0d2f5b6f097)

## Organisation projects with categories filter
![image](https://github.com/user-attachments/assets/13f67d64-ff12-4af6-8995-e6270f64ed1b)

## Community software categories filter
![image](https://github.com/user-attachments/assets/01f1306b-46f4-431b-b951-880b18dd3926)

## Software categories filter (global custom categories)
![image](https://github.com/user-attachments/assets/29122a48-9e11-4b3d-97d1-769d484a10d4)

## Software hightlight/spotlight categories filter
![image](https://github.com/user-attachments/assets/1b63e4d2-7df7-407b-8e7f-b93f4a7fbe3b)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
