### PR TITLE
feat: add news module to settings.json and handle menu and page items

### DIFF
--- a/frontend/components/AppHeader/AddMenu.test.tsx
+++ b/frontend/components/AppHeader/AddMenu.test.tsx
@@ -1,28 +1,73 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {render,screen, fireEvent} from '@testing-library/react'
-import {WrappedComponentWithProps} from '../../utils/jest/WrappedComponents'
 
-import AddMenu from '../AppHeader/AddMenu'
+import {WithAppContext, mockSession} from '~/utils/jest/WithAppContext'
+import {defaultRsdSettings, RsdSettingsState} from '~/config/rsdSettingsReducer'
+import AddMenu from './AddMenu'
+
+const mockSettings:RsdSettingsState = {
+  ...defaultRsdSettings
+}
 
 it('should render AddMenu',()=>{
-  render(WrappedComponentWithProps(AddMenu))
+  render(
+    <WithAppContext>
+      <AddMenu />
+    </WithAppContext>
+  )
   const userMenu = screen.queryByTestId('add-menu-button')
   expect(userMenu).toBeInTheDocument()
   // screen.debug()
 })
 
-it('should have AddMenu options',async()=>{
-  render(WrappedComponentWithProps(AddMenu))
+it('all menu options for rsd-admin',async()=>{
+  mockSettings.host.modules = ['software','projects','news']
+  // admin should have more items
+  if (mockSession.user) mockSession.user.role='rsd_admin'
+
+  render(
+    <WithAppContext options={{
+      session: mockSession,
+      settings: mockSettings
+    }}>
+      <AddMenu />
+    </WithAppContext>
+  )
   const menuButton = screen.queryByTestId('add-menu-button')
   // click on the button to display menu options
   fireEvent.click(menuButton as HTMLElement)
   // select all menu options
   const menuOptions = screen.queryAllByTestId('add-menu-option')
-  // assert only 2 items
-  expect(menuOptions.length).toEqual(2)
+  // assert only 1 item
+  expect(menuOptions.length).toEqual(mockSettings.host.modules.length)
+  // screen.debug()
+})
+
+it('no news option for rsd-user',async()=>{
+  mockSettings.host.modules = ['software','projects','news']
+  // admin should have more items
+  if (mockSession.user) mockSession.user.role='rsd_user'
+
+  render(
+    <WithAppContext options={{
+      session: mockSession,
+      settings: mockSettings
+    }}>
+      <AddMenu />
+    </WithAppContext>
+  )
+  const menuButton = screen.queryByTestId('add-menu-button')
+  // click on the button to display menu options
+  fireEvent.click(menuButton as HTMLElement)
+  // select all menu options
+  const menuOptions = screen.queryAllByTestId('add-menu-option')
+  // assert only 1 item
+  expect(menuOptions.length).toEqual(mockSettings.host.modules.length-1)
   // screen.debug()
 })

--- a/frontend/components/AppHeader/AddMenu.tsx
+++ b/frontend/components/AppHeader/AddMenu.tsx
@@ -10,25 +10,28 @@ import {useRouter} from 'next/router'
 import Menu from '@mui/material/Menu'
 import MenuItem from '@mui/material/MenuItem'
 import AddIcon from '@mui/icons-material/Add'
-import TerminalIcon from '@mui/icons-material/Terminal'
-import ListAltIcon from '@mui/icons-material/ListAlt'
 import IconButton from '@mui/material/IconButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
-import NewspaperIcon from '@mui/icons-material/Newspaper'
 
-import {useSession} from '~/auth'
 import CaretIcon from '~/components/icons/caret.svg'
 import useDisableScrollLock from '~/utils/useDisableScrollLock'
+import useAddItemMenu from './useAddItemMenu'
 
 export default function AddMenu() {
-  const {user} = useSession()
   const router = useRouter()
   const disable = useDisableScrollLock()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
+  const addItemMenu = useAddItemMenu()
 
   function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
-    setAnchorEl(event.currentTarget)
+    // only one option so click direct to action
+    if (addItemMenu.length===1 && addItemMenu[0]?.path){
+      handleClose(addItemMenu[0]?.path)
+    }else{
+      // show menu items
+      setAnchorEl(event.currentTarget)
+    }
   }
 
   function handleClose(path?: string) {
@@ -38,6 +41,14 @@ export default function AddMenu() {
     }
     setAnchorEl(null)
   }
+
+  // console.group('AddMenu')
+  // console.log('open...',open)
+  // console.log('addItemMenu...',addItemMenu)
+  // console.groupEnd()
+
+  // if no items to shown hide it
+  if (addItemMenu.length === 0) return null
 
   return (
     <>
@@ -76,29 +87,20 @@ export default function AddMenu() {
           list: {'aria-labelledby': 'menu-button'}
         }}
       >
-        <MenuItem data-testid="add-menu-option" onClick={() => handleClose('/add/software')}>
-          <ListItemIcon>
-            <TerminalIcon/>
-          </ListItemIcon>
-          New Software
-        </MenuItem>
-
-        <MenuItem data-testid="add-menu-option" onClick={() => handleClose('/add/project')}>
-          <ListItemIcon>
-            <ListAltIcon/>
-          </ListItemIcon>
-          New Project
-        </MenuItem>
         {
-          // ADMIN ONLY options
-          user?.role==='rsd_admin' ?
-            <MenuItem data-testid="add-menu-option" onClick={() => handleClose('/add/news')}>
-              <ListItemIcon>
-                <NewspaperIcon/>
-              </ListItemIcon>
-              Add News
-            </MenuItem>
-            : null
+          addItemMenu.map(item=>{
+            return (
+              <MenuItem
+                key={item.path}
+                data-testid="add-menu-option"
+                onClick={() => handleClose(item.path)}>
+                <ListItemIcon>
+                  {item.icon}
+                </ListItemIcon>
+                {item.label}
+              </MenuItem>
+            )
+          })
         }
       </Menu>
     </>

--- a/frontend/components/AppHeader/__mocks__/useAddItemMenu.tsx
+++ b/frontend/components/AppHeader/__mocks__/useAddItemMenu.tsx
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {JSX} from 'react'
+
+
+import {useSession} from '~/auth'
+import TerminalIcon from '@mui/icons-material/Terminal'
+import ListAltIcon from '@mui/icons-material/ListAlt'
+import NewspaperIcon from '@mui/icons-material/Newspaper'
+import useRsdSettings from '~/config/useRsdSettings'
+
+type AddItemMenuItem={
+  type: 'link' | 'divider'
+  label: string
+  icon: JSX.Element,
+  path?: string,
+  // used to customize menu items per user/profile
+  active:(props:any)=>boolean
+}
+
+export const addItemMenu:AddItemMenuItem[]=[{
+  type: 'link',
+  label: 'New Software',
+  icon: <TerminalIcon/>,
+  path: '/add/software',
+  active: ({modules})=>modules.includes('software')
+},{
+  type: 'link',
+  label: 'New Project',
+  icon: <ListAltIcon/>,
+  path: '/add/project',
+  active: ({modules})=>modules.includes('projects')
+},{
+  type: 'link',
+  label: 'Add News',
+  icon: <NewspaperIcon/>,
+  path: '/add/news',
+  active: ({role,modules})=> {
+    return role ==='rsd_admin' && modules.includes('news')
+  }
+}]
+
+
+function useAddItemMenu(){
+  const {user} = useSession()
+  const {host} = useRsdSettings()
+
+  const menuItems = addItemMenu.filter(item=>{
+    return item.active({role: user?.role, modules: host.modules}) ?? false
+  })
+
+  // console.group('useAddItemMenu')
+  // console.log('user...', user)
+  // console.log('host...', host)
+  // console.log('menuItems...', menuItems)
+  // console.groupEnd()
+
+  return menuItems
+}
+
+export default useAddItemMenu

--- a/frontend/components/AppHeader/useAddItemMenu.tsx
+++ b/frontend/components/AppHeader/useAddItemMenu.tsx
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {JSX} from 'react'
+
+
+import {useSession} from '~/auth'
+import TerminalIcon from '@mui/icons-material/Terminal'
+import ListAltIcon from '@mui/icons-material/ListAlt'
+import NewspaperIcon from '@mui/icons-material/Newspaper'
+import useRsdSettings from '~/config/useRsdSettings'
+
+type AddItemMenuItem={
+  type: 'link' | 'divider'
+  label: string
+  icon: JSX.Element,
+  path?: string,
+  // used to customize menu items per user/profile
+  active:(props:any)=>boolean
+}
+
+const addItemMenu:AddItemMenuItem[]=[{
+  type: 'link',
+  label: 'New Software',
+  icon: <TerminalIcon/>,
+  path: '/add/software',
+  active: ({modules})=>modules.includes('software')
+},{
+  type: 'link',
+  label: 'New Project',
+  icon: <ListAltIcon/>,
+  path: '/add/project',
+  active: ({modules})=>modules.includes('projects')
+},{
+  type: 'link',
+  label: 'Add News',
+  icon: <NewspaperIcon/>,
+  path: '/add/news',
+  active: ({role,modules})=> {
+    return role ==='rsd_admin' && modules.includes('news')
+  }
+}]
+
+
+function useAddItemMenu(){
+  const {user} = useSession()
+  const {host} = useRsdSettings()
+
+  const menuItems = addItemMenu.filter(item=>{
+    return item.active({role: user?.role, modules: host.modules}) ?? false
+  })
+
+  // console.group('useAddItemMenu')
+  // console.log('user...', user)
+  // console.log('host...', host)
+  // console.log('menuItems...', menuItems)
+  // console.groupEnd()
+
+  return menuItems
+}
+
+export default useAddItemMenu

--- a/frontend/config/menuItems.tsx
+++ b/frontend/config/menuItems.tsx
@@ -157,12 +157,14 @@ export const userMenuItems: MenuItemType[] = [
     module: 'user',
     type: 'divider',
     label: 'divider3',
-    active: ({role})=>['rsd_admin'].includes(role),
+    // news devider
+    active: ({role, modules})=>['rsd_admin'].includes(role) && modules.includes('news'),
   }, {
     module: 'user',
     type: 'link',
     label: 'News',
-    active: ({role})=>['rsd_admin'].includes(role),
+    // news menu item
+    active: ({role,modules})=>['rsd_admin'].includes(role) && modules.includes('news'),
     path: '/news',
     icon: <CalendarViewMonthIcon />,
   }, {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "3.3.0",
+  "version": "3.4.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,19 +1,20 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {app} from '~/config/app'
+import {getRsdModules} from '~/config/getSettingsServerSide'
+import useRsdSettings from '~/config/useRsdSettings'
 import {getHomepageCounts} from '~/components/home/getHomepageCounts'
 import HelmholtzHome from '~/components/home/helmholtz'
 import ImperialCollegeHome from '~/components/home/imperial'
 import RsdHome,{RsdHomeProps} from '~/components/home/rsd'
 import PageMeta from '~/components/seo/PageMeta'
 import CanonicalUrl from '~/components/seo/CanonicalUrl'
-import useRsdSettings from '~/config/useRsdSettings'
 import {TopNewsProps, getTopNews} from '~/components/news/apiNews'
 
 export type HomeProps = {
@@ -73,16 +74,18 @@ export default function Home({counts,news}: HomeProps) {
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps() {
   // get counts for default rsd home page
-  const [counts,news] = await Promise.all([
+  const [counts,news,modules] = await Promise.all([
     getHomepageCounts(),
     // get top 3 (most recent) news items
-    getTopNews(3)
+    getTopNews(3),
+    getRsdModules()
   ])
   // provide props to home component
   return {
     props: {
       counts,
-      news
+      // remove top news if news module is not enabled
+      news: modules.includes('news') ? news : [],
     },
   }
 }

--- a/frontend/pages/news/index.tsx
+++ b/frontend/pages/news/index.tsx
@@ -9,6 +9,7 @@ import Pagination from '@mui/material/Pagination'
 import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
+import {getRsdModules} from '~/config/getSettingsServerSide'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
 import {getUserSettings, setDocumentCookie} from '~/utils/userSettings'
 import PageMeta from '~/components/seo/PageMeta'
@@ -142,6 +143,14 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     const {req} = context
     const {search, rows, page} = ssrBasicParams(context.query)
     const token = req?.cookies['rsd_token']
+    const modules = await getRsdModules()
+
+    // show 404 page if module is not enabled
+    if (modules.includes('news')===false){
+      return {
+        notFound: true,
+      }
+    }
 
     // extract user settings from cookie
     const {rsd_page_layout,rsd_page_rows} = getUserSettings(context.req)

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -20,7 +20,7 @@
       "description": null
     },
     "orcid_search":true,
-    "modules":["software","projects","organisations","communities"]
+    "modules":["software","projects","organisations","communities","news"]
   },
   "links": [
     {

--- a/frontend/utils/jest/WithAppContext.tsx
+++ b/frontend/utils/jest/WithAppContext.tsx
@@ -6,8 +6,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {ThemeProvider} from '@mui/material/styles'
-import {loadMuiTheme} from '../../styles/rsdMuiTheme'
-import {AuthProvider,defaultSession,Session} from '../../auth'
+import {loadMuiTheme} from '~/styles/rsdMuiTheme'
+import {AuthProvider,defaultSession,Session} from '~/auth'
+import {LoginProvidersProvider} from '~/auth/loginProvidersContext'
+import {Provider} from '~/auth/api/getLoginProviders'
 import {RsdSettingsState,defaultRsdSettings} from '~/config/rsdSettingsReducer'
 import {RsdSettingsProvider} from '~/config/RsdSettingsContext'
 import {UserSettingsProps, UserSettingsProvider} from '~/config/UserSettingsContext'
@@ -18,6 +20,7 @@ export type WrapProps = {
   session?: Session
   settings?: RsdSettingsState
   user?: UserSettingsProps
+  providers?: Provider[]
 }
 
 type WithAppContextProps = {
@@ -59,6 +62,8 @@ export function WithAppContext({children,options}:WithAppContextProps) {
   const {muiTheme} = loadMuiTheme(settings.theme)
   // user settings
   const user = options?.user ?? defaultUserSettings
+  // providers list
+  const providers = options?.providers ?? []
 
   // console.group('WithAppContext')
   // console.log('session...', session)
@@ -72,7 +77,10 @@ export function WithAppContext({children,options}:WithAppContextProps) {
         <RsdSettingsProvider settings={settings}>
           {/* User settings rows, page layout etc. */}
           <UserSettingsProvider user={user}>
-            {children}
+            {/* Login providers list */}
+            <LoginProvidersProvider providers = {providers}>
+              {children}
+            </LoginProvidersProvider>
           </UserSettingsProvider>
         </RsdSettingsProvider>
       </AuthProvider>


### PR DESCRIPTION
# Add news module to settings.json and handle menu items

Changes proposed in this pull request:
* Comparing KIN implementation where menu add options should only be New Project and Add News I decided to make add menu react on modules defined in the settings.json. For this purpose I needed to add "news" in the list of the modules. 
* In addition, I handled news overview page and the homepage when "news" module is not enabled. 

How to test:
* `make start` to build app and create test data
* confirm that news section is shown on the homepage and you can view /news route.
* login to rsd. First user should be admin. Confirm that Add news options is shown in the Add menu at the top right.
* confirm that news menu item is present in the user menu
* remove "news" item from module in settings.json.  If you use localhost build version restart RSD. 
* confirm that news section is not shown on the homepage.
* confirm that "Add news" menu option is not shown.
* confirm that "News" menu option is not in user menu. 
* confirm that /news route show 404 - page not found
* remove "software" module from settings.json. With "software" and "news" modules removed the plus button will automatically activate remaining "New project" option and you will be redirected to Add project page.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
