### PR TITLE
Change software description title

### DIFF
--- a/frontend/components/software/AboutStatement.tsx
+++ b/frontend/components/software/AboutStatement.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,7 +24,7 @@ export default function AboutStatement({brand_name = '', description = '', descr
         className="text-[2rem] text-primary pb-4"
         data-testid="about-statement-title"
       >
-        What {brand_name} can do for you
+        Description
       </h2>
       <ReactMarkdownWithSettings
         markdown={description}

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
 //
@@ -48,7 +48,7 @@ export const softwareInformation = {
   },
   // field for markdown
   description: {
-    label: (brand_name: string) => `What ${brand_name} can do for you`,
+    label: 'Description',
     help: '/documentation/users/adding-software/#description',
     validation: {
       // we do not show error message for this one, we use only maxLength value

--- a/frontend/components/software/edit/information/AutosaveSoftwareMarkdown.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareMarkdown.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -40,9 +40,9 @@ export default function AutosaveSoftwareMarkdown() {
   })
 
   const [
-    id, brand_name, description_type, description, description_url
+    id, description_type, description, description_url
   ] = watch([
-    'id','brand_name','description_type','description','description_url'
+    'id','description_type','description','description_url'
   ])
 
   // console.group('AutosaveSoftwareMarkdown')
@@ -159,7 +159,7 @@ export default function AutosaveSoftwareMarkdown() {
   return (
     <>
       <EditSectionTitle
-        title={config.description.label(brand_name ?? '')}
+        title={config.description.label}
         infoLink={config.description.help}
       />
       <RadioGroup


### PR DESCRIPTION
# Change software description title

Closes #1422

Changes proposed in this pull request:
* Change description title on software page from "What {software_name} can do for you?" to "Description"
* Change description title on software edit page too

How to test:
* `make start` to build solution and generate test data
* navigate to software page and confirm "Description" title
* login and create new software. Confirm on description page the title is "Description"

## Example description title on software page
![image](https://github.com/user-attachments/assets/5e0c2375-ef16-46d4-b3f9-08361aab23f0)

## Example description title on edit software page
![image](https://github.com/user-attachments/assets/36d531ca-1e4c-4a55-99d4-86951b31400c)


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
