### PR TITLE
Robots modules

### DIFF
--- a/database/026-user-profile.sql
+++ b/database/026-user-profile.sql
@@ -117,7 +117,8 @@ CREATE FUNCTION public_user_profile() RETURNS TABLE (
 	avatar_id VARCHAR(40),
 	orcid VARCHAR,
 	account UUID,
-	is_public BOOLEAN
+	is_public BOOLEAN,
+	updated_at TIMESTAMPTZ
 ) LANGUAGE sql STABLE SECURITY DEFINER AS
 $$
 SELECT
@@ -130,7 +131,8 @@ SELECT
 	user_profile.avatar_id,
 	login_for_account.sub AS orcid,
 	user_profile.account,
-	user_profile.is_public
+	user_profile.is_public,
+	user_profile.updated_at
 FROM
 	user_profile
 LEFT JOIN

--- a/frontend/components/seo/getCommunitiesSitemap.ts
+++ b/frontend/components/seo/getCommunitiesSitemap.ts
@@ -1,0 +1,40 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {getBaseUrl} from '~/utils/fetchHelpers'
+import {getSitemap, SitemapInfo} from './getSitemap'
+
+async function getCommunitiesList() {
+  try {
+    const baseUrl = getBaseUrl()
+    // select only top level organisations (parent IS NULL)
+    const query = 'select=slug,updated_at&limit=50000&offset=0'
+    const url = `${baseUrl}/community?${query}`
+
+    const resp = await fetch(url)
+
+    if (resp.status === 200) {
+      const json: SitemapInfo[] = await resp.json()
+      return json
+    }
+    logger(`getCommunitiesList...${resp.status} ${resp.statusText}`, 'warn')
+    return []
+  } catch (e: any) {
+    logger(`getCommunitiesList...${e.message}`, 'error')
+    return []
+  }
+}
+
+
+export async function getCommunitiesSitemap(domain:string) {
+  // get software list
+  const items = await getCommunitiesList()
+
+  return getSitemap({
+    baseUrl: `${domain}/communities`,
+    items
+  })
+}

--- a/frontend/components/seo/getNewsSitemap.ts
+++ b/frontend/components/seo/getNewsSitemap.ts
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {getBaseUrl} from '~/utils/fetchHelpers'
+import {getSitemap, SitemapInfo} from './getSitemap'
+
+type NewsList={
+  publication_date: string
+  slug: string
+  updated_at: string
+}
+
+async function getNewsList() {
+  try {
+    const baseUrl = getBaseUrl()
+    // select only top level organisations (parent IS NULL)
+    const query = 'select=publication_date,slug,updated_at&limit=50000&offset=0'
+    const url = `${baseUrl}/news?${query}`
+
+    const resp = await fetch(url)
+
+    if (resp.status === 200) {
+      const json: NewsList[] = await resp.json()
+      const news:SitemapInfo[] = json.map(item=>{
+        return {
+          slug: `${item.publication_date}/${item.slug}`,
+          updated_at: item.updated_at
+        }
+      })
+
+      return news
+    }
+    logger(`getNewsList...${resp.status} ${resp.statusText}`, 'warn')
+    return []
+  } catch (e: any) {
+    logger(`getNewsList...${e.message}`, 'error')
+    return []
+  }
+}
+
+
+export async function getNewsSitemap(domain:string) {
+  // get software list
+  const items = await getNewsList()
+
+  return getSitemap({
+    baseUrl: `${domain}/news`,
+    items
+  })
+}

--- a/frontend/components/seo/getPersonsSitemap.ts
+++ b/frontend/components/seo/getPersonsSitemap.ts
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import logger from '~/utils/logger'
+import {getBaseUrl} from '~/utils/fetchHelpers'
+import {getSitemap, SitemapInfo} from './getSitemap'
+
+type PublicProfileInfo={
+  account: string
+  updated_at: string
+}
+
+async function getPublicProfilesList() {
+  try {
+    const baseUrl = getBaseUrl()
+    // select only top level organisations (parent IS NULL)
+    const query = 'select=account,updated_at&limit=50000&offset=0'
+    const url = `${baseUrl}/rpc/public_user_profile?${query}`
+
+    const resp = await fetch(url)
+
+    if (resp.status === 200) {
+      const json: PublicProfileInfo[] = await resp.json()
+      const persons:SitemapInfo[] = json.map(item=>{
+        return {
+          slug: item.account,
+          updated_at: item.updated_at
+        }
+      })
+      return persons
+    }
+    logger(`getPublicProfilesList...${resp.status} ${resp.statusText}`, 'warn')
+    return []
+  } catch (e: any) {
+    logger(`getPublicProfilesList...${e.message}`, 'error')
+    return []
+  }
+}
+
+
+export async function getPublicProfileSitemap(domain:string) {
+  // get software list
+  const items = await getPublicProfilesList()
+
+  return getSitemap({
+    baseUrl: `${domain}/persons`,
+    items
+  })
+}

--- a/frontend/pages/robots.txt.tsx
+++ b/frontend/pages/robots.txt.tsx
@@ -1,9 +1,13 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {GetServerSidePropsContext} from 'next'
+import {getRsdModules} from '~/config/getSettingsServerSide'
+import {RsdModule} from '~/config/rsdSettingsReducer'
 import {getDomain} from '~/utils/getDomain'
 
 export default function RobotsTxt() {
@@ -11,20 +15,48 @@ export default function RobotsTxt() {
 }
 
 
-async function generateRobotsFile(domain:string) {
-
-  return `User-agent: *
+async function generateRobotsFile(domain:string, modules: RsdModule[]) {
+  // base body
+  let robots = `User-agent: *
 
 Disallow: /admin/
 Disallow: /auth/
 Disallow: /invite/
 Disallow: /login/
 Disallow: /user/
-
-Sitemap: ${domain}/sitemap/software.xml
-Sitemap: ${domain}/sitemap/projects.xml
-Sitemap: ${domain}/sitemap/organisations.xml
 `
+  // conditional bodu based on enabled modules
+  if (modules.includes('software')){
+    robots+= `
+Sitemap: ${domain}/sitemap/software.xml`
+  }
+
+  if (modules.includes('projects')){
+    robots+= `
+Sitemap: ${domain}/sitemap/projects.xml`
+  }
+
+  if (modules.includes('organisations')){
+    robots+= `
+Sitemap: ${domain}/sitemap/organisations.xml`
+  }
+
+  if (modules.includes('communities')){
+    robots+= `
+Sitemap: ${domain}/sitemap/communities.xml`
+  }
+
+  if (modules.includes('persons')){
+    robots+= `
+Sitemap: ${domain}/sitemap/persons.xml`
+  }
+
+  if (modules.includes('news')){
+    robots+= `
+Sitemap: ${domain}/sitemap/news.xml`
+  }
+
+  return robots
 }
 
 export async function getServerSideProps(context:GetServerSidePropsContext) {
@@ -37,8 +69,9 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // console.log('getServerSideProps...req.headers...', req)
   // extract domain info from request headers
   const domain = getDomain(req)
+  const modules = await getRsdModules()
   // We generate the XML sitemap with the posts data
-  const content = await generateRobotsFile(domain)
+  const content = await generateRobotsFile(domain,modules)
 
   res.setHeader('Content-Type', 'text/plain; charset=UTF-8')
   res.setHeader('x-generator', 'custom-next-script')

--- a/frontend/pages/sitemap/communities.xml.tsx
+++ b/frontend/pages/sitemap/communities.xml.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next'
+import {getDomain} from '~/utils/getDomain'
+import {getCommunitiesSitemap} from '~/components/seo/getCommunitiesSitemap'
+
+export default function RobotsTxt() {
+  // getServerSideProps will create response
+}
+
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  // extract response object
+  const {req,res} = context
+  // extract domain info from request headers
+  const domain = getDomain(req)
+
+  // generate the XML sitemap for software
+  const content = await getCommunitiesSitemap(domain)
+
+  res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
+
+  // send XML to the browser
+  res.write(content)
+  res.end()
+
+  return {
+    props: {},
+  }
+}

--- a/frontend/pages/sitemap/communities.xml.tsx
+++ b/frontend/pages/sitemap/communities.xml.tsx
@@ -6,7 +6,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {GetServerSidePropsContext} from 'next'
+
 import {getDomain} from '~/utils/getDomain'
+import {getRsdModules} from '~/config/getSettingsServerSide'
 import {getCommunitiesSitemap} from '~/components/seo/getCommunitiesSitemap'
 
 export default function RobotsTxt() {
@@ -20,7 +22,17 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   const domain = getDomain(req)
 
   // generate the XML sitemap for software
-  const content = await getCommunitiesSitemap(domain)
+  const [content, modules]= await Promise.all([
+    getCommunitiesSitemap(domain),
+    getRsdModules()
+  ])
+
+  // return 404 if module is not defined
+  if (modules.includes('communities')===false){
+    return {
+      notFound: true,
+    }
+  }
 
   res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
 

--- a/frontend/pages/sitemap/news.xml.tsx
+++ b/frontend/pages/sitemap/news.xml.tsx
@@ -7,6 +7,7 @@
 
 import {GetServerSidePropsContext} from 'next'
 import {getDomain} from '~/utils/getDomain'
+import {getRsdModules} from '~/config/getSettingsServerSide'
 import {getNewsSitemap} from '~/components/seo/getNewsSitemap'
 
 export default function RobotsTxt() {
@@ -20,7 +21,17 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   const domain = getDomain(req)
 
   // generate the XML sitemap for software
-  const content = await getNewsSitemap(domain)
+  const [content, modules]= await Promise.all([
+    getNewsSitemap(domain),
+    getRsdModules()
+  ])
+
+  // return 404 if module is not defined
+  if (modules.includes('news')===false){
+    return {
+      notFound: true,
+    }
+  }
 
   res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
 

--- a/frontend/pages/sitemap/news.xml.tsx
+++ b/frontend/pages/sitemap/news.xml.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next'
+import {getDomain} from '~/utils/getDomain'
+import {getNewsSitemap} from '~/components/seo/getNewsSitemap'
+
+export default function RobotsTxt() {
+  // getServerSideProps will create response
+}
+
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  // extract response object
+  const {req,res} = context
+  // extract domain info from request headers
+  const domain = getDomain(req)
+
+  // generate the XML sitemap for software
+  const content = await getNewsSitemap(domain)
+
+  res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
+
+  // send XML to the browser
+  res.write(content)
+  res.end()
+
+  return {
+    props: {},
+  }
+}

--- a/frontend/pages/sitemap/organisations.xml.tsx
+++ b/frontend/pages/sitemap/organisations.xml.tsx
@@ -1,11 +1,15 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {GetServerSidePropsContext} from 'next'
-import {getOrganisationSitemap} from '~/components/seo/getOrganisationSitemap'
+
 import {getDomain} from '~/utils/getDomain'
+import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getOrganisationSitemap} from '~/components/seo/getOrganisationSitemap'
 
 export default function RobotsTxt() {
   // getServerSideProps will create response
@@ -18,7 +22,17 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   const domain = getDomain(req)
 
   // generate the XML sitemap for software
-  const content = await getOrganisationSitemap(domain)
+  const [content, modules]= await Promise.all([
+    getOrganisationSitemap(domain),
+    getRsdModules()
+  ])
+
+  // return 404 if module is not defined
+  if (modules.includes('organisations')===false){
+    return {
+      notFound: true,
+    }
+  }
 
   res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
 

--- a/frontend/pages/sitemap/persons.xml.tsx
+++ b/frontend/pages/sitemap/persons.xml.tsx
@@ -6,8 +6,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {GetServerSidePropsContext} from 'next'
+
 import {getDomain} from '~/utils/getDomain'
 import {getPublicProfileSitemap} from '~/components/seo/getPersonsSitemap'
+import {getRsdModules} from '~/config/getSettingsServerSide'
 
 export default function RobotsTxt() {
   // getServerSideProps will create response
@@ -20,7 +22,17 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   const domain = getDomain(req)
 
   // generate the XML sitemap for software
-  const content = await getPublicProfileSitemap(domain)
+  const [content, modules]= await Promise.all([
+    getPublicProfileSitemap(domain),
+    getRsdModules()
+  ])
+
+  // return 404 if module is not defined
+  if (modules.includes('persons')===false){
+    return {
+      notFound: true,
+    }
+  }
 
   res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
 

--- a/frontend/pages/sitemap/persons.xml.tsx
+++ b/frontend/pages/sitemap/persons.xml.tsx
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {GetServerSidePropsContext} from 'next'
+import {getDomain} from '~/utils/getDomain'
+import {getPublicProfileSitemap} from '~/components/seo/getPersonsSitemap'
+
+export default function RobotsTxt() {
+  // getServerSideProps will create response
+}
+
+export async function getServerSideProps(context:GetServerSidePropsContext) {
+  // extract response object
+  const {req,res} = context
+  // extract domain info from request headers
+  const domain = getDomain(req)
+
+  // generate the XML sitemap for software
+  const content = await getPublicProfileSitemap(domain)
+
+  res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
+
+  // send XML to the browser
+  res.write(content)
+  res.end()
+
+  return {
+    props: {},
+  }
+}

--- a/frontend/pages/sitemap/projects.xml.tsx
+++ b/frontend/pages/sitemap/projects.xml.tsx
@@ -1,12 +1,15 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {GetServerSidePropsContext} from 'next'
 
-import {getProjectsSitemap} from '~/components/seo/getProjectsSitemap'
 import {getDomain} from '~/utils/getDomain'
+import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getProjectsSitemap} from '~/components/seo/getProjectsSitemap'
 
 export default function RobotsTxt() {
   // getServerSideProps will create response
@@ -18,7 +21,17 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // extract domain info from request headers
   const domain = getDomain(req)
   // generate the XML sitemap for software
-  const content = await getProjectsSitemap(domain)
+  const [content, modules]= await Promise.all([
+    getProjectsSitemap(domain),
+    getRsdModules()
+  ])
+
+  // return 404 if module is not defined
+  if (modules.includes('projects')===false){
+    return {
+      notFound: true,
+    }
+  }
 
   res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
 

--- a/frontend/pages/sitemap/software.xml.tsx
+++ b/frontend/pages/sitemap/software.xml.tsx
@@ -1,12 +1,15 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {GetServerSidePropsContext} from 'next'
 
-import {getSoftwareSitemap} from '~/components/seo/getSoftwareSitemap'
 import {getDomain} from '~/utils/getDomain'
+import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getSoftwareSitemap} from '~/components/seo/getSoftwareSitemap'
 
 export default function RobotsTxt() {
   // getServerSideProps will create response
@@ -18,7 +21,17 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   const domain = getDomain(req)
 
   // generate the XML sitemap for software
-  const content = await getSoftwareSitemap(domain)
+  const [content, modules]= await Promise.all([
+    getSoftwareSitemap(domain),
+    getRsdModules()
+  ])
+
+  // return 404 if module is not defined
+  if (modules.includes('software')===false){
+    return {
+      notFound: true,
+    }
+  }
 
   res.setHeader('Content-Type', 'text/xml; charset=UTF-8')
 

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -20,7 +20,7 @@
       "description": null
     },
     "orcid_search":true,
-    "modules":["software","projects","organisations","communities"]
+    "modules":["software","projects","organisations","communities","news"]
   },
   "links": [
     {


### PR DESCRIPTION
# Make robots.txt file list only active module entries

Changes proposed in this pull request:
* Based on KIN-RPD repo I came to conclusion that we can improve robots.txt file based on active modules in settings.json   
* This PR implements dynamic writing of robots.txt based on active modules in settings.json
* It also requires "news" to be added into modules list in order to include news in the robots.txt content 
* The persons sitemap required minor change in `public_user_profile` RPC.

How to test:
* `make start` to build and generate test data.
* navigate to http://localhost/robots.txt
* confirm robots.txt lists sitemaps for active modules
```bash
User-agent: *

Disallow: /admin/
Disallow: /auth/
Disallow: /invite/
Disallow: /login/
Disallow: /user/

Sitemap: http://localhost/sitemap/software.xml
Sitemap: http://localhost/sitemap/projects.xml
Sitemap: http://localhost/sitemap/organisations.xml
Sitemap: http://localhost/sitemap/communities.xml
Sitemap: http://localhost/sitemap/news.xml
```
* confirm that each of sitemap lists the page entries. For example http://localhost:3000/sitemap/news.xml lists following generated news items. Conform that provided URL opens valid news page.
```xml
<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
<url>
<loc>http://localhost/news/2024-10-19/rsd-released</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2025-08-21/some-big-news</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2025-09-08/you-wont-believe-this</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2024-08-20/10-clickbait-headlines</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2025-08-09/never-dependency</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2025-06-07/sunsetting-the-rsd</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2025-09-09/last-package</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2025-07-03/project-success</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2025-01-02/5-best-dependencies</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2026-06-01/rewrite-rsd-crablang</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2025-01-19/rsd-joins-big-company</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
<url>
<loc>http://localhost/news/2025-10-18/3-features</loc>
<lastmod>2025-06-10T14:48:51.61986+00:00</lastmod>
</url>
</urlset>
```
* enable/disable some of the modules in the settings.json and confirm that robots.txt reflects the changes.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
