### PR TITLE
Correctly parse Julia downloads

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/JuliaScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/JuliaScraper.java
@@ -45,6 +45,7 @@ public class JuliaScraper implements PackageManagerScraper {
 
 	@Override
 	public Long downloads() throws IOException, RsdResponseException, InterruptedException {
+		// example: https://juliapkgstats.com/api/v1/total_downloads/Makie
 		URI url = URI.create("https://juliapkgstats.com/api/v1/total_downloads/" + packageName);
 
 		try (HttpClient client = HttpClient.newBuilder().connectTimeout(DEFAULT_TIMEOUT).build()) {
@@ -55,10 +56,13 @@ public class JuliaScraper implements PackageManagerScraper {
 				throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Unexpected response getting Julia downloads for package: " + packageName);
 			}
 
-			return JsonParser.parseString(response.body())
+			String numberAsString = JsonParser.parseString(response.body())
 				.getAsJsonObject()
 				.getAsJsonPrimitive("total_requests")
-				.getAsLong();
+				.getAsString()
+				.replace(",", "");
+
+			return Long.parseLong(numberAsString);
 		}
 	}
 


### PR DESCRIPTION
## Correctly parse Julia downloads

### Changes proposed in this pull request

* Correctly parse Julia downloads that might contain commmas (e.g. https://juliapkgstats.com/api/v1/total_downloads/Makie), since [this issue](https://github.com/pricklypointer/JuliaPkgStats/issues/8) probably won't be fixed

### How to test

* Follow the instructions of #1539
* The scraper should run without errors in the logs, the download count for Makie should be visible

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
