### PR TITLE
feat: create separate login page

### DIFF
--- a/frontend/auth/api/getLoginProviders.tsx
+++ b/frontend/auth/api/getLoginProviders.tsx
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {Provider} from 'pages/api/fe/auth'
+import logger from '~/utils/logger'
+
+// save info after initial call
+let loginProviders:Provider[] = []
+
+export async function getLoginProviders(baseUrl?:string) {
+  try{
+    // console.group('getLoginProviders')
+    // console.log('baseUrl...', baseUrl)
+    // console.log('loginProviders...', loginProviders)
+    // console.groupEnd()
+
+    if (loginProviders.length === 0){
+      // baseUrl is required for requests from server side
+      // this is internal url of frontend, by default this
+      // is http://localhost:3000
+      const url = `${baseUrl ?? ''}/api/fe/auth`
+      // console.log('url...', url)
+      const resp = await fetch(url)
+
+      if (resp.status === 200){
+        const providers: Provider[] = await resp.json()
+        // api response is the same once the app is started
+        // because the info eventually comes from .env file
+        // to avoid additional api calls we save api response
+        // into the loginProviders variable and reuse it
+        loginProviders = [
+          ...providers
+        ]
+      }else{
+        logger(`getLoginProviders: ${resp.status}: ${resp.statusText}`, 'warn')
+      }
+    }
+    return loginProviders
+  }catch(e:any){
+    logger(`getLoginProviders: ${e.message}`, 'error')
+    return loginProviders
+  }
+}

--- a/frontend/auth/api/useLoginProviders.tsx
+++ b/frontend/auth/api/useLoginProviders.tsx
@@ -1,51 +1,31 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useEffect, useState} from 'react'
 
 import {Provider} from 'pages/api/fe/auth'
-
-// save info after initial call
-let loginProviders:Provider[] = []
+import {getLoginProviders} from './getLoginProviders'
 
 export default function useLoginProviders() {
   const [providers, setProviders] = useState<Provider[]>([])
 
   // console.group('useLoginProviders')
   // console.log('providers...', providers)
-  // console.log('loginProviders...', loginProviders)
   // console.groupEnd()
 
   useEffect(() => {
     let abort = false
 
-    async function getProviders() {
-      if (loginProviders.length === 0){
-        const url = '/api/fe/auth'
-        const resp = await fetch(url)
-        if (resp.status === 200 && abort === false) {
-          const providers: Provider[] = await resp.json()
-          if (abort) return
-          setProviders(providers)
-          // api response is the same once the app is started
-          // because the info eventually comes from .env file
-          // to avoid additional api calls we save api response
-          // into the loginProviders variable and reuse it
-          loginProviders = [
-            ...providers
-          ]
-        }
-      }else if (abort===false){
-        setProviders(loginProviders)
-      }
-    }
-    if (abort === false) {
-      getProviders()
-    }
+    getLoginProviders()
+      .then(providers=>{
+        if (abort) return
+        setProviders(providers)
+      })
+      .catch(()=>setProviders([]))
 
     return () => { abort = true }
   }, [])

--- a/frontend/auth/locationCookie.ts
+++ b/frontend/auth/locationCookie.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +13,7 @@ export function saveLocationCookie() {
   if (typeof location == 'undefined') return
   // for specific routes
   switch (location.pathname.toLowerCase()) {
-    // ingnore these paths
+    // ignore these paths
     case '/auth':
     case '/login':
     case '/logout':

--- a/frontend/components/login/LoginDialog.tsx
+++ b/frontend/components/login/LoginDialog.tsx
@@ -5,27 +5,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import Link from 'next/link'
-
 import Dialog from '@mui/material/Dialog'
 import DialogContent from '@mui/material/DialogContent'
 import DialogTitle from '@mui/material/DialogTitle'
 import useMediaQuery from '@mui/material/useMediaQuery'
 import {useTheme} from '@mui/material/styles'
-import List from '@mui/material/List'
-import ListItem from '@mui/material/ListItem'
-import ListItemText from '@mui/material/ListItemText'
 import CloseIcon from '@mui/icons-material/Close'
 import IconButton from '@mui/material/IconButton'
 
 import {Provider} from 'pages/api/fe/auth'
 import useRsdSettings from '~/config/useRsdSettings'
+import LoginProviders from './LoginProviders'
 
-type LoginDialogProps = {
+type LoginDialogProps = Readonly<{
   providers: Provider[]
   open:boolean,
   onClose:()=>void
-}
+}>
 
 export default function LoginDialog({providers,open, onClose}: LoginDialogProps) {
   const {host} = useRsdSettings()
@@ -54,54 +50,10 @@ export default function LoginDialog({providers,open, onClose}: LoginDialogProps)
         </IconButton>
       </DialogTitle>
       <DialogContent>
-        <>
-          <List>
-            {providers.map(provider => {
-              return (
-                <Link
-                  key={provider.redirectUrl}
-                  href={provider.redirectUrl}
-                  passHref
-                >
-                  <ListItem
-                    alignItems="flex-start"
-                    className="rounded-[0.25rem] border my-2"
-                    sx={{
-                      opacity: 0.75,
-                      '&:hover': {
-                        opacity: 1,
-                        backgroundColor:'background.default'
-                      }
-                    }}
-                  >
-                    <ListItemText
-                      primary={provider.name}
-                      secondary={provider?.html ?
-                        <span
-                          dangerouslySetInnerHTML={{__html: provider.html}}
-                        />
-                        : null
-                      }
-                      sx={{
-                        '.MuiListItemText-primary': {
-                          color:'primary.main',
-                          fontSize: '1.5rem',
-                          fontWeight: 700,
-                          letterSpacing: '0.125rem'
-                        }
-                      }}
-                    />
-                  </ListItem>
-                </Link>
-              )
-            })}
-          </List>
-          {host.login_info_url &&
-            <p className="text-base-content-disabled text-sm">
-              You can find more information on signing in to the RSD in our <a href={host.login_info_url} target="_blank" rel="noreferrer"><strong>documentation</strong></a>.
-            </p>
-          }
-        </>
+        <LoginProviders
+          providers={providers}
+          login_info_url={host.login_info_url}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/frontend/components/login/LoginProviders.tsx
+++ b/frontend/components/login/LoginProviders.tsx
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import ListItemText from '@mui/material/ListItemText'
+
+import {Provider} from 'pages/api/fe/auth'
+
+type LoginProvidersProps=Readonly<{
+  providers: Provider[]
+  login_info_url?:string
+}>
+
+export default function LoginProviders({providers,login_info_url}:LoginProvidersProps) {
+  return (
+    <>
+      <List>
+        {providers.map(provider => {
+          return (
+            <Link
+              key={provider.redirectUrl}
+              href={provider.redirectUrl}
+              passHref
+            >
+              <ListItem
+                alignItems="flex-start"
+                className="rounded-[0.25rem] border my-2"
+                sx={{
+                  opacity: 0.75,
+                  '&:hover': {
+                    opacity: 1,
+                    backgroundColor:'background.default'
+                  }
+                }}
+              >
+                <ListItemText
+                  primary={provider.name}
+                  secondary={provider?.html ?
+                    <span
+                      dangerouslySetInnerHTML={{__html: provider.html}}
+                    />
+                    : null
+                  }
+                  sx={{
+                    '.MuiListItemText-primary': {
+                      color:'primary.main',
+                      fontSize: '1.5rem',
+                      fontWeight: 700,
+                      letterSpacing: '0.125rem'
+                    }
+                  }}
+                />
+              </ListItem>
+            </Link>
+          )
+        })}
+      </List>
+      {login_info_url ?
+        <p className="text-base-content-disabled text-sm">
+        You can find more information on signing in to the RSD in our <a href={login_info_url} target="_blank" rel="noreferrer"><strong>documentation</strong></a>.
+        </p>
+        : null
+      }
+    </>
+  )
+}

--- a/frontend/pages/login/failed.tsx
+++ b/frontend/pages/login/failed.tsx
@@ -1,15 +1,16 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
-// SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {useEffect, useState} from 'react'
 import Link from 'next/link'
+
 import ContentInTheMiddle from '../../components/layout/ContentInTheMiddle'
-import {useEffect} from 'react'
-import {useState} from 'react'
 
 export default function LoginFailed() {
   const [errorMessage, setErrorMessage] = useState<string>()

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -6,9 +6,13 @@
 import {GetServerSidePropsContext} from 'next'
 
 import {getRsdTokenNode, useSession} from '~/auth'
+import MainContent from '~/components/layout/MainContent'
+import PageBackground from '~/components/layout/PageBackground'
+import AppHeader from '~/components/AppHeader'
+import AppFooter from '~/components/AppFooter'
 import LoginProviders from '~/components/login/LoginProviders'
 import {getLoginProviders} from '~/auth/api/getLoginProviders'
-import {Provider} from '../api/fe/auth'
+import {Provider} from 'pages/api/fe/auth'
 
 export default function LoginPage({providers}:Readonly<{providers:Provider[]}>) {
   const {status} = useSession()
@@ -23,13 +27,16 @@ export default function LoginPage({providers}:Readonly<{providers:Provider[]}>) 
   }
 
   return (
-    <article className="flex-1 flex flex-col items-center justify-center">
-      <section className="border p-12 rounded-md m-8">
-        <h1 className="flex-1">Sign in with</h1>
-        <LoginProviders providers={providers} />
-      </section>
-    </article>
-
+    <PageBackground>
+      <AppHeader />
+      <MainContent className="justify-center items-center">
+        <section className="bg-base-100 p-12 rounded-md">
+          <h1 className="flex-1">Sign in with</h1>
+          <LoginProviders providers={providers} />
+        </section>
+      </MainContent>
+      <AppFooter />
+    </PageBackground>
   )
 }
 

--- a/frontend/pages/login/index.tsx
+++ b/frontend/pages/login/index.tsx
@@ -1,0 +1,80 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next'
+
+import {getRsdTokenNode, useSession} from '~/auth'
+import LoginProviders from '~/components/login/LoginProviders'
+import {getLoginProviders} from '~/auth/api/getLoginProviders'
+import {Provider} from '../api/fe/auth'
+
+export default function LoginPage({providers}:Readonly<{providers:Provider[]}>) {
+  const {status} = useSession()
+
+  // console.group('LoginPage')
+  // console.log('status...',status)
+  // console.log('providers...', providers)
+  // console.groupEnd()
+
+  if (status === 'loading') {
+    return null
+  }
+
+  return (
+    <article className="flex-1 flex flex-col items-center justify-center">
+      <section className="border p-12 rounded-md m-8">
+        <h1 className="flex-1">Sign in with</h1>
+        <LoginProviders providers={providers} />
+      </section>
+    </article>
+
+  )
+}
+
+export async function getServerSideProps(context: GetServerSidePropsContext) {
+  const {req} = context
+  // get token
+  const token = getRsdTokenNode(req)
+
+  // USER already logged in
+  if (token){
+    // get last visited path
+    const redirect = req.cookies['rsd_pathname']
+    // redirect to last visited page
+    return {
+      redirect: {
+        destination: redirect ?? '/',
+        permanent: false
+      },
+    }
+  }
+
+  // get list of available providers
+  // on server side we need complete url incl. domain
+  // we can use localhost because this is "internal communication"
+  const providers = await getLoginProviders('http://localhost:3000')
+
+  // if no providers we show 404 page
+  if (providers?.length === 0){
+    return {
+      notFound: true
+    }
+  }else if (providers?.length === 1 && providers[0]?.redirectUrl){
+    // when only 1 provider we redirect directly
+    return {
+      redirect: {
+        destination: providers[0]?.redirectUrl,
+        permanent: false
+      },
+    }
+  }
+
+  // finally we pass list of providers to FE
+  return {
+    props:{
+      providers
+    }
+  }
+}


### PR DESCRIPTION
# Create login page

Closes #1417
Closes #1438 

Changes proposed in this pull request:
* create a dedicated login page at pages/login
* refactor login dialog content to be used in both situations
* login page working: 
    * if you are already logged in we redirect you to last "saved" RSD page or homepage 
    * if one provider we redirect directly to login page of the provider
    * if more providers we show the content similar to login modal
    * if no providers returned we shown 404 page

How to test:
* `make start` to build and generate some test data (test data is not required)
* set RSD_AUTH_PROVIDERS in env to multiple providers and test both login button and login page. The working of both approaches should produce similair results. You should be able to login/logout and land on the page you left before starting login process
* set RSD_AUTH_PROVIDERS in env to ONE provider and test both login button and login page. On the login page you should be directly redirected to login screen of the provider.
* remove RSD_AUTH_PROVIDERS, this will default SURFCONEXT being default provider

## Example login page (multiple providers)
![image](https://github.com/user-attachments/assets/3e3b053a-c33b-4779-bccc-a44f52b61614)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
