### PR TITLE
Use anchor tags on tabs and buttons

### DIFF
--- a/e2e/helpers/project.ts
+++ b/e2e/helpers/project.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -40,7 +41,7 @@ export async function createProject({title, desc, slug, page}: CreateSoftwarePro
     // fill in title
     page.locator('#Title').fill(title),
     // wait for response on slug validation
-    page.waitForResponse( RegExp(slug))
+    page.waitForResponse(RegExp(slug))
   ])
 
   // add subtitle
@@ -52,7 +53,7 @@ export async function createProject({title, desc, slug, page}: CreateSoftwarePro
 
   // click save button
   await Promise.all([
-    page.waitForURL(url,{
+    page.waitForURL(url, {
       waitUntil: 'networkidle'
     }),
     saveBtn.click()
@@ -237,7 +238,7 @@ export async function openProjectPage(page: Page, name?: string) {
 
 }
 
-export async function openEditProjectPage(page:Page, name:string) {
+export async function openEditProjectPage(page: Page, name: string) {
   // navigate first to software page
   await openProjectPage(page, name)
   // open edit software
@@ -250,7 +251,7 @@ export async function openEditProjectPage(page:Page, name:string) {
 
 export async function openEditTeamPage(page: Page) {
   // open edit team members section
-  await page.getByRole('button', {
+  await page.getByRole('link', {
     name: 'Team'
   }).click()
 }

--- a/e2e/helpers/utils.ts
+++ b/e2e/helpers/utils.ts
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +14,7 @@ import {expect, Locator, Page} from '@playwright/test'
  * @param factor
  * @returns number
  */
-export function generateId(factor=100000){
+export function generateId(factor = 100000) {
   const id = Math.round(Math.random() * factor)
   return id
 }
@@ -66,7 +67,7 @@ export async function openEditPage(page: Page, url: string, title: string) {
  * @returns
  */
 export async function uploadFile(page: Page, inputSelector: string,
-  file: string, imageSelector = '[role="img"]') {
+                                 file: string, imageSelector = '[role="img"]') {
   // breakpoint
   // await page.pause()
 
@@ -78,8 +79,8 @@ export async function uploadFile(page: Page, inputSelector: string,
   return true
 }
 
-export function createMarkdown(browser) {
-return `
+export function createMarkdown(browser: string) {
+  return `
 ## Test software ${browser}
 
 This is test software markdown test.
@@ -90,25 +91,27 @@ Second level header here!
 `
 }
 
-export async function openEditSection(page:Page,name:string) {
+export async function openEditSection(page: Page, name: string) {
   // open contributors section
   await Promise.all([
     // we need to wait for authentication response to settle
     page.waitForLoadState('networkidle'),
-    page.getByRole('button', {
+    page.getByRole('link', {
       name
-    }).click()
+    })
+      .filter({has: page.getByRole('paragraph')})
+      .click()
   ])
 }
 
-export async function selectTab(page:Page,name:string){
+export async function selectTab(page: Page, name: string) {
   // select tab
   await page.getByRole('tab', {
     name
   }).click()
 }
 
-export async function addRelatedSoftware(page: Page, waitForResponse:string) {
+export async function addRelatedSoftware(page: Page, waitForResponse: string) {
   const findSoftware = page
     .getByTestId('find-related-software')
     .locator('#async-autocomplete')
@@ -147,7 +150,7 @@ export async function addRelatedSoftware(page: Page, waitForResponse:string) {
   }
 }
 
-export async function addRelatedProject(page: Page, waitForResponse:string) {
+export async function addRelatedProject(page: Page, waitForResponse: string) {
   const findSoftware = page
     .getByTestId('find-related-project')
     .locator('#async-autocomplete')

--- a/frontend/components/communities/tabs/index.tsx
+++ b/frontend/components/communities/tabs/index.tsx
@@ -1,12 +1,13 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
 import {useRouter} from 'next/router'
 import {TabKey, communityTabItems} from './CommunityTabItems'
+import TabAsLink from '~/components/layout/TabAsLink'
 
 // extract tab items (object keys)
 const tabItems = Object.keys(communityTabItems) as TabKey[]
@@ -32,24 +33,6 @@ export default function CommunityTabs({
       variant="scrollable"
       allowScrollButtonsMobile
       value={tab}
-      onChange={(_, value) => {
-        // create url
-        const url:any={
-          pathname:`/communities/[slug]/${value}`,
-          query:{
-            slug: router.query['slug']
-          }
-        }
-        // add default order for software and project tabs
-        if (value === 'software' ||
-          value === 'requests' ||
-          value === 'rejected'
-        ) {
-          url.query['order'] = 'mention_cnt'
-        }
-        // push route change
-        router.push(url,undefined,{scroll:false})
-      }}
       aria-label="community tabs"
     >
       {tabItems.map(key => {
@@ -57,8 +40,8 @@ export default function CommunityTabs({
         if (item.isVisible({
           isMaintainer,
           description
-        }) === true) {
-          return <Tab
+        })) {
+          return <TabAsLink
             icon={item.icon}
             key={key}
             label={item.label({
@@ -68,8 +51,10 @@ export default function CommunityTabs({
             })}
             value={key}
             sx={{
-              minWidth:'9rem'
+              minWidth: '9rem'
             }}
+            href={`/communities/${router.query['slug']}/${key}`}
+            scroll={false}
           />
         }})}
     </Tabs>

--- a/frontend/components/news/item/NavButtons.tsx
+++ b/frontend/components/news/item/NavButtons.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,6 +15,7 @@ import {deleteImage} from '~/utils/editImage'
 import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
 import {NewsImageProps, deleteNewsItem, deleteNewsImages} from '../apiNews'
 import useSnackbar from '~/components/snackbar/useSnackbar'
+import Link from 'next/link'
 
 type NavButtonsProps={
   id:string
@@ -98,9 +100,8 @@ export function NavButtons({id,slug,title,image_for_news,isMaintainer}:NavButton
             textTransform:'capitalize',
             minWidth: '7rem'
           }}
-          onClick={() => {
-            router.push(url)
-          }}
+          href={url}
+          LinkComponent={Link}
         >
           {/* Edit page */}
           Edit

--- a/frontend/components/organisation/tabs/OrganisationTabs.tsx
+++ b/frontend/components/organisation/tabs/OrganisationTabs.tsx
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
 import {useRouter} from 'next/router'
 
 import {TabKey, organisationTabItems} from './OrganisationTabItems'
 import useOrganisationContext from '../context/useOrganisationContext'
 import useSelectedTab from './useSelectedTab'
+import TabAsLink from '~/components/layout/TabAsLink'
 
 // extract tab items (object keys)
 const tabItems = Object.keys(organisationTabItems) as TabKey[]
@@ -34,18 +34,19 @@ export default function OrganisationTabs({tab_id}:{tab_id:TabKey|null}) {
       variant="scrollable"
       allowScrollButtonsMobile
       value={select_tab}
-      onChange={(_, value) => {
-        const query:any={
-          slug: router.query['slug'],
-          tab: value,
-        }
-        // push route change
-        router.push({query},undefined,{scroll:false})
-      }}
       aria-label="organisation tabs"
     >
       {tabItems.map(key => {
         const item = organisationTabItems[key]
+        const slugAsArray = router.query['slug']
+        let fullSlug: string
+        if (Array.isArray(slugAsArray)) {
+          fullSlug = slugAsArray.join('/')
+        } else if (slugAsArray === undefined) {
+          fullSlug = ''
+        } else {
+          fullSlug = slugAsArray
+        }
         if (item.isVisible({
           isMaintainer,
           software_cnt,
@@ -54,7 +55,7 @@ export default function OrganisationTabs({tab_id}:{tab_id:TabKey|null}) {
           children_cnt,
           description
         })) {
-          return <Tab
+          return <TabAsLink
             icon={item.icon}
             key={key}
             label={item.label({
@@ -64,6 +65,8 @@ export default function OrganisationTabs({tab_id}:{tab_id:TabKey|null}) {
               children_cnt
             })}
             value={key}
+            href={`/organisations/${fullSlug}?tab=${key}`}
+            scroll={false}
           />
         }})}
     </Tabs>

--- a/frontend/components/projects/edit/EditProjectNav.tsx
+++ b/frontend/components/projects/edit/EditProjectNav.tsx
@@ -1,12 +1,12 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useRouter} from 'next/router'
 import List from '@mui/material/List'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
@@ -14,9 +14,9 @@ import ListItemText from '@mui/material/ListItemText'
 
 import {editMenuItemButtonSx} from '~/config/menuItems'
 import {editProjectPage} from './editProjectPages'
+import Link from 'next/link'
 
 export default function EditProjectNav({slug,pageId}:{slug:string,pageId:string}) {
-  const router = useRouter()
   return (
     <nav>
       <List sx={{
@@ -28,10 +28,8 @@ export default function EditProjectNav({slug,pageId}:{slug:string,pageId:string}
               data-testid="edit-project-nav-item"
               key={`step-${pos}`}
               selected={item.id === pageId}
-              onClick={() => {
-                const location = `/projects/${slug}/edit/${item.id}`
-                router.push(location)
-              }}
+              href={`/projects/${slug}/edit/${item.id}`}
+              LinkComponent={Link}
               sx={editMenuItemButtonSx}
             >
               <ListItemIcon>

--- a/frontend/components/software/edit/EditSoftwareNav.tsx
+++ b/frontend/components/software/edit/EditSoftwareNav.tsx
@@ -2,9 +2,10 @@
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,6 +21,7 @@ import useRsdSettings from '~/config/useRsdSettings'
 import {usePluginSlots} from '~/config/RsdPluginContext'
 import SvgFromString from '~/components/icons/SvgFromString'
 import {editSoftwarePage} from './editSoftwarePages'
+import Link from 'next/link'
 
 export default function EditSoftwareNav({slug,pageId}:{slug:string,pageId:string}) {
   const router = useRouter()
@@ -43,10 +45,8 @@ export default function EditSoftwareNav({slug,pageId}:{slug:string,pageId:string
                 data-testid="edit-software-nav-item"
                 key={item.id}
                 selected={item.id === pageId}
-                onClick={() => {
-                  const location = `/software/${slug}/edit/${item.id}`
-                  router.push(location)
-                }}
+                href={`/software/${slug}/edit/${item.id}`}
+                LinkComponent={Link}
                 sx={editMenuItemButtonSx}
               >
                 <ListItemIcon>

--- a/frontend/components/user/settings/nav/index.tsx
+++ b/frontend/components/user/settings/nav/index.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -11,6 +12,7 @@ import ListItemText from '@mui/material/ListItemText'
 
 import {editMenuItemButtonSx} from '~/config/menuItems'
 import {settingsMenu} from './UserSettingsNavItems'
+import Link from 'next/link'
 
 export default function UserSettingsNav() {
   const router = useRouter()
@@ -33,14 +35,8 @@ export default function UserSettingsNav() {
             data-testid="user-settings-nav-item"
             key={item.id}
             selected={selected}
-            onClick={() => {
-              router.push({
-                query: {
-                  ...router.query,
-                  settings:item.id
-                }
-              },{},{scroll:false})
-            }}
+            href={`${router.query.section}?settings=${item.id}`}
+            LinkComponent={Link}
             sx={editMenuItemButtonSx}
           >
             <ListItemIcon>

--- a/frontend/components/user/tabs/UserTabs.tsx
+++ b/frontend/components/user/tabs/UserTabs.tsx
@@ -1,16 +1,16 @@
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useRouter} from 'next/router'
-import Tab from '@mui/material/Tab'
 import Tabs from '@mui/material/Tabs'
 
 import {useSession} from '~/auth'
 import useRsdSettings from '~/config/useRsdSettings'
 import {UserCounts, useUserContext} from '~/components/user/context/UserContext'
 import {UserPageId, userTabItems} from './UserTabItems'
+import TabAsLink from '~/components/layout/TabAsLink'
 
 // extract tab items (object keys)
 const tabItems = Object.keys(userTabItems) as UserPageId[]
@@ -32,7 +32,6 @@ export type UserTabsProps=Readonly<{
 }>
 
 export default function UserTabs({tab,counts}:UserTabsProps) {
-  const router = useRouter()
   const select_tab = useSelectedTab(tab)
   const {host} = useRsdSettings()
   const {user} = useSession()
@@ -50,13 +49,6 @@ export default function UserTabs({tab,counts}:UserTabsProps) {
       variant="scrollable"
       allowScrollButtonsMobile
       value={select_tab}
-      onChange={(_, value) => {
-        const query:any={
-          section: value,
-        }
-        // push route change
-        router.push({query},undefined,{scroll:false})
-      }}
       aria-label="User profile tabs"
     >
       {tabItems.map(key => {
@@ -65,11 +57,13 @@ export default function UserTabs({tab,counts}:UserTabsProps) {
           modules: host.modules,
           isMaintainer
         })) {
-          return <Tab
+          return <TabAsLink
             icon={item.icon}
             key={key}
             label={item.label(counts)}
             value={key}
+            href={key}
+            scroll={false}
           />
         }})}
     </Tabs>


### PR DESCRIPTION
## Use anchor tags on tabs and buttons

### Changes proposed in this pull request

* Add anchor (`<a>`) tags to tabs and buttons

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin
* Check that the following are clickable:
	* edit software tabs in sidebar
	* edit project tabs in sidebar
	* tabs of an organisation
	* tabs of a research unit (check that the link is correct)
	* tabs of a community
	* when viewing a news item, the edit button
	* the tabs at "My settings"
	* the tabs at the admin interface

closes #1518

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
