### PR TITLE
Update of Imperial landing page

### DIFF
--- a/frontend/components/home/imperial/CounterBox.tsx
+++ b/frontend/components/home/imperial/CounterBox.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/home/imperial/CounterBox.tsx
+++ b/frontend/components/home/imperial/CounterBox.tsx
@@ -10,7 +10,7 @@ type CounterBoxProps = {
 
 export default function CounterBox({label,value}:CounterBoxProps) {
   return (
-    <div className="bg-primary text-primary-content p-4 text-center rounded-md">
+    <div className="bg-base-300 text-secondary-content p-4 text-center rounded-md">
       <div className="text-2xl">{label}</div>
       <div className="text-4xl">{value}</div>
     </div>

--- a/frontend/components/home/imperial/KeywordBox.tsx
+++ b/frontend/components/home/imperial/KeywordBox.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/home/imperial/KeywordBox.tsx
+++ b/frontend/components/home/imperial/KeywordBox.tsx
@@ -5,14 +5,14 @@
 
 import Link from 'next/link'
 
-import {ssrProjectsUrl} from '~/utils/postgrestUrl'
+import {ssrSoftwareUrl} from '~/utils/postgrestUrl'
 
 type KeywordBoxProps = {
     label: string
 }
 
 export default function KeywordBox({label}: KeywordBoxProps) {
-  const url = ssrProjectsUrl({keywords: [label]})
+  const url = ssrSoftwareUrl({keywords: [label]})
   return (
     <div className="bg-secondary text-primary-content p-2 text-center rounded-md">
       <div className="text-lg">

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -43,7 +43,7 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
       <div className="w-10/12 mx-auto p-5 md:p-10 grid lg:grid-cols-[1fr_1fr] gap-[2rem]">
         <div className="flex flex-col justify-left">
           <Image
-            src="/images/imperial-college-logo.svg"
+            src="/images/imperial-college-logo-body.svg"
             width="361"
             height="85"
             layout="fixed"
@@ -78,12 +78,8 @@ export default function MainContentImperialCollege({counts}: HomeProps) {
 
       <div className="max-w-(--breakpoint-xl) mx-auto flex flex-wrap justify-between gap-10 md:gap-16 p-5 md:p-10 ">
         <CounterBox
-          label="Open-Source Software"
-          value={counts.open_software_cnt.toString()}
-        />
-        <CounterBox
-          label="Closed-Source Software"
-          value={(counts.software_cnt - counts.open_software_cnt).toString()}
+          label="Software Submissions"
+          value={counts.software_cnt.toString()}
         />
         <CounterBox
           label="Software Mentions"

--- a/frontend/components/home/imperial/MainContentImperialCollege.tsx
+++ b/frontend/components/home/imperial/MainContentImperialCollege.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/home/imperial/index.tsx
+++ b/frontend/components/home/imperial/index.tsx
@@ -24,7 +24,7 @@ export default function ImperialCollegeHome({counts,news}: HomeProps) {
       />
       <CanonicalUrl />
 
-      <section className="flex-1 flex flex-col text-secondary-content  bg-[url('/images/campus_south_ken.jpg')] bg-contain bg-no-repeat bg-center bg-black bg-scroll">
+      <section className="flex-1 flex flex-col text-secondary-content bg-base-100">
         <AppHeader />
         <MainContentImperialCollege counts={counts} news={news}/>
         <AppFooter/>

--- a/frontend/components/home/imperial/index.tsx
+++ b/frontend/components/home/imperial/index.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/home/imperial/useImperialData.tsx
+++ b/frontend/components/home/imperial/useImperialData.tsx
@@ -8,6 +8,21 @@ import {createJsonHeaders} from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
 
 /**
+ * Filters the information about the keywords such that only those used are inlcuded.
+ * 
+ * They are also sorted by number of software that use them and the top 10 picked. 
+ * 
+ * @param jsonData The total list of keyword data to filter and sort.
+ * @returns The filtered list, leaving only the top ten keywords sorted.
+ */
+function filterAndSortJson(jsonData: any[]): any[] {
+  return jsonData
+    .filter(entry => entry.cnt !== null) // Remove entries where cnt is null
+    .sort((a, b) => b.cnt - a.cnt) // Sort by cnt in descending order
+    .slice(0, 10); // Select only the top 10 results
+}
+
+/**
  * Example of actual request to api with error handling and logging
  * @param param0
  * @returns
@@ -24,7 +39,7 @@ async function getKeywordList({url, token}: {url: string, token?: string}) {
     if ([200, 206].includes(resp.status)) {
       const json = await resp.json()
       return {
-        data: json
+        data: filterAndSortJson(json)
       }
     }
     // otherwise request failed

--- a/frontend/components/home/imperial/useImperialData.tsx
+++ b/frontend/components/home/imperial/useImperialData.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
# Update of Imperial landing page

Fixes https://github.com/ImperialCollegeLondon/RSD-as-a-service/issues/30
Fixes https://github.com/ImperialCollegeLondon/RSD-as-a-service/issues/24

Partly addressing new Imperial branding. 

## Changes proposed in this pull request

This PR makes some usability improvements of Imperial's landing page and adapts it to the new Imperial branding, so the right colours can be set to the right things via the `settings.json` file. 

## How to test:

Just use a settings file that sets `imperial` as the host name. The colours and logo will be different, but the changes in functionality, indicated in the two issues above, should be reproducible. Attached a short video showcasing the result. 

https://github.com/user-attachments/assets/680baf31-e7c9-49ac-8d8f-18368a573436

## PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
