### PR TITLE
fix: use null instead of empty string value when updating contributor

### DIFF
--- a/frontend/components/admin/rsd-contributors/apiRsdContributors.ts
+++ b/frontend/components/admin/rsd-contributors/apiRsdContributors.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -85,6 +85,8 @@ export async function patchPerson({id, key, value, origin, token}: {
         message: 'Property origin is missing'
       }
     }
+    // convert empty string value to null
+    if (value === '') value = null
     const url = `${getBaseUrl()}/${origin}?id=eq.${id}`
     // debugger
     const resp = await fetch(url, {


### PR DESCRIPTION
# Use null instead of empty string for contributor update

Closes #1409

Changes proposed in this pull request:
*   When updating contributor data we convert empty string "" to null. This enables removing existing values. 

How to test:
* `make start` to build solution and create test data
* login as rsd admin and navigate to /admin/rsd-contributors page
* add ORCID to an contributor. The value should be saved
* remove ORCID value from the contributor, this should not produce error. You can also validate patch call passing null value.
* You can also remove other values from the contributor like email or affiliation
* Note! You cannot remove first name and last name because these are required values. If you try it you will get error.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
