### PR TITLE
TabAsLink to be used when tab should be a link

### DIFF
--- a/frontend/components/layout/TabAsLink.tsx
+++ b/frontend/components/layout/TabAsLink.tsx
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+import Tab, {TabProps} from '@mui/material/Tab'
+
+type TabAsLinkProps = TabProps & {
+  href: string
+  scroll?: boolean
+}
+
+export default function TabAsLink(props:TabAsLinkProps) {
+
+  // console.group('TabAsLink')
+  // console.log('props...',props)
+  // console.groupEnd()
+
+  return (
+    // NOTE! scroll feature is not part of MUI Tab props.
+    // The scroll feature works ONLY with Next Link component because Tab
+    // passes this property (prop spread) to a Link component without any checks.
+    <Tab
+      LinkComponent={Link}
+      scroll={props?.scroll ?? false}
+      {...props}
+    />
+  )
+}

--- a/frontend/components/profile/tabs/index.tsx
+++ b/frontend/components/profile/tabs/index.tsx
@@ -1,15 +1,14 @@
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useRouter} from 'next/router'
-import Link from 'next/link'
 import Tabs from '@mui/material/Tabs'
-import Tab from '@mui/material/Tab'
 
-import {useProfileContext} from '../context/ProfileContext'
+import TabAsLink from '~/components/layout/TabAsLink'
+import {useProfileContext} from '~/components/profile/context/ProfileContext'
 import {ProfileTabKey, profileTabItems} from './ProfileTabItems'
 
 type ProfileTabsProps={
@@ -25,6 +24,7 @@ export default function ProfileTabs({tab_id, isMaintainer}:ProfileTabsProps) {
   const {software_cnt,project_cnt} = useProfileContext()
   return (
     <Tabs
+      component="nav"
       variant="scrollable"
       allowScrollButtonsMobile
       value={tab_id}
@@ -33,27 +33,18 @@ export default function ProfileTabs({tab_id, isMaintainer}:ProfileTabsProps) {
       {tabItems.map(key => {
         const item = profileTabItems[key]
         if (item.isVisible({isMaintainer})===true){
-          // @ts-expect-error scroll is not present in Tab
-          return <Tab
-            LinkComponent={Link}
-            scroll={false}
-            href={`../${router.query['orcid']}/${key}`}
-            icon={item.icon}
-            key={key}
-            label={item.label({
-              software_cnt,
-              project_cnt
-            })}
-            value={key}
-            sx={{
-              '&:hover':{
-                color:'text.secondary'
-              },
-              '&.Mui-selected:hover':{
-                color:'primary.main'
-              }
-            }}
-          />
+          return (
+            <TabAsLink
+              key={key}
+              href={`../${router.query['orcid']}/${key}`}
+              value={key}
+              icon={item.icon}
+              label={item.label({
+                software_cnt,
+                project_cnt
+              })}
+            />
+          )
         }
       })}
     </Tabs>


### PR DESCRIPTION
# TabAsLink

Closes #1461

Changes proposed in this pull request:
* Created TabAsLink component to be used when tab should be a link instead of JS button (default). Created comment about disabling TS and current working of the component
* Applied new component to public Profile page

How to test:
* `make start` to build and created test data
* navigate to software page where random user has a link. 
* confirm that tab is a link and works properly with JS enabled
* disable JS and confirm that link still works

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
