### PR TITLE
Fix remote RSD harvester

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/aggregator/RemoteRsdConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/aggregator/RemoteRsdConnector.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,14 +12,37 @@ import nl.esciencecenter.rsd.scraper.Utils;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.StringJoiner;
 
 public class RemoteRsdConnector {
+
+	private static final String SELECT_LIST;
+
+	static {
+		// column `categories` from `software_overview()` is not in table `remote_software`
+		StringJoiner selectListBuilder = new StringJoiner(",");
+		selectListBuilder.add("id");
+		selectListBuilder.add("slug");
+		selectListBuilder.add("brand_name");
+		selectListBuilder.add("short_statement");
+		selectListBuilder.add("image_id");
+		selectListBuilder.add("updated_at");
+		selectListBuilder.add("contributor_cnt");
+		selectListBuilder.add("mention_cnt");
+		selectListBuilder.add("is_published");
+		selectListBuilder.add("keywords");
+		selectListBuilder.add("keywords_text");
+		selectListBuilder.add("prog_lang");
+		selectListBuilder.add("licenses");
+
+		SELECT_LIST = selectListBuilder.toString();
+	}
 
 	private RemoteRsdConnector() {
 	}
 
 	public static JsonArray getAllSoftware(URI remoteDomain) throws RsdResponseException, IOException, InterruptedException {
-		String path = "/api/v1/rpc/software_overview";
+		String path = "/api/v1/rpc/software_overview?select=" + SELECT_LIST;
 		String url = remoteDomain.toString() + path;
 
 		String response = Utils.get(url);


### PR DESCRIPTION
## Fix remote RSD harvester

### Changes proposed in this pull request

* Use a select list to prevent errors for the remote RSD harvester when extra columns are added to the RPC `software_overview()`

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin, add a remote RSD like https://research-software-directory.org/
* Wait or run `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.aggregator.MainAggregator`
* The remote software should have been added successfully


Closes #1455

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
