### PR TITLE
feat: add dedicated login page

### DIFF
--- a/frontend/components/login/LoginButton.tsx
+++ b/frontend/components/login/LoginButton.tsx
@@ -1,32 +1,24 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useState} from 'react'
-import Link from 'next/link'
-
-import {useSession} from '~/auth'
-import useLoginProviders from '~/auth/api/useLoginProviders'
-import UserMenu from '~/components/layout/UserMenu'
+import useLoginHandler from '~/utils/loginHandler'
 import LoginDialog from './LoginDialog'
+import {useSession} from '~/auth'
+import UserMenu from '~/components/layout/UserMenu'
 
 export default function LoginButton() {
-  const providers = useLoginProviders()
+  const {showModal, setShowModal, handleLogin} = useLoginHandler()
   const {status} = useSession()
-  const [open, setOpen] = useState(false)
-
-  // console.group('LoginButton')
-  // console.log('status...', status)
-  // console.log('menuItems...', menuItems)
-  // console.groupEnd()
 
   if (status === 'loading') {
     return null
@@ -39,35 +31,21 @@ export default function LoginButton() {
     )
   }
 
-  // when there are multiple providers
-  // we show modal with the list of login options
-  if (providers && providers.length > 1) {
-    return (
-      <div className="whitespace-nowrap ml-2">
-        <button
-          tabIndex={0}
-          onClick={()=>setOpen(true)}
-        >
-          Sign in
-        </button>
-        <LoginDialog
-          providers={providers}
-          open={open}
-          onClose={()=>setOpen(false)}
-        />
-      </div>
-    )
-  }
-
-  // If there is only 1 provider we
-  // link redirect directly to Sign in button
   return (
-    <Link
-      href={providers[0]?.redirectUrl ?? ''}
-      className="whitespace-nowrap ml-2" tabIndex={0}
-      passHref
-    >
-      Sign in
-    </Link>
+    <div className="whitespace-nowrap ml-2">
+      <button
+        tabIndex={0}
+        onClick={handleLogin}
+      >
+          Sign in
+      </button>
+      { showModal && (
+        <LoginDialog
+          open={showModal}
+          onClose={()=>setShowModal(false)}
+        />
+      )}
+    </div>
   )
+
 }

--- a/frontend/components/login/LoginDialog.tsx
+++ b/frontend/components/login/LoginDialog.tsx
@@ -1,34 +1,30 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
-
-import Link from 'next/link'
 
 import Dialog from '@mui/material/Dialog'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import {useTheme} from '@mui/material/styles'
-import List from '@mui/material/List'
-import ListItem from '@mui/material/ListItem'
-import ListItemText from '@mui/material/ListItemText'
 import CloseIcon from '@mui/icons-material/Close'
 import IconButton from '@mui/material/IconButton'
+import LoginOptions from './LoginOptions'
 
-import {Provider} from 'pages/api/fe/auth'
-import useRsdSettings from '~/config/useRsdSettings'
+import useLoginProviders from '~/auth/api/useLoginProviders'
 
 type LoginDialogProps = {
-  providers: Provider[]
   open:boolean,
-  onClose:()=>void
+  onClose?:()=>void
 }
 
-export default function LoginDialog({providers,open, onClose}: LoginDialogProps) {
-  const {host} = useRsdSettings()
+export default function LoginDialog({open, onClose}: LoginDialogProps) {
   const theme = useTheme()
   const fullScreen = useMediaQuery(theme.breakpoints.down('md'))
+  const providers = useLoginProviders()
 
   return (
     <Dialog
@@ -47,59 +43,12 @@ export default function LoginDialog({providers,open, onClose}: LoginDialogProps)
         }}
       >
         Sign in with
-        <IconButton onClick={onClose}>
+        { onClose && <IconButton onClick={onClose}>
           <CloseIcon />
-        </IconButton>
+        </IconButton>}
       </DialogTitle>
       <DialogContent>
-        <>
-          <List>
-            {providers.map(provider => {
-              return (
-                <Link
-                  key={provider.redirectUrl}
-                  href={provider.redirectUrl}
-                  passHref
-                >
-                  <ListItem
-                    alignItems="flex-start"
-                    className="rounded-[0.25rem] border outline-1 my-2"
-                    sx={{
-                      opacity: 0.75,
-                      '&:hover': {
-                        opacity: 1,
-                        backgroundColor:'background.default'
-                      }
-                    }}
-                  >
-                    <ListItemText
-                      primary={provider.name}
-                      secondary={provider?.html ?
-                        <span
-                          dangerouslySetInnerHTML={{__html: provider.html}}
-                        />
-                        : null
-                      }
-                      sx={{
-                        '.MuiListItemText-primary': {
-                          color:'primary.main',
-                          fontSize: '1.5rem',
-                          fontWeight: 700,
-                          letterSpacing: '0.125rem'
-                        }
-                      }}
-                    />
-                  </ListItem>
-                </Link>
-              )
-            })}
-          </List>
-          {host.login_info_url &&
-            <p className="text-base-content-disabled text-sm">
-              You can find more information on signing in to the RSD in our <a href={host.login_info_url} target="_blank" rel="noreferrer"><strong>documentation</strong></a>.
-            </p>
-          }
-        </>
+        <LoginOptions providers={providers} />
       </DialogContent>
     </Dialog>
   )

--- a/frontend/components/login/LoginOptions.tsx
+++ b/frontend/components/login/LoginOptions.tsx
@@ -1,0 +1,73 @@
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import ListItemText from '@mui/material/ListItemText'
+import {Provider} from 'pages/api/fe/auth'
+import useRsdSettings from '~/config/useRsdSettings'
+
+type LoginOptionsProps = {
+  providers: Provider[]
+}
+
+export default function LoginOptions({providers}: LoginOptionsProps) {
+  const {host} = useRsdSettings()
+
+  return (
+    <>
+      <List>
+        {providers.map(provider => {
+          return (
+            <Link
+              key={provider.redirectUrl}
+              href={provider.redirectUrl}
+              passHref
+            >
+              <ListItem
+                alignItems="flex-start"
+                className="rounded-[0.25rem] border outline-1 my-2"
+                sx={{
+                  opacity: 0.75,
+                  '&:hover': {
+                    opacity: 1,
+                    backgroundColor:'background.default'
+                  }
+                }}
+              >
+                <ListItemText
+                  primary={provider.name}
+                  secondary={provider?.html ?
+                    <span
+                      dangerouslySetInnerHTML={{__html: provider.html}}
+                    />
+                    : null
+                  }
+                  sx={{
+                    '.MuiListItemText-primary': {
+                      color:'primary.main',
+                      fontSize: '1.5rem',
+                      fontWeight: 700,
+                      letterSpacing: '0.125rem'
+                    }
+                  }}
+                />
+              </ListItem>
+            </Link>
+          )
+        })}
+      </List>
+      {host.login_info_url &&
+        <p className="text-base-content-disabled text-sm">
+          You can find more information on signing in to the RSD in our <a href={host.login_info_url} target="_blank" rel="noreferrer"><strong>documentation</strong></a>.
+        </p>
+      }
+    </>
+  )
+}

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import useLoginHandler from '~/utils/loginHandler'
+import LoginDialog from '~/components/login/LoginDialog'
+import {useEffect} from 'react'
+import AppHeader from '~/components/AppHeader'
+
+export default function LoginPage() {
+  const {showModal, handleLogin, isReady} = useLoginHandler()
+
+  useEffect(() => {
+    if (isReady) {
+      handleLogin()
+    } else {
+      //console.log('Waiting for providers to be ready...')
+    }
+
+  }, [isReady])
+
+  return (
+    <>
+      <AppHeader/>
+      { showModal && (
+        <LoginDialog
+          open={true}
+        />
+      )}
+    </>
+  )
+}

--- a/frontend/utils/loginHandler.tsx
+++ b/frontend/utils/loginHandler.tsx
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {useEffect, useState} from 'react'
+import {useSession} from '~/auth'
+import useLoginProviders from '~/auth/api/useLoginProviders'
+import {useRouter} from 'next/router'
+
+interface LoginHandler {
+  showModal: boolean;
+  setShowModal: React.Dispatch<React.SetStateAction<boolean>>;
+  handleLogin: () => void;
+  isReady: boolean;
+}
+
+const useLoginHandler = (): LoginHandler => {
+  const providers = useLoginProviders()
+  const {status} = useSession()
+  const router = useRouter()
+  const [showModal, setShowModal] = useState(false)
+  const [isReady, setIsReady] = useState(false)
+
+  useEffect(() => {
+    if (providers.length > 0) {
+      setIsReady(true)
+    }
+  }, [providers])
+
+  const handleLogin = () => {
+    if (!isReady) return
+
+    if (status == 'loading') {
+      return null
+    }
+
+    if (status === 'authenticated') {
+      router.push('/')
+    }
+
+    if (providers) {
+      if (providers.length > 1) {
+        setShowModal(true)
+      } else if (providers.length === 1) {
+        router.push(providers[0]?.redirectUrl)
+      }
+    }
+  }
+
+  return {showModal, setShowModal, handleLogin, isReady}
+}
+
+export default useLoginHandler


### PR DESCRIPTION
Fixes #1417 

Changes proposed in this pull request:

* create a dedicated login page at `pages/login`
* use LoginHandler to handle login action (dialog or redirect) for LoginButton and login page

How to test:

* set `RSD_AUTH_PROVIDERS` in env to only one provider / multiple providers respectively
* running the application, check: 
  * clicking on login button on landing page
  * opening `/login`
* if only one provider is set, this should result in a redirect to the provider URL
* if multiple providers are available, a dialog modal with all provider options should show up

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
