### PR TITLE
feat: better category search

### DIFF
--- a/frontend/components/category/CategoriesDialogBody.tsx
+++ b/frontend/components/category/CategoriesDialogBody.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -104,25 +105,51 @@ export default function CategoriesDialogBody({
       )
 
     case 'ready':
-      return (
-        <>
-          {(categories === null || categories.length === 0)
-            ?
-            <Alert severity="info" sx={{'padding': '2rem', height:'inherit', width:'inherit'}}>
-              <AlertTitle sx={{fontWeight:500}}>No categories</AlertTitle>
-              {noItemsMsg}
-            </Alert>
-            :
-            <List>
-              <CategoryList
-                categories={categories}
-                isSelected={isSelected}
-                onSelect={onSelect}
-                searchFor={searchFor}
-              />
-            </List>
+      if (categories.length === 0) {
+        return (
+          <Alert severity="info" sx={{'padding': '2rem', height:'inherit', width:'inherit'}}>
+            <AlertTitle sx={{fontWeight:500}}>No categories</AlertTitle>
+            {noItemsMsg}
+          </Alert>
+        )
+      }
+
+
+      // copy to filtered
+      let filtered = [...categories]
+      // filter if search provided
+      if (searchFor){
+        filtered = []
+        const lowerCaseQuery = searchFor.toLocaleLowerCase()
+        for (const root of categories) {
+          const filteredTree = root.subTreeWhereNodesSatisfy(item =>
+            item.short_name.toLocaleLowerCase().includes(lowerCaseQuery) ||
+            item.name.toLocaleLowerCase().includes(lowerCaseQuery)
+          )
+
+          if (filteredTree !== null) {
+            filtered.push(filteredTree)
           }
-        </>
+        }
+      }
+
+      if (filtered.length === 0) {
+        return (
+          <Alert severity="info">
+            <AlertTitle sx={{fontWeight:500}}>No match</AlertTitle>
+            No category label or description found for <strong>{searchFor}</strong>.
+          </Alert>
+        )
+      }
+
+      return (
+        <List>
+          <CategoryList
+            categories={filtered}
+            isSelected={isSelected}
+            onSelect={onSelect}
+          />
+        </List>
       )
   }
 

--- a/frontend/components/category/CategoryList.tsx
+++ b/frontend/components/category/CategoryList.tsx
@@ -50,7 +50,6 @@ function CategoryContent({
     <ListItemButton
       onClick={onSelect}
     >
-
       <ListItemIcon>
         <Checkbox
           edge="start"
@@ -58,7 +57,6 @@ function CategoryContent({
           checked={isSelected}
         />
       </ListItemIcon>
-
       <ListItemText
         // alias Label
         primary={cat.short_name}

--- a/frontend/types/TreeNode.test.ts
+++ b/frontend/types/TreeNode.test.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {TreeNode} from '~/types/TreeNode'
+
+test('method subTreeWhereNodesSatisfy works correctly', () => {
+  const root = new TreeNode('abc')
+  root.addChild(new TreeNode('def'))
+  root.addChild(new TreeNode('123'))
+
+  const filteredTree = root.subTreeWhereNodesSatisfy(s => s === 'abc')
+  expect(filteredTree).toBeTruthy()
+  expect(filteredTree?.childrenCount()).toBe(2)
+
+  const filteredTree2 = root.subTreeWhereNodesSatisfy(s => s === '123')
+  expect(filteredTree2).toBeTruthy()
+  expect(filteredTree2?.childrenCount()).toBe(1)
+})
+
+test('method subTreeWhereLeavesSatisfy works correctly', () => {
+  const root = new TreeNode('abc')
+  root.addChild(new TreeNode('def'))
+  root.addChild(new TreeNode('123'))
+
+  const filteredTree = root.subTreeWhereLeavesSatisfy(s => s === 'abc')
+  expect(filteredTree).toBeNull()
+
+  const filteredTree2 = root.subTreeWhereNodesSatisfy(s => s === '123')
+  expect(filteredTree2).toBeTruthy()
+  expect(filteredTree2?.childrenCount()).toBe(1)
+})

--- a/frontend/types/TreeNode.ts
+++ b/frontend/types/TreeNode.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -42,6 +42,16 @@ export class TreeNode<T> {
     }
   }
 
+  clone(): TreeNode<T> {
+    const clone = new TreeNode(this.#value)
+
+    for (const child of this.#children) {
+      clone.addChild(child.clone())
+    }
+
+    return clone
+  }
+
   subTreeWhereLeavesSatisfy(predicate: (value: T) => boolean): TreeNode<T> | null {
     if (this.#children.size === 0) {
       return predicate(this.#value) ? new TreeNode<T>(this.#value) : null
@@ -50,6 +60,22 @@ export class TreeNode<T> {
     const newNode = new TreeNode<T>(this.#value)
     for (const child of this.#children) {
       const newSubTree = child.subTreeWhereLeavesSatisfy(predicate)
+      if (newSubTree !== null) {
+        newNode.addChild(newSubTree)
+      }
+    }
+
+    return newNode.#children.size === 0 ? null : newNode
+  }
+
+  subTreeWhereNodesSatisfy(predicate: (value: T) => boolean): TreeNode<T> | null {
+    if (predicate(this.#value)) {
+      return this.clone()
+    }
+
+    const newNode = new TreeNode<T>(this.#value)
+    for (const child of this.#children) {
+      const newSubTree = child.subTreeWhereNodesSatisfy(predicate)
       if (newSubTree !== null) {
         newNode.addChild(newSubTree)
       }


### PR DESCRIPTION
## Improved category search

### Changes proposed in this pull request

* When searching categories, we not only search in the leaves (i.e. categories without children), but all nodes

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin, add an organisation
* Create categories for that organisation as in #1421 (enable it for software)
* Create a software page and add the organisation
* When searching for `international` in the category list, the respective node, its parent and children should be visible

Closes #1421

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests
