### PR TITLE
Not accepting terms and conditions sends you to homepage

### DIFF
--- a/frontend/components/user/settings/agreements/UserAgreementModal.tsx
+++ b/frontend/components/user/settings/agreements/UserAgreementModal.tsx
@@ -5,7 +5,7 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -164,8 +164,8 @@ export default function UserAgreementModal() {
           padding: '1rem 1.5rem',
         }}>
           <Button
-            // on cancel go back to previous page
-            onClick={()=>router.back()}
+            // on cancel go to the homepage
+            onClick={()=>router.push('/')}
             color="secondary"
             sx={{
               marginRight: '1rem',


### PR DESCRIPTION
## Not accepting terms and conditions sends you to homepage

### Changes proposed in this pull request

* When clicking the cancel button on the user agreements modal, you are sent to the homepage instead of one page back, as that might send you to the sign in provider (SURFConext, LinkedIn, etc.)

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in (if dev mode, sign in again with a new account, so you are not an admin with the second account)
* Click cancel on any page with the user agreements modal, you will be send to the homepage instead of one page back in your history

closes #1487

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
