### PR TITLE
Use alternative ROR names

### DIFF
--- a/database/013-create-organisation-table.sql
+++ b/database/013-create-organisation-table.sql
@@ -1,7 +1,7 @@
 -- SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 - 2023 dv4all
--- SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 -- SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 -- SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -22,6 +22,7 @@ CREATE TABLE organisation (
 	country VARCHAR(100),
 	city VARCHAR(100),
 	wikipedia_url VARCHAR(300),
+	ror_names VARCHAR(200)[],
 	ror_types VARCHAR(100)[],
 	lat float8,
 	lon float8,

--- a/database/013-create-organisation-table.sql
+++ b/database/013-create-organisation-table.sql
@@ -8,6 +8,26 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
+CREATE FUNCTION varchar_array_to_string(arr VARCHAR[])
+RETURNS VARCHAR
+LANGUAGE plpgsql
+IMMUTABLE
+AS
+$$
+	DECLARE entry VARCHAR;
+	DECLARE result VARCHAR := '';
+	BEGIN
+	IF arr IS NULL THEN
+		RETURN NULL;
+	END IF;
+	FOREACH entry IN ARRAY arr LOOP
+		CONTINUE WHEN entry IS NULL;
+		IF result = '' THEN result := entry; ELSE result := result || ';' || entry; END IF;
+	END LOOP;
+	RETURN result;
+	END;
+$$;
+
 CREATE TABLE organisation (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
 	parent UUID REFERENCES organisation (id),
@@ -23,6 +43,7 @@ CREATE TABLE organisation (
 	city VARCHAR(100),
 	wikipedia_url VARCHAR(300),
 	ror_names VARCHAR(200)[],
+	ror_names_string VARCHAR GENERATED ALWAYS AS (varchar_array_to_string(ror_names)) STORED,
 	ror_types VARCHAR(100)[],
 	lat float8,
 	lon float8,

--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -2,7 +2,7 @@
 -- SPDX-FileCopyrightText: 2021 - 2023 dv4all
 -- SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 -- SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
--- SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 --
@@ -343,6 +343,7 @@ CREATE FUNCTION organisations_overview(public BOOLEAN DEFAULT TRUE) RETURNS TABL
 	ror_id VARCHAR,
 	website VARCHAR,
 	is_tenant BOOLEAN,
+	ror_names_string VARCHAR,
 	rsd_path VARCHAR,
 	parent_names VARCHAR,
 	logo_id VARCHAR,
@@ -364,6 +365,7 @@ SELECT
 	organisation.ror_id,
 	organisation.website,
 	organisation.is_tenant,
+	organisation.ror_names_string,
 	organisation_route.rsd_path,
 	organisation_route.parent_names,
 	organisation.logo_id,

--- a/database/125-global-search.sql
+++ b/database/125-global-search.sql
@@ -73,7 +73,7 @@ $$
 			WHEN aggregated_software_search.keywords_text ILIKE CONCAT('%', query, '%') THEN 0
 			WHEN aggregated_software_search.slug ILIKE CONCAT(query, '%') OR aggregated_software_search.brand_name ILIKE CONCAT(query, '%') THEN 0
 			WHEN aggregated_software_search.slug ILIKE CONCAT('%', query, '%') OR aggregated_software_search.brand_name ILIKE CONCAT('%', query, '%')
-				THEN LEAST(NULLIF(POSITION(query IN aggregated_software_search.slug), 0), NULLIF(POSITION(query IN aggregated_software_search.brand_name), 0))
+				THEN LEAST(NULLIF(POSITION(LOWER(query) IN aggregated_software_search.slug), 0), NULLIF(POSITION(LOWER(query) IN LOWER(aggregated_software_search.brand_name)), 0))
 			ELSE 0
 		END) AS index_found
 	FROM
@@ -99,7 +99,7 @@ $$
 			WHEN BOOL_OR(keyword.value ILIKE query) THEN 0
 			WHEN project.slug ILIKE CONCAT(query, '%') OR project.title ILIKE CONCAT(query, '%') THEN 0
 			WHEN project.slug ILIKE CONCAT('%', query, '%') OR project.title ILIKE CONCAT('%', query, '%')
-				THEN LEAST(NULLIF(POSITION(query IN project.slug), 0), NULLIF(POSITION(query IN project.title), 0))
+				THEN LEAST(NULLIF(POSITION(LOWER(query) IN project.slug), 0), NULLIF(POSITION(LOWER(query) IN LOWER(project.title)), 0))
 			ELSE 0
 		END) AS index_found
 	FROM
@@ -133,7 +133,7 @@ $$
 			WHEN organisation.slug ILIKE query OR organisation."name" ILIKE query OR index_of_ror_query(query, organisation.id) = 0 THEN 0
 			WHEN organisation.slug ILIKE CONCAT(query, '%') OR organisation."name" ILIKE CONCAT(query, '%') OR index_of_ror_query(query, organisation.id) = 1 THEN 0
 			ELSE
-				LEAST(NULLIF(POSITION(query IN organisation.slug), 0), NULLIF(POSITION(query IN organisation."name"), 0), NULLIF(index_of_ror_query(query, organisation.id), -1))
+				LEAST(NULLIF(POSITION(LOWER(query) IN organisation.slug), 0), NULLIF(POSITION(LOWER(query) IN LOWER(organisation."name")), 0), NULLIF(index_of_ror_query(query, organisation.id), -1))
 		END) AS index_found
 	FROM
 		organisation
@@ -160,7 +160,7 @@ $$
 			WHEN community.slug ILIKE query OR community."name" ILIKE query THEN 0
 			WHEN community.slug ILIKE CONCAT(query, '%') OR community."name" ILIKE CONCAT(query, '%') THEN 0
 			ELSE
-				LEAST(NULLIF(POSITION(query IN community.slug), 0), NULLIF(POSITION(query IN community."name"), 0))
+				LEAST(NULLIF(POSITION(LOWER(query) IN community.slug), 0), NULLIF(POSITION(LOWER(query) IN LOWER(community."name")), 0))
 		END) AS index_found
 	FROM
 		community

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorData.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,6 +12,7 @@ public record RorData(
 	String city,
 	String wikipediaUrl,
 	List<String> rorTypes,
+	List<String> rorNames,
 	Double lat,
 	Double lon
 ) {

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorId.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorId.java
@@ -1,21 +1,26 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package nl.esciencecenter.rsd.scraper.ror;
 
 import java.net.URI;
+import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+/**
+ * This class represents ROR identifiers as described in <a href="https://ror.readme.io/docs/identifier">the ROR documentation</a>.
+ * <p>
+ * A {@link #isValidRorUrl(String) static factory method} is provided to construct instances of this class from a full URL string.
+ * As such, any instance of this class is guaranteed to contain a syntactically valid ROR ID.
+ * However, the last two digits of a ROR ID should be a checksum;  we don't currently validate this checksum.
+ */
 public class RorId {
 
 	private static final String ROR_BASE_URL = "https://ror.org/";
 	private static final String ROR_BASE_API_URL = "https://api.ror.org/organizations/";
-	// https://ror.readme.io/docs/identifier
-	// we haven't implemented the checksum of the last two digits, maybe something to do later;
-	// but we don't have this check in the database either
 	private static final Pattern ROR_URL_PATTERN = Pattern.compile("^https://ror\\.org/(0[a-hj-km-np-tv-z|\\d]{6}\\d{2})$");
 
 	private final String id;
@@ -24,13 +29,33 @@ public class RorId {
 		this.id = id;
 	}
 
+	/**
+	 * Tests if a URL string is a valid ROR ID as described in <a href="https://ror.readme.io/docs/identifier">the ROR documentation</a>.
+	 * The checksum is not validated though.
+	 *
+	 * @param url the URL string to validate
+	 * @return whether or not the provided URL is a valid ROR ID
+	 */
 	public static boolean isValidRorUrl(String url) {
 		return url != null && ROR_URL_PATTERN.asPredicate().test(url);
 	}
 
+	/**
+	 * A factory method to create instanced of RorId.
+	 * Only full URLs that look like {@code https://ror.org/02mhbdp94} are accepted.
+	 * <p>
+	 * Callers of this method should call {@link #isValidRorUrl(String)} first to validate their URL and
+	 * thus to prevent an exception from being thrown.
+	 *
+	 * @param url a non-null URL string that satisfies the conditions in <a href="https://ror.readme.io/docs/identifier">the ROR documentation</a>
+	 * @return a non-null instance of a RorId
+	 * @throws NullPointerException     when {@code url} is {@code null}
+	 * @throws IllegalArgumentException when {@code url} is not a valid ROR ID
+	 */
 	public static RorId fromUrlString(String url) {
+		Objects.requireNonNull(url);
 		if (!isValidRorUrl(url)) {
-			throw new IllegalArgumentException();
+			throw new IllegalArgumentException("The url %s is not a valid ROR ID".formatted(url));
 		}
 
 		Matcher matcher = ROR_URL_PATTERN.matcher(url);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorId.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorId.java
@@ -20,7 +20,8 @@ import java.util.regex.Pattern;
 public class RorId {
 
 	private static final String ROR_BASE_URL = "https://ror.org/";
-	private static final String ROR_BASE_API_URL = "https://api.ror.org/organizations/";
+	// https://ror.org/blog/2024-04-15-announcing-ror-v2/
+	private static final String ROR_BASE_API_V1_URL = "https://api.ror.org/v1/organizations/";
 	private static final Pattern ROR_URL_PATTERN = Pattern.compile("^https://ror\\.org/(0[a-hj-km-np-tv-z|\\d]{6}\\d{2})$");
 
 	private final String id;
@@ -68,8 +69,8 @@ public class RorId {
 		return URI.create(ROR_BASE_URL + id);
 	}
 
-	public URI asApiUrl() {
-		return URI.create(ROR_BASE_API_URL + id);
+	public URI asApiV1Url() {
+		return URI.create(ROR_BASE_API_V1_URL + id);
 	}
 
 	@Override

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorPostgrestConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorPostgrestConnector.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -51,6 +51,7 @@ public class RorPostgrestConnector {
 		jsonObject.addProperty("country", organisationData.data().country());
 		jsonObject.addProperty("city", organisationData.data().city());
 		jsonObject.addProperty("wikipedia_url", organisationData.data().wikipediaUrl());
+
 		JsonArray rorTypesJsonArray = new JsonArray();
 		List<String> rorTypes = organisationData.data().rorTypes();
 		if (rorTypes != null) {
@@ -59,6 +60,16 @@ public class RorPostgrestConnector {
 			}
 		}
 		jsonObject.add("ror_types", rorTypesJsonArray);
+
+		JsonArray rorNamesJsonArray = new JsonArray();
+		List<String> rorNames = organisationData.data().rorNames();
+		if (rorNames != null) {
+			for (String rorName : rorNames) {
+				rorNamesJsonArray.add(rorName);
+			}
+		}
+		jsonObject.add("ror_names", rorNamesJsonArray);
+
 		jsonObject.addProperty("lat", organisationData.data().lat());
 		jsonObject.addProperty("lon", organisationData.data().lon());
 

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ror/RorIdTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ror/RorIdTest.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -80,6 +80,6 @@ class RorIdTest {
 		RorId rorId = RorId.fromUrlString("https://ror.org/04tsk2644");
 
 		Assertions.assertEquals(URI.create("https://ror.org/04tsk2644"), rorId.asUrl());
-		Assertions.assertEquals(URI.create("https://api.ror.org/organizations/04tsk2644"), rorId.asApiUrl());
+		Assertions.assertEquals(URI.create("https://api.ror.org/v1/organizations/04tsk2644"), rorId.asApiV1Url());
 	}
 }


### PR DESCRIPTION
## Use alternative ROR names

### Changes proposed in this pull request

* Add a column in the `organisation` table that stores extra ROR names
* Adapt the ROR scraper to harvest these names
* Adapt `global_search` and `organisations_overview` to use these names
* Fix a bug in `global_search` that didn't convert strings to the same case when doing a substring index lookup

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, create a software of project page, publish it and add the organisations `Amsterdam University of Applied Sciences` and `Vrije Universiteit Amsterdam`
* Wait for the ROR scraper to run or execute `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.ror.MainRor`
* In the global search bar, search for `VU Amsterdam` and `Hogeschool van Amsterdam` (or substrings), the previously added organisations should show up
* Do the same on the organisation overview
* For performance, rerun with data generation: `docker compose down --volumes && docker compose up --scale data-generation=1`
* Search should be fast
* Let the ROR scraper run a few times
* Search should still be fast
* Look at http://localhost/api/v1/organisation?ror_names=not.is.null&select=name,slug,name,website,ror_names,ror_names_string for ideas of ROR names to search for; note that the names of the organisations are randomly generated and don't match the ROR names

**Nice to have**

When adding a new organisation with a ROR ID, add the extra names immediately.

Closes #1386

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [x] Tests
