### PR TITLE
fix: do not enforce login and consent prompt

### DIFF
--- a/frontend/auth/api/authHelpers.test.ts
+++ b/frontend/auth/api/authHelpers.test.ts
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -45,6 +47,7 @@ const mockProps: RedirectToProps = {
   client_id: '1234567',
   scope: 'openid',
   response_mode: 'form',
+  prompt: 'login'
 }
 
 // mock console log
@@ -63,9 +66,16 @@ beforeEach(() => {
 
 
 it('crates RedirectUrl', () => {
-  const {authorization_endpoint, redirect_uri, client_id, scope, response_mode} = mockProps
-  const expectedRedirect = `${authorization_endpoint}?redirect_uri=${redirect_uri}&client_id=${client_id}&scope=${scope}&response_type=code&response_mode=${response_mode}&prompt=login+consent`
+  const {authorization_endpoint, redirect_uri, client_id, scope, response_mode, prompt} = mockProps
+  const expectedRedirect = `${authorization_endpoint}?redirect_uri=${redirect_uri}&client_id=${client_id}&scope=${scope}&response_type=code&response_mode=${response_mode}&prompt=${prompt}`
   const redirectUrl = getRedirectUrl(mockProps)
+  expect(redirectUrl).toEqual(expectedRedirect)
+})
+
+it('does not enforce prompt parameter', () => {
+  const {authorization_endpoint, redirect_uri, client_id, scope, response_mode} = mockProps
+  const expectedRedirect = `${authorization_endpoint}?redirect_uri=${redirect_uri}&client_id=${client_id}&scope=${scope}&response_type=code&response_mode=${response_mode}`
+  const redirectUrl = getRedirectUrl({...mockProps, prompt: undefined})
   expect(redirectUrl).toEqual(expectedRedirect)
 })
 

--- a/frontend/auth/api/authHelpers.ts
+++ b/frontend/auth/api/authHelpers.ts
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -42,8 +44,11 @@ export function getRedirectUrl(props: RedirectToProps) {
     '&client_id=' + props.client_id +
     '&scope=' + props.scope +
     '&response_type=code' +
-    '&response_mode=' + props.response_mode +
-    '&prompt=' + (props.prompt ? props.prompt : 'login+consent')
+    '&response_mode=' + props.response_mode
+
+  if (props?.prompt) {
+    redirectUrl += '&prompt=' + props.prompt
+  }
 
   if (props?.claims){
     redirectUrl += '&claims=' + encodeURIComponent(JSON.stringify(props.claims))


### PR DESCRIPTION
Fixes #1483 

Changes proposed in this pull request:

* do not enforce `prompt=login+consent`

I tested login for Surfconext and HelmholtzID, both still work.

How to test:

* `docker compose build --parallel && docker compose up --scale scrapers=0`
* confirm that login via all IdPs works (especially Linkedin, Azure and Orcid)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
