### PR TITLE
fix: filter only participating organisations in RPC category_for_proj…

### DIFF
--- a/database/114-keyword-category-views.sql
+++ b/database/114-keyword-category-views.sql
@@ -50,7 +50,7 @@ WITH
 SELECT
 	CASE
 		WHEN (SELECT organisation FROM category_data) IS NULL THEN 'global'
-		WHEN (SELECT organisation FROM category_data AS organisation_id) IS NOT NULL THEN (SELECT status FROM project_for_organisation WHERE project_for_organisation.project = project_id AND project_for_organisation.organisation = (SELECT organisation FROM category_data AS organisation_id))::VARCHAR
+		WHEN (SELECT organisation FROM category_data AS organisation_id) IS NOT NULL THEN (SELECT status FROM project_for_organisation WHERE project_for_organisation.project = project_id AND project_for_organisation.organisation = (SELECT organisation FROM category_data AS organisation_id) AND role = 'participating')::VARCHAR
 		ELSE 'other'
 		END
 $$;


### PR DESCRIPTION
## NASSA scraper

### Changes proposed in this pull request

* Fix the bug described in #1444 by improving a WHERE clause in the function `category_for_project_status`

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Create or edit a project page so that is has categories from an organisation and also add that organisation as a funding organisation
* The categories should be visible on the public project page


Closes #1444

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
