### PR TITLE
Show progress bar when status is known for projects

### DIFF
--- a/frontend/components/charts/progress/PeriodProgressBar.tsx
+++ b/frontend/components/charts/progress/PeriodProgressBar.tsx
@@ -1,7 +1,8 @@
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,15 +17,26 @@ type PeriodProgressBar = {
 
 export default function PeriodProgressBar({date_start,date_end,className, height='0.5rem'}:PeriodProgressBar) {
 
-  // if one of date values is missing we do not show progressbar
-  if (date_start === null || date_end === null) return null
+  // if both of date values is missing we do not show the progress bar
+  if (date_start === null && date_end === null) {
+    return null
+  }
 
-  function getProgressValue({date_start, date_end}: PeriodProgressBar) {
-    if (date_start === null || date_end === null) return 0
+  function getProgressValue({date_start, date_end}: PeriodProgressBar): number | null {
+    const start_date = date_start === null ? null : new Date(date_start)
+    const end_date = date_end === null ? null : new Date(date_end)
+    if (start_date === null && end_date === null) {
+      return null
+    }
 
-    const start_date = new Date(date_start)
-    const end_date = new Date(date_end)
     const now = new Date()
+
+    if (start_date === null) {
+      return (end_date as Date) < now ? 100 : null
+    }
+    if (end_date === null) {
+      return start_date > now ? 0 : null
+    }
 
     // define x scale as time scale
     // from 0 - 100 so we convert is to %
@@ -43,6 +55,9 @@ export default function PeriodProgressBar({date_start,date_end,className, height
     date_start,
     date_end
   })
+  if (progress === null) {
+    return null
+  }
 
   return (
     <div

--- a/frontend/components/projects/ProjectStatus.tsx
+++ b/frontend/components/projects/ProjectStatus.tsx
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,7 +20,9 @@ type ProjectStatusProps = {
 
 export default function ProjectStatus({date_start, date_end}: ProjectStatusProps) {
 
-  if (date_start === null || date_end === null) return null
+  if (date_start === null && date_end === null) {
+    return null
+  }
 
   const status = getProjectStatus({
     date_start,
@@ -35,8 +38,8 @@ export default function ProjectStatus({date_start, date_end}: ProjectStatusProps
         className="mb-2 rounded-md"
       />
       <div className="flex justify-between text-sm">
-        <span>{getMonthYearDate(date_start)}</span>
-        <span>{getMonthYearDate(date_end)}</span>
+        <span>{date_start ? getMonthYearDate(date_start) : 'N/A'}</span>
+        <span>{date_end ? getMonthYearDate(date_end) : 'N/A'}</span>
       </div>
       <div className="py-2 text-sm text-center">{status}</div>
     </ProjectSidebarSection>

--- a/frontend/components/projects/overview/cards/ProjectPeriod.tsx
+++ b/frontend/components/projects/overview/cards/ProjectPeriod.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +18,7 @@ export default function ProjectPeriod({date_start, date_end}: ProjectPeriodProps
 
   // show both dates and progressbar
   return (
-    <>
+    <div style={{width: '150px'}}>
       <ProjectDuration
         date_start={date_start}
         date_end={date_end}
@@ -28,6 +29,6 @@ export default function ProjectPeriod({date_start, date_end}: ProjectPeriodProps
         className="mt-[0.0625rem] rounded-sm"
         height="0.375rem"
       />
-    </>
+    </div>
   )
 }

--- a/frontend/utils/getProjects.ts
+++ b/frontend/utils/getProjects.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -143,23 +144,26 @@ export async function getOrganisations({project, token, frontend = true}:
  * 2. Ensure used labels are same as ProjectStatusLabels used in the filter dropdown
  */
 export function getProjectStatus({date_start, date_end}:
-  {date_start: string, date_end: string}) {
+  {date_start: string | null, date_end: string | null}) {
   try {
-    const start_date = new Date(date_start)
-    const end_date = new Date(date_end)
+    const start_date = date_start ? new Date(date_start) : null
+    const end_date = date_end ? new Date(date_end) : null
     const today = new Date()
 
     let statusKey: ProjectStatusKey = 'unknown'
 
-    if (today < start_date) statusKey = 'upcoming'
-    if (today > end_date) statusKey = 'finished'
-    if (today > start_date && today < end_date) statusKey = 'in_progress'
-
-    if (statusKey!=='unknown') {
-      return ProjectStatusLabels[statusKey]
+    if (start_date !== null && end_date !== null && start_date > end_date) {
+      statusKey = 'unknown'
+    } else if (start_date !== null && today < start_date) {
+      statusKey = 'upcoming'
+    } else if (end_date !== null && today > end_date) {
+      statusKey = 'finished'
+    } else if (start_date !== null && end_date !== null && today >= start_date && today <= end_date) {
+      statusKey = 'in_progress'
     }
-    return ''
-  } catch (e:any) {
+
+    return ProjectStatusLabels[statusKey]
+  } catch (e: any) {
     logger(`getProjectStatus: ${e?.message}`, 'error')
     // error value return starting
     return ''


### PR DESCRIPTION
## Show progress bar when status is known for projects

### Changes proposed in this pull request

* Show the progress bar on project cards that have a start date in the future or an end date in the past, when the other date is missing

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Check the projects overview page
* For upcoming projects, the progress bar is always shown (empty), even if the end date is missing
* For finished projects, the progress bar is always shown (full), even if the start date is missing

closes #933

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
