### PR TITLE
fix: clickable mobile menu button

### DIFF
--- a/frontend/components/AppHeader/ResponsiveMenu.tsx
+++ b/frontend/components/AppHeader/ResponsiveMenu.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -67,11 +67,18 @@ export default function ResponsiveMenu({activePath}:{activePath:string}) {
         {menuItems.map(item => {
           const isActive = isActiveMenuItem({item, activePath})
           return (
-            <MenuItem onClick={handleCloseResponsiveMenu} key={item.path}>
-              <Link href={item.path ?? ''} className={`${isActive ? 'nav-active' : ''}`}>
+            <Link
+              key={item.path}
+              href={item.path ?? ''}
+            >
+              <MenuItem
+                key={item.path}
+                onClick={handleCloseResponsiveMenu}
+                selected={isActive}
+              >
                 {item.label}
-              </Link>
-            </MenuItem>
+              </MenuItem>
+            </Link>
           )
         })}
       </Menu>

--- a/frontend/components/login/LoginButton.tsx
+++ b/frontend/components/login/LoginButton.tsx
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -41,7 +41,7 @@ export default function LoginButton() {
 
   // when there are multiple providers
   // we show modal with the list of login options
-  if (providers && providers.length > 1) {
+  if (providers?.length > 1) {
     return (
       <div className="whitespace-nowrap ml-2">
         <button
@@ -59,15 +59,19 @@ export default function LoginButton() {
     )
   }
 
-  // If there is only 1 provider we
-  // link redirect directly to Sign in button
-  return (
-    <Link
-      href={providers[0]?.redirectUrl ?? ''}
-      className="whitespace-nowrap ml-2" tabIndex={0}
-      passHref
-    >
-      Sign in
-    </Link>
-  )
+  if (providers?.length===1){
+    // if there is only 1 provider we link the redirect directly to Sign in button
+    return (
+      <Link
+        href={providers[0]?.redirectUrl ?? ''}
+        className="whitespace-nowrap ml-2" tabIndex={0}
+        passHref
+      >
+        Sign in
+      </Link>
+    )
+  }
+
+  // if no providers we do not shown login button
+  return null
 }


### PR DESCRIPTION
# Fix mobile menu items

fix: hide login button when no valid providers

Closes #1474

Changes proposed in this pull request:
* fix mobile menu items to be clickable as complete button and mark selected item
* do not show login button when no valid login providers

How to test:
* `make start` to build and generate test data (test data is not required)
* open developer console (F12), select mobile device, the mobile menu will appear. You can click anywhere in the button and the menu should work.
* in your .env file remove all entries from `RSD_AUTH_PROVIDERS` or use invalid values. The login button should not be shown. If you use only one value the login button will forward you directly to login screen of the provider. If there is more than one login provider the modal will appear.

## Example mobile menu

![image](https://github.com/user-attachments/assets/618f8af8-698b-4560-8e8f-7e57514da603)



PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
