### PR TITLE
feat: don't allow white spaces in URLs

### DIFF
--- a/database/004-create-software-table.sql
+++ b/database/004-create-software-table.sql
@@ -1,11 +1,12 @@
 -- SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 -- SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
--- SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 -- SPDX-FileCopyrightText: 2022 dv4all
 -- SPDX-FileCopyrightText: 2023 Diego Alonso Alvarez (ICL) <d.alonso-alvarez@imperial.ac.uk>
 -- SPDX-FileCopyrightText: 2023 Imperial College London
+-- SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -26,9 +27,9 @@ CREATE TABLE software (
 	closed_source BOOLEAN DEFAULT FALSE NOT NULL,
 	concept_doi CITEXT CHECK (concept_doi ~ '^10(\.\w+)+/\S+$' AND LENGTH(concept_doi) <= 255),
 	description VARCHAR(10000),
-	description_url VARCHAR(200) CHECK (description_url ~ '^https?://'),
+	description_url VARCHAR(200) CHECK (description_url ~ '^https?://\S+$'),
 	description_type description_type DEFAULT 'markdown' NOT NULL,
-	get_started_url VARCHAR(200) CHECK (get_started_url ~ '^https?://'),
+	get_started_url VARCHAR(200) CHECK (get_started_url ~ '^https?://\S+$'),
 	image_id VARCHAR(40) REFERENCES image(id),
 	is_published BOOLEAN DEFAULT FALSE NOT NULL,
 	short_statement VARCHAR(300),

--- a/database/005-create-relations-for-software.sql
+++ b/database/005-create-relations-for-software.sql
@@ -2,10 +2,11 @@
 -- SPDX-FileCopyrightText: 2021 - 2025 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 - 2024 dv4all
+-- SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 -- SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
--- SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 -- SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 -- SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
+-- SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -18,7 +19,7 @@ CREATE TYPE platform_type AS ENUM (
 
 CREATE TABLE repository_url (
 	software UUID REFERENCES software (id) PRIMARY KEY,
-	url VARCHAR(200) NOT NULL CHECK (url ~ '^https?://'),
+	url VARCHAR(200) NOT NULL CHECK (url ~ '^https?://\S+$'),
 	code_platform platform_type NOT NULL DEFAULT 'other',
 	archived BOOLEAN,
 	license VARCHAR(200),
@@ -64,7 +65,7 @@ CREATE TYPE package_manager_type AS ENUM (
 CREATE TABLE package_manager (
 	id UUID PRIMARY KEY,
 	software UUID REFERENCES software (id) NOT NULL,
-	url VARCHAR(200) NOT NULL CHECK (url ~ '^https?://'),
+	url VARCHAR(200) NOT NULL CHECK (url ~ '^https?://\S+$'),
 	package_manager package_manager_type NOT NULL DEFAULT 'other',
 	download_count BIGINT,
 	download_count_last_error VARCHAR(500),
@@ -113,7 +114,7 @@ CREATE TABLE license_for_software (
 	software UUID REFERENCES software (id) NOT NULL,
 	license VARCHAR(100) NOT NULL,
 	name VARCHAR(200) NULL,
-	reference VARCHAR(200) NULL CHECK (reference ~ '^https?://'),
+	reference VARCHAR(200) NULL CHECK (reference ~ '^https?://\S+$'),
 	open_source BOOLEAN NOT NULL DEFAULT TRUE,
 	UNIQUE(software, license),
 	created_at TIMESTAMPTZ NOT NULL,

--- a/database/006-create-project-table.sql
+++ b/database/006-create-project-table.sql
@@ -2,6 +2,8 @@
 -- SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 dv4all
+-- SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+-- SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -57,7 +59,7 @@ CREATE TABLE url_for_project (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
 	project UUID REFERENCES project (id),
 	title VARCHAR(100) NOT NULL,
-	url VARCHAR(200) NOT NULL CHECK (url ~ '^https?://'),
+	url VARCHAR(200) NOT NULL CHECK (url ~ '^https?://\S+$'),
 	position INTEGER
 );
 

--- a/database/011-create-mention-table.sql
+++ b/database/011-create-mention-table.sql
@@ -2,6 +2,8 @@
 -- SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 dv4all
+-- SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+-- SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -32,14 +34,14 @@ CREATE TABLE mention (
 	doi CITEXT UNIQUE CHECK (doi ~ '^10(\.\w+)+/\S+$' AND LENGTH(doi) <= 255),
 	doi_registration_date TIMESTAMPTZ,
 	openalex_id CITEXT UNIQUE CHECK (openalex_id ~ '^https://openalex\.org/[WwAaSsIiCcPpFf]\d{3,13}$'),
-	url VARCHAR(500) CHECK (url ~ '^https?://'),
+	url VARCHAR(500) CHECK (url ~ '^https?://\S+$'),
 	title VARCHAR(3000) NOT NULL,
 	authors VARCHAR(50000),
 	publisher VARCHAR(255),
 	publication_year SMALLINT,
 	journal VARCHAR(500),
 	page VARCHAR(50),
-	image_url VARCHAR(500) CHECK (image_url ~ '^https?://'),
+	image_url VARCHAR(500) CHECK (image_url ~ '^https?://\S+$'),
 	mention_type mention_type NOT NULL,
 	source VARCHAR(50) NOT NULL,
 	version VARCHAR(100),

--- a/frontend/components/mention/config.ts
+++ b/frontend/components/mention/config.ts
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -119,8 +121,8 @@ export const mentionModal = {
         message: 'Maximum length is 500'
       },
       pattern: {
-        value: /^https?:\/\/.+\..+/,
-        message: 'Url should start with http(s):// have at least one dot (.)'
+        value: /^https?:\/\/\S+$/,
+        message: 'Url must start with http(s):// and cannot contain white spaces'
       }
     }
   },
@@ -156,8 +158,8 @@ export const mentionModal = {
         message: 'Maximum length is 500'
       },
       pattern: {
-        value: /^https?:\/\/.+\..+/,
-        message: 'Url should start with http(s):// have at least one dot (.)'
+        value: /^https?:\/\/\S+$/,
+        message: 'Url must start with http(s):// and cannot contain white spaces'
       }
     }
   },

--- a/frontend/components/organisation/settings/general/generalSettingsConfig.ts
+++ b/frontend/components/organisation/settings/general/generalSettingsConfig.ts
@@ -2,8 +2,9 @@
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -32,8 +33,8 @@ export const generalSettingsConfig = {
       minLength: {value: 6, message: 'Minimum length is 6'},
       maxLength: {value: 200, message: 'Maximum length is 200'},
       pattern: {
-        value: /^https?:\/\/.+\..+/,
-        message: 'Url should start with http(s):// and have at least one dot (.)'
+        value: /^https?:\/\/\S+$/,
+        message: 'Url should start with http(s):// and cannot contain white spaces'
       }
     }
   },
@@ -65,8 +66,8 @@ export const generalSettingsConfig = {
       minLength: {value: 16, message: 'Minimum length is 16'},
       maxLength: {value: 200, message: 'Maximum length is 200'},
       pattern: {
-        value: /^https:\/\/ror.org\/.+/,
-        message: 'ROR id is url and starts with https://ror.org/'
+        value: /^https:\/\/ror.org\/\S+$/,
+        message: 'ROR ID must start with https://ror.org/ and cannot include white spaces'
       }
     }
   },

--- a/frontend/components/projects/edit/information/config.ts
+++ b/frontend/components/projects/edit/information/config.ts
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
+// SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -113,8 +114,8 @@ export const projectInformation = {
       validation: {
         required: 'Link url is required',
         pattern: {
-          value: /^https?:\/\/.+\..+/,
-          message: 'Url should start with http(s):// and have at least one dot (.)'
+          value: /^https?:\/\/\S+$/,
+          message: 'Url should start with http(s):// and cannot include white spaces'
         }
       }
     }

--- a/frontend/components/projects/edit/organisations/config.ts
+++ b/frontend/components/projects/edit/organisations/config.ts
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -34,8 +36,8 @@ export const cfgOrganisations = {
       minLength: {value: 6, message: 'Minimum length is 6'},
       maxLength: {value: 200, message: 'Maximum length is 200'},
       pattern: {
-        value: /^https?:\/\/.+\..+/,
-        message: 'Url should start with http(s):// and have at least one dot (.)'
+        value: /^https?:\/\/\S+$/,
+        message: 'Url must start with http(s):// and cannot include white spaces'
       }
     }
   },

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -1,13 +1,14 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
+// SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -141,8 +142,8 @@ export const organisationInformation = {
       minLength: {value: 6, message: 'Minimum length is 6'},
       maxLength: {value: 200, message: 'Maximum length is 200'},
       pattern: {
-        value: /^https?:\/\/.+\..+/,
-        message: 'URL should start with http(s):// and have at least one dot (.)'
+        value: /^https?:\/\/\S+$/,
+        message: 'URL should start with http(s):// and cannot include white spaces'
       }
     }
   },
@@ -217,8 +218,8 @@ export const mentionInformation = {
     help: 'Provide URL to publication',
     validation: {
       pattern: {
-        value: /^https?:\/\/.+\..+/,
-        message: 'URL should start with http(s):// have at least one dot (.)'
+        value: /^https?:\/\/\S+$/,
+        message: 'URL should start with http(s):// and cannot include white spaces'
       }
     }
   },
@@ -233,8 +234,8 @@ export const mentionInformation = {
     help: 'Provide URL to image',
     validation: {
       pattern: {
-        value: /^https?:\/\/.+\..+/,
-        message: 'URL should start with http(s):// have at least one dot (.)'
+        value: /^https?:\/\/\S+$/,
+        message: 'URL must start with http(s):// and cannot include white spaces'
       }
     }
   },

--- a/frontend/components/software/edit/links/config.tsx
+++ b/frontend/components/software/edit/links/config.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,8 +15,8 @@ export const config={
     validation: {
       maxLength: {value: 200, message: 'Maximum length is 200'},
       pattern: {
-        value: /^https?:\/\/.+\..+/,
-        message: 'URL should start with http(s):// and use at least one dot (.)'
+        value: /^https?:\/\/\S+$/,
+        message: 'URL must start with http(s):// and cannot include white spaces'
       }
     }
   },
@@ -25,8 +26,8 @@ export const config={
     validation: {
       maxLength: {value: 200, message: 'Maximum length is 200'},
       pattern: {
-        value: /^https?:\/\/.+\..+/,
-        message: 'URL should start with http(s)://, have at least one dot (.) and at least one slash (/).'
+        value: /^https?:\/\/\S+$/,
+        message: 'URL must start with http(s):// and cannot include white spaces.'
       }
     }
   },
@@ -124,8 +125,8 @@ export const config={
           minLength: {value: 10, message: 'Minimum length is 10'},
           maxLength: {value: 200, message: 'Maximum length is 200'},
           pattern: {
-            value: /^https?:\/\/.+\..+/,
-            message: 'URL should start with http(s):// and use at least one dot (.)'
+            value: /^https?:\/\/\S+$/,
+            message: 'URL must start with http(s):// and cannot include white spaces'
           }
         }
       },

--- a/frontend/components/software/edit/package-managers/config.ts
+++ b/frontend/components/software/edit/package-managers/config.ts
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,8 +21,8 @@ export const config = {
           message: 'Maximum length is 200'
         },
         pattern: {
-          value: /^https?:\/\/.+\..+/,
-          message: 'URL should start with http(s):// and use at least one dot (.)'
+          value: /^https?:\/\/\S+$/,
+          message: 'URL must start with http(s):// and cannot include white spaces'
         }
       }
     },


### PR DESCRIPTION
Fixes #1442 

Changes proposed in this pull request:

* update regex in database tables and patterns for frontend input fields to not allow white spaces within or at the end of URLs
* allow URLs without dots in frontend URL fields for testing purposes (e.g. `http:///localhost`)

How to test:

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
*  Sign in as admin
*  Edit any URL e.g. repository URL
*  When entering a white space within or at the end of the otherwise valid URL, an error message should appear

Cleanup for production:
When this becomes part of production, existing entries in tables `software`, `repository_url`, `package_manager`, `url_for_project`, `mention` need cleanup first.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
