### PR TITLE
feat: drag and drop images to upload

### DIFF
--- a/frontend/components/form/ControlledImageInput.tsx
+++ b/frontend/components/form/ControlledImageInput.tsx
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,6 +17,7 @@ import {deleteImage, getImageUrl} from '~/utils/editImage'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {handleFileUpload} from '~/utils/handleFileUpload'
 import ImageInput from './ImageInput'
+import ImageDropZone from '~/components/form/ImageDropZone'
 
 export type FormInputsForImage={
   logo_id: string|null
@@ -35,17 +36,19 @@ export default function ControlledImageInput({name,logo_b64,logo_id,setValue}:Im
   const {token} = useSession()
   const {showWarningMessage,showErrorMessage} = useSnackbar()
 
-  async function onFileUpload(e:ChangeEvent<HTMLInputElement>|undefined) {
-    if (typeof e !== 'undefined') {
-      const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
-      if (status === 200 && image_b64 && image_mime_type) {
-        // save image
-        replaceLogo(image_b64,image_mime_type)
-      } else if (status===413) {
-        showWarningMessage(message)
-      } else {
-        showErrorMessage(message)
-      }
+  async function onFileUpload(e: ChangeEvent<HTMLInputElement> | {target: {files: FileList | Blob[]}} | undefined): Promise<void> {
+    if (e === undefined) {
+      return
+    }
+
+    const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
+    if (status === 200 && image_b64 && image_mime_type) {
+      // save image
+      replaceLogo(image_b64,image_mime_type)
+    } else if (status===413) {
+      showWarningMessage(message)
+    } else {
+      showErrorMessage(message)
     }
   }
 
@@ -80,27 +83,29 @@ export default function ControlledImageInput({name,logo_b64,logo_id,setValue}:Im
 
   return (
     <div>
-      <label htmlFor="upload-avatar-image"
-        style={{cursor:'pointer'}}
-        title="Click to upload an image"
-      >
-        <Avatar
-          alt={name ?? ''}
-          src={logo_b64 ?? getImageUrl(logo_id ?? null) ?? undefined}
-          sx={{
-            width: '8rem',
-            height: '8rem',
-            fontSize: '3rem',
-            marginRight: '0rem',
-            '& img': {
-              height:'auto'
-            }
-          }}
-          variant="square"
+      <ImageDropZone onImageDrop={onFileUpload}>
+        <label htmlFor="upload-avatar-image"
+          style={{cursor:'pointer'}}
+          title="Click or drop to upload an image"
         >
-          {name ? name.slice(0,3) : ''}
-        </Avatar>
-      </label>
+          <Avatar
+            alt={name ?? ''}
+            src={logo_b64 ?? getImageUrl(logo_id ?? null) ?? undefined}
+            sx={{
+              width: '8rem',
+              height: '8rem',
+              fontSize: '3rem',
+              marginRight: '0rem',
+              '& img': {
+                height:'auto'
+              }
+            }}
+            variant="square"
+          >
+            {name ? name.slice(0,3) : ''}
+          </Avatar>
+        </label>
+      </ImageDropZone>
       <ImageInput
         id="upload-avatar-image"
         onChange={onFileUpload}

--- a/frontend/components/form/ImageDropZone.tsx
+++ b/frontend/components/form/ImageDropZone.tsx
@@ -3,16 +3,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import logger from '~/utils/logger'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+
 export type ImageDropZoneProps = {
   children: React.ReactNode,
   onImageDrop: (targetLike: {target: {files: FileList | Blob[]}}) => void
 }
 
 export default function ImageDropZone(props: Readonly<ImageDropZoneProps>) {
+  const {showErrorMessage} = useSnackbar()
+
   return (
     <div
-      onDragOver={e => e.preventDefault()}
-      onDrop={e => {
+      onDragOver={(e: any) => {
+        e.preventDefault()
+        e.currentTarget.style.border = '3px dashed grey'
+      }}
+      onDragLeave={(e: any) => {
+        e.currentTarget.style.border = 'inherit'
+      }}
+      onDrop={(e: any) => {
+        e.currentTarget.style.border = 'inherit'
         e.preventDefault()
         if (e.dataTransfer.files.length) {
           props.onImageDrop({target: {files: e.dataTransfer.files}})
@@ -20,6 +32,10 @@ export default function ImageDropZone(props: Readonly<ImageDropZoneProps>) {
           fetch(e.dataTransfer.getData('text/uri-list'))
             .then(resp => resp.blob())
             .then(blob => props.onImageDrop({target: {files: [blob]}}))
+            .catch(e => {
+              logger(e, 'error')
+              showErrorMessage('Could not download image, try downloading and uploading it manually.')
+            })
         }
       }}>
       {props.children}

--- a/frontend/components/form/ImageDropZone.tsx
+++ b/frontend/components/form/ImageDropZone.tsx
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export type ImageDropZoneProps = {
+  children: React.ReactNode,
+  onImageDrop: (targetLike: {target: {files: FileList | Blob[]}}) => void
+}
+
+export default function ImageDropZone(props: Readonly<ImageDropZoneProps>) {
+  return (
+    <div
+      onDragOver={e => e.preventDefault()}
+      onDrop={e => {
+        e.preventDefault()
+        if (e.dataTransfer.files.length) {
+          props.onImageDrop({target: {files: e.dataTransfer.files}})
+        } else if (e.dataTransfer.getData('text/uri-list')) {
+          fetch(e.dataTransfer.getData('text/uri-list'))
+            .then(resp => resp.blob())
+            .then(blob => props.onImageDrop({target: {files: [blob]}}))
+        }
+      }}>
+      {props.children}
+    </div>
+  )
+}

--- a/frontend/components/form/LogoDropZone.tsx
+++ b/frontend/components/form/LogoDropZone.tsx
@@ -4,6 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {ImageDataProps} from '~/components/layout/Logo'
+import logger from '~/utils/logger'
+import useSnackbar from '~/components/snackbar/useSnackbar'
 
 export type ImageDropZoneProps = {
   children: React.ReactNode,
@@ -11,10 +13,19 @@ export type ImageDropZoneProps = {
 }
 
 export default function LogoDropZone(props: Readonly<ImageDropZoneProps>) {
+  const {showErrorMessage} = useSnackbar()
+
   return (
     <div
-      onDragOver={e => e.preventDefault()}
-      onDrop={e => {
+      onDragOver={(e: any) => {
+        e.preventDefault()
+        e.currentTarget.style.border = '3px dashed grey'
+      }}
+      onDragLeave={(e: any) => {
+        e.currentTarget.style.border = 'inherit'
+      }}
+      onDrop={(e: any) => {
+        e.currentTarget.style.border = 'inherit'
         e.preventDefault()
         const reader = new FileReader()
 
@@ -32,6 +43,10 @@ export default function LogoDropZone(props: Readonly<ImageDropZoneProps>) {
                 props.onImageDrop({data: reader.result as string, mime_type: blob.type})
               }
               reader.readAsDataURL(blob)
+            })
+            .catch(e => {
+              logger(e, 'error')
+              showErrorMessage('Could not download image, try downloading and uploading it manually.')
             })
         }
       }}>

--- a/frontend/components/form/LogoDropZone.tsx
+++ b/frontend/components/form/LogoDropZone.tsx
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {ImageDataProps} from '~/components/layout/Logo'
+
+export type ImageDropZoneProps = {
+  children: React.ReactNode,
+  onImageDrop: (image: ImageDataProps) => any
+}
+
+export default function LogoDropZone(props: Readonly<ImageDropZoneProps>) {
+  return (
+    <div
+      onDragOver={e => e.preventDefault()}
+      onDrop={e => {
+        e.preventDefault()
+        const reader = new FileReader()
+
+        if (e.dataTransfer.files.length) {
+          const file = e.dataTransfer.files[0]
+          reader.onloadend = () => {
+            props.onImageDrop({data: reader.result as string, mime_type: file.type})
+          }
+          reader.readAsDataURL(file)
+        } else if (e.dataTransfer.getData('text/uri-list')) {
+          fetch(e.dataTransfer.getData('text/uri-list'))
+            .then(resp => resp.blob())
+            .then(blob => {
+              reader.onloadend = () => {
+                props.onImageDrop({data: reader.result as string, mime_type: blob.type})
+              }
+              reader.readAsDataURL(blob)
+            })
+        }
+      }}>
+      {props.children}
+    </div>
+  )
+}

--- a/frontend/components/layout/Logo.tsx
+++ b/frontend/components/layout/Logo.tsx
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Avatar from '@mui/material/Avatar'
 import LogoMenu from './LogoMenu'
+import LogoDropZone from '~/components/form/LogoDropZone'
 
 export type ImageDataProps = {
   data: string,
@@ -34,29 +36,31 @@ export default function Logo({
 }:LogoProps) {
   return (
     <>
-      <Avatar
-        data-testid="logo-avatar"
-        alt={name}
-        src={src}
-        sx={{
-        // lighthouse audit requires explicit width and height
-          width: '100%',
-          height: '100%',
-          fontSize: '3rem',
-          '& img': {
-          // height: 'auto',
-            maxHeight: '100%',
-            // width: 'auto',
-            maxWidth: '100%'
-          },
-          ...sx
-        }}
-        variant={variant}
-        title={name}
-        {...props}
-      >
-        {initials ?? name.slice(0,3)}
-      </Avatar>
+      <LogoDropZone onImageDrop={canEdit ? onAddLogo : () => {}}>
+        <Avatar
+          data-testid="logo-avatar"
+          alt={name}
+          src={src}
+          sx={{
+            // lighthouse audit requires explicit width and height
+            width: '100%',
+            height: '100%',
+            fontSize: '3rem',
+            '& img': {
+              // height: 'auto',
+              maxHeight: '100%',
+              // width: 'auto',
+              maxWidth: '100%'
+            },
+            ...sx
+          }}
+          variant={variant}
+          title={name}
+          {...props}
+        >
+          {initials ?? name.slice(0,3)}
+        </Avatar>
+      </LogoDropZone>
       {canEdit ?
         <LogoMenu
           logo={logo}

--- a/frontend/components/layout/Logo.tsx
+++ b/frontend/components/layout/Logo.tsx
@@ -34,41 +34,44 @@ export default function Logo({
   // other avatar props
   ...props
 }:LogoProps) {
-  return (
-    <>
-      <LogoDropZone onImageDrop={canEdit ? onAddLogo : () => {}}>
-        <Avatar
-          data-testid="logo-avatar"
-          alt={name}
-          src={src}
-          sx={{
-            // lighthouse audit requires explicit width and height
-            width: '100%',
-            height: '100%',
-            fontSize: '3rem',
-            '& img': {
-              // height: 'auto',
-              maxHeight: '100%',
-              // width: 'auto',
-              maxWidth: '100%'
-            },
-            ...sx
-          }}
-          variant={variant}
-          title={name}
-          {...props}
-        >
-          {initials ?? name.slice(0,3)}
-        </Avatar>
-      </LogoDropZone>
-      {canEdit ?
+  const logoElement = (<Avatar
+    data-testid="logo-avatar"
+    alt={name}
+    src={src}
+    sx={{
+      // lighthouse audit requires explicit width and height
+      width: '100%',
+      height: '100%',
+      fontSize: '3rem',
+      '& img': {
+        // height: 'auto',
+        maxHeight: '100%',
+        // width: 'auto',
+        maxWidth: '100%'
+      },
+      ...sx
+    }}
+    variant={variant}
+    title={name}
+    {...props}
+  >
+    {initials ?? name.slice(0,3)}
+  </Avatar>)
+
+  if (canEdit) {
+    return (
+      <>
+        <LogoDropZone onImageDrop={onAddLogo}>
+          {logoElement}
+        </LogoDropZone>
         <LogoMenu
           logo={logo}
           onAddLogo={onAddLogo}
           onRemoveLogo={onRemoveLogo}
         />
-        : null
-      }
-    </>
-  )
+      </>
+    )
+  }
+
+  return logoElement
 }

--- a/frontend/components/news/edit/AutosaveNewsImage.tsx
+++ b/frontend/components/news/edit/AutosaveNewsImage.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -24,6 +24,7 @@ import CopyToClipboard from '~/components/layout/CopyToClipboard'
 import {NewsImageProps,NewsItem,addNewsImage,deleteNewsImage} from '../apiNews'
 import {newsConfig as config} from './config'
 import ImageInput from '~/components/form/ImageInput'
+import ImageDropZone from '~/components/form/ImageDropZone'
 
 type UploadedImageProps={
   imgUrl: string|null,
@@ -44,7 +45,7 @@ function UploadedImage({imgUrl,onDelete}:UploadedImageProps){
   }
 
   return (
-    <div className="relative pb-4">
+    <div className="relative pb-4" onDragOver={e => e.preventDefault()} onDrop={e => e.preventDefault()}>
       <ImageWithPlaceholder
         placeholder="Uploaded image < 2MB"
         src={imgUrl}
@@ -116,16 +117,18 @@ export default function AutosaveNewsImage() {
     ])
   }
 
-  async function onFileUpload(e:ChangeEvent<HTMLInputElement>|undefined) {
-    if (typeof e !== 'undefined') {
-      const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
-      if (status === 200 && image_b64 && image_mime_type) {
-        saveImage(image_b64, image_mime_type)
-      } else if (status===413) {
-        showWarningMessage(message)
-      } else {
-        showErrorMessage(message)
-      }
+  async function onFileUpload(e: ChangeEvent<HTMLInputElement> | {target: {files: FileList | Blob[]}} | undefined): Promise<void> {
+    if (e === undefined) {
+      return
+    }
+
+    const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
+    if (status === 200 && image_b64 && image_mime_type) {
+      saveImage(image_b64, image_mime_type)
+    } else if (status===413) {
+      showWarningMessage(message)
+    } else {
+      showErrorMessage(message)
     }
   }
 
@@ -182,19 +185,21 @@ export default function AutosaveNewsImage() {
         })
       }
 
-      <label htmlFor='upload-article-image'
-        style={{cursor: 'pointer'}}
-        title="Click to upload an image"
-      >
-        <ImageWithPlaceholder
-          placeholder="Click to upload image < 2MB"
-          src={null}
-          alt={'image'}
-          bgSize={'scale-down'}
-          bgPosition={'left center'}
-          className="w-full h-[9rem]"
-        />
-      </label>
+      <ImageDropZone onImageDrop={onFileUpload}>
+        <label htmlFor='upload-article-image'
+          style={{cursor: 'pointer'}}
+          title="Click or drop to upload an image"
+        >
+          <ImageWithPlaceholder
+            placeholder="Click or drop to upload image < 2MB"
+            src={null}
+            alt={'image'}
+            bgSize={'scale-down'}
+            bgPosition={'left center'}
+            className="w-full h-[9rem]"
+          />
+        </label>
+      </ImageDropZone>
 
       <ImageInput
         id="upload-article-image"

--- a/frontend/components/organisation/units/ResearchUnitModal.tsx
+++ b/frontend/components/organisation/units/ResearchUnitModal.tsx
@@ -4,7 +4,7 @@
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -31,6 +31,7 @@ import {handleFileUpload} from '~/utils/handleFileUpload'
 import {getSlugFromString} from '~/utils/getSlugFromString'
 import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
 import ImageInput from '~/components/form/ImageInput'
+import ImageDropZone from '~/components/form/ImageDropZone'
 
 
 type EditOrganisationModalProps = {
@@ -101,16 +102,18 @@ export default function ResearchUnitModal({
     onCancel()
   }
 
-  async function onFileUpload(e:ChangeEvent<HTMLInputElement>|undefined) {
-    if (typeof e !== 'undefined') {
-      const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
-      if (status === 200 && image_b64 && image_mime_type) {
-        replaceLogo(image_b64, image_mime_type)
-      } else if (status===413) {
-        showWarningMessage(message)
-      } else {
-        showErrorMessage(message)
-      }
+  async function onFileUpload(e: ChangeEvent<HTMLInputElement> | {target: {files: FileList | Blob[]}} | undefined): Promise<void> {
+    if (e === undefined) {
+      return
+    }
+
+    const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
+    if (status === 200 && image_b64 && image_mime_type) {
+      replaceLogo(image_b64, image_mime_type)
+    } else if (status===413) {
+      showWarningMessage(message)
+    } else {
+      showErrorMessage(message)
     }
   }
 
@@ -182,27 +185,29 @@ export default function ResearchUnitModal({
         }}>
           <section className="grid grid-cols-[1fr_3fr] gap-8">
             <div>
-              <label htmlFor="upload-avatar-image-modal"
-                style={{cursor:'pointer'}}
-                title="Click to upload an image"
-              >
-                <Avatar
-                  alt={formData.name ?? ''}
-                  src={formData.logo_b64 ?? getImageUrl(formData?.logo_id) ?? undefined}
-                  sx={{
-                    width: '8rem',
-                    height: '8rem',
-                    fontSize: '3rem',
-                    marginRight: '0rem',
-                    '& img': {
-                      height:'auto'
-                    }
-                  }}
-                  variant="square"
+              <ImageDropZone onImageDrop={onFileUpload}>
+                <label htmlFor="upload-avatar-image-modal"
+                  style={{cursor:'pointer'}}
+                  title="Click or drop to upload an image"
                 >
-                  {formData.name ? formData.name.slice(0,3) : ''}
-                </Avatar>
-              </label>
+                  <Avatar
+                    alt={formData.name ?? ''}
+                    src={formData.logo_b64 ?? getImageUrl(formData?.logo_id) ?? undefined}
+                    sx={{
+                      width: '8rem',
+                      height: '8rem',
+                      fontSize: '3rem',
+                      marginRight: '0rem',
+                      '& img': {
+                        height:'auto'
+                      }
+                    }}
+                    variant="square"
+                  >
+                    {formData.name ? formData.name.slice(0,3) : ''}
+                  </Avatar>
+                </label>
+              </ImageDropZone>
               <ImageInput
                 id="upload-avatar-image-modal"
                 onChange={onFileUpload}

--- a/frontend/components/person/AvatarOptions.tsx
+++ b/frontend/components/person/AvatarOptions.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,6 +15,7 @@ import {getImageUrl} from '~/utils/editImage'
 import {getDisplayInitials, getDisplayName} from '~/utils/getDisplayName'
 import ImageInput from '~/components/form/ImageInput'
 import ContentLoader from '../layout/ContentLoader'
+import ImageDropZone from '~/components/form/ImageDropZone'
 
 type AvatarOptionsProps = {
   given_names: string
@@ -23,7 +24,7 @@ type AvatarOptionsProps = {
   avatar_options: string[]
   onSelectAvatar: (avatar_id:string)=>void
   onNoAvatar:()=>void
-  onFileUpload:(e:ChangeEvent<HTMLInputElement>|undefined)=>void
+  onFileUpload:(e: ChangeEvent<HTMLInputElement> | {target: {files: FileList | Blob[]}} | undefined)=>void
   loading: boolean
 }
 
@@ -49,29 +50,31 @@ export default function AvatarOptions(props: AvatarOptionsProps) {
   return (
     <div className="grid grid-cols-[1fr_3fr] gap-4">
       <div>
-        <label htmlFor="upload-avatar-image"
-          title="Click to upload new image"
-          style={{
-            display: 'flex',
-            cursor: 'pointer',
-            padding: '0.5rem',
-            justifyContent: 'center',
-            alignItems: 'center'
-          }}
-        >
-          <Avatar
-            alt={getDisplayName({given_names, family_names}) ?? 'Unknown'}
-            src={avatar}
-            sx={{
-              width: '8rem',
-              height: '8rem',
-              fontSize: '3rem',
-              margin: '1rem'
+        <ImageDropZone onImageDrop={onFileUpload}>
+          <label htmlFor="upload-avatar-image"
+            title="Click or drop to upload new image"
+            style={{
+              display: 'flex',
+              cursor: 'pointer',
+              padding: '0.5rem',
+              justifyContent: 'center',
+              alignItems: 'center'
             }}
           >
-            {getDisplayInitials({given_names, family_names}) ?? ''}
-          </Avatar>
-        </label>
+            <Avatar
+              alt={getDisplayName({given_names, family_names}) ?? 'Unknown'}
+              src={avatar}
+              sx={{
+                width: '8rem',
+                height: '8rem',
+                fontSize: '3rem',
+                margin: '1rem'
+              }}
+            >
+              {getDisplayInitials({given_names, family_names}) ?? ''}
+            </Avatar>
+          </label>
+        </ImageDropZone>
         <ImageInput
           data-testid="upload-avatar-input"
           id="upload-avatar-image"

--- a/frontend/components/person/AvatarOptionsPerson.tsx
+++ b/frontend/components/person/AvatarOptionsPerson.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -67,17 +68,19 @@ export default function AvatarOptionsPerson(props: AvatarOptionsProps) {
     }
   },[avatar_options,avatar_id,loading])
 
-  async function onFileUpload(e:ChangeEvent<HTMLInputElement>|undefined) {
-    if (typeof e !== 'undefined') {
-      const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
-      if (status === 200 && image_b64 && image_mime_type) {
-        // save it as selected
-        setValue('avatar_id', image_b64, {shouldDirty: true, shouldValidate:true})
-      } else if (status===413) {
-        showWarningMessage(message)
-      } else {
-        showErrorMessage(message)
-      }
+  async function onFileUpload(e: ChangeEvent<HTMLInputElement> | {target: {files: FileList | Blob[]}} | undefined): Promise<void> {
+    if (e === undefined) {
+      return
+    }
+
+    const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
+    if (status === 200 && image_b64 && image_mime_type) {
+      // save it as selected
+      setValue('avatar_id', image_b64, {shouldDirty: true, shouldValidate:true})
+    } else if (status===413) {
+      showWarningMessage(message)
+    } else {
+      showErrorMessage(message)
     }
   }
 

--- a/frontend/components/projects/edit/information/AutosaveProjectImage.test.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectImage.test.tsx
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -71,7 +72,7 @@ it('renders upload image inputs', () => {
   const imageInput = container.querySelector('#upload-avatar-image')
   expect(imageInput).toBeInTheDocument()
   // has click to upload message
-  const clickToUpload = screen.getByText('Click to upload image < 2MB')
+  const clickToUpload = screen.getByText('Click or drop to upload image < 2MB')
   expect(clickToUpload).toBeInTheDocument()
 })
 

--- a/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
@@ -24,6 +24,7 @@ import {upsertImage,deleteImage} from '~/utils/editImage'
 import {ChangeEvent} from 'react'
 import {handleFileUpload} from '~/utils/handleFileUpload'
 import ImageInput from '~/components/form/ImageInput'
+import ImageDropZone from '~/components/form/ImageDropZone'
 
 export default function AutosaveProjectImage() {
   const {token} = useSession()
@@ -85,17 +86,19 @@ export default function AutosaveProjectImage() {
     }
   }
 
-  async function onFileUpload(e:ChangeEvent<HTMLInputElement>|undefined) {
-    if (typeof e !== 'undefined') {
-      const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
-      if (status === 200 && image_b64 && image_mime_type) {
-        // save image
-        saveImage(image_b64,image_mime_type)
-      } else if (status===413) {
-        showWarningMessage(message)
-      } else {
-        showErrorMessage(message)
-      }
+  async function onFileUpload(e: ChangeEvent<HTMLInputElement> | {target: {files: FileList | Blob[]}} | undefined): Promise<void> {
+    if (e === undefined) {
+      return
+    }
+
+    const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
+    if (status === 200 && image_b64 && image_mime_type) {
+      // save image
+      saveImage(image_b64,image_mime_type)
+    } else if (status===413) {
+      showWarningMessage(message)
+    } else {
+      showErrorMessage(message)
     }
   }
 
@@ -197,19 +200,21 @@ export default function AutosaveProjectImage() {
 
   return (
     <div>
-      <label htmlFor="upload-avatar-image"
-        style={{cursor:'pointer'}}
-        title="Click to upload an image"
-      >
-        <ImageAsBackground
-          src={imageUrl()}
-          alt={form_image_caption ?? 'image'}
-          bgSize={form_image_contain ? 'contain' : 'cover'}
-          bgPosition={form_image_contain ? 'center' : 'center center'}
-          className="w-full h-[23rem]"
-          noImgMsg="Click to upload image < 2MB"
-        />
-      </label>
+      <ImageDropZone onImageDrop={onFileUpload}>
+        <label htmlFor="upload-avatar-image"
+          style={{cursor: 'pointer'}}
+          title="Click or drop to upload an image"
+        >
+          <ImageAsBackground
+            src={imageUrl()}
+            alt={form_image_caption ?? 'image'}
+            bgSize={form_image_contain ? 'contain' : 'cover'}
+            bgPosition={form_image_contain ? 'center' : 'center center'}
+            className="w-full h-[23rem]"
+            noImgMsg="Click or drop to upload image < 2MB"
+          />
+        </label>
+      </ImageDropZone>
 
       <ImageInput
         id="upload-avatar-image"

--- a/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -24,6 +24,7 @@ import useSnackbar from '~/components/snackbar/useSnackbar'
 import ImageInput from '~/components/form/ImageInput'
 import {softwareInformation as config} from '../editSoftwareConfig'
 import {patchSoftwareTable} from './patchSoftwareTable'
+import ImageDropZone from '~/components/form/ImageDropZone'
 
 export default function AutosaveSoftwareLogo() {
   const {token} = useSession()
@@ -120,16 +121,18 @@ export default function AutosaveSoftwareLogo() {
     }
   }
 
-  async function onFileUpload(e:ChangeEvent<HTMLInputElement>|undefined) {
-    if (typeof e !== 'undefined') {
-      const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
-      if (status === 200 && image_b64 && image_mime_type) {
-        saveImage(image_b64, image_mime_type)
-      } else if (status===413) {
-        showWarningMessage(message)
-      } else {
-        showErrorMessage(message)
-      }
+  async function onFileUpload(e: ChangeEvent<HTMLInputElement> | {target: {files: FileList | Blob[]}} | undefined): Promise<void> {
+    if (e === undefined) {
+      return
+    }
+
+    const {status, message, image_b64, image_mime_type} = await handleFileUpload(e)
+    if (status === 200 && image_b64 && image_mime_type) {
+      saveImage(image_b64, image_mime_type)
+    } else if (status===413) {
+      showWarningMessage(message)
+    } else {
+      showErrorMessage(message)
     }
   }
 
@@ -156,19 +159,21 @@ export default function AutosaveSoftwareLogo() {
         subtitle={config.logo.help}
       />
 
-      <label htmlFor='upload-software-logo'
-        style={{cursor: 'pointer'}}
-        title="Click to upload a logo"
-      >
-        <ImageWithPlaceholder
-          placeholder="Click to upload a logo < 2MB"
-          src={imageUrl()}
-          alt={'logo'}
-          bgSize={'contain'}
-          bgPosition={'left center'}
-          className="w-full h-[9rem]"
-        />
-      </label>
+      <ImageDropZone onImageDrop={onFileUpload}>
+        <label htmlFor='upload-software-logo'
+          style={{cursor: 'pointer'}}
+          title="Click or drop to upload a logo"
+        >
+          <ImageWithPlaceholder
+            placeholder="Click or drop to upload a logo < 2MB"
+            src={imageUrl()}
+            alt={'logo'}
+            bgSize={'contain'}
+            bgPosition={'left center'}
+            className="w-full h-[9rem]"
+          />
+        </label>
+      </ImageDropZone>
 
       <ImageInput
         id="upload-software-logo"


### PR DESCRIPTION
## Drop images to upload them

### Changes proposed in this pull request

* Allow to drop images from either your file system or the browser to upload them, reducing the need to download images first

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin
* Try to edit images in all places with drag and drop
* The existing method of clicking to get a file chooser should still work

closes #1387

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
