### PR TITLE
777 optimise gitlab scraper new

### DIFF
--- a/documentation/docs/01-users/05-adding-software.md
+++ b/documentation/docs/01-users/05-adding-software.md
@@ -253,6 +253,8 @@ Here, you can see all the people who can maintain this software page. You can al
 
 Here you can find the information about the background services that RSD offers and their last status.
 
+You can clear the data that the scrapers collected by clicking on the delete icons next to the individual services. This is useful for example if you changed your default branch or rebased your git commit history.
+
 :::tip
 Please check this section from time to time to confirm that information you provided is correct and that RSD background services are able to use provided information in the proper way.
 :::

--- a/frontend/components/software/edit/services/SoftwareRepoServices.tsx
+++ b/frontend/components/software/edit/services/SoftwareRepoServices.tsx
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -30,7 +33,8 @@ export default function SoftwareRepoServices() {
             scraped_at: services ? services[service.props.scraped_at] : null,
             last_error: services ? services[service.props.last_error] : null,
             url: services ? services[service.props.url] : null,
-            platform: services ? services['code_platform'] : null
+            platform: services ? services['code_platform'] : null,
+            dbprops: service.dbprops
           }
           return (
             <ServiceInfoListItem key={service.name} scraping_disabled_reason={null} {...props} />

--- a/frontend/components/software/edit/services/SoftwareRepoServices.tsx
+++ b/frontend/components/software/edit/services/SoftwareRepoServices.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -16,7 +16,7 @@ import {ServiceInfoListItem} from './ServiceInfoListItem'
 
 
 export default function SoftwareRepoServices() {
-  const {loading,services} = useSoftwareServices()
+  const {loading,services,loadServices} = useSoftwareServices()
 
   if (loading) return <ContentLoader />
 
@@ -37,12 +37,15 @@ export default function SoftwareRepoServices() {
             dbprops: service.dbprops
           }
           return (
-            <ServiceInfoListItem key={service.name} scraping_disabled_reason={null} {...props} />
+            <ServiceInfoListItem
+              key={service.name}
+              scraping_disabled_reason={null}
+              onClear={()=>loadServices(false)}
+              {...props}
+            />
           )
         })}
       </List>
     </>
-
   )
-
 }

--- a/frontend/components/software/edit/services/apiSoftwareServices.tsx
+++ b/frontend/components/software/edit/services/apiSoftwareServices.tsx
@@ -1,6 +1,9 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -158,5 +161,38 @@ export function useSoftwareServices(){
   return {
     loading,
     services
+  }
+}
+
+export async function deleteServiceDataFromDb({dbprops, software, token}:
+  {dbprops:string[], software: string, token:string}){
+  try {
+    const query = `repository_url?software=eq.${software}`
+    const url = `${getBaseUrl()}/${query}`
+    const resp = await fetch(url, {
+      method: 'PATCH',
+      headers: {
+        ...createJsonHeaders(token),
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify(
+        dbprops.reduce((acc, dbprop) => ({...acc, [dbprop]: null}), {})
+      )
+    })
+    if (resp.status === 204) {
+      const formattedProps = dbprops
+        .map((str, index) => (index === 0 ? str.replace(/_/g, ' ').replace(/^./, c => c.toUpperCase()) : str.replace(/_/g, ' ')))
+        .join(', ')
+      return {
+        status: 204,
+        message: `${formattedProps} cleared from database.`
+      }
+    }
+  } catch (e: any) {
+    logger(`deleteServiceDataFromDb: ${e?.message}`, 'error')
+    return {
+      status: 500,
+      message: e?.message
+    }
   }
 }

--- a/frontend/components/software/edit/services/config.ts
+++ b/frontend/components/software/edit/services/config.ts
@@ -1,5 +1,8 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,21 +15,25 @@ type ServiceListProps={
     scraped_at: keyof SoftwareServices,
     last_error: keyof SoftwareServices,
     url: keyof SoftwareServices
-  }
+  },
+  dbprops: string[]
 }
 
 export const repoServiceList:ServiceListProps[]=[{
   name: 'Commit history',
   desc: 'Information is extracted from the repository api (github/gitlab)',
-  props:{scraped_at:'commit_history_scraped_at',last_error:'commit_history_last_error',url:'url'}
+  props:{scraped_at:'commit_history_scraped_at',last_error:'commit_history_last_error',url:'url'},
+  dbprops: ['commit_history']
 },{
   name: 'Programming languages',
   desc: 'Information is extracted from the repository api (github/gitlab)',
-  props:{scraped_at:'languages_scraped_at',last_error:'languages_last_error',url:'url'}
+  props:{scraped_at:'languages_scraped_at',last_error:'languages_last_error',url:'url'},
+  dbprops: ['languages']
 },{
   name: 'Repository statistics',
   desc: 'Information is extracted from the repository api (github/gitlab)',
-  props:{scraped_at:'basic_data_scraped_at',last_error:'basic_data_last_error',url:'url'}
+  props:{scraped_at:'basic_data_scraped_at',last_error:'basic_data_last_error',url:'url'},
+  dbprops: ['star_count', 'fork_count', 'open_issue_count', 'contributor_count']
 }]
 
 

--- a/frontend/components/software/edit/services/config.ts
+++ b/frontend/components/software/edit/services/config.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
@@ -23,17 +23,17 @@ export const repoServiceList:ServiceListProps[]=[{
   name: 'Commit history',
   desc: 'Information is extracted from the repository api (github/gitlab)',
   props:{scraped_at:'commit_history_scraped_at',last_error:'commit_history_last_error',url:'url'},
-  dbprops: ['commit_history']
+  dbprops: ['commit_history','commit_history_scraped_at']
 },{
   name: 'Programming languages',
   desc: 'Information is extracted from the repository api (github/gitlab)',
   props:{scraped_at:'languages_scraped_at',last_error:'languages_last_error',url:'url'},
-  dbprops: ['languages']
+  dbprops: ['languages','languages_scraped_at']
 },{
   name: 'Repository statistics',
   desc: 'Information is extracted from the repository api (github/gitlab)',
   props:{scraped_at:'basic_data_scraped_at',last_error:'basic_data_last_error',url:'url'},
-  dbprops: ['star_count', 'fork_count', 'open_issue_count', 'contributor_count']
+  dbprops: ['star_count', 'fork_count', 'open_issue_count', 'contributor_count','basic_data_scraped_at']
 }]
 
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicRepositoryDataWithHistory.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicRepositoryDataWithHistory.java
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper.git;
+
+import java.time.ZonedDateTime;
+import java.util.UUID;
+
+public record BasicRepositoryDataWithHistory(UUID software, String url, ZonedDateTime commitHistoryScrapedAt, CommitsPerWeek commitsPerWeek) {
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeek.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeek.java
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,6 +15,7 @@ import com.google.gson.JsonSerializer;
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.Period;
+import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
@@ -26,11 +29,15 @@ import java.util.TreeMap;
  */
 public class CommitsPerWeek {
 
-	final SortedMap<Instant, Long> data = new TreeMap<>();
+	private final SortedMap<Instant, Long> data = new TreeMap<>();
 	static final Gson gson = new GsonBuilder()
 			.enableComplexMapKeySerialization()
 			.registerTypeAdapter(Instant.class, (JsonSerializer<Instant>) (src, typeOfSrc, context) -> new JsonPrimitive(src.getEpochSecond()))
 			.create();
+
+	SortedMap<Instant, Long> getData() {
+		return new TreeMap<>(data);
+	}
 
 	public void addCommits(ZonedDateTime zonedDateTime, long count) {
 		ZonedDateTime utcTime = zonedDateTime.withZoneSameInstant(ZoneOffset.UTC);
@@ -41,6 +48,15 @@ public class CommitsPerWeek {
 	public void addCommits(Instant instant, long count) {
 		ZonedDateTime utcTime = ZonedDateTime.ofInstant(instant, ZoneOffset.UTC);
 		addCommits(utcTime, count);
+	}
+
+	public ZonedDateTime popLatestTimestamp() {
+		if (this.data.size() > 0) {
+			Instant lastTimeStamp = this.data.lastKey();
+			this.data.remove(lastTimeStamp);
+			return ZonedDateTime.ofInstant(lastTimeStamp, ZoneId.systemDefault());
+		}
+		return null;
 	}
 
 	/**

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeekTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeekTest.java
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,11 +24,12 @@ class CommitsPerWeekTest {
 	@Test
 	void givenInstance_whenValidOperations_thenCorrectResults() {
 		CommitsPerWeek commitsPerWeek = new CommitsPerWeek();
-		Map<Instant, Long> underlyingMap = commitsPerWeek.data;
+		Map<Instant, Long> underlyingMap;
 
 		Instant sundayMidnight1 = Instant.ofEpochSecond(1670716800);
 		commitsPerWeek.addCommits(sundayMidnight1, 10);
 
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(1, underlyingMap.size());
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight1));
 		Assertions.assertEquals(10, underlyingMap.get(sundayMidnight1));
@@ -34,6 +37,7 @@ class CommitsPerWeekTest {
 
 		commitsPerWeek.addCommits(sundayMidnight1, 20);
 
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(1, underlyingMap.size());
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight1));
 		Assertions.assertEquals(30, underlyingMap.get(sundayMidnight1));
@@ -43,6 +47,7 @@ class CommitsPerWeekTest {
 			.plus(Duration.ofSeconds(12345));
 		commitsPerWeek.addCommits(smallTimeAfterSundayMidnight1, 10);
 
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(1, underlyingMap.size());
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight1));
 		Assertions.assertEquals(40, underlyingMap.get(sundayMidnight1));
@@ -51,6 +56,7 @@ class CommitsPerWeekTest {
 		Instant sundayMidnight2 = sundayMidnight1.plus(Period.ofWeeks(5));
 		commitsPerWeek.addCommits(sundayMidnight2, 5);
 
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(2, underlyingMap.size());
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight2));
 		Assertions.assertEquals(5, underlyingMap.get(sundayMidnight2));
@@ -58,6 +64,7 @@ class CommitsPerWeekTest {
 
 
 		commitsPerWeek.addMissingZeros();
+		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(6, underlyingMap.size());
 		Assertions.assertEquals(0, underlyingMap.get(sundayMidnight1.plus(Period.ofWeeks(1))));
 		Assertions.assertEquals(0, underlyingMap.get(sundayMidnight1.plus(Period.ofWeeks(2))));


### PR DESCRIPTION
**This is the successor of #1374**

Fixes #777

Changes proposed in this pull request:

* optimise gitlab scrapers so that they do not scrape the entire commit history every time they run
* scraper uses the last timestamp in `commit_history` to query the GitLab APIs
* the commit history could become incorrect if
  * if the entire commit history was rewritten
  * if the default branch changed
* added delete buttons to reset scraped metadata (commit history, programming languages, repository statistics)

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up`
* login and create a new software that uses a gitlab repository url, e.g.
  ```
  https://codebase.helmholtz.cloud/research-software-directory/RSD-as-a-service
  ```
* publish the software entry
* start the commit scrapers
  ```
  docker compose exec scrapers /opt/java/openjdk/bin/java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainCommits
  ```
* the first time the scraping will take a while until it is finished
* in the database, modify the `commit_history` field of the software, e.g. by removing the last timestamp value. Optionally, modify the last commit value to a very high number.
* modify the `commit_history_scraped_at` field to a timestamp that is older than one hour
* verify the new commit history in the frontend
* rerun scrapers
* `commit_history` should now be updated, the new timestamp was added, and (if modified), the second-to-last timestamp value should now be correct
* click on all delete buttons in the backend services tab and verify that the logs are removed

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
