### PR TITLE
feat: enable removing avatar and enable selection when single image available

### DIFF
--- a/frontend/components/admin/rsd-contributors/AvatarOptions.tsx
+++ b/frontend/components/admin/rsd-contributors/AvatarOptions.tsx
@@ -12,8 +12,9 @@ import Badge from '@mui/material/Badge'
 import IconButton from '@mui/material/IconButton'
 
 import {useSession} from '~/auth'
-import {deleteImage, getImageUrl} from '~/utils/editImage'
+import {getImageUrl} from '~/utils/editImage'
 import {getDisplayInitials} from '~/utils/getDisplayName'
+import useSnackbar from '~/components/snackbar/useSnackbar'
 import {RsdContributor} from './useContributors'
 import {patchPerson} from './apiRsdContributors'
 
@@ -23,6 +24,7 @@ type AvatarOptionsProps={
 
 export default function AvatarOptions({data}:Readonly<AvatarOptionsProps>) {
   const {token} = useSession()
+  const {showErrorMessage} = useSnackbar()
   const [anchorEl, setAnchorEl] = useState(null)
   const menu = Boolean(anchorEl)
   const displayInitials = getDisplayInitials({
@@ -47,16 +49,11 @@ export default function AvatarOptions({data}:Readonly<AvatarOptionsProps>) {
       token
     })
     // debugger
-    if (resp.status===200){
-      // try to remove old avatar image
-      if (data.avatar_id){
-        deleteImage({
-          id: data.avatar_id,
-          token
-        })
-      }
+    if (resp.status==200){
       // update image
       data.avatar_id = avatar
+    }else{
+      showErrorMessage(`Failed to update avatar. ${resp?.message ?? ''}`)
     }
     // NOTE! this will refresh state
     handleClose()

--- a/frontend/components/admin/rsd-contributors/AvatarOptions.tsx
+++ b/frontend/components/admin/rsd-contributors/AvatarOptions.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -37,7 +37,7 @@ export default function AvatarOptions({data}:Readonly<AvatarOptionsProps>) {
   // console.log('avatars...', data.avatars)
   // console.groupEnd()
 
-  async function patchAvatar(avatar:string){
+  async function patchAvatar(avatar:string|null){
     // console.log('patchAvatar...', avatar)
     const resp = await patchPerson({
       id: data.id,
@@ -72,7 +72,7 @@ export default function AvatarOptions({data}:Readonly<AvatarOptionsProps>) {
   }
 
   // menu options to change avatar
-  if (data.avatars && data.avatars?.length > 1){
+  if (data.avatars && data.avatars?.length > 0){
     return (
       <>
         <Badge
@@ -107,15 +107,13 @@ export default function AvatarOptions({data}:Readonly<AvatarOptionsProps>) {
           anchorEl={anchorEl}
           onClose={handleClose}
         >
+          {/* LIST avatar options */}
           {data.avatars
             // show all options EXCEPT used one
             .filter(item=>item!==data.avatar_id)
             // render menu options
             .map((item:string)=>{
-              const displayInitials = getDisplayInitials({
-                given_names: data.given_names,
-                family_names: data.family_names
-              })
+
               const imageUrl = getImageUrl(item) ?? ''
               // debugger
               return (
@@ -137,12 +135,32 @@ export default function AvatarOptions({data}:Readonly<AvatarOptionsProps>) {
                 </MenuItem>
               )
             })}
+          {/* option to remove avatar */}
+          {data.avatar_id!==null ?
+            <MenuItem
+              data-testid="remove-avatar-option"
+              key={data.id}
+              onClick={()=>patchAvatar(null)}
+            >
+              <Avatar
+                src=""
+                sx={{
+                  width: '3rem',
+                  height: '3rem',
+                  fontSize: '1rem',
+                }}
+              >
+                {displayInitials}
+              </Avatar>
+            </MenuItem>
+            :null
+          }
         </Menu>
       </>
     )
   }
 
-  // one or NO avatar options
+  // NO avatar options
   return (
     <Badge
       overlap="circular"

--- a/frontend/components/admin/rsd-contributors/ContributorsTable.tsx
+++ b/frontend/components/admin/rsd-contributors/ContributorsTable.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -87,6 +87,9 @@ export default function ContributorsTable() {
       <div className="py-4 text-sm">
         * Avatars are aggregated by combination of Given names and Family names or ORCID.
         If there is more than one avatar option you can click on the avatar to change it.
+        <div className="text-sm">
+          * Unused avatar images are not removed from RSD database.
+        </div>
       </div>
     </div>
   )

--- a/frontend/components/admin/rsd-contributors/RsdContributorsPage.test.tsx
+++ b/frontend/components/admin/rsd-contributors/RsdContributorsPage.test.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -46,7 +46,7 @@ describe('components/admin/rsd-contributors/index.tsx', () => {
     // screen.debug(rows)
   })
 
-  it('shows avatar menu option', async()=>{
+  it('shows avatar menu options', async()=>{
     render(
       <WithAppContext options={{session: testSession}}>
         <RsdContributorsPage />
@@ -58,11 +58,15 @@ describe('components/admin/rsd-contributors/index.tsx', () => {
     // it should have menu options based on mocked data file person_mentions.json
     // const options = await screen.findAllByTestId('avatar-menu-options')
     // screen.debug(options)
-    const optionsBtn = screen.getByTestId('avatar-options')
+    const optionsBtn = screen.getAllByTestId('avatar-options')
     // click on options button
-    fireEvent.click(optionsBtn)
+    fireEvent.click(optionsBtn[0])
+
     // get menu items (it should be 1 option)
     const options = await screen.findAllByTestId('avatar-menu-option')
     expect(options.length).toBeGreaterThanOrEqual(1)
+
+    // it should also have option to remove avatar
+    screen.getByTestId('remove-avatar-option')
   })
 })

--- a/frontend/components/admin/rsd-contributors/useContributors.tsx
+++ b/frontend/components/admin/rsd-contributors/useContributors.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,7 +19,7 @@ export type RsdContributor = {
   affiliation: string
   role: string
   orcid: string
-  avatar_id: string
+  avatar_id: string | null
   origin: 'contributor' | 'team_member'
   slug: string
   public_orcid_profile: null | string


### PR DESCRIPTION
# Enable removing avatar on rsd contributor page

Closes #1410

Changes proposed in this pull request:
* Enable removing of avatar image of contributor on rsd contributors admin page
* Enable selection of avatar image when only one avatar image available 
* Do not remove changed avatar from RSD. Note! This will produce "dangling" avatar images in RSD database. We will address this by introducing background services in rsd admin section. New issue will be created for this.

How to test:
* `make start` to build app and generate data
* login as rsd admin and navigate to rsd contributors page of admin section
* select contributor with one image. Confirm you can remove avatar.
* find contributor without avatar which has one avatar option. Confirm you can assign avatar.
* find contributor with avatar and multiple options. Confirm you can remove avatar or assign another image

## Example remove avatar from contributor
![image](https://github.com/user-attachments/assets/d01a7d48-4e6d-4798-b701-197ebe52b85a)

## Example assigning avatar when only one item available
![image](https://github.com/user-attachments/assets/7cef0207-07a4-497f-8161-5b58d855df21)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
