### PR TITLE
fix: package manager icons layout in Safari

### DIFF
--- a/frontend/components/software/AboutPackageManagers.tsx
+++ b/frontend/components/software/AboutPackageManagers.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,7 +21,7 @@ function PackageManagerItem({item}:{item:PackageManager}){
     const info = packageManagerSettings[item.package_manager ?? 'other']
     const link = new URL(item.url)
     return (
-      <a href={item.url} target="_blank" rel="noreferrer">
+      <a href={item.url} target="_blank" rel="noreferrer" className="basis-17 shrink-0">
         <LogoAvatar
           name={link.hostname}
           src={info.icon ?? undefined}


### PR DESCRIPTION
# Pull request Title

Fixes #1463 

Changes proposed in this pull request:

* change tailwind css in AboutPackageManagers to fix icons layout in Safari

How to test:

* test for different amounts of package managers to consider spacing and flex-wrap behavior for different combinations: create a software entry and add various package managers
* open software page with multiple package managers in Safari: icons should be displayed with even spacing and wrap to multiple lines for more than three or four package managers
* open the same software page in other browsers to check if the layout is also correct there

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
