### PR TITLE
fix: postgrest or+ilike error when using , in search term

### DIFF
--- a/database/125-global-search.sql
+++ b/database/125-global-search.sql
@@ -164,11 +164,11 @@ $$
 	FROM
 		community
 	WHERE
-		community.slug ILIKE CONCAT('%', query, '%') OR community."name" ILIKE CONCAT('%', query, '%');
-
+		community.slug ILIKE CONCAT('%', query, '%') OR community."name" ILIKE CONCAT('%', query, '%')
+	UNION ALL
 	-- PERSONS search
 	SELECT
-		public_user_profile.account as slug,
+		CAST (public_user_profile.account AS VARCHAR) as slug,
 		NULL AS domain,
 		NULL as rsd_host,
 		public_user_profile.display_name as "name",

--- a/frontend/components/admin/logs/apiLogs.ts
+++ b/frontend/components/admin/logs/apiLogs.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -17,7 +17,7 @@ export async function getLogs({page, rows, token, searchFor, orderBy}: ApiParams
   try {
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
-      query+=`&or=(service_name.ilike.*${searchFor}*,table_name.ilike.*${searchFor}*,message.ilike.*${searchFor}*,stack_trace.ilike.*${searchFor}*,slug.ilike.*${searchFor}*)`
+      query+=`&or=(service_name.ilike."*${searchFor}*",table_name.ilike."*${searchFor}*",message.ilike."*${searchFor}*",stack_trace.ilike."*${searchFor}*",slug.ilike."*${searchFor}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy.column}.${orderBy.direction}`

--- a/frontend/components/admin/mentions/MentionsOverview.tsx
+++ b/frontend/components/admin/mentions/MentionsOverview.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -55,7 +55,7 @@ export default function MentionsOverview() {
       case 'openalex':
         return `openalex_id=eq.${termEscaped}`
       case 'title':
-        return `or=(title.ilike.*${termEscaped}*,authors.ilike.*${termEscaped}*,journal.ilike.*${termEscaped}*,url.ilike.*${termEscaped}*,note.ilike.*${termEscaped}*,openalex_id.ilike.*${termEscaped}*)`
+        return `or=(title.ilike."*${termEscaped}*",authors.ilike."*${termEscaped}*",journal.ilike."*${termEscaped}*",url.ilike."*${termEscaped}*",note.ilike."*${termEscaped}*",openalex_id.ilike."*${termEscaped}*")`
     }
   }
 

--- a/frontend/components/admin/organisations/apiOrganisation.tsx
+++ b/frontend/components/admin/organisations/apiOrganisation.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -38,7 +38,7 @@ async function getOrganisations({page, rows, token, searchFor, orderBy}: getOrga
     const selectList = 'id,parent,name,website,is_tenant,rsd_path,logo_id,ror_id,software_cnt,project_cnt'
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
-      query+=`&or=(name.ilike.*${searchFor}*,website.ilike.*${searchFor}*,ror_id.ilike.*${searchFor}*)`
+      query+=`&or=(name.ilike."*${searchFor}*",website.ilike."*${searchFor}*",ror_id.ilike."*${searchFor}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy}`

--- a/frontend/components/admin/remote-rsd/apiRemoteRsd.ts
+++ b/frontend/components/admin/remote-rsd/apiRemoteRsd.ts
@@ -37,7 +37,7 @@ export async function getRemoteRsd({page,rows,token,searchFor,orderBy}:GetRemote
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
       // search in name and short description
-      query+=`&or=(label.ilike.*${searchFor}*,domain.ilike.*${searchFor}*)`
+      query+=`&or=(label.ilike."*${searchFor}*",domain.ilike."*${searchFor}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy}`

--- a/frontend/components/admin/rsd-contributors/apiRsdContributors.ts
+++ b/frontend/components/admin/rsd-contributors/apiRsdContributors.ts
@@ -20,7 +20,7 @@ export async function getContributors({page, rows, token, searchFor, orderBy}: A
   try {
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
-      query+=`&or=(given_names.ilike.*${searchFor}*,family_names.ilike.*${searchFor}*,email_address.ilike.*${searchFor}*,orcid.ilike.*${searchFor}*)`
+      query+=`&or=(given_names.ilike."*${searchFor}*",family_names.ilike."*${searchFor}*",email_address.ilike."*${searchFor}*",orcid.ilike."*${searchFor}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy.column}.${orderBy.direction}`

--- a/frontend/components/admin/rsd-info/apiRsdInfo.ts
+++ b/frontend/components/admin/rsd-info/apiRsdInfo.ts
@@ -31,7 +31,7 @@ export async function getRsdInfo({page, rows, token, searchFor, orderBy}: ApiPar
   try {
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
-      query+=`&or=(key.ilike.*${searchFor}*,value.ilike.*${searchFor}*)`
+      query+=`&or=(key.ilike."*${searchFor}*",value.ilike."*${searchFor}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy.column}.${orderBy.direction}`

--- a/frontend/components/admin/rsd-users/apiRsdUsers.ts
+++ b/frontend/components/admin/rsd-users/apiRsdUsers.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -37,7 +37,7 @@ export async function getRsdAccounts({page,rows,token,searchFor,adminsOnly,inact
         query += `&id=eq.${searchFor}`
       } else {
         // else we search by name, email or organisation
-        query+=`&login_for_account_text_filter.or=(name.ilike.*${searchFor}*,email.ilike.*${searchFor}*,home_organisation.ilike.*${searchFor}*)`
+        query+=`&login_for_account_text_filter.or=(name.ilike."*${searchFor}*",email.ilike."*${searchFor}*",home_organisation.ilike."*${searchFor}*")`
       }
     }
     // complete url

--- a/frontend/components/admin/software-highlights/apiSoftwareHighlights.ts
+++ b/frontend/components/admin/software-highlights/apiSoftwareHighlights.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
@@ -32,7 +32,7 @@ export async function getSoftwareHighlights({limit, offset, token, searchFor, or
     // let query = paginationUrlParams({ rows, page })
     let query = ''
     if (searchFor) {
-      query+=`&or=(brand_name.ilike.*${searchFor}*,short_statement.ilike.*${searchFor}*)`
+      query+=`&or=(brand_name.ilike."*${searchFor}*",short_statement.ilike."*${searchFor}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy}`

--- a/frontend/components/communities/apiCommunities.ts
+++ b/frontend/components/communities/apiCommunities.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -44,7 +44,7 @@ export async function getCommunityList({page,rows,token,searchFor,orderBy}:GetCo
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
       // search in name and short description
-      query+=`&or=(name.ilike.*${searchFor}*,short_description.ilike.*${searchFor}*)`
+      query+=`&or=(name.ilike."*${searchFor}*",short_description.ilike."*${searchFor}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy}`

--- a/frontend/components/news/apiNews.tsx
+++ b/frontend/components/news/apiNews.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -191,7 +191,7 @@ export async function getNewsList({page,rows,is_published=true,token,searchFor,o
     // get published meta pages ordered by position
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
-      query+=`&or=(title.ilike.*${searchFor}*,summary.ilike.*${searchFor}*,author.ilike.*${searchFor}*)`
+      query+=`&or=(title.ilike."*${searchFor}*",summary.ilike."*${searchFor}*",author.ilike."*${searchFor}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy}`

--- a/frontend/components/organisation/apiOrganisations.ts
+++ b/frontend/components/organisation/apiOrganisations.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,7 +29,7 @@ export function organisationListUrl({search, rows = 12, page = 0}: {
   let url = `${getBaseUrl()}/rpc/organisations_overview?parent=is.null&score=gt.0&order=is_tenant.desc,score.desc.nullslast,name.asc&select=${selectList}`
   // add search params
   if (search) {
-    url += `&or=(name.ilike.*${search}*, website.ilike.*${search}*, ror_names_string.ilike.*${search}*)`
+    url += `&or=(name.ilike."*${search}*", website.ilike."*${search}*", ror_names_string.ilike."*${search}*")`
   }
   // add pagination params
   url += paginationUrlParams({

--- a/frontend/components/profile/apiProfile.ts
+++ b/frontend/components/profile/apiProfile.ts
@@ -42,7 +42,7 @@ export async function getProfileSoftware({orcid,account,rows=12,page=0,search,to
     // include search
     if (search){
       const encodedSearch = encodeURIComponent(search)
-      query+=`&or=(brand_name.ilike.*${encodedSearch}*,short_statement.ilike.*${encodedSearch}*,keywords_text.ilike.*${encodedSearch}*)`
+      query+=`&or=(brand_name.ilike."*${encodedSearch}*",short_statement.ilike."*${encodedSearch}*",keywords_text.ilike."*${encodedSearch}*")`
     }
     // complete url
     const url = `${getBaseUrl()}/rpc/software_by_public_profile?${query}`

--- a/frontend/components/user/communities/index.tsx
+++ b/frontend/components/user/communities/index.tsx
@@ -39,7 +39,7 @@ export default function UserCommunities() {
     <div className="flex-1">
       {/* SEARCH */}
       <SearchPanel
-        placeholder='Find software'
+        placeholder='Find community'
         layout={view}
         rows={rsd_page_rows}
         search={searchFor ?? null}

--- a/frontend/components/user/organisations/useUserOrganisations.tsx
+++ b/frontend/components/user/organisations/useUserOrganisations.tsx
@@ -34,7 +34,7 @@ export async function getOrganisationsForMaintainer(
 
     // search
     if (searchFor) {
-      url += `&or=(name.ilike.*${encodeURIComponent(searchFor)}*,short_description.ilike.*${encodeURIComponent(searchFor)}*)`
+      url += `&or=(name.ilike."*${searchFor}*",short_description.ilike."*${searchFor}*")`
     }
 
     // pagination

--- a/frontend/components/user/project/useUserProjects.tsx
+++ b/frontend/components/user/project/useUserProjects.tsx
@@ -48,7 +48,7 @@ export async function getProjectsForMaintainer(
 
     // search
     if (searchFor) {
-      url += `&or=(title.ilike.*${encodeURIComponent(searchFor)}*, subtitle.ilike.*${encodeURIComponent(searchFor)}*)`
+      url += `&or=(title.ilike."*${searchFor}*", subtitle.ilike."*${searchFor}*")`
     }
 
     // pagination

--- a/frontend/components/user/software/useUserSoftware.tsx
+++ b/frontend/components/user/software/useUserSoftware.tsx
@@ -43,7 +43,7 @@ export async function getSoftwareForMaintainer({
     let url =`/api/v1/rpc/software_by_maintainer?maintainer_id=${account}&order=brand_name`
     // search
     if (searchFor) {
-      url+=`&or=(brand_name.ilike.*${encodeURIComponent(searchFor)}*, short_statement.ilike.*${encodeURIComponent(searchFor)}*)`
+      url+=`&or=(brand_name.ilike."*${searchFor}*", short_statement.ilike."*${searchFor}*")`
     }
     // pagination
     url += paginationUrlParams({rows, page})

--- a/frontend/utils/editOrganisation.ts
+++ b/frontend/utils/editOrganisation.ts
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -60,9 +60,9 @@ export async function findRSDOrganisation({searchFor, token, rorIds}:
 
     if (rorIds.length) {
       const rorIdsCommaSeparated = rorIds.join(',')
-      query += `&or=(name.ilike.*${searchFor}*,website.ilike.*${searchFor}*,ror_id.in.(${rorIdsCommaSeparated}))&limit=20`
+      query += `&or=(name.ilike."*${searchFor}*",website.ilike."*${searchFor}*",ror_id.in.(${rorIdsCommaSeparated}))&limit=20`
     } else {
-      query += `&or=(name.ilike.*${searchFor}*,website.ilike.*${searchFor}*)&limit=20`
+      query += `&or=(name.ilike."*${searchFor}*",website.ilike."*${searchFor}*")&limit=20`
     }
 
     const url = `${getBaseUrl()}/rpc/organisations_overview?${query}`


### PR DESCRIPTION
# Fix search part of postgrest api calls

Closes #1504

Changes proposed in this pull request:
* When `or`  and `ilike` search is performed using postgrest syntax and , is used in search term the search query fails due to reserved charter (,). In order to prevent error search term need to be enclosed between quotes ("test,").

How to test:
* `make start` to build the solution and generate test data
* change one software entry title to contain "," and invite yourself to be maintainer
* change one project entry title to contain "," and invite yourself to be maintainer
* change one organisation entry to contain "," and invite yourself to be maintainer
* change one community entry to contain "," and invite yourself to be maintainer
* add "," in your profile name too and make your profile public
* search for software with "," entry on software overview page
* search for project with "," entry on project overview page
* search for organisation with "," entry on organisation page
* search for community with "," entry on community page
* add yourself to software as contributor searching for your name with "," in it
* add yourself to project as team member searching for your name with "," in it
* navigate to rsd admin pages. Open developers tab and monitor network api calls
* use "test," as searchterm on all pages and confirm that no api call fails

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
