### PR TITLE
fix: add explanation about reference papers

### DIFF
--- a/documentation/docs/01-users/05-adding-software.md
+++ b/documentation/docs/01-users/05-adding-software.md
@@ -174,6 +174,12 @@ This section allows you to add mentions to your software page. You can use this 
 
 ### Reference papers
 
+:::info
+A reference paper is an article or artifact with a DOI that primarily describes your software, such as analysing its implementation efficiency or detailing new features.
+
+If other researchers use your software and mention it in their studies, please list these papers under [Related output](#related-output).
+:::
+
 Use the _Search_ box on the right hand side to find papers by DOI, OpenAlex ID or title. All the relevant data about the publication will be retrieved automatically. A background scraper will use [OpenAlex](https://openalex.org/) to collect all citations of reference papers that have a DOI or an OpenAlex ID.
 
 ### Citations

--- a/documentation/docs/01-users/05-adding-software.md.license
+++ b/documentation/docs/01-users/05-adding-software.md.license
@@ -1,10 +1,10 @@
 SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 Jason Maassen (Netherlands eScience Center) <j.maassen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2024 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
 SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2024 dv4all
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/frontend/components/software/edit/mentions/reference-papers/ReferencePapersInfo.tsx
+++ b/frontend/components/software/edit/mentions/reference-papers/ReferencePapersInfo.tsx
@@ -1,15 +1,22 @@
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import AlertTitle from '@mui/material/AlertTitle'
 import Alert from '@mui/material/Alert'
 
 export default function ReferencePapersInfo() {
   return (
     <Alert severity="info">
+      <AlertTitle sx={{fontWeight:500}}>About Reference papers</AlertTitle>
         Here you can add reference papers of your software. The RSD will periodically
         look for citations of this output using OpenAlex and add them to the citations list on this page.
+      <AlertTitle sx={{fontWeight:500, pt:"1rem"}}>What is a Reference paper?</AlertTitle>
+        A reference paper is an article or artifact with a DOI that primarily describes your software, such as analysing its implementation efficiency or detailing new features.
+        If other researchers use your software and mention it in their studies, please list these papers under &quot;Related output&quot;.
     </Alert>
   )
 }


### PR DESCRIPTION
This PR attempts to solve #1204 by adding a definition of reference papers.

Changes proposed in this pull request:

* adds a definition of reference paper to the software edit view and documentation
  ![image](https://github.com/user-attachments/assets/9aeedb9f-f466-44e0-b400-06a734f99e3a)

How to test:

* `docker compose build --parallel && docker compose up`
* create a new software, go to mentions
* open the documentation and navigate to -> User Manual -> Adding software -> Reference papers

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
