### PR TITLE
fix: enable delete of parent categories after tree is changed

### DIFF
--- a/frontend/components/category/CategoriesDialogBody.tsx
+++ b/frontend/components/category/CategoriesDialogBody.tsx
@@ -122,7 +122,7 @@ export default function CategoriesDialogBody({
         filtered = []
         const lowerCaseQuery = searchFor.toLocaleLowerCase()
         for (const root of categories) {
-          const filteredTree = root.subTreeWhereNodesSatisfy(item =>
+          const filteredTree = root.subTreeWhereNodesSatisfyWithChildren(item =>
             item.short_name.toLocaleLowerCase().includes(lowerCaseQuery) ||
             item.name.toLocaleLowerCase().includes(lowerCaseQuery)
           )

--- a/frontend/components/category/CategoryTree.tsx
+++ b/frontend/components/category/CategoryTree.tsx
@@ -16,27 +16,11 @@ import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
 
 export type CategoryTreeLevelProps = {
   items: TreeNode<CategoryEntry>[]
+  selectedList?: Set<string>
   showLongNames?: boolean
   onRemove?: (categoryId: string) => void
 }
-export const CategoryTreeLevel = ({onRemove, ...props}: CategoryTreeLevelProps) => {
-
-  const onRemoveHandler = (event: React.MouseEvent<HTMLElement>) => {
-    event.stopPropagation()
-    const categoryId = event.currentTarget.dataset.id!
-    onRemove?.(categoryId)
-  }
-
-  return <TreeLevel {...props} onRemoveHandler={onRemove && onRemoveHandler}/>
-}
-
-
-type TreeLevelProps = {
-  items: TreeNode<CategoryEntry>[]
-  showLongNames?: boolean
-  onRemoveHandler? : (event: React.MouseEvent<HTMLElement>) => void
-}
-const TreeLevel = ({items, showLongNames, onRemoveHandler}: TreeLevelProps) => {
+export default function CategoryTree({onRemove,items,showLongNames,selectedList}: CategoryTreeLevelProps){
   return (
     <ul className={'list-disc list-outside pl-6'}>
       {items.map((item) => {
@@ -51,15 +35,24 @@ const TreeLevel = ({items, showLongNames, onRemoveHandler}: TreeLevelProps) => {
                   <span className='pb-1'>{showLongNames ? category.name : category.short_name}</span>
                 </Tooltip>
               </Link>
-              { onRemoveHandler && children.length === 0 ?
-				          <IconButton sx={{top: '-0.25rem'}} data-id={category.id} size='small'onClick={onRemoveHandler}>
+              { onRemove && selectedList && selectedList.has(category.id) ?
+				        <IconButton
+                  // sx={{top: '-0.25rem'}}
+                  // data-id={category.id}
+                  size='small'
+                  onClick={()=>onRemove(category.id)}>
                   <CancelIcon fontSize='small'/>
                 </IconButton>
                 :null
               }
             </div>
             {children.length > 0 ?
-			        <TreeLevel items={children} showLongNames={showLongNames} onRemoveHandler={onRemoveHandler}/>
+			        <CategoryTree
+                items={children}
+                showLongNames={showLongNames}
+                selectedList={selectedList}
+                onRemove={onRemove}
+              />
               : null
             }
           </li>

--- a/frontend/components/category/CategoryTree.tsx
+++ b/frontend/components/category/CategoryTree.tsx
@@ -14,12 +14,13 @@ import {CategoryEntry} from '~/types/Category'
 import {TreeNode} from '~/types/TreeNode'
 import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
 
-export type CategoryTreeLevelProps = {
+export type CategoryTreeLevelProps = Readonly<{
   items: TreeNode<CategoryEntry>[]
   selectedList?: Set<string>
   showLongNames?: boolean
   onRemove?: (categoryId: string) => void
-}
+}>
+
 export default function CategoryTree({onRemove,items,showLongNames,selectedList}: CategoryTreeLevelProps){
   return (
     <ul className={'list-disc list-outside pl-6'}>
@@ -35,10 +36,8 @@ export default function CategoryTree({onRemove,items,showLongNames,selectedList}
                   <span className='pb-1'>{showLongNames ? category.name : category.short_name}</span>
                 </Tooltip>
               </Link>
-              { onRemove && selectedList && selectedList.has(category.id) ?
+              { onRemove && selectedList?.has(category.id) ?
 				        <IconButton
-                  // sx={{top: '-0.25rem'}}
-                  // data-id={category.id}
                   size='small'
                   onClick={()=>onRemove(category.id)}>
                   <CancelIcon fontSize='small'/>

--- a/frontend/components/category/TreeSelect.tsx
+++ b/frontend/components/category/TreeSelect.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -41,7 +41,9 @@ export function RecursivelyGenerateItems<T>({
 
     const key = keyExtractor(val)
     const text = textExtractor(val)
-    if (node.childrenCount() === 0) {
+
+    // show checkbox only on 'lower level' items where parent!=null
+    if (node.childrenCount() === 0 && (val as any)?.parent !== null) {
       return (
         <MenuItem dense disableRipple key={key} onClick={() => onSelect(node)}>
           <Checkbox disableRipple checked={isSelected(node)} />

--- a/frontend/components/software/CategoriesSection.tsx
+++ b/frontend/components/software/CategoriesSection.tsx
@@ -10,7 +10,7 @@ import {CategoryPath} from '~/types/Category'
 import PageContainer from '~/components/layout/PageContainer'
 import {useCategoryTree} from '~/components/category/useCategoryTree'
 import {CategoryTable} from '~/components//category/CategoryTable'
-import {CategoryTreeLevel} from '~/components/category/CategoryTree'
+import CategoryTree from '~/components/category/CategoryTree'
 
 export type CategoriesSectionProps = Readonly<{
   categories: CategoryPath[]
@@ -36,7 +36,7 @@ export default function CategoriesSection({categories}: CategoriesSectionProps) 
           <CategoryTable tree={node} />
         </section>
         <section className="sm:hidden">
-          <CategoryTreeLevel items={children} showLongNames/>
+          <CategoryTree items={children} showLongNames/>
         </section>
       </PageContainer>
     )

--- a/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
+++ b/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
@@ -14,7 +14,7 @@ import {addCategoryToSoftware, deleteCategoryToSoftware} from '~/utils/getSoftwa
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import {categoryTreeNodesSort} from '~/components/category/useCategoryTree'
 import TreeSelect from '~/components/category/TreeSelect'
-import {CategoryTreeLevel} from '~/components/category/CategoryTree'
+import CategoryTree from '~/components/category/CategoryTree'
 import {ReorderedCategories} from '~/components/category/useReorderedCategories'
 import {config} from '~/components/software/edit/links/config'
 
@@ -32,7 +32,7 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
   const selectedNodes: TreeNode<CategoryEntry>[] = []
 
   for (const root of reorderedCategories.all) {
-    const rootSelectedSubTree= root.subTreeWhereLeavesSatisfy(value => associatedCategoryIds.has(value.id))
+    const rootSelectedSubTree= root.subTreeWhereNodesSatisfy(value => associatedCategoryIds.has(value.id))
     if (rootSelectedSubTree !== null) {
       selectedNodes.push(rootSelectedSubTree)
     }
@@ -116,11 +116,23 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
     return result
   }
 
+  // console.group('AutosaveSoftwareCategories')
+  // console.log('associatedCategoryIds...',associatedCategoryIds)
+  // console.log('availableCategoriesTree...',availableCategoriesTree)
+  // console.groupEnd()
+
   return (
     <>
       {availableCategoriesTree.map(root => {
         const rootValue = root.getValue()
         const children = root.children()
+        const selected = extractSelectedRoots(root)
+
+        // console.group('availableCategoriesTree.map')
+        // console.log('rootValue...',rootValue)
+        // console.log('children...',children)
+        // console.log('selected...',selected)
+        // console.groupEnd()
 
         return (
           <Fragment key={rootValue.id}>
@@ -142,7 +154,13 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
 
             <div className="mt-6"/>
 
-            <CategoryTreeLevel showLongNames items={extractSelectedRoots(root)} onRemove={deleteCategoryId}/>
+            <CategoryTree
+              showLongNames
+              items={selected}
+              onRemove={deleteCategoryId}
+              selectedList={associatedCategoryIds}
+            />
+
           </Fragment>
         )
       })}

--- a/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
+++ b/frontend/components/software/edit/links/AutosaveSoftwareCategories.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -32,7 +32,7 @@ export default function AutosaveSoftwareCategories({softwareId, reorderedCategor
   const selectedNodes: TreeNode<CategoryEntry>[] = []
 
   for (const root of reorderedCategories.all) {
-    const rootSelectedSubTree= root.subTreeWhereNodesSatisfy(value => associatedCategoryIds.has(value.id))
+    const rootSelectedSubTree= root.subTreeWhereNodesSatisfyWithoutChildren(value => associatedCategoryIds.has(value.id))
     if (rootSelectedSubTree !== null) {
       selectedNodes.push(rootSelectedSubTree)
     }

--- a/frontend/components/software/edit/links/AutosaveSoftwareLicenses.test.tsx
+++ b/frontend/components/software/edit/links/AutosaveSoftwareLicenses.test.tsx
@@ -101,7 +101,6 @@ it('can add NEW license', async() => {
   defaultValues.licenses = []
   defaultValues.concept_doi = null
 
-
   // render
   render(
     <WithAppContext options={{session: mockSession}}>
@@ -116,10 +115,11 @@ it('can add NEW license', async() => {
   const combo = screen.getByRole('combobox')
   fireEvent.change(combo, {target: {value: newLicense.name}})
 
-  // find Add option
-  const addLicense = await screen.findByRole('option', {
-    name: `Add "${newLicense.name}"`
-  })
+  // find Add option by testId
+  const addLicense = await screen.findByTestId('add-license-option')
+  // const addLicense = await screen.findByRole('option', {
+  //   name: `Add "${newLicense.name}"`
+  // })
   // select to add new license
   fireEvent.click(addLicense)
 

--- a/frontend/components/software/edit/links/AutosaveSoftwareLicenses.tsx
+++ b/frontend/components/software/edit/links/AutosaveSoftwareLicenses.tsx
@@ -2,9 +2,9 @@
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -191,7 +191,7 @@ export default function AutosaveSoftwareLicenses() {
   function renderAddOption(props: HTMLAttributes<HTMLLIElement>,
     option: AutocompleteOption<License>) {
     return (
-      <li {...props} key={option.key}>
+      <li {...props} key={option.key} data-testid="add-license-option">
         {/* if new option (has input) show label and count  */}
         <strong>{`Add "${option.label}"`}</strong>
       </li>

--- a/frontend/components/software/edit/mentions/reference-papers/ReferencePapersInfo.tsx
+++ b/frontend/components/software/edit/mentions/reference-papers/ReferencePapersInfo.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -14,7 +14,7 @@ export default function ReferencePapersInfo() {
       <AlertTitle sx={{fontWeight:500}}>About Reference papers</AlertTitle>
         Here you can add reference papers of your software. The RSD will periodically
         look for citations of this output using OpenAlex and add them to the citations list on this page.
-      <AlertTitle sx={{fontWeight:500, pt:"1rem"}}>What is a Reference paper?</AlertTitle>
+      <AlertTitle sx={{fontWeight:500, pt:'1rem'}}>What is a Reference paper?</AlertTitle>
         A reference paper is an article or artifact with a DOI that primarily describes your software, such as analysing its implementation efficiency or detailing new features.
         If other researchers use your software and mention it in their studies, please list these papers under &quot;Related output&quot;.
     </Alert>

--- a/frontend/types/TreeNode.test.ts
+++ b/frontend/types/TreeNode.test.ts
@@ -5,16 +5,32 @@
 
 import {TreeNode} from '~/types/TreeNode'
 
-test('method subTreeWhereNodesSatisfy works correctly', () => {
+test('method subTreeWhereNodesSatisfyWithChildren works correctly', () => {
   const root = new TreeNode('abc')
   root.addChild(new TreeNode('def'))
   root.addChild(new TreeNode('123'))
 
-  const filteredTree = root.subTreeWhereNodesSatisfy(s => s === 'abc')
+  const filteredTree = root.subTreeWhereNodesSatisfyWithChildren(s => s === 'abc')
   expect(filteredTree).toBeTruthy()
   expect(filteredTree?.childrenCount()).toBe(2)
+  expect(filteredTree?.getValue()).toBe('abc')
 
-  const filteredTree2 = root.subTreeWhereNodesSatisfy(s => s === '123')
+  const filteredTree2 = root.subTreeWhereNodesSatisfyWithChildren(s => s === '123')
+  expect(filteredTree2).toBeTruthy()
+  expect(filteredTree2?.childrenCount()).toBe(1)
+})
+
+test('method subTreeWhereNodesSatisfyWithoutChildren works correctly', () => {
+  const root = new TreeNode('abc')
+  root.addChild(new TreeNode('def'))
+  root.addChild(new TreeNode('123'))
+
+  const filteredTree = root.subTreeWhereNodesSatisfyWithoutChildren(s => s === 'abc')
+  expect(filteredTree).toBeTruthy()
+  expect(filteredTree?.childrenCount()).toBe(0)
+  expect(filteredTree?.getValue()).toBe('abc')
+
+  const filteredTree2 = root.subTreeWhereNodesSatisfyWithoutChildren(s => s === '123')
   expect(filteredTree2).toBeTruthy()
   expect(filteredTree2?.childrenCount()).toBe(1)
 })
@@ -27,7 +43,7 @@ test('method subTreeWhereLeavesSatisfy works correctly', () => {
   const filteredTree = root.subTreeWhereLeavesSatisfy(s => s === 'abc')
   expect(filteredTree).toBeNull()
 
-  const filteredTree2 = root.subTreeWhereNodesSatisfy(s => s === '123')
+  const filteredTree2 = root.subTreeWhereLeavesSatisfy(s => s === '123')
   expect(filteredTree2).toBeTruthy()
   expect(filteredTree2?.childrenCount()).toBe(1)
 })

--- a/frontend/types/TreeNode.ts
+++ b/frontend/types/TreeNode.ts
@@ -68,20 +68,32 @@ export class TreeNode<T> {
     return newNode.#children.size === 0 ? null : newNode
   }
 
-  subTreeWhereNodesSatisfy(predicate: (value: T) => boolean): TreeNode<T> | null {
+  subTreeWhereNodesSatisfyWithChildren(predicate: (value: T) => boolean): TreeNode<T> | null {
     if (predicate(this.#value)) {
       return this.clone()
     }
 
     const newNode = new TreeNode<T>(this.#value)
     for (const child of this.#children) {
-      const newSubTree = child.subTreeWhereNodesSatisfy(predicate)
+      const newSubTree = child.subTreeWhereNodesSatisfyWithChildren(predicate)
       if (newSubTree !== null) {
         newNode.addChild(newSubTree)
       }
     }
 
     return newNode.#children.size === 0 ? null : newNode
+  }
+
+  subTreeWhereNodesSatisfyWithoutChildren(predicate: (value: T) => boolean): TreeNode<T> | null {
+    const newNode = new TreeNode<T>(this.#value)
+    for (const child of this.#children) {
+      const newSubTree = child.subTreeWhereNodesSatisfyWithoutChildren(predicate)
+      if (newSubTree !== null) {
+        newNode.addChild(newSubTree)
+      }
+    }
+
+    return newNode.#children.size === 0 && !predicate(this.#value) ? null : newNode
   }
 
   sortRecursively(comparator: (val1: T, val2: T) => number) {


### PR DESCRIPTION
# Enable deletion of parent items when present in data

Closes #1430

Changes proposed in this pull request:
* Enable deletion of higher level category item(s) if these are present in the data. The 

How to test:
* `make start` to build and generate test data
* create new software entry
* select custom category and confirm it is shown on software page
* now add additional leaf item to category you selected in the admin section of categories
* navigate to software page. Old values are shown. Now go to edit categories page and confirm that delete button is present and you can remove this entry. Note! If you select new item there will be 2 delete buttons because you will need to remove two entries.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
