### PR TITLE
Remove unused software filter rpc

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -59,6 +59,7 @@ $$;
 -- Keywords grouped by software for filtering
 -- We use array for selecting software with specific keywords
 -- We use text value for "wild card" search
+-- used by software_overview & software_search rpc
 CREATE FUNCTION keyword_filter_for_software() RETURNS TABLE (
 	software UUID,
 	keywords CITEXT[],
@@ -94,7 +95,7 @@ SELECT
 $$;
 
 -- programming language filter for software
--- used by software_overview func
+-- used by software_overview & software_search rpc
 CREATE FUNCTION prog_lang_filter_for_software() RETURNS TABLE (
 	software UUID,
 	prog_lang TEXT[]
@@ -112,7 +113,7 @@ $$
 $$;
 
 -- license filter for software
--- used by software_search func
+-- used by software_overview & software_search rpc
 CREATE FUNCTION license_filter_for_software() RETURNS TABLE (
 	software UUID,
 	licenses VARCHAR[]

--- a/database/104-software-views.sql
+++ b/database/104-software-views.sql
@@ -231,6 +231,7 @@ $$;
 
 -- SOFTWARE OVERVIEW LIST
 -- WITH COUNTS and KEYWORDS for filtering
+-- USED BY remote RSD scraper!
 CREATE FUNCTION software_overview() RETURNS TABLE (
 	id UUID,
 	slug VARCHAR,
@@ -322,7 +323,6 @@ RIGHT JOIN
 	software_highlight ON software_overview.id=software_highlight.software
 ;
 $$;
-
 
 -- SOFTWARE OVERVIEW LIST FOR SEARCH
 -- WITH COUNTS and KEYWORDS for filtering
@@ -445,7 +445,6 @@ INNER JOIN
 ;
 $$;
 
-
 -- Get a list of all software highlights
 CREATE FUNCTION software_for_highlight() RETURNS TABLE (
 	id UUID,
@@ -496,36 +495,6 @@ LEFT JOIN
 ;
 $$;
 
-
--- REACTIVE KEYWORD FILTER WITH COUNTS FOR SOFTWARE
--- PROVIDES AVAILABLE KEYWORDS FOR APPLIED FILTERS
-CREATE FUNCTION software_keywords_filter(
-	search_filter TEXT DEFAULT '',
-	keyword_filter CITEXT[] DEFAULT '{}',
-	prog_lang_filter TEXT[] DEFAULT '{}',
-	license_filter VARCHAR[] DEFAULT '{}'
-) RETURNS TABLE (
-	keyword CITEXT,
-	keyword_cnt INTEGER
-) LANGUAGE sql STABLE AS
-$$
-SELECT
-	UNNEST(keywords) AS keyword,
-	COUNT(id) AS keyword_cnt
-FROM
-	software_search(search_filter)
-WHERE
-	COALESCE(keywords, '{}') @> keyword_filter
-	AND
-	COALESCE(prog_lang, '{}') @> prog_lang_filter
-	AND
-	COALESCE(licenses, '{}') @> license_filter
-GROUP BY
-	keyword
-;
-$$;
-
-
 -- REACTIVE KEYWORD FILTER WITH COUNTS FOR HIGHLIGHTS
 -- PROVIDES AVAILABLE KEYWORDS FOR APPLIED FILTERS
 CREATE FUNCTION highlight_keywords_filter(
@@ -557,34 +526,6 @@ GROUP BY
 ;
 $$;
 
--- REACTIVE PROGRAMMING LANGUAGES WITH COUNTS FOR SOFTWARE
--- PROVIDES AVAILABLE PROGRAMMING LANGUAGES FOR APPLIED FILTERS
-CREATE FUNCTION software_languages_filter(
-	search_filter TEXT DEFAULT '',
-	keyword_filter CITEXT[] DEFAULT '{}',
-	prog_lang_filter TEXT[] DEFAULT '{}',
-	license_filter VARCHAR[] DEFAULT '{}'
-) RETURNS TABLE (
-	prog_language TEXT,
-	prog_language_cnt INTEGER
-) LANGUAGE sql STABLE AS
-$$
-SELECT
-	UNNEST(prog_lang) AS prog_language,
-	COUNT(id) AS prog_language_cnt
-FROM
-	software_search(search_filter)
-WHERE
-	COALESCE(keywords, '{}') @> keyword_filter
-	AND
-	COALESCE(prog_lang, '{}') @> prog_lang_filter
-	AND
-	COALESCE(licenses, '{}') @> license_filter
-GROUP BY
-	prog_language
-;
-$$;
-
 -- REACTIVE PROGRAMMING LANGUAGES WITH COUNTS FOR HIGHLIGHTS
 -- PROVIDES AVAILABLE PROGRAMMING LANGUAGES FOR APPLIED FILTERS
 CREATE FUNCTION highlight_languages_filter(
@@ -613,35 +554,6 @@ WHERE
 	COALESCE(categories, '{}') @> category_filter
 GROUP BY
 	prog_language
-;
-$$;
-
-
--- REACTIVE LICENSES FILTER WITH COUNTS FOR SOFTWARE
--- PROVIDES AVAILABLE LICENSES FOR APPLIED FILTERS
-CREATE FUNCTION software_licenses_filter(
-	search_filter TEXT DEFAULT '',
-	keyword_filter CITEXT[] DEFAULT '{}',
-	prog_lang_filter TEXT[] DEFAULT '{}',
-	license_filter VARCHAR[] DEFAULT '{}'
-) RETURNS TABLE (
-	license VARCHAR,
-	license_cnt INTEGER
-) LANGUAGE sql STABLE AS
-$$
-SELECT
-	UNNEST(licenses) AS license,
-	COUNT(id) AS license_cnt
-FROM
-	software_search(search_filter)
-WHERE
-	COALESCE(keywords, '{}') @> keyword_filter
-	AND
-	COALESCE(prog_lang, '{}') @> prog_lang_filter
-	AND
-	COALESCE(licenses, '{}') @> license_filter
-GROUP BY
-	license
 ;
 $$;
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ version: "3.0"
 services:
   database:
     build: ./database
-    image: rsd/database:2.6.0
+    image: rsd/database:3.0.0
     ports:
       # enable connection from outside (development mode)
       - "5432:5432"

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -366,7 +366,7 @@ export function softwareListUrl(props: PostgrestParams) {
   if (search) {
     // console.log('softwareListUrl...keywords...', props.keywords)
     const encodedSearch = encodeURIComponent(search)
-    // search query is performed in software_search RPC
+    // search query is performed in aggregated_software_search RPC
     // we search in title,subtitle,slug,keywords_text and prog_lang
     // check rpc in 105-project-views.sql for exact filtering
     query += `&search=${encodedSearch}`


### PR DESCRIPTION
# Remove unused software filter rpc's

Closes #1404

Changes proposed in this pull request:
*  Remove unused software filter rpc's. During introduction of remote rsd new aggregated filter rpcs where created and used on software overview page  
* This is BREAKING CHANGE, it should bump rsd to v3. I used `!` and BREAKING CHANGE in the commit.

How to test:
* `make start` to build and generate test data
* try software overview page and filter including search
* try other pages
* try remote rsd scraper

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
