### PR TITLE
feat: persons overview page

### DIFF
--- a/database/125-global-search.sql
+++ b/database/125-global-search.sql
@@ -39,7 +39,6 @@ $$
 	END;
 $$;
 
-
 -- GLOBAL SEARCH
 -- depends on: aggregated_software_search
 CREATE FUNCTION global_search(query VARCHAR) RETURNS TABLE(
@@ -166,4 +165,23 @@ $$
 		community
 	WHERE
 		community.slug ILIKE CONCAT('%', query, '%') OR community."name" ILIKE CONCAT('%', query, '%');
+
+	-- PERSONS search
+	SELECT
+		public_user_profile.account as slug,
+		NULL AS domain,
+		NULL as rsd_host,
+		public_user_profile.display_name as "name",
+		'persons' AS "source",
+		public_user_profile.is_public AS is_published,
+		(CASE
+			WHEN public_user_profile.display_name ILIKE query OR public_user_profile.affiliation ILIKE query THEN 0
+			WHEN public_user_profile.display_name ILIKE CONCAT(query, '%') OR public_user_profile.affiliation ILIKE CONCAT(query, '%') THEN 2
+			ELSE 3
+		END) AS rank,
+		0 as index_found
+	FROM
+		public_user_profile()
+	WHERE
+		public_user_profile.display_name ILIKE CONCAT('%', query, '%') OR public_user_profile.affiliation ILIKE CONCAT('%', query, '%');
 $$;

--- a/database/125-global-search.sql
+++ b/database/125-global-search.sql
@@ -40,7 +40,7 @@ $$
 $$;
 
 -- GLOBAL SEARCH
--- depends on: aggregated_software_search
+-- depends on: aggregated_software_search, public_user_profile
 CREATE FUNCTION global_search(query VARCHAR) RETURNS TABLE(
 	slug VARCHAR,
 	domain VARCHAR,
@@ -175,13 +175,13 @@ $$
 		'persons' AS "source",
 		public_user_profile.is_public AS is_published,
 		(CASE
-			WHEN public_user_profile.display_name ILIKE query OR public_user_profile.affiliation ILIKE query THEN 0
-			WHEN public_user_profile.display_name ILIKE CONCAT(query, '%') OR public_user_profile.affiliation ILIKE CONCAT(query, '%') THEN 2
+			WHEN public_user_profile.display_name ILIKE query THEN 0
+			WHEN public_user_profile.display_name ILIKE CONCAT(query, '%') THEN 2
 			ELSE 3
 		END) AS rank,
 		0 as index_found
 	FROM
 		public_user_profile()
 	WHERE
-		public_user_profile.display_name ILIKE CONCAT('%', query, '%') OR public_user_profile.affiliation ILIKE CONCAT('%', query, '%');
+		public_user_profile.display_name ILIKE CONCAT('%', query, '%');
 $$;

--- a/database/126-public-persons-overview.sql
+++ b/database/126-public-persons-overview.sql
@@ -1,0 +1,91 @@
+-- SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+-- SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Software count per person
+-- based on account id OR ORCID
+-- acc_id = account, orc_id = ORCID
+CREATE FUNCTION software_cnt_by_person(acc_id UUID, orc_id VARCHAR) RETURNS TABLE(
+	software_cnt BIGINT,
+	acc_id UUID,
+	orc_id VARCHAR
+) LANGUAGE sql STABLE as
+$$
+SELECT
+	count(*) AS software_cnt,
+	acc_id,
+	orc_id
+FROM
+	software_by_public_profile()
+WHERE
+	software_by_public_profile.orcid = orc_id
+	OR
+	software_by_public_profile.account = acc_id
+$$;
+
+-- Project count per person
+-- based on account id OR ORCID
+-- acc_id = account, orc_id = ORCID
+CREATE FUNCTION project_cnt_by_person(acc_id UUID, orc_id VARCHAR) RETURNS TABLE(
+	project_cnt BIGINT,
+	acc_id UUID,
+	orc_id VARCHAR
+) LANGUAGE sql STABLE as
+$$
+SELECT
+	count(*) AS project_cnt,
+	acc_id,
+	orc_id
+FROM
+	project_by_public_profile()
+WHERE
+	project_by_public_profile.orcid = orc_id
+	OR
+	project_by_public_profile.account = acc_id
+$$;
+
+-- Public user profile information for profile page
+-- this info overwrites aggregated contributors/team member info
+-- from /rpc/person_mentions in 104-person-views
+CREATE FUNCTION public_persons_overview() RETURNS TABLE (
+	account UUID,
+	display_name VARCHAR,
+	affiliation VARCHAR,
+	"role" VARCHAR,
+	avatar_id VARCHAR(40),
+	orcid VARCHAR,
+	is_public BOOLEAN,
+	software_cnt BIGINT,
+	project_cnt BIGINT,
+	-- include keywords for future use
+	keywords VARCHAR[]
+) LANGUAGE sql STABLE SECURITY DEFINER AS
+$$
+SELECT
+	public_user_profile.account,
+	public_user_profile.display_name,
+	public_user_profile.affiliation,
+	public_user_profile.role,
+	public_user_profile.avatar_id,
+	public_user_profile.orcid,
+	public_user_profile.is_public,
+	software_cnt_by_person.software_cnt,
+	project_cnt_by_person.project_cnt,
+	-- include keywords for future use
+	array[]::varchar[] AS keywords
+FROM
+	public_user_profile()
+LEFT JOIN
+	software_cnt_by_person(public_user_profile.account,public_user_profile.orcid) ON (
+		software_cnt_by_person.acc_id = public_user_profile.account
+		OR
+		software_cnt_by_person.orc_id = public_user_profile.orcid
+	)
+LEFT JOIN
+	project_cnt_by_person(public_user_profile.account,public_user_profile.orcid) ON (
+		project_cnt_by_person.acc_id = public_user_profile.account
+		OR
+		project_cnt_by_person.orc_id = public_user_profile.orcid
+	)
+$$;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -123,7 +123,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:4.0.0
+    image: rsd/frontend:3.3.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/documentation/docs/03-rsd-instance/02-configurations.md
+++ b/documentation/docs/03-rsd-instance/02-configurations.md
@@ -160,7 +160,7 @@ The `host` section of settings.json defines following settings. **Most of them s
 - `privacy_statement_url`: the link to your privacy statement page. Used on the user profile page to let user accept the privacy statement.
 - `software_highlights`: the definitions for the software highlights section on the top of the software overview page. You can specify title and the number of items loaded in the carousel. The default values are shown below.
 - `orcid_search`: should ORCID api be used when searching for contributors or team members? By default ORCID search api is enabled and the entries from RSD and ORCID are combined in the search result. If you want your users to be able to search only within the existing RSD entries set this value to false.
-- `modules`: defines RSD "modules" displayed in the main menu in the page header. Possible values are: software, projects, organisations and communities.
+- `modules`: defines RSD "modules" displayed in the main menu in the page header. Possible values are: software, projects, organisations, communities and persons.
 
 ```json
 ...
@@ -185,7 +185,7 @@ The `host` section of settings.json defines following settings. **Most of them s
       "description": null
     },
     "orcid_search": true,
-    "modules":["software","projects","organisations","communities"]
+    "modules":["software","projects","organisations","communities","persons"]
   }
 ...
 ```

--- a/frontend/components/GlobalSearchAutocomplete/SearchItemIcon.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/SearchItemIcon.tsx
@@ -7,10 +7,11 @@ import TerminalIcon from '@mui/icons-material/Terminal'
 import ListAltIcon from '@mui/icons-material/ListAlt'
 import BusinessIcon from '@mui/icons-material/Business'
 import Diversity3Icon from '@mui/icons-material/Diversity3'
+import AccountCircleIcon from '@mui/icons-material/AccountCircle'
 
-import {GlobalSearchResultsSource} from './apiGlobalSearch'
+import {RsdModule} from '~/config/rsdSettingsReducer'
 
-export default function SearchItemIcon({source}:Readonly<{source:GlobalSearchResultsSource}>) {
+export default function SearchItemIcon({source}:Readonly<{source:RsdModule}>) {
   switch (source){
     case 'software':
       return <TerminalIcon/>
@@ -20,6 +21,8 @@ export default function SearchItemIcon({source}:Readonly<{source:GlobalSearchRes
       return <BusinessIcon/>
     case 'communities':
       return <Diversity3Icon/>
+    case 'persons':
+      return <AccountCircleIcon/>
     default:
       return null
   }

--- a/frontend/components/GlobalSearchAutocomplete/apiGlobalSearch.ts
+++ b/frontend/components/GlobalSearchAutocomplete/apiGlobalSearch.ts
@@ -8,15 +8,16 @@
 
 import logger from '~/utils/logger'
 import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import {RsdModule} from '~/config/rsdSettingsReducer'
 
-export type GlobalSearchResultsSource = 'software' | 'projects' | 'organisations' | 'communities'
+// export type GlobalSearchResultsSource = 'software' | 'projects' | 'organisations' | 'communities' | 'persons'
 
 export type GlobalSearchResults = {
   rsd_host: string | null
   domain: string | null
   slug: string,
   name: string,
-  source: GlobalSearchResultsSource,
+  source: RsdModule,
   is_published?: boolean,
   search_text?: string
 }

--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -84,6 +84,9 @@ export default function GlobalSearchAutocomplete(props: Props) {
   if (host.modules?.includes('communities')) {
     defaultValues.push({name: 'Go to Communities page', slug: '', source: 'communities', domain: null, rsd_host: null})
   }
+  if (host.modules?.includes('persons')) {
+    defaultValues.push({name: 'Go to Persons page', slug: '', source: 'persons', domain: null, rsd_host: null})
+  }
 
 
   async function fetchData(search: string) {

--- a/frontend/components/profile/ProfileSearchPanel.tsx
+++ b/frontend/components/profile/ProfileSearchPanel.tsx
@@ -21,7 +21,7 @@ export default function ProfileSearchPanel({
   onSetView,handleQueryChange
 }:ProfileSearchPanelProps) {
   return (
-    <div className="flex border rounded-md shadow-xs bg-base-100 p-2">
+    <div className="flex rounded-md bg-base-100 p-2">
       <SearchInput
         placeholder={placeholder}
         onSearch={(search: string) => handleQueryChange('search', search)}

--- a/frontend/components/profile/overview/PersonCard.tsx
+++ b/frontend/components/profile/overview/PersonCard.tsx
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+import Avatar from '@mui/material/Avatar'
+
+import LogoOrcid from '~/assets/logos/logo-orcid.svg'
+import {getImageUrl} from '~/utils/editImage'
+import {getDisplayInitials} from '~/utils/getDisplayName'
+import CardImageFrame from '~/components/cards/CardImageFrame'
+import CardContentFrame from '~/components/cards/CardContentFrame'
+import KeywordList from '~/components/cards/KeywordList'
+import PersonMetrics from './PersonMetrics'
+import {PersonsOverview} from './apiPersonsOverview'
+
+export default function PersonCard({person}:{person:PersonsOverview}) {
+  const given_names = person.display_name.split(' ')[0] ?? ''
+  const family_names = person.display_name.split(' ')[1] ?? ''
+  const initials = getDisplayInitials({given_names,family_names})
+  return (
+    <Link
+      data-testid="person-card-link"
+      href={`/persons/${person.account}`}
+      className="flex h-full hover:text-inherit"
+      passHref
+    >
+      <div className="flex flex-col transition overflow-hidden bg-base-100 shadow-md hover:shadow-lg rounded-lg hover:cursor-pointer select-none w-full relative">
+        <CardImageFrame>
+          <div className="flex-1 flex gap-8 justify-between items-start pt-4 px-4">
+            <Avatar
+              alt={person.display_name ?? ''}
+              src={getImageUrl(person?.avatar_id ?? null) ?? ''}
+              sx={{
+                width: '8rem',
+                height: '8rem',
+                fontSize: '3.25rem'
+              }}
+            >
+              {initials}
+            </Avatar>
+            <div className="flex gap-4">
+              <PersonMetrics
+                software_cnt={person.software_cnt ?? 0}
+                project_cnt={person.project_cnt ?? 0}
+              />
+            </div>
+          </div>
+        </CardImageFrame>
+        <CardContentFrame>
+          {/* personal info  */}
+          <h2
+            title={person.display_name}
+            className="text-xl font-medium line-clamp-1 my-1"
+          >
+            {person.display_name}
+          </h2>
+          <div className="grid gap-2">
+            {person?.role ? <div>{person.role}</div> : null}
+            {person?.affiliation ? <div>{person?.affiliation}</div>:null}
+            {person?.orcid ? <div>
+              <LogoOrcid className="inline max-w-[1.125rem] mr-1" />
+              <span className="text-sm align-bottom">{person.orcid}</span>
+            </div>: null}
+          </div>
+          {/* keywords */}
+          <div className="flex-1 overflow-auto py-2">
+            <KeywordList
+              keywords={person.keywords}
+            />
+          </div>
+        </CardContentFrame>
+      </div>
+    </Link>
+  )
+}

--- a/frontend/components/profile/overview/PersonListItem.tsx
+++ b/frontend/components/profile/overview/PersonListItem.tsx
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+import Avatar from '@mui/material/Avatar'
+
+import {getImageUrl} from '~/utils/editImage'
+import {getDisplayInitials} from '~/utils/getDisplayName'
+import OverviewListItem from '~/components/software/overview/list/OverviewListItem'
+import {PersonsOverview} from './apiPersonsOverview'
+import PersonMetrics from './PersonMetrics'
+
+export default function CommunityListItem({person}:{person:PersonsOverview}) {
+  const given_names = person.display_name.split(' ')[0] ?? ''
+  const family_names = person.display_name.split(' ')[1] ?? ''
+  const initials = getDisplayInitials({given_names,family_names})
+
+  return (
+    <OverviewListItem className="flex-none">
+      <Link
+        data-testid="community-list-item"
+        key={person.account}
+        href={`/persons/${person.account}`}
+        className='flex-1 flex items-center hover:text-inherit bg-base-100 rounded-xs'
+      >
+        <div className="p-2">
+          <Avatar
+            alt={person.display_name ?? ''}
+            src={getImageUrl(person?.avatar_id ?? null) ?? ''}
+            sx={{
+              width: '3rem',
+              height: '3rem',
+              fontSize: '1.25rem'
+            }}
+          >
+            {initials}
+          </Avatar>
+        </div>
+        <div className="flex-1 flex flex-col md:flex-row gap-3 py-2">
+          {/* basic info */}
+          <div className="flex-1">
+            <div className='line-clamp-2 md:line-clamp-1 break-words font-medium'>
+              {person.display_name}
+            </div>
+            <div className='line-clamp-4 md:line-clamp-2 break-words text-sm opacity-70'>
+              {person.role ? `${person.role},` : null} {person.affiliation}
+            </div>
+          </div>
+          {/* software count */}
+          <div className="flex items-center gap-4 mr-4">
+            <PersonMetrics
+              software_cnt={person.software_cnt ?? 0}
+              project_cnt={person.project_cnt ?? 0}
+            />
+          </div>
+        </div>
+      </Link>
+    </OverviewListItem>
+  )
+}

--- a/frontend/components/profile/overview/PersonMetrics.tsx
+++ b/frontend/components/profile/overview/PersonMetrics.tsx
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Tooltip from '@mui/material/Tooltip'
+import TerminalIcon from '@mui/icons-material/Terminal'
+import ListAltIcon from '@mui/icons-material/ListAlt'
+
+import useRsdSettings from '~/config/useRsdSettings'
+
+type PersonMetricsProps = {
+  software_cnt: number | null
+  project_cnt: number | null
+}
+
+export default function PersonMetrics({software_cnt,project_cnt}:PersonMetricsProps) {
+  const {host} = useRsdSettings()
+
+  function softwareMessage(){
+    if (software_cnt && software_cnt === 1) {
+      return `${software_cnt} software package`
+    }
+    return `${software_cnt ?? 0} software packages`
+  }
+
+  function projectMessage(){
+    if (project_cnt && project_cnt === 1) {
+      return `${project_cnt} research project`
+    }
+    return `${project_cnt ?? 0} research projects`
+  }
+
+  return (
+    <>
+      {
+        host.modules?.includes('software') ?
+          <Tooltip title={softwareMessage()} placement="top">
+            <div className="flex gap-2 items-center text-base-content-secondary">
+              <TerminalIcon sx={{width:20}} />
+              <span className="text-sm">{software_cnt ?? 0}</span>
+            </div>
+          </Tooltip>
+          :null
+      }
+      {
+        host.modules?.includes('projects') ?
+          <Tooltip title={projectMessage()} placement="top">
+            <div className="flex gap-2 items-center text-base-content-secondary">
+              <ListAltIcon sx={{width:20}} />
+              <span className="text-sm">{project_cnt}</span>
+            </div>
+          </Tooltip>
+          : null
+      }
+    </>
+  )
+}

--- a/frontend/components/profile/overview/PersonsGrid.tsx
+++ b/frontend/components/profile/overview/PersonsGrid.tsx
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import NoContent from '~/components/layout/NoContent'
+
+import {PersonsOverview} from './apiPersonsOverview'
+import PersonCard from './PersonCard'
+
+
+export default function PersonsGrid({items}:{items:PersonsOverview[]}) {
+
+  if (typeof items == 'undefined' || items.length===0){
+    return <NoContent />
+  }
+
+  return (
+    <section
+      data-testid="persons-grid"
+      className="my-12 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 auto-rows-[27rem]">
+      {items.map((item) => (
+        <PersonCard key={item.account} person={item} />
+      ))}
+    </section>
+  )
+}

--- a/frontend/components/profile/overview/PersonsList.tsx
+++ b/frontend/components/profile/overview/PersonsList.tsx
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import NoContent from '~/components/layout/NoContent'
+import {PersonsOverview} from './apiPersonsOverview'
+import PersonListItem from './PersonListItem'
+
+
+export default function PersonsList({items}:{items:PersonsOverview[]}) {
+  if (typeof items == 'undefined' || items.length===0){
+    return <NoContent />
+  }
+  return (
+    <section
+      data-testid="persons-list"
+      className="flex-1 my-12 flex flex-col gap-2">
+      {items.map((item) => (
+        <PersonListItem key={item.account} person={item} />
+      ))}
+    </section>
+  )
+}

--- a/frontend/components/profile/overview/apiPersonsOverview.ts
+++ b/frontend/components/profile/overview/apiPersonsOverview.ts
@@ -34,7 +34,7 @@ export async function getPersonsList({page,rows,token,searchFor,orderBy}:GetPers
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
       // search in name and short description
-      query+=`&or=(display_name.ilike.*${searchFor}*,affiliation.ilike.*${searchFor}*)`
+      query+=`&or=(display_name.ilike."*${searchFor}*",affiliation.ilike."*${searchFor}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy}`
@@ -42,9 +42,7 @@ export async function getPersonsList({page,rows,token,searchFor,orderBy}:GetPers
       query+='&order=affiliation.asc,display_name.asc'
     }
     // complete url
-    const url = `${getBaseUrl()}/rpc/public_persons_overview?${query}`
-
-    // console.log(url)
+    const url = encodeURI(`${getBaseUrl()}/rpc/public_persons_overview?${query}`)
 
     // get community
     const resp = await fetch(url, {

--- a/frontend/components/profile/overview/apiPersonsOverview.ts
+++ b/frontend/components/profile/overview/apiPersonsOverview.ts
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {extractCountFromHeader} from '~/utils/extractCountFromHeader'
+import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
+import {paginationUrlParams} from '~/utils/postgrestUrl'
+
+export type PersonsOverview = {
+  account: string
+  display_name: string
+  role: string | null
+  affiliation: string | null
+  avatar_id: string | null
+  orcid: string | null
+  is_public: boolean
+  software_cnt: number | null
+  project_cnt: number | null
+  keywords: string[] | null
+}
+
+type GetPersonsListParams={
+  page: number,
+  rows: number,
+  token?: string
+  searchFor?:string,
+  orderBy?:string,
+}
+
+export async function getPersonsList({page,rows,token,searchFor,orderBy}:GetPersonsListParams){
+  try{
+    let query = paginationUrlParams({rows, page})
+    if (searchFor) {
+      // search in name and short description
+      query+=`&or=(display_name.ilike.*${searchFor}*,affiliation.ilike.*${searchFor}*)`
+    }
+    if (orderBy) {
+      query+=`&order=${orderBy}`
+    } else {
+      query+='&order=affiliation.asc,display_name.asc'
+    }
+    // complete url
+    const url = `${getBaseUrl()}/rpc/public_persons_overview?${query}`
+
+    // console.log(url)
+
+    // get community
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+        // request record count to be returned
+        // note: it's returned in the header
+        'Prefer': 'count=exact'
+      }
+    })
+
+    if ([200,206].includes(resp.status)) {
+      const persons: PersonsOverview[] = await resp.json()
+      return {
+        count: extractCountFromHeader(resp.headers) ?? 0,
+        persons
+      }
+    }
+    logger(`getPersonsList: ${resp.status}: ${resp.statusText}`,'warn')
+    return {
+      count: 0,
+      persons: []
+    }
+  }catch(e:any){
+    logger(`getPersonsList: ${e.message}`,'error')
+    return {
+      count: 0,
+      persons: []
+    }
+  }
+}

--- a/frontend/components/profile/tabs/index.tsx
+++ b/frontend/components/profile/tabs/index.tsx
@@ -7,8 +7,10 @@
 import {useRouter} from 'next/router'
 import Tabs from '@mui/material/Tabs'
 
+import useRsdSettings from '~/config/useRsdSettings'
 import TabAsLink from '~/components/layout/TabAsLink'
 import {useProfileContext} from '~/components/profile/context/ProfileContext'
+import BaseSurfaceRounded from '~/components/layout/BaseSurfaceRounded'
 import {ProfileTabKey, profileTabItems} from './ProfileTabItems'
 
 type ProfileTabsProps={
@@ -21,32 +23,49 @@ const tabItems = Object.keys(profileTabItems) as ProfileTabKey[]
 
 export default function ProfileTabs({tab_id, isMaintainer}:ProfileTabsProps) {
   const router = useRouter()
+  const {host} = useRsdSettings()
   const {software_cnt,project_cnt} = useProfileContext()
+
+  // if only one module active we do not show tabs
+  if (
+    host?.modules?.includes('software')===false ||
+    host?.modules?.includes('projects')===false
+  ){
+    return (
+      <div className="my-2"></div>
+    )
+  }
+
   return (
-    <Tabs
-      component="nav"
-      variant="scrollable"
-      allowScrollButtonsMobile
-      value={tab_id}
-      aria-label="profile tabs"
+    <BaseSurfaceRounded
+      className="my-4 p-2"
+      type="section"
     >
-      {tabItems.map(key => {
-        const item = profileTabItems[key]
-        if (item.isVisible({isMaintainer})===true){
-          return (
-            <TabAsLink
-              key={key}
-              href={`../${router.query['id']}/${key}`}
-              value={key}
-              icon={item.icon}
-              label={item.label({
-                software_cnt,
-                project_cnt
-              })}
-            />
-          )
-        }
-      })}
-    </Tabs>
+      <Tabs
+        component="nav"
+        variant="scrollable"
+        allowScrollButtonsMobile
+        value={tab_id}
+        aria-label="profile tabs"
+      >
+        {tabItems.map(key => {
+          const item = profileTabItems[key]
+          if (item.isVisible({isMaintainer})===true){
+            return (
+              <TabAsLink
+                key={key}
+                href={`../${router.query['id']}/${key}`}
+                value={key}
+                icon={item.icon}
+                label={item.label({
+                  software_cnt,
+                  project_cnt
+                })}
+              />
+            )
+          }
+        })}
+      </Tabs>
+    </BaseSurfaceRounded>
   )
 }

--- a/frontend/components/search/useSearchParams.tsx
+++ b/frontend/components/search/useSearchParams.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -8,8 +8,8 @@ import {useRouter} from 'next/router'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
 import {QueryParams,buildFilterUrl} from '~/utils/postgrestUrl'
 import {useUserSettings} from '~/config/UserSettingsContext'
+import {RsdModule} from '~/config/rsdSettingsReducer'
 
-type RsdViews='organisations'|'communities'|'news'
 
 /**
  * Hook to extract basic query parameters rows, page and search from the url.
@@ -17,7 +17,7 @@ type RsdViews='organisations'|'communities'|'news'
  * @param view the route of the overview page (organisations | communities | news)
  * @returns handleQueryChange and resetFilters methods.
  */
-export default function useSearchParams(view:RsdViews){
+export default function useSearchParams(view:RsdModule){
   const router = useRouter()
   const {rsd_page_rows, setPageRows} = useUserSettings()
 

--- a/frontend/components/software/ContactPersonCard.tsx
+++ b/frontend/components/software/ContactPersonCard.tsx
@@ -62,7 +62,7 @@ export default function ContactPersonCard({person,section='software'}: {person: 
         <div className="flex-1 flex flex-col items-start">
           <h4 className="text-primary text-2xl">
             {person?.is_public ?
-              <a href={`/profile/${person.account}/${section}`}>
+              <a href={`/persons/${person.account}/${section}`}>
                 {displayName} <LaunchIcon sx={{width:'1rem'}}/>
               </a>
               :

--- a/frontend/components/software/ContributorsList.tsx
+++ b/frontend/components/software/ContributorsList.tsx
@@ -102,7 +102,7 @@ export default function ContributorsList({contributors,section='software'}: { co
                 <div className='flex-1'>
                   <div className="text-xl font-medium">
                     {item?.is_public ?
-                      <a href={`/profile/${item.account}/${section}`} className="flex gap-2 items-center">
+                      <a href={`/persons/${item.account}/${section}`} className="flex gap-2 items-center">
                         {displayName} <LaunchIcon sx={{width:'1rem'}}/>
                       </a>
                       :

--- a/frontend/components/user/settings/profile/ProfileInput.tsx
+++ b/frontend/components/user/settings/profile/ProfileInput.tsx
@@ -93,7 +93,7 @@ export default function ProfileInput() {
           />
 
           {is_public === true && account ?
-            <a href={`/profile/${account}/software`} className="flex gap-2 items-center" target='_blank'>
+            <a href={`/persons/${account}`} className="flex gap-2 items-center" target='_blank'>
               Enabled <LaunchIcon sx={{width:'1rem'}}/>
             </a>
             :<span>Disabled (<a href="/documentation/users/user-settings/#public-profile" target='_blank'>Why should I enable it? <LaunchIcon sx={{width:'1rem'}}/></a>)</span>

--- a/frontend/components/user/settings/profile/apiUserProfile.ts
+++ b/frontend/components/user/settings/profile/apiUserProfile.ts
@@ -23,6 +23,7 @@ export type UserProfile = {
 }
 
 export type PublicUserProfile = UserProfile & {
+  display_name: string
   orcid: string | null
 }
 

--- a/frontend/config/UserSettingsContext.tsx
+++ b/frontend/config/UserSettingsContext.tsx
@@ -56,7 +56,7 @@ export function UserSettingsProvider(props:any){
 export function useUserSettings(){
   const {user,setUser} = useContext(UserSettingsContext)
 
-  function setPageLayout(layout:LayoutType){
+  function setPageLayout(layout:LayoutType='grid'){
     // save to cookie
     setDocumentCookie(layout,'rsd_page_layout')
     // save to state
@@ -66,7 +66,7 @@ export function useUserSettings(){
     })
   }
 
-  function setPageRows(rows:number){
+  function setPageRows(rows:number=12){
     // save to cookie
     setDocumentCookie(rows.toString(),'rsd_page_rows')
     // save to state

--- a/frontend/config/getSettingsServerSide.ts
+++ b/frontend/config/getSettingsServerSide.ts
@@ -1,9 +1,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,9 +11,12 @@ import {IncomingMessage} from 'http'
 
 import logger from '~/utils/logger'
 import {getPageLinks} from '~/components/admin/pages/useMarkdownPages'
-import {defaultRsdSettings, RsdSettingsState} from './rsdSettingsReducer'
+import {defaultRsdSettings, RsdModule, RsdSettingsState} from './rsdSettingsReducer'
 import defaultSettings from '~/config/defaultSettings.json'
 import {getAnnouncement} from '~/components/admin/announcements/apiAnnouncement'
+
+// cache module list
+let modules:RsdModule[]=[]
 
 /**
  * getThemeSettings from local json file
@@ -69,4 +72,27 @@ export async function getSettingsServerSide(req: IncomingMessage | undefined): P
   // console.log('rsdSettings...', rsdSettings)
   // console.groupEnd()
   return rsdSettings
+}
+
+/**
+ * Get RSD modules from settings.json server side
+ * @returns
+ */
+export async function getRsdModules(){
+  try{
+    if (modules?.length > 0 && process.env.NODE_ENV == 'production'){
+      // console.log('cached modules...', modules)
+      return modules
+    }
+    const settings = await getRsdSettings()
+
+    if (settings?.host?.modules){
+      modules = settings?.host?.modules
+      return modules
+    }
+    return modules
+  }catch(e:any){
+    logger(`getRsdModules failed: ${e?.message}`,'warn')
+    return []
+  }
 }

--- a/frontend/config/menuItems.tsx
+++ b/frontend/config/menuItems.tsx
@@ -43,7 +43,8 @@ export const menuItems:MenuItemType[] = [
   {path: '/software', match:'/software', label:'Software', module:'software'},
   {path: '/projects', match: '/projects', label: 'Projects', module:'projects'},
   {path: '/organisations', match: '/organisations', label: 'Organisations', module:'organisations'},
-  {path: '/communities', match: '/communities', label: 'Communities', module:'communities'}
+  {path: '/communities', match: '/communities', label: 'Communities', module:'communities'},
+  {path: '/persons', match: '/persons', label: 'Persons', module:'persons'}
 ]
 
 // ListItemButton styles for menus used on the edit pages

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -20,7 +20,7 @@ export type RsdSettingsState = {
   announcement?: string | null
 }
 
-export type RsdModule= 'software'| 'projects' | 'organisations' | 'communities' | 'news' | 'user'
+export type RsdModule= 'software'| 'projects' | 'organisations' | 'communities' | 'news' | 'user' | 'persons'
 
 export type RsdHost = {
   name: string,

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -50,10 +50,10 @@ const nextConfig: NextConfig = {
         destination: '/communities/:slug/software',
         permanent: true,
       },
-      // profile default page
+      // forward old links to new location
       {
-        source: '/profile/:orcid',
-        destination: '/profile/:orcid/software',
+        source: '/profile/:orcid*',
+        destination: '/persons/:orcid*',
         permanent: true,
       },
     ]

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "4.0.0",
+  "version": "3.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/frontend/pages/persons/[id]/index.tsx
+++ b/frontend/pages/persons/[id]/index.tsx
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next/types'
+import {getRsdModules} from '~/config/getSettingsServerSide'
+
+export default function Profile() {
+  return (
+    <h1>Profile redirect</h1>
+  )
+}
+
+// see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  try{
+
+    const {params} = context
+    const id = params?.id as string
+
+    // determine active modules
+    const modules = await getRsdModules()
+    // default tab is software
+    let tab = ''
+    if (modules?.includes('software')){
+      tab='software'
+    } else if (modules?.includes('projects')){
+      tab='projects'
+    }
+    // if software and projects module are disabled we do not forward
+    if (tab===''){
+      return {
+        notFound: true,
+      }
+    }
+    // redirect to default tab
+    return {
+      redirect: {
+        destination: `/persons/${id}/${tab}`,
+        permanent: false
+      },
+    }
+  }catch{
+    return {
+      notFound: true,
+    }
+  }
+}


### PR DESCRIPTION
# Persons overview page and module

Closes #1482

Changes proposed in this pull request:
* Persons module added to settings.json
* Persons overview page added (see image 1) with card and list layout. The person metrics, software & project counts, is shown if the module is enabled in settings.json. Persons overview page shows 404 if the module "persons" is not enabled. The order of overview is by affiliation and display name.
* Redirect old profile/{id} route to persons/{id} route
* Person/Profile page, does not shows tabs if only one module of "software/projects" is enabled

How to test:
* `make start` to build and generate random test data. Note! Software/project counts used on person card for random data do not correlate initially. Not sure why.
* Enable persons module by adding "persons" into modules prop of settings.json
* Confirm Persons menu options is shown in the main and mobile menu.
* Confirm person link from the overview opens person/profile page.
* Now, remove "software" module from settings.json. Confirm that person cards show only projects count and when you navigate to person page the tab (software, projects) is not shown. Do the same with "projects" module.
* Test links to profile from software and project pages.
* Test old link: change "/persons/" to "/profile/" in the link and conform that you are forwarded to profile page.

## Example persons overview page (card)
![image](https://github.com/user-attachments/assets/7d662a46-7235-40c7-acbc-74e4ad178787)

## Example persons overview page (list)
![image](https://github.com/user-attachments/assets/87c221be-0e19-49d0-a447-1162e1785f7b)

## Example person overview
When only projects module is enabled
![image](https://github.com/user-attachments/assets/41dbbd5d-b230-4094-8f54-90df1f6218ce)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
