### PR TITLE
Expand Prettier to Java files

### DIFF
--- a/.github/workflows/prettier-check.yml
+++ b/.github/workflows/prettier-check.yml
@@ -1,5 +1,5 @@
+# SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
-# SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -8,20 +8,21 @@ name: "Run Prettier check"
 on:
   pull_request:
     paths:
-      - "data-generation/**"
+      - "authentication/**/*.java"
+      - "backend-tests/**/*.java"
+      - "background-services/**/*.java"
+      - "data-generation/**/*.js"
+      - "scrapers/**/*.java"
   workflow_dispatch:
 jobs:
   run-prettier-check:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: "data-generation"
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22.13
           cache: "npm"
-          cache-dependency-path: "data-generation/package-lock.json"
+          cache-dependency-path: "package-lock.json"
       - run: npm ci
       - run: npm run format:check

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+#
+# SPDX-License-Identifier: Apache-2.0
+
+#################
+#If you edit this file, you should also update prettier-check.yml
+#################
+
+*.*
+
+!/authentication/**/*.java
+!/backend-tests/**/*.java
+!/background-services/**/*.java
+!/data-generation/**/*.js
+!/scrapers/**/*.java

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,8 +1,8 @@
 {
+	"plugins": ["prettier-plugin-java"],
 	"printWidth": 120,
 	"useTabs": true,
 	"tabWidth": 4,
-	"semi": true,
 	"singleQuote": true,
 	"bracketSpacing": false,
 	"arrowParens": "avoid"

--- a/.prettierrc.json.license
+++ b/.prettierrc.json.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+
+SPDX-License-Identifier: Apache-2.0

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,7 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "bradlc.vscode-tailwindcss"
+    "bradlc.vscode-tailwindcss",
+    "esbenp.prettier-vscode"
   ]
 }

--- a/.vscode/extensions.json.license
+++ b/.vscode/extensions.json.license
@@ -1,3 +1,5 @@
-SPDX-FileCopyrightText: 2022 Netherlands eScience Center
+SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
 
+SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: CC0-1.0

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,9 +8,14 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit"
   },
-  "[javascript][javascriptreact][typescript][typescriptreact]": {
+  "[javascriptreact][typescript][typescriptreact]": {
     "editor.tabSize": 2,
     "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+    "editor.formatOnSave": true,
+  },
+  "[javascript]": {
+    // "editor.tabSize": 2,
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
     "editor.formatOnSave": true,
   },
   // Tailwind plugin integration
@@ -26,6 +31,9 @@
     "editor.suggest.snippetsPreventQuickSuggestions": false,
     "editor.useTabStops": true,
     "editor.insertSpaces": false,
+    // enable prettier format on save in VScode
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "editor.formatOnSave": true,
   },
   "cSpell.words": [
     "dompurify"

--- a/.vscode/settings.json.license
+++ b/.vscode/settings.json.license
@@ -1,5 +1,5 @@
-SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
-SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 SPDX-FileCopyrightText: 2023 dv4all
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2022 Jason Maassen (Netherlands eScience Center) <j.maassen@esciencecenter.nl>
@@ -61,14 +61,14 @@ To request a feature you can submit an issue on GitHub. Please keep in mind that
 1. if your issue search did not yield any relevant results, make a new issue, making sure to provide enough information to the rest of the community to understand the feature you are requesting. We may get back to you with further questions.
 1. apply the "feature" label; apply other labels when relevant.
 
-## You want to make some kind of change to the code base youself
+## You want to make some kind of change to the code base yourself
 
 Contributions to the code base are very welcome. Keep in mind, however, that this also requires a good interaction with the community to ensure that your contribution is adopted.
 
 1. (**important**) announce your plan to the rest of the community _before you start working_. This announcement should be in the form of a (new) issue;
 1. (**important**) wait until some kind of concensus is reached about your idea being a good idea;
 1. (**important**) we are applying the [REUSE specification](https://reuse.software/) in order to keep track of copyright and licenses in this repository. See the [section below](#license-and-copyright-information-according-to-the-reuse-specification) for an example. We run a REUSE linter job upon every pull request to make sure all files have at least license information attached. To automate the task of adding REUSE compliant headers you can optionally use our [pre-commit hook template](#automatically-updating-headers-using-a-pre-commit-hook).
-1. if needed, fork the repository to your own Github profile and create your own feature branch off of the latest master commit. While working on your feature branch, make sure to stay up to date with the master branch by pulling in changes, possibly from the 'upstream' repository (follow the instructions [here](https://help.github.com/articles/configuring-a-remote-for-a-fork/) and [here](https://help.github.com/articles/syncing-a-fork/));
+1. if needed, fork the repository to your own GitHub profile and create your own feature branch off of the latest master commit. While working on your feature branch, make sure to stay up to date with the master branch by pulling in changes, possibly from the 'upstream' repository (follow the instructions [here](https://help.github.com/articles/configuring-a-remote-for-a-fork/) and [here](https://help.github.com/articles/syncing-a-fork/));
 1. make sure the existing unit tests still work;
 1. make sure that the existing integration tests still work;
 1. add your own unit tests and integration tests (if necessary);
@@ -77,6 +77,10 @@ Contributions to the code base are very welcome. Keep in mind, however, that thi
 1. create a pull request, e.g. following the instructions [here](https://help.github.com/articles/creating-a-pull-request/).
 
 In case you feel like you've made a valuable contribution, but you don't know how to write or run tests for it, or how to generate the documentation: don't let this discourage you from making the pull request; we can help you! Just go ahead and submit the pull request, but keep in mind that you might be asked to append additional commits to your pull request (have a look at some of our old pull requests to see how this works.
+
+### Formatting
+
+We use [Prettier](https://prettier.io/) for source code formatting for a few of the modules. See the file `.prettierrc` for the applied [configuration options](https://prettier.io/docs/en/options) and see the file `.prettierignore` for files that are [included for formatting](https://prettier.io/docs/en/ignore). Please make sure your contributions in these modules are compliant with Prettier. You can run `npm run format:check` to see which files are not compliant and `npm run format:fix` to fix them. A GitHub workflow runs on every pull request to check if all files are formatted properly. For contributions to modules that don't use Prettier (yet), please follow the existing formatting conventions.
 
 ## You want to contribute in some other way
 

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AccessToken.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AccessToken.java
@@ -17,6 +17,4 @@ public record AccessToken(
 	ZonedDateTime createdAt,
 	ZonedDateTime expiresAt,
 	String displayName
-) {
-
-}
+) {}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AccessTokenVerifier.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AccessTokenVerifier.java
@@ -7,32 +7,32 @@
 
 package nl.esciencecenter.rsd.authentication;
 
-import java.time.ZonedDateTime;
-import java.util.Optional;
-
 import com.google.gson.FieldNamingPolicy;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonDeserializer;
-import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
-
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-
+import java.time.ZonedDateTime;
+import java.util.Optional;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 
 public class AccessTokenVerifier {
 
 	private static final Gson gson = new GsonBuilder()
 		.setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
-		.registerTypeAdapter(ZonedDateTime.class, (JsonDeserializer<ZonedDateTime>) (src, typeOfSrc, context) -> ZonedDateTime.parse(src.getAsString()))
+		.registerTypeAdapter(
+			ZonedDateTime.class,
+			(JsonDeserializer<ZonedDateTime>) (src, typeOfSrc, context) -> ZonedDateTime.parse(src.getAsString())
+		)
 		.create();
 
 	Optional<String> getAccountIdIfValid(String secret, String tokenID) throws RsdAccessTokenException {
 		AccessToken accessToken = getHashForTokenID(tokenID);
 		Argon2PasswordEncoder encoder = Argon2Creator.argon2Encoder();
-		boolean tokenIsValid = encoder.matches(secret, accessToken.secret()) && ZonedDateTime.now()
-			.isBefore(accessToken.expiresAt());
+		boolean tokenIsValid =
+			encoder.matches(secret, accessToken.secret()) && ZonedDateTime.now().isBefore(accessToken.expiresAt());
 
 		return tokenIsValid ? Optional.of(accessToken.account().toString()) : Optional.empty();
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Account.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Account.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
@@ -10,6 +10,6 @@ package nl.esciencecenter.rsd.authentication;
 import java.io.IOException;
 
 public interface Account {
-
-	AccountInfo account(OpenIdInfo openIdInfo, OpenidProvider provider) throws IOException, InterruptedException, PostgresCustomException, PostgresForeignKeyConstraintException;
+	AccountInfo account(OpenIdInfo openIdInfo, OpenidProvider provider)
+		throws IOException, InterruptedException, PostgresCustomException, PostgresForeignKeyConstraintException;
 }

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AccountInfo.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AccountInfo.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -11,10 +11,4 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public record AccountInfo(
-		UUID account,
-		String name,
-		boolean isAdmin,
-		Map<String, List<String>> data
-) {
-}
+public record AccountInfo(UUID account, String name, boolean isAdmin, Map<String, List<String>> data) {}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Argon2Creator.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Argon2Creator.java
@@ -1,18 +1,18 @@
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 package nl.esciencecenter.rsd.authentication;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.io.IOException;
 import java.net.URI;
 import java.util.UUID;
-
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
-
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 public class Argon2Creator {
 
@@ -22,7 +22,8 @@ public class Argon2Creator {
 	private static final Integer MEMORY = 12288;
 	private static final Integer ITERATIONS = 3;
 
-	public static String generateNewAccessToken(String account, String displayName, String expiresAt) throws RsdAccessTokenException, InterruptedException {
+	public static String generateNewAccessToken(String account, String displayName, String expiresAt)
+		throws RsdAccessTokenException, InterruptedException {
 		String opaqueToken = generateOpaqueToken();
 		String secret = generateArgon2Hash(opaqueToken);
 		String tokenID = saveTokenToDatabase(secret, account, displayName, expiresAt);
@@ -43,7 +44,8 @@ public class Argon2Creator {
 		return UUID.randomUUID().toString();
 	}
 
-	private static String saveTokenToDatabase(String secret, String account, String displayName, String expiresAt) throws RsdAccessTokenException, InterruptedException {
+	private static String saveTokenToDatabase(String secret, String account, String displayName, String expiresAt)
+		throws RsdAccessTokenException, InterruptedException {
 		JsonObject userAccessTokenData = new JsonObject();
 		userAccessTokenData.addProperty("secret", secret);
 		userAccessTokenData.addProperty("account", account);
@@ -58,18 +60,11 @@ public class Argon2Creator {
 		try {
 			String tokenResponse = PostgrestAccount.postJsonAsAdmin(queryUri, userAccessTokenData.toString(), jwtToken);
 			UUID tokenID = UUID.fromString(
-				JsonParser.parseString(tokenResponse)
-					.getAsJsonArray()
-					.get(0)
-					.getAsJsonObject()
-					.get("id")
-					.getAsString()
+				JsonParser.parseString(tokenResponse).getAsJsonArray().get(0).getAsJsonObject().get("id").getAsString()
 			);
 			return tokenID.toString();
 		} catch (PostgresForeignKeyConstraintException | PostgresCustomException | IOException e) {
 			throw new RsdAccessTokenException("RsdAccessTokenException: " + e.getMessage(), e);
 		}
-
 	}
-
 }

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AzureLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/AzureLogin.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -10,7 +10,6 @@ package nl.esciencecenter.rsd.authentication;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.gson.JsonParser;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -58,7 +57,8 @@ public class AzureLogin implements Login {
 		return form;
 	}
 
-	private String getTokensFromAzureconext(Map<String, String> form) throws IOException, InterruptedException, RsdResponseException {
+	private String getTokensFromAzureconext(Map<String, String> form)
+		throws IOException, InterruptedException, RsdResponseException {
 		URI tokenEndpoint = Utils.getTokenUrlFromWellKnownUrl(URI.create(Config.azureWellknown()));
 		return Utils.postForm(tokenEndpoint, form);
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Config.java
@@ -16,8 +16,7 @@ import java.net.URISyntaxException;
 
 public class Config {
 
-	private Config() {
-	}
+	private Config() {}
 
 	public static String hostUrl() {
 		return System.getenv("HOST_URL");
@@ -60,7 +59,6 @@ public class Config {
 		return System.getenv("POSTGREST_URL");
 	}
 
-
 	// SURFconext
 	public static String surfconextClientId() {
 		return System.getenv("SURFCONEXT_CLIENT_ID");
@@ -73,7 +71,6 @@ public class Config {
 	public static String surfconextClientSecret() {
 		return System.getenv("AUTH_SURFCONEXT_CLIENT_SECRET");
 	}
-
 
 	//	Helmholtz ID
 	public static String helmholtzIdClientId() {
@@ -93,9 +90,7 @@ public class Config {
 	}
 
 	public static boolean helmholtzIdAllowExternalUsers() {
-		return Boolean.parseBoolean(
-			System.getenv("HELMHOLTZID_ALLOW_EXTERNAL_USERS")
-		);
+		return Boolean.parseBoolean(System.getenv("HELMHOLTZID_ALLOW_EXTERNAL_USERS"));
 	}
 
 	// ORCID
@@ -110,7 +105,6 @@ public class Config {
 	public static String orcidClientSecret() {
 		return System.getenv("AUTH_ORCID_CLIENT_SECRET");
 	}
-
 
 	// Azure Active Directory
 	public static String azureClientId() {
@@ -128,7 +122,6 @@ public class Config {
 	public static String azureOrganisation() {
 		return System.getenv("AZURE_ORGANISATION");
 	}
-
 
 	// LinkedIn
 	public static String linkedinClientId() {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzIdLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/HelmholtzIdLogin.java
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 //
@@ -27,8 +27,6 @@ import com.nimbusds.oauth2.sdk.token.BearerAccessToken;
 import com.nimbusds.openid.connect.sdk.UserInfoRequest;
 import com.nimbusds.openid.connect.sdk.UserInfoResponse;
 import com.nimbusds.openid.connect.sdk.claims.UserInfo;
-import net.minidev.json.JSONArray;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -42,6 +40,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import net.minidev.json.JSONArray;
 
 public class HelmholtzIdLogin implements Login {
 
@@ -51,7 +50,24 @@ public class HelmholtzIdLogin implements Login {
 
 	// See https://hifis.net/doc/helmholtz-aai/list-of-vos/#vos-representing-helmholtz-centres
 	private static final Collection<String> knownHgfOrganisations = Set.of(
-			"AWI", "CISPA", "DESY", "DKFZ", "DLR", "DZNE", "FZJ", "GEOMAR", "GFZ", "GSI", "hereon", "HMGU", "HZB", "HZDR", "HZI", "KIT", "MDC", "UFZ"
+		"AWI",
+		"CISPA",
+		"DESY",
+		"DKFZ",
+		"DLR",
+		"DZNE",
+		"FZJ",
+		"GEOMAR",
+		"GFZ",
+		"GSI",
+		"hereon",
+		"HMGU",
+		"HZB",
+		"HZDR",
+		"HZI",
+		"KIT",
+		"MDC",
+		"UFZ"
 	);
 
 	public HelmholtzIdLogin(String code, String redirectUrl) {
@@ -138,11 +154,9 @@ public class HelmholtzIdLogin implements Login {
 		String userinfoUrl;
 
 		/* get the userinfo endpoint URL first */
-		HttpRequest request = HttpRequest.newBuilder(
-						URI.create(Config.helmholtzIdWellknown())
-				)
-				.header("accept", "application/json")
-				.build();
+		HttpRequest request = HttpRequest.newBuilder(URI.create(Config.helmholtzIdWellknown()))
+			.header("accept", "application/json")
+			.build();
 
 		try (HttpClient client = HttpClient.newHttpClient()) {
 			HttpResponse<String> response = client.send(request, BodyHandlers.ofString());
@@ -165,9 +179,7 @@ public class HelmholtzIdLogin implements Login {
 				scopes.add(scope);
 			}
 
-			TokenRequest tokenRequest = new TokenRequest(
-					tokenEndpoint, clientAuth, codeGrant, scopes
-			);
+			TokenRequest tokenRequest = new TokenRequest(tokenEndpoint, clientAuth, codeGrant, scopes);
 			TokenResponse response = TokenResponse.parse(tokenRequest.toHTTPRequest().send());
 
 			if (!response.indicatesSuccess()) {
@@ -179,9 +191,7 @@ public class HelmholtzIdLogin implements Login {
 
 			URI userInfoEndpoint = new URI(userinfoUrl);
 			BearerAccessToken token = successResponse.getTokens().getBearerAccessToken();
-			HTTPResponse httpResponse = new UserInfoRequest(userInfoEndpoint, token)
-					.toHTTPRequest()
-					.send();
+			HTTPResponse httpResponse = new UserInfoRequest(userInfoEndpoint, token).toHTTPRequest().send();
 
 			UserInfoResponse userInfoResponse = UserInfoResponse.parse(httpResponse);
 
@@ -210,7 +220,7 @@ public class HelmholtzIdLogin implements Login {
 		String organisation = getOrganisationFromEntitlements(entitlements);
 
 		List<String> eduPersonEntitlements = new ArrayList<>();
-		for (int i=0; i<entitlements.size(); i++) {
+		for (int i = 0; i < entitlements.size(); i++) {
 			eduPersonEntitlements.add(entitlements.get(i).toString());
 		}
 
@@ -218,11 +228,11 @@ public class HelmholtzIdLogin implements Login {
 		data.put("eduPersonEntitlements", eduPersonEntitlements);
 
 		return new OpenIdInfo(
-				userInfo.getSubject().toString(),
-				userInfo.getName(),
-				userInfo.getEmailAddress(),
-				organisation,
-				data
+			userInfo.getSubject().toString(),
+			userInfo.getName(),
+			userInfo.getEmailAddress(),
+			organisation,
+			data
 		);
 	}
 }

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtCreator.java
@@ -10,16 +10,15 @@
 
 package nl.esciencecenter.rsd.authentication;
 
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.google.gson.Gson;
 import java.io.IOException;
 import java.util.Date;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
-
-import com.auth0.jwt.JWT;
-import com.auth0.jwt.algorithms.Algorithm;
-import com.auth0.jwt.interfaces.DecodedJWT;
-import com.google.gson.Gson;
 
 public class JwtCreator {
 
@@ -45,7 +44,6 @@ public class JwtCreator {
 			.withExpiresAt(new Date(System.currentTimeMillis() + ONE_HOUR_IN_MILLISECONDS))
 			.sign(signingAlgorithm);
 	}
-
 
 	String createAdminJwt() {
 		return JWT.create()

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtVerifier.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/JwtVerifier.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,6 @@ import com.auth0.jwt.JWTVerifier;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
-
 import java.util.Objects;
 
 public class JwtVerifier {

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/LinkedinLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/LinkedinLogin.java
@@ -8,7 +8,6 @@ package nl.esciencecenter.rsd.authentication;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.gson.JsonParser;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -58,7 +57,8 @@ public class LinkedinLogin implements Login {
 		return form;
 	}
 
-	private String getTokensFromLinkedin(Map<String, String> form) throws IOException, InterruptedException, RsdResponseException {
+	private String getTokensFromLinkedin(Map<String, String> form)
+		throws IOException, InterruptedException, RsdResponseException {
 		URI tokenEndpoint = Utils.getTokenUrlFromWellKnownUrl(URI.create(Config.linkedinWellknown()));
 		return Utils.postForm(tokenEndpoint, form);
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Login.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Login.java
@@ -8,6 +8,5 @@ package nl.esciencecenter.rsd.authentication;
 import java.io.IOException;
 
 public interface Login {
-
 	OpenIdInfo openidInfo() throws IOException, InterruptedException, RsdResponseException;
 }

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OpenIdInfo.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OpenIdInfo.java
@@ -10,11 +10,4 @@ package nl.esciencecenter.rsd.authentication;
 import java.util.List;
 import java.util.Map;
 
-public record OpenIdInfo(
-	String sub,
-	String name,
-	String email,
-	String organisation,
-	Map<String, List<String>> data
-) {
-}
+public record OpenIdInfo(String sub, String name, String email, String organisation, Map<String, List<String>> data) {}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OrcidLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/OrcidLogin.java
@@ -10,7 +10,6 @@ package nl.esciencecenter.rsd.authentication;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.gson.JsonParser;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -60,7 +59,8 @@ public class OrcidLogin implements Login {
 		return form;
 	}
 
-	private String getTokensFromOrcidconext(Map<String, String> form) throws IOException, InterruptedException, RsdResponseException {
+	private String getTokensFromOrcidconext(Map<String, String> form)
+		throws IOException, InterruptedException, RsdResponseException {
 		URI tokenEndpoint = Utils.getTokenUrlFromWellKnownUrl(URI.create(Config.orcidWellknown()));
 		return Utils.postForm(tokenEndpoint, form);
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgresCustomException.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgresCustomException.java
@@ -6,15 +6,15 @@
 package nl.esciencecenter.rsd.authentication;
 
 public class PostgresCustomException extends Exception {
+
 	public PostgresCustomException(String message) {
 		super(message);
 	}
 
 	public static class PostgresAccessTokenExpirationException extends PostgresCustomException {
+
 		public PostgresAccessTokenExpirationException(String message) {
 			super(message);
 		}
 	}
 }
-
-

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgresForeignKeyConstraintException.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgresForeignKeyConstraintException.java
@@ -6,6 +6,7 @@
 package nl.esciencecenter.rsd.authentication;
 
 public class PostgresForeignKeyConstraintException extends Exception {
+
 	public PostgresForeignKeyConstraintException(String message) {
 		super(message);
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdAccessTokenException.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdAccessTokenException.java
@@ -6,6 +6,7 @@
 package nl.esciencecenter.rsd.authentication;
 
 public class RsdAccessTokenException extends Exception {
+
 	public RsdAccessTokenException(String message) {
 		super(message);
 	}
@@ -15,6 +16,7 @@ public class RsdAccessTokenException extends Exception {
 	}
 
 	public static class UnverifiedAccessTokenException extends RsdAccessTokenException {
+
 		public UnverifiedAccessTokenException(String message) {
 			super(message);
 		}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdAccountInviteException.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdAccountInviteException.java
@@ -6,6 +6,7 @@
 package nl.esciencecenter.rsd.authentication;
 
 public class RsdAccountInviteException extends Exception {
+
 	public RsdAccountInviteException(String message) {
 		super(message);
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdInvalidHeaderException.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdInvalidHeaderException.java
@@ -6,6 +6,7 @@
 package nl.esciencecenter.rsd.authentication;
 
 public class RsdInvalidHeaderException extends IllegalArgumentException {
+
 	public RsdInvalidHeaderException(String message) {
 		super(message);
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdProviderData.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/RsdProviderData.java
@@ -14,5 +14,4 @@ public record RsdProviderData(
 	String displayName,
 	String htmlDescription,
 	int order
-) {
-}
+) {}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/SurfconextLogin.java
@@ -13,7 +13,6 @@ package nl.esciencecenter.rsd.authentication;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import com.google.gson.JsonParser;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
@@ -58,7 +57,8 @@ public class SurfconextLogin implements Login {
 		return form;
 	}
 
-	private String getTokensFromSurfconext(Map<String, String> form) throws IOException, InterruptedException, RsdResponseException {
+	private String getTokensFromSurfconext(Map<String, String> form)
+		throws IOException, InterruptedException, RsdResponseException {
 		URI tokenEndpoint = Utils.getTokenUrlFromWellKnownUrl(URI.create(Config.surfconextWellknown()));
 		return Utils.postForm(tokenEndpoint, form);
 	}

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/Utils.java
@@ -7,6 +7,8 @@
 
 package nl.esciencecenter.rsd.authentication;
 
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URLEncoder;
@@ -20,24 +22,28 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.StringJoiner;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 public class Utils {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Utils.class);
 	private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
 	private static final Set<String> FORBIDDEN_HEADERS = Set.of(
-		"host", "content-length", "transfer-encoding", "connection",
-		"upgrade", "te", "expect", ":method", ":path", ":scheme", ":authority"
+		"host",
+		"content-length",
+		"transfer-encoding",
+		"connection",
+		"upgrade",
+		"te",
+		"expect",
+		":method",
+		":path",
+		":scheme",
+		":authority"
 	);
 
-	private Utils() {
-	}
+	private Utils() {}
 
 	@SafeVarargs
 	public static <T> T coalesce(T... objects) {
@@ -49,18 +55,32 @@ public class Utils {
 		throw new NullPointerException("No non-null reference found");
 	}
 
-	public static URI getAuthUrlFromWellKnownUrl(URI wellKnownUrl) throws IOException, InterruptedException, RsdResponseException {
+	public static URI getAuthUrlFromWellKnownUrl(URI wellKnownUrl)
+		throws IOException, InterruptedException, RsdResponseException {
 		HttpRequest request = HttpRequest.newBuilder(wellKnownUrl).build();
 		try (HttpClient client = HttpClient.newHttpClient()) {
-			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+			HttpResponse<String> response = client.send(
+				request,
+				HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+			);
 
 			if (response.statusCode() != 200) {
-				throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Wrong status code querying well-known URL");
+				throw new RsdResponseException(
+					response.statusCode(),
+					response.uri(),
+					response.body(),
+					"Wrong status code querying well-known URL"
+				);
 			}
 			try {
 				return extractAuthUrlFromWellKnownData(response.body());
 			} catch (RuntimeException e) {
-				throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Could not extract auth URL from well-known URL response body");
+				throw new RsdResponseException(
+					response.statusCode(),
+					response.uri(),
+					response.body(),
+					"Could not extract auth URL from well-known URL response body"
+				);
 			}
 		}
 	}
@@ -68,7 +88,10 @@ public class Utils {
 	public static URI getTokenUrlFromWellKnownUrl(URI wellKnownUrl) throws IOException, InterruptedException {
 		HttpRequest request = HttpRequest.newBuilder(wellKnownUrl).build();
 		try (HttpClient client = HttpClient.newHttpClient()) {
-			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+			HttpResponse<String> response = client.send(
+				request,
+				HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8)
+			);
 			return extractTokenUrlFromWellKnownData(response.body());
 		}
 	}
@@ -105,19 +128,30 @@ public class Utils {
 			.build();
 	}
 
-	public static String postForm(URI uri, Map<String, String> form) throws IOException, InterruptedException, RsdResponseException {
+	public static String postForm(URI uri, Map<String, String> form)
+		throws IOException, InterruptedException, RsdResponseException {
 		HttpRequest request = formToHttpRequest(uri, form);
 		try (HttpClient client = HttpClient.newHttpClient()) {
 			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 			if (response.statusCode() >= 300) {
 				LOGGER.error("Error posting form: {}, {}", response.statusCode(), response.body());
-				throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Error posting form");
+				throw new RsdResponseException(
+					response.statusCode(),
+					response.uri(),
+					response.body(),
+					"Error posting form"
+				);
 			}
 			return response.body();
 		}
 	}
 
-	public static HttpResponse<String> makeBasicRequest(String method, Optional<String> jsonBody, URI uri, String jwtToken) {
+	public static HttpResponse<String> makeBasicRequest(
+		String method,
+		Optional<String> jsonBody,
+		URI uri,
+		String jwtToken
+	) {
 		HttpRequest.Builder builder = HttpRequest.newBuilder()
 			.uri(uri)
 			.timeout(DEFAULT_TIMEOUT)
@@ -152,7 +186,9 @@ public class Utils {
 		}
 
 		if (response.statusCode() >= 300) {
-			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+			throw new RuntimeException(
+				"Error fetching data from endpoint " + uri + " with response: " + response.body()
+			);
 		}
 		return response;
 	}
@@ -189,7 +225,9 @@ public class Utils {
 		}
 
 		if (response.statusCode() >= 300) {
-			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+			throw new RuntimeException(
+				"Error fetching data from endpoint " + uri + " with response: " + response.body()
+			);
 		}
 		return response.body();
 	}

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/HelmholtzIdLoginTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/HelmholtzIdLoginTest.java
@@ -8,39 +8,34 @@
 
 package nl.esciencecenter.rsd.authentication;
 
-import net.minidev.json.JSONArray;
-import org.junit.jupiter.api.Test;
-
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import net.minidev.json.JSONArray;
+import org.junit.jupiter.api.Test;
+
 class HelmholtzIdLoginTest {
+
 	@Test
 	void testOrganisationFromEntitlementsExpected() {
 		JSONArray arr = new JSONArray();
 
 		arr.add("urn:geant:h-df.de:group:test-vo#login-dev.helmholtz.de");
-		assertNull(
-				HelmholtzIdLogin.getOrganisationFromEntitlements(arr)
-		);
+		assertNull(HelmholtzIdLogin.getOrganisationFromEntitlements(arr));
 
 		arr.add("urn:geant:helmholtz.de:group:Helmholtz-member#login-dev.helmholtz.de");
 		arr.add("urn:geant:helmholtz.de:group:GFZ#login-dev.helmholtz.de");
 		arr.add("urn:geant:helmholtz.de:group:HIFIS#login-dev.helmholtz.de");
 		arr.add("urn:mace:dir:entitlement:common-lib-terms");
 
-		assertEquals(
-				"GFZ",
-				HelmholtzIdLogin.getOrganisationFromEntitlements(arr)
-		);
+		assertEquals("GFZ", HelmholtzIdLogin.getOrganisationFromEntitlements(arr));
 
 		arr.add("urn:geant:helmholtz.de:group:UFZ#login-dev.helmholtz.de");
 		assertTrue(
-				"GFZ".equals(HelmholtzIdLogin.getOrganisationFromEntitlements(arr))
-						||
-						"UFZ".equals(HelmholtzIdLogin.getOrganisationFromEntitlements(arr))
+			"GFZ".equals(HelmholtzIdLogin.getOrganisationFromEntitlements(arr)) ||
+			"UFZ".equals(HelmholtzIdLogin.getOrganisationFromEntitlements(arr))
 		);
 
 		JSONArray nohash = new JSONArray();
@@ -48,10 +43,7 @@ class HelmholtzIdLoginTest {
 		nohash.add("urn:geant:helmholtz.de:group:Helmholtz-member");
 		nohash.add("urn:geant:helmholtz.de:group:GFZ");
 
-		assertEquals(
-				"GFZ",
-				HelmholtzIdLogin.getOrganisationFromEntitlements(nohash)
-		);
+		assertEquals("GFZ", HelmholtzIdLogin.getOrganisationFromEntitlements(nohash));
 	}
 
 	@Test
@@ -62,20 +54,13 @@ class HelmholtzIdLoginTest {
 		arr.add("urn:geant:helmholtz.de:group:GFZ#login-dev.helmholtz.de");
 		arr.add("urn:mace:dir:entitlement:common-lib-terms");
 
-		assertEquals(
-				"GFZ",
-				HelmholtzIdLogin.getOrganisationFromEntitlements(arr)
-		);
+		assertEquals("GFZ", HelmholtzIdLogin.getOrganisationFromEntitlements(arr));
 
-		assertNull(
-				HelmholtzIdLogin.getOrganisationFromEntitlements(null)
-		);
+		assertNull(HelmholtzIdLogin.getOrganisationFromEntitlements(null));
 
 		JSONArray empty = new JSONArray();
 
-		assertNull(
-				HelmholtzIdLogin.getOrganisationFromEntitlements(empty)
-		);
+		assertNull(HelmholtzIdLogin.getOrganisationFromEntitlements(empty));
 	}
 
 	@Test
@@ -88,10 +73,7 @@ class HelmholtzIdLoginTest {
 		arr.add("GFZ#login-dev.helmholtz.de");
 		arr.add("GFZ");
 
-		assertEquals(
-				HelmholtzIdLogin.DEFAULT_ORGANISATION,
-				HelmholtzIdLogin.getOrganisationFromEntitlements(arr)
-		);
+		assertEquals(HelmholtzIdLogin.DEFAULT_ORGANISATION, HelmholtzIdLogin.getOrganisationFromEntitlements(arr));
 	}
 
 	@Test
@@ -99,43 +81,27 @@ class HelmholtzIdLoginTest {
 		JSONArray arr = new JSONArray();
 
 		// No entitlements -> Null
-		assertNull(
-				HelmholtzIdLogin.getOrganisationFromEntitlements(null)
-		);
+		assertNull(HelmholtzIdLogin.getOrganisationFromEntitlements(null));
 
-		assertNull(
-				HelmholtzIdLogin.getOrganisationFromEntitlements(arr)
-		);
+		assertNull(HelmholtzIdLogin.getOrganisationFromEntitlements(arr));
 
 		// Default value should be returned if user is part of the Helmholtz
 		// association but no fitting centre could be found
 		arr.add("urn:geant:helmholtz.de:group:Helmholtz-member#login.helmholtz.de");
 
-		assertEquals(
-				HelmholtzIdLogin.DEFAULT_ORGANISATION,
-				HelmholtzIdLogin.getOrganisationFromEntitlements(arr)
-		);
+		assertEquals(HelmholtzIdLogin.DEFAULT_ORGANISATION, HelmholtzIdLogin.getOrganisationFromEntitlements(arr));
 
 		// Unknown or new institution
 		arr.add("urn:geant:helmholtz.de:group:NoRealCentre#login-dev.helmholtz.de");
-		assertEquals(
-				HelmholtzIdLogin.DEFAULT_ORGANISATION,
-				HelmholtzIdLogin.getOrganisationFromEntitlements(arr)
-		);
+		assertEquals(HelmholtzIdLogin.DEFAULT_ORGANISATION, HelmholtzIdLogin.getOrganisationFromEntitlements(arr));
 
 		arr.add("");
 		arr.add("test");
 
-		assertEquals(
-				HelmholtzIdLogin.DEFAULT_ORGANISATION,
-				HelmholtzIdLogin.getOrganisationFromEntitlements(arr)
-		);
+		assertEquals(HelmholtzIdLogin.DEFAULT_ORGANISATION, HelmholtzIdLogin.getOrganisationFromEntitlements(arr));
 
 		// Actual centre does not return default value
 		arr.add("urn:geant:helmholtz.de:group:GFZ#login-dev.helmholtz.de");
-		assertNotEquals(
-				HelmholtzIdLogin.DEFAULT_ORGANISATION,
-				HelmholtzIdLogin.getOrganisationFromEntitlements(arr)
-		);
+		assertNotEquals(HelmholtzIdLogin.DEFAULT_ORGANISATION, HelmholtzIdLogin.getOrganisationFromEntitlements(arr));
 	}
 }

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/MainTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/MainTest.java
@@ -8,23 +8,19 @@
 
 package nl.esciencecenter.rsd.authentication;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
 class MainTest {
+
 	Map<String, List<String>> emptyData = Collections.emptyMap();
-	OpenIdInfo userinfo = new OpenIdInfo(
-		"12345", "User Name", "user@example.com", "Example User", emptyData
-	);
-	OpenIdInfo userinfoNullOrganisation = new OpenIdInfo(
-		"12345", "User Name", "user@example.com", null, emptyData
-	);
+	OpenIdInfo userinfo = new OpenIdInfo("12345", "User Name", "user@example.com", "Example User", emptyData);
+	OpenIdInfo userinfoNullOrganisation = new OpenIdInfo("12345", "User Name", "user@example.com", null, emptyData);
 	static MockedStatic<Config> utilities;
 
 	@BeforeAll

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
@@ -5,11 +5,10 @@
 
 package nl.esciencecenter.rsd.authentication;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.time.ZonedDateTime;
 import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class PostgrestAccountTest {
 
@@ -48,7 +47,10 @@ class PostgrestAccountTest {
 	@Test
 	void givenArrayOfSizeTwoWithCorrectUuid_whenCheckingIfAdmin_thenFalseReturned() {
 		UUID adminUuid = UUID.randomUUID();
-		String wrongIdResponse = "[{\"account_id\": \"%s\"}, {\"account_id\": \"%s\"}]".formatted(adminUuid, UUID.randomUUID());
+		String wrongIdResponse = "[{\"account_id\": \"%s\"}, {\"account_id\": \"%s\"}]".formatted(
+			adminUuid,
+			UUID.randomUUID()
+		);
 
 		Assertions.assertFalse(PostgrestAccount.parseIsAdminResponse(adminUuid, wrongIdResponse));
 	}
@@ -61,7 +63,9 @@ class PostgrestAccountTest {
 	void givenEmptyInviteResponse_whenParsed_thenExceptionThrown() {
 		String json = "[]";
 
-		Assertions.assertThrowsExactly(RsdAccountInviteException.class, () -> PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json));
+		Assertions.assertThrowsExactly(RsdAccountInviteException.class, () ->
+			PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json)
+		);
 	}
 
 	@Test
@@ -69,7 +73,9 @@ class PostgrestAccountTest {
 		int expectedUsesLeft = 1;
 		String json = formatInviteResponse(expectedUsesLeft, ZonedDateTime.now().plusMinutes(1));
 
-		int actualUsesLeft = Assertions.assertDoesNotThrow(() -> PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json));
+		int actualUsesLeft = Assertions.assertDoesNotThrow(() ->
+			PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json)
+		);
 		Assertions.assertEquals(expectedUsesLeft, actualUsesLeft);
 	}
 
@@ -77,7 +83,9 @@ class PostgrestAccountTest {
 	void givenValidInviteResponseWithInfiniteUses_whenParsed_thenNullReturned() {
 		String json = formatInviteResponse(null, ZonedDateTime.now().plusMinutes(1));
 
-		Integer actualUsesLeft = Assertions.assertDoesNotThrow(() -> PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json));
+		Integer actualUsesLeft = Assertions.assertDoesNotThrow(() ->
+			PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json)
+		);
 		Assertions.assertNull(actualUsesLeft);
 	}
 
@@ -85,20 +93,26 @@ class PostgrestAccountTest {
 	void givenInviteResponseWithZeroUses_whenParsed_thenExceptionThrown() {
 		String json = formatInviteResponse(0, ZonedDateTime.now().plusMinutes(1));
 
-		Assertions.assertThrowsExactly(RsdAccountInviteException.class, () -> PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json));
+		Assertions.assertThrowsExactly(RsdAccountInviteException.class, () ->
+			PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json)
+		);
 	}
 
 	@Test
 	void givenInviteResponseWithNegativeUses_whenParsed_thenExceptionThrown() {
 		String json = formatInviteResponse(-1, ZonedDateTime.now().plusMinutes(1));
 
-		Assertions.assertThrowsExactly(RsdAccountInviteException.class, () -> PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json));
+		Assertions.assertThrowsExactly(RsdAccountInviteException.class, () ->
+			PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json)
+		);
 	}
 
 	@Test
 	void givenInviteResponseExpired_whenParsed_thenExceptionThrown() {
 		String json = formatInviteResponse(1, ZonedDateTime.now().minusMinutes(1));
 
-		Assertions.assertThrowsExactly(RsdAccountInviteException.class, () -> PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json));
+		Assertions.assertThrowsExactly(RsdAccountInviteException.class, () ->
+			PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json)
+		);
 	}
 }

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/QueryParameterBuilderTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/QueryParameterBuilderTest.java
@@ -20,14 +20,20 @@ class QueryParameterBuilderTest {
 	}
 
 	@ParameterizedTest
-	@CsvSource({
-		"key,value,?key=value",
-		"123,456,?123=456",
-		"scope,openid profile email,?scope=openid+profile+email",
-		"url,https://www.example.com,?url=https%3A%2F%2Fwww.example.com",
-		"a?b&c,d&e?f=g,?a%3Fb%26c=d%26e%3Ff%3Dg",
-	})
-	void givenKeyValuePairs_whenBuildingAndCallingToString_thenCorrectOutputProduced(String key, String value, String expected) {
+	@CsvSource(
+		{
+			"key,value,?key=value",
+			"123,456,?123=456",
+			"scope,openid profile email,?scope=openid+profile+email",
+			"url,https://www.example.com,?url=https%3A%2F%2Fwww.example.com",
+			"a?b&c,d&e?f=g,?a%3Fb%26c=d%26e%3Ff%3Dg",
+		}
+	)
+	void givenKeyValuePairs_whenBuildingAndCallingToString_thenCorrectOutputProduced(
+		String key,
+		String value,
+		String expected
+	) {
 		QueryParameterBuilder queryParameterBuilder = new QueryParameterBuilder();
 
 		queryParameterBuilder.addQueryParameter(key, value);
@@ -39,10 +45,14 @@ class QueryParameterBuilderTest {
 	void givenMultipleKeyValuePairs_whenBuildingAndCallingToString_thenCorrectOutputProduced() {
 		QueryParameterBuilder queryParameterBuilder = new QueryParameterBuilder();
 
-		queryParameterBuilder.addQueryParameter("key", "value")
+		queryParameterBuilder
+			.addQueryParameter("key", "value")
 			.addQueryParameter("123", "456")
 			.addQueryParameter("url", "https://www.example.com");
 
-		Assertions.assertEquals("?key=value&123=456&url=https%3A%2F%2Fwww.example.com", queryParameterBuilder.toString());
+		Assertions.assertEquals(
+			"?key=value&123=456&url=https%3A%2F%2Fwww.example.com",
+			queryParameterBuilder.toString()
+		);
 	}
 }

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/RsdProvidersTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/RsdProvidersTest.java
@@ -5,18 +5,18 @@
 
 package nl.esciencecenter.rsd.authentication;
 
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.Map;
-
 class RsdProvidersTest {
 
 	@Test
 	void whenGivenNullOrEmptyString_whenParsingAuthConfig_thenEmptyMapReturned() {
-		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> emptyMap = RsdProviders.parseAuthProvidersEnvString(null);
+		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> emptyMap =
+			RsdProviders.parseAuthProvidersEnvString(null);
 		Assertions.assertTrue(emptyMap.isEmpty());
 
 		emptyMap = RsdProviders.parseAuthProvidersEnvString("");
@@ -26,100 +26,132 @@ class RsdProvidersTest {
 	@Test
 	void whenGivenValidConfig_whenParsingAuthConfig_thenCorrectMapReturned() {
 		String authConfig = "SURFCONEXT:EVERYONE;HELMHOLTZ:INVITE_ONLY;ORCID:INVITE_ONLY;AZURE:EVERYONE";
-		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap = RsdProviders.parseAuthProvidersEnvString(authConfig);
+		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap =
+			RsdProviders.parseAuthProvidersEnvString(authConfig);
 
 		Assertions.assertEquals(4, authMap.size());
-		Assertions.assertEquals(OpenidProviderAccessMethod.EVERYONE, authMap.get(OpenidProvider.surfconext)
-			.accessMethod());
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.EVERYONE,
+			authMap.get(OpenidProvider.surfconext).accessMethod()
+		);
 		Assertions.assertEquals(OpenidProviderAccessMethod.EVERYONE, authMap.get(OpenidProvider.azure).accessMethod());
-		Assertions.assertEquals(OpenidProviderAccessMethod.INVITE_ONLY, authMap.get(OpenidProvider.helmholtz)
-			.accessMethod());
-		Assertions.assertEquals(OpenidProviderAccessMethod.INVITE_ONLY, authMap.get(OpenidProvider.orcid)
-			.accessMethod());
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.INVITE_ONLY,
+			authMap.get(OpenidProvider.helmholtz).accessMethod()
+		);
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.INVITE_ONLY,
+			authMap.get(OpenidProvider.orcid).accessMethod()
+		);
 
-		Assertions.assertTrue(authMap.get(OpenidProvider.surfconext).order() < authMap.get(OpenidProvider.helmholtz)
-			.order());
-		Assertions.assertTrue(authMap.get(OpenidProvider.helmholtz).order() < authMap.get(OpenidProvider.orcid)
-			.order());
+		Assertions.assertTrue(
+			authMap.get(OpenidProvider.surfconext).order() < authMap.get(OpenidProvider.helmholtz).order()
+		);
+		Assertions.assertTrue(
+			authMap.get(OpenidProvider.helmholtz).order() < authMap.get(OpenidProvider.orcid).order()
+		);
 		Assertions.assertTrue(authMap.get(OpenidProvider.orcid).order() < authMap.get(OpenidProvider.azure).order());
 	}
 
 	@Test
 	void whenGivenConfigWithDuplicates_whenParsingAuthConfig_thenDuplicatesAreMisconfigured() {
 		String authConfig = "SURFCONEXT:EVERYONE;ORCID:INVITE_ONLY;SURFCONEXT:EVERYONE";
-		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap = RsdProviders.parseAuthProvidersEnvString(authConfig);
+		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap =
+			RsdProviders.parseAuthProvidersEnvString(authConfig);
 
 		Assertions.assertEquals(2, authMap.size());
-		Assertions.assertEquals(OpenidProviderAccessMethod.MISCONFIGURED, authMap.get(OpenidProvider.surfconext)
-			.accessMethod());
-		Assertions.assertEquals(OpenidProviderAccessMethod.INVITE_ONLY, authMap.get(OpenidProvider.orcid)
-			.accessMethod());
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.MISCONFIGURED,
+			authMap.get(OpenidProvider.surfconext).accessMethod()
+		);
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.INVITE_ONLY,
+			authMap.get(OpenidProvider.orcid).accessMethod()
+		);
 	}
 
 	@Test
 	void whenGivenConfigWithNonExistingKey_whenParsingAuthConfig_thenThoseAreSkipped() {
 		String authConfig = "SURFCONEXT:EVERYONE;ORCID:INVITE_ONLY;DOESNOTEXIST:EVERYONE";
-		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap = Assertions.assertDoesNotThrow(() -> RsdProviders.parseAuthProvidersEnvString(authConfig));
+		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap = Assertions.assertDoesNotThrow(() ->
+			RsdProviders.parseAuthProvidersEnvString(authConfig)
+		);
 
 		Assertions.assertEquals(2, authMap.size());
-		Assertions.assertEquals(OpenidProviderAccessMethod.EVERYONE, authMap.get(OpenidProvider.surfconext)
-			.accessMethod());
-		Assertions.assertEquals(OpenidProviderAccessMethod.INVITE_ONLY, authMap.get(OpenidProvider.orcid)
-			.accessMethod());
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.EVERYONE,
+			authMap.get(OpenidProvider.surfconext).accessMethod()
+		);
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.INVITE_ONLY,
+			authMap.get(OpenidProvider.orcid).accessMethod()
+		);
 	}
 
 	@Test
 	void whenGivenConfigWithNonExistingValue_whenParsingAuthConfig_thenThoseAreMisconfigured() {
 		String authConfig = "SURFCONEXT:EVERYONE;ORCID:INVITE_ONLY;AZURE:MISTAKE;LOCAL:";
-		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap = RsdProviders.parseAuthProvidersEnvString(authConfig);
+		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap =
+			RsdProviders.parseAuthProvidersEnvString(authConfig);
 
 		Assertions.assertEquals(4, authMap.size());
-		Assertions.assertEquals(OpenidProviderAccessMethod.EVERYONE, authMap.get(OpenidProvider.surfconext)
-			.accessMethod());
-		Assertions.assertEquals(OpenidProviderAccessMethod.INVITE_ONLY, authMap.get(OpenidProvider.orcid)
-			.accessMethod());
-		Assertions.assertEquals(OpenidProviderAccessMethod.MISCONFIGURED, authMap.get(OpenidProvider.azure)
-			.accessMethod());
-		Assertions.assertEquals(OpenidProviderAccessMethod.MISCONFIGURED, authMap.get(OpenidProvider.local)
-			.accessMethod());
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.EVERYONE,
+			authMap.get(OpenidProvider.surfconext).accessMethod()
+		);
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.INVITE_ONLY,
+			authMap.get(OpenidProvider.orcid).accessMethod()
+		);
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.MISCONFIGURED,
+			authMap.get(OpenidProvider.azure).accessMethod()
+		);
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.MISCONFIGURED,
+			authMap.get(OpenidProvider.local).accessMethod()
+		);
 
 		authConfig = "SURFCONEXT:EVERYONE:INVITE_ONLY;ORCID:INVITE_ONLY";
 		authMap = RsdProviders.parseAuthProvidersEnvString(authConfig);
 
 		Assertions.assertEquals(2, authMap.size());
-		Assertions.assertEquals(OpenidProviderAccessMethod.MISCONFIGURED, authMap.get(OpenidProvider.surfconext)
-			.accessMethod());
-		Assertions.assertEquals(OpenidProviderAccessMethod.INVITE_ONLY, authMap.get(OpenidProvider.orcid)
-			.accessMethod());
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.MISCONFIGURED,
+			authMap.get(OpenidProvider.surfconext).accessMethod()
+		);
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.INVITE_ONLY,
+			authMap.get(OpenidProvider.orcid).accessMethod()
+		);
 	}
 
 	@Test
 	void whenGivenConfigWithMissingValue_whenParsingAuthConfig_thenThoseAreMisconfigured() {
 		String authConfig = "SURFCONEXT;ORCID:INVITE_ONLY;AZURE:EVERYONE";
-		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap = RsdProviders.parseAuthProvidersEnvString(authConfig);
+		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap =
+			RsdProviders.parseAuthProvidersEnvString(authConfig);
 
 		Assertions.assertEquals(3, authMap.size());
-		Assertions.assertEquals(OpenidProviderAccessMethod.MISCONFIGURED, authMap.get(OpenidProvider.surfconext)
-			.accessMethod());
-		Assertions.assertEquals(OpenidProviderAccessMethod.INVITE_ONLY, authMap.get(OpenidProvider.orcid)
-			.accessMethod());
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.MISCONFIGURED,
+			authMap.get(OpenidProvider.surfconext).accessMethod()
+		);
+		Assertions.assertEquals(
+			OpenidProviderAccessMethod.INVITE_ONLY,
+			authMap.get(OpenidProvider.orcid).accessMethod()
+		);
 		Assertions.assertEquals(OpenidProviderAccessMethod.EVERYONE, authMap.get(OpenidProvider.azure).accessMethod());
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-		";",
-		";;;",
-		":",
-		":::",
-		";:",
-		":;",
-		";;::;;:;;;;::",
-		"::;;;;:;;;:;;;;:;;:;:;:;",
-		"a=b;c=d:e=f",
-	})
+	@ValueSource(
+		strings = { ";", ";;;", ":", ":::", ";:", ":;", ";;::;;:;;;;::", "::;;;;:;;;:;;;;:;;:;:;:;", "a=b;c=d:e=f" }
+	)
 	void whenGivenMisconfiguredConfig_whenParsingAuthConfig_thenNoExceptionThrown(String authConfig) {
-		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap = Assertions.assertDoesNotThrow(() -> RsdProviders.parseAuthProvidersEnvString(authConfig));
+		Map<OpenidProvider, RsdProviders.OpenidProviderAccessMethodOrder> authMap = Assertions.assertDoesNotThrow(() ->
+			RsdProviders.parseAuthProvidersEnvString(authConfig)
+		);
 		Assertions.assertTrue(authMap.isEmpty());
 	}
 }

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/UtilsTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/UtilsTest.java
@@ -5,15 +5,14 @@
 
 package nl.esciencecenter.rsd.authentication;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.net.URI;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpRequest;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class UtilsTest {
 

--- a/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
@@ -16,15 +16,14 @@ import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+import java.util.List;
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.util.List;
-
-@ExtendWith({SetupAllTests.class})
+@ExtendWith({ SetupAllTests.class })
 public class AuthenticationIntegrationTest {
 
 	@Test
@@ -36,11 +35,14 @@ public class AuthenticationIntegrationTest {
 	void givenUserWithoutAgreeingOnTerms_whenCreatingSoftware_thenNotAllowed() {
 		User user = User.create(false);
 
-		String expectedMessage = "You need to agree to our Terms of Service and the Privacy Statement before proceeding. Please open your user profile settings to agree.";
+		String expectedMessage =
+			"You need to agree to our Terms of Service and the Privacy Statement before proceeding. Please open your user profile settings to agree.";
 		RestAssured.given()
 			.header(user.authHeader)
 			.contentType(ContentType.JSON)
-			.body("{\"slug\": \"test-slug-user\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}")
+			.body(
+				"{\"slug\": \"test-slug-user\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}"
+			)
 			.when()
 			.post("software")
 			.then()
@@ -65,8 +67,11 @@ public class AuthenticationIntegrationTest {
 		RestAssured.given()
 			.header(user.authHeader)
 			.contentType(ContentType.JSON)
-			.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}"
-				.formatted(slug))
+			.body(
+				"{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}".formatted(
+					slug
+				)
+			)
 			.when()
 			.post("software")
 			.then()
@@ -94,8 +99,11 @@ public class AuthenticationIntegrationTest {
 		RestAssured.given()
 			.header(SetupAllTests.adminAuthHeader)
 			.contentType(ContentType.JSON)
-			.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}"
-				.formatted(slug))
+			.body(
+				"{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": true, \"short_statement\": \"Test software for testing\"}".formatted(
+					slug
+				)
+			)
 			.when()
 			.post("software")
 			.then()
@@ -130,17 +138,9 @@ public class AuthenticationIntegrationTest {
 
 	@Test
 	void givenUnauthenticatedUser_whenViewingTables_thenSuccess() {
-		RestAssured
-			.when()
-			.get("software")
-			.then()
-			.statusCode(200);
+		RestAssured.when().get("software").then().statusCode(200);
 
-		RestAssured
-			.when()
-			.get("project")
-			.then()
-			.statusCode(200);
+		RestAssured.when().get("project").then().statusCode(200);
 	}
 
 	@Test
@@ -149,8 +149,11 @@ public class AuthenticationIntegrationTest {
 		RestAssured.given()
 			.header(SetupAllTests.adminAuthHeader)
 			.contentType(ContentType.JSON)
-			.body("{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": false, \"short_statement\": \"Test software for testing\"}"
-				.formatted(slug))
+			.body(
+				"{\"slug\": \"%s\", \"brand_name\": \"Test software user\", \"is_published\": false, \"short_statement\": \"Test software for testing\"}".formatted(
+					slug
+				)
+			)
 			.when()
 			.post("software")
 			.then()
@@ -193,24 +196,17 @@ public class AuthenticationIntegrationTest {
 
 	@Test
 	void givenUnauthenticatedUser_createCategory() {
-		requestCreateDummyCategory(null)
-			.then()
-			.statusCode(401);
-
+		requestCreateDummyCategory(null).then().statusCode(401);
 	}
 
 	@Test
 	void givenAuthenticatedUser_createCategory() {
-		requestCreateDummyCategory(User.create().authHeader)
-			.then()
-			.statusCode(403);
+		requestCreateDummyCategory(User.create().authHeader).then().statusCode(403);
 	}
 
 	@Test
 	void givenAdmin_createCategory() {
-		requestCreateDummyCategory(SetupAllTests.adminAuthHeader)
-			.then()
-			.statusCode(201);
+		requestCreateDummyCategory(SetupAllTests.adminAuthHeader).then().statusCode(201);
 	}
 
 	@Test
@@ -219,9 +215,7 @@ public class AuthenticationIntegrationTest {
 
 		User user = User.create();
 		String softwareId = user.createSoftware("Software 1");
-		requestAddCategoryForSoftware(user, softwareId, categoryId)
-			.then()
-			.statusCode(201);
+		requestAddCategoryForSoftware(user, softwareId, categoryId).then().statusCode(201);
 	}
 
 	@Test
@@ -232,9 +226,7 @@ public class AuthenticationIntegrationTest {
 		String softwareId = user1.createSoftware("Software 1");
 
 		User user2 = User.create();
-		requestAddCategoryForSoftware(user2, softwareId, categoryId)
-			.then()
-			.statusCode(403);
+		requestAddCategoryForSoftware(user2, softwareId, categoryId).then().statusCode(403);
 	}
 
 	@Test
@@ -247,8 +239,7 @@ public class AuthenticationIntegrationTest {
 		addCategoryForSoftware(user, softwareId, catIds[0]);
 		addCategoryForSoftware(user, softwareId, catIds[1]);
 
-		String response = RestAssured
-			.get("/rpc/category_paths_by_software_expanded?software_id=" + softwareId)
+		String response = RestAssured.get("/rpc/category_paths_by_software_expanded?software_id=" + softwareId)
 			.then()
 			.contentType(ContentType.JSON)
 			.extract()
@@ -299,11 +290,10 @@ public class AuthenticationIntegrationTest {
 		String catId2 = createUniqueCategory("top level 2", "top level 2 long", null);
 		String catId2_1 = createUniqueCategory("sub category 2.1", "sub category 2.1 long", catId2);
 		String catId2_2 = createUniqueCategory("sub category 2.2", "sub category 2.2 long", catId2);
-		return new String[]{catId1_1, catId1_2, catId2_1, catId2_2};
+		return new String[] { catId1_1, catId1_2, catId2_1, catId2_2 };
 	}
 
 	String createCategory(String name, String short_name, String parentId, boolean makeUnique) {
-
 		if (makeUnique) {
 			String unique = " (" + Commons.createUUID() + ")";
 			name += unique;
@@ -334,13 +324,10 @@ public class AuthenticationIntegrationTest {
 	}
 
 	void addCategoryForSoftware(User user, String softwareId, String categoryId) {
-		requestAddCategoryForSoftware(user, softwareId, categoryId)
-			.then()
-			.statusCode(201);
+		requestAddCategoryForSoftware(user, softwareId, categoryId).then().statusCode(201);
 	}
 
 	Response requestAddCategoryForSoftware(User user, String softwareId, String categoryId) {
-
 		JsonObject obj = new JsonObject();
 		obj.addProperty("software_id", softwareId);
 		obj.addProperty("category_id", categoryId);
@@ -354,7 +341,6 @@ public class AuthenticationIntegrationTest {
 	}
 
 	Response requestCreateDummyCategory(Header authHeader) {
-
 		String unique = Commons.createUUID();
 
 		JsonObject obj = new JsonObject();
@@ -365,10 +351,6 @@ public class AuthenticationIntegrationTest {
 		if (authHeader != null) {
 			request.header(authHeader);
 		}
-		return request
-			.contentType(ContentType.JSON)
-			.body(obj.toString())
-			.when()
-			.post("category");
+		return request.contentType(ContentType.JSON).body(obj.toString()).when().post("category");
 	}
 }

--- a/backend-tests/src/test/java/nl/esciencecenter/Commons.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/Commons.java
@@ -1,10 +1,10 @@
 package nl.esciencecenter;
 
+import io.restassured.http.Header;
 import java.util.UUID;
 
-import io.restassured.http.Header;
-
 public class Commons {
+
 	static final Header requestEntry = new Header("Prefer", "return=representation");
 
 	static String createUUID() {

--- a/backend-tests/src/test/java/nl/esciencecenter/SetupAllTests.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/SetupAllTests.java
@@ -9,15 +9,14 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
-import org.junit.jupiter.api.extension.BeforeAllCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Date;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
 
 public class SetupAllTests implements BeforeAllCallback {
 
@@ -38,17 +37,32 @@ public class SetupAllTests implements BeforeAllCallback {
 			try {
 				HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
 				if (response.statusCode() == 200) {
-					System.out.println("Attempt %d/%d to connect to the backend on %s succeeded, continuing with the tests"
-							.formatted(i, maxTries, backendUri));
+					System.out.println(
+						"Attempt %d/%d to connect to the backend on %s succeeded, continuing with the tests".formatted(
+							i,
+							maxTries,
+							backendUri
+						)
+					);
 					client.close();
 					return;
 				}
-				System.out.println("Attempt %d/%d to connect to the backend on %s failed, trying again in 1 second"
-						.formatted(i, maxTries, backendUri));
+				System.out.println(
+					"Attempt %d/%d to connect to the backend on %s failed, trying again in 1 second".formatted(
+						i,
+						maxTries,
+						backendUri
+					)
+				);
 				Thread.sleep(1000);
 			} catch (IOException e) {
-				System.out.println("Attempt %d/%d to connect to the backend on %s failed, trying again in 1 second"
-						.formatted(i, maxTries, backendUri));
+				System.out.println(
+					"Attempt %d/%d to connect to the backend on %s failed, trying again in 1 second".formatted(
+						i,
+						maxTries,
+						backendUri
+					)
+				);
 				Thread.sleep(1000);
 			}
 		}
@@ -64,10 +78,10 @@ public class SetupAllTests implements BeforeAllCallback {
 		Algorithm signingAlgorithm = Algorithm.HMAC256(secret);
 
 		String adminToken = JWT.create()
-				.withClaim("iss", "rsd_test")
-				.withClaim("role", "rsd_admin")
-				.withExpiresAt(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // expires in one hour
-				.sign(signingAlgorithm);
+			.withClaim("iss", "rsd_test")
+			.withClaim("role", "rsd_admin")
+			.withExpiresAt(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // expires in one hour
+			.sign(signingAlgorithm);
 		adminAuthHeader = new Header("Authorization", "bearer " + adminToken);
 
 		User.adminAuthHeader = adminAuthHeader;

--- a/backend-tests/src/test/java/nl/esciencecenter/User.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/User.java
@@ -11,10 +11,10 @@ import com.google.gson.JsonObject;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
-
 import java.util.Date;
 
 public class User {
+
 	String accountId;
 	String token;
 	Header authHeader;
@@ -27,14 +27,14 @@ public class User {
 		}
 
 		String accountId = RestAssured.given()
-				.header(adminAuthHeader)
-				.header(Commons.requestEntry)
-				.when()
-				.post("account")
-				.then()
-				.statusCode(201)
-				.extract()
-				.path("[0].id");
+			.header(adminAuthHeader)
+			.header(Commons.requestEntry)
+			.when()
+			.post("account")
+			.then()
+			.statusCode(201)
+			.extract()
+			.path("[0].id");
 
 		return new User(accountId, hasAgreedTerms);
 	}
@@ -49,18 +49,17 @@ public class User {
 		obj.addProperty("notice_privacy_statement", true);
 
 		RestAssured.given()
-				.header(authHeader)
-				.contentType(ContentType.JSON)
-				.body(obj.toString())
-				.when()
-				.patch("account?id=eq." + accountId)
-				.then()
-				.statusCode(204);
+			.header(authHeader)
+			.contentType(ContentType.JSON)
+			.body(obj.toString())
+			.when()
+			.patch("account?id=eq." + accountId)
+			.then()
+			.statusCode(204);
 		return this;
 	}
 
 	String createSoftware(String brand_name) {
-
 		JsonObject obj = new JsonObject();
 		obj.addProperty("slug", "slug-" + Commons.createUUID());
 		obj.addProperty("brand_name", brand_name);
@@ -68,16 +67,16 @@ public class User {
 		obj.addProperty("short_statement", "Test software for testing");
 
 		return RestAssured.given()
-				.header(authHeader)
-				.header(Commons.requestEntry)
-				.contentType(ContentType.JSON)
-				.body(obj.toString())
-				.when()
-				.post("software")
-				.then()
-				.statusCode(201)
-				.extract()
-				.path("[0].id");
+			.header(authHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body(obj.toString())
+			.when()
+			.post("software")
+			.then()
+			.statusCode(201)
+			.extract()
+			.path("[0].id");
 	}
 
 	// To create User objects use create() instead.
@@ -96,10 +95,10 @@ public class User {
 		Algorithm signingAlgorithm = Algorithm.HMAC256(secret);
 
 		return JWT.create()
-				.withClaim("account", accountId)
-				.withClaim("iss", "rsd_test")
-				.withClaim("role", "rsd_user")
-				.withExpiresAt(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // expires in one hour
-				.sign(signingAlgorithm);
+			.withClaim("account", accountId)
+			.withClaim("iss", "rsd_test")
+			.withClaim("role", "rsd_user")
+			.withExpiresAt(new Date(System.currentTimeMillis() + 1000 * 60 * 60)) // expires in one hour
+			.sign(signingAlgorithm);
 	}
 }

--- a/backend-tests/src/test/java/nl/esciencecenter/UserDeletingItemsIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/UserDeletingItemsIntegrationTest.java
@@ -11,37 +11,37 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-@ExtendWith({SetupAllTests.class})
+@ExtendWith({ SetupAllTests.class })
 public class UserDeletingItemsIntegrationTest {
 
 	@Test
 	void givenAnonymousUser_whenCallingSoftwareDeleteEndpoint_thenErrorReturned() {
 		String softwareSlug = Commons.createUUID();
-		String softwareId = RestAssured
-				.given()
-				.header(SetupAllTests.adminAuthHeader)
-				.header(Commons.requestEntry)
-				.contentType(ContentType.JSON)
-				.body("{\"slug\":  \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug))
-				.when()
-				.post("software")
-				.then()
-				.statusCode(201)
-				.extract()
-				.jsonPath()
-				.getString("[0].id");
+		String softwareId = RestAssured.given()
+			.header(SetupAllTests.adminAuthHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body(
+				"{\"slug\":  \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug)
+			)
+			.when()
+			.post("software")
+			.then()
+			.statusCode(201)
+			.extract()
+			.jsonPath()
+			.getString("[0].id");
 
-		String errorMessage = RestAssured
-				.given()
-				.contentType(ContentType.JSON)
-				.body("{\"id\": \"%s\"}".formatted(softwareId))
-				.when()
-				.post("rpc/delete_software")
-				.then()
-				.statusCode(400)
-				.extract()
-				.jsonPath()
-				.getString("message");
+		String errorMessage = RestAssured.given()
+			.contentType(ContentType.JSON)
+			.body("{\"id\": \"%s\"}".formatted(softwareId))
+			.when()
+			.post("rpc/delete_software")
+			.then()
+			.statusCode(400)
+			.extract()
+			.jsonPath()
+			.getString("message");
 
 		Assertions.assertEquals("You are not allowed to delete this software", errorMessage);
 	}
@@ -51,32 +51,32 @@ public class UserDeletingItemsIntegrationTest {
 		User user = User.create(true);
 
 		String softwareSlug = Commons.createUUID();
-		String softwareId = RestAssured
-				.given()
-				.header(user.authHeader)
-				.header(Commons.requestEntry)
-				.contentType(ContentType.JSON)
-				.body("{\"slug\":  \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug))
-				.when()
-				.post("software")
-				.then()
-				.statusCode(201)
-				.extract()
-				.jsonPath()
-				.getString("[0].id");
+		String softwareId = RestAssured.given()
+			.header(user.authHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body(
+				"{\"slug\":  \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug)
+			)
+			.when()
+			.post("software")
+			.then()
+			.statusCode(201)
+			.extract()
+			.jsonPath()
+			.getString("[0].id");
 
-		String errorMessage = RestAssured
-				.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"id\": \"%s\"}".formatted(softwareId))
-				.when()
-				.post("rpc/delete_software")
-				.then()
-				.statusCode(400)
-				.extract()
-				.jsonPath()
-				.getString("message");
+		String errorMessage = RestAssured.given()
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"id\": \"%s\"}".formatted(softwareId))
+			.when()
+			.post("rpc/delete_software")
+			.then()
+			.statusCode(400)
+			.extract()
+			.jsonPath()
+			.getString("message");
 
 		Assertions.assertEquals("You are not allowed to delete this software", errorMessage);
 	}
@@ -86,68 +86,63 @@ public class UserDeletingItemsIntegrationTest {
 		User user = User.create(true);
 
 		String projectSlug = Commons.createUUID();
-		String projectId = RestAssured
-				.given()
-				.header(user.authHeader)
-				.header(Commons.requestEntry)
-				.contentType(ContentType.JSON)
-				.body("{\"slug\":  \"%s\", \"is_published\": true, \"title\": \"test project\"}".formatted(projectSlug))
-				.when()
-				.post("project")
-				.then()
-				.statusCode(201)
-				.extract()
-				.jsonPath()
-				.getString("[0].id");
+		String projectId = RestAssured.given()
+			.header(user.authHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body("{\"slug\":  \"%s\", \"is_published\": true, \"title\": \"test project\"}".formatted(projectSlug))
+			.when()
+			.post("project")
+			.then()
+			.statusCode(201)
+			.extract()
+			.jsonPath()
+			.getString("[0].id");
 
-		String errorMessage = RestAssured
-				.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"id\": \"%s\"}".formatted(projectId))
-				.when()
-				.post("rpc/delete_project")
-				.then()
-				.statusCode(400)
-				.extract()
-				.jsonPath()
-				.getString("message");
+		String errorMessage = RestAssured.given()
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"id\": \"%s\"}".formatted(projectId))
+			.when()
+			.post("rpc/delete_project")
+			.then()
+			.statusCode(400)
+			.extract()
+			.jsonPath()
+			.getString("message");
 
 		Assertions.assertEquals("You are not allowed to delete this project", errorMessage);
 	}
-
 
 	@Test
 	void givenRegularUser_whenCallingOrganisationDeleteEndpoint_thenErrorReturned() {
 		User user = User.create(true);
 
 		String organisationSlug = Commons.createUUID();
-		String organisationId = RestAssured
-				.given()
-				.header(user.authHeader)
-				.header(Commons.requestEntry)
-				.contentType(ContentType.JSON)
-				.body("{\"slug\":  \"%s\", \"name\": \"test organisation\"}".formatted(organisationSlug))
-				.when()
-				.post("organisation")
-				.then()
-				.statusCode(201)
-				.extract()
-				.jsonPath()
-				.getString("[0].id");
+		String organisationId = RestAssured.given()
+			.header(user.authHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body("{\"slug\":  \"%s\", \"name\": \"test organisation\"}".formatted(organisationSlug))
+			.when()
+			.post("organisation")
+			.then()
+			.statusCode(201)
+			.extract()
+			.jsonPath()
+			.getString("[0].id");
 
-		String errorMessage = RestAssured
-				.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"id\": \"%s\"}".formatted(organisationId))
-				.when()
-				.post("rpc/delete_organisation")
-				.then()
-				.statusCode(400)
-				.extract()
-				.jsonPath()
-				.getString("message");
+		String errorMessage = RestAssured.given()
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"id\": \"%s\"}".formatted(organisationId))
+			.when()
+			.post("rpc/delete_organisation")
+			.then()
+			.statusCode(400)
+			.extract()
+			.jsonPath()
+			.getString("message");
 
 		Assertions.assertEquals("You are not allowed to delete this organisation", errorMessage);
 	}
@@ -155,33 +150,31 @@ public class UserDeletingItemsIntegrationTest {
 	@Test
 	void givenRegularUser_whenCallingCommunityDeleteEndpoint_thenErrorReturned() {
 		String communitySlug = Commons.createUUID();
-		String communityId = RestAssured
-				.given()
-				.header(SetupAllTests.adminAuthHeader)
-				.header(Commons.requestEntry)
-				.contentType(ContentType.JSON)
-				.body("{\"slug\":  \"%s\", \"name\": \"test community\"}".formatted(communitySlug))
-				.when()
-				.post("community")
-				.then()
-				.statusCode(201)
-				.extract()
-				.jsonPath()
-				.getString("[0].id");
+		String communityId = RestAssured.given()
+			.header(SetupAllTests.adminAuthHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body("{\"slug\":  \"%s\", \"name\": \"test community\"}".formatted(communitySlug))
+			.when()
+			.post("community")
+			.then()
+			.statusCode(201)
+			.extract()
+			.jsonPath()
+			.getString("[0].id");
 
 		User user = User.create(true);
-		String errorMessage = RestAssured
-				.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body("{\"id\": \"%s\"}".formatted(communityId))
-				.when()
-				.post("rpc/delete_community")
-				.then()
-				.statusCode(400)
-				.extract()
-				.jsonPath()
-				.getString("message");
+		String errorMessage = RestAssured.given()
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body("{\"id\": \"%s\"}".formatted(communityId))
+			.when()
+			.post("rpc/delete_community")
+			.then()
+			.statusCode(400)
+			.extract()
+			.jsonPath()
+			.getString("message");
 
 		Assertions.assertEquals("You are not allowed to delete this community", errorMessage);
 	}

--- a/backend-tests/src/test/java/nl/esciencecenter/UserIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/UserIntegrationTest.java
@@ -8,14 +8,13 @@ package nl.esciencecenter;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.path.json.JsonPath;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
-import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
-
-@ExtendWith({SetupAllTests.class})
+@ExtendWith({ SetupAllTests.class })
 public class UserIntegrationTest {
 
 	@Test
@@ -23,49 +22,73 @@ public class UserIntegrationTest {
 		User user = User.create();
 		String accountId = user.accountId;
 
-
 		JsonPath body = RestAssured.given()
-				.header(user.authHeader)
-				.when()
-				.get("account?select=agree_terms_updated_at,notice_privacy_statement_updated_at&id=eq.%s".formatted(accountId))
-				.then()
-				.statusCode(200)
-				.extract()
-				.jsonPath();
+			.header(user.authHeader)
+			.when()
+			.get(
+				"account?select=agree_terms_updated_at,notice_privacy_statement_updated_at&id=eq.%s".formatted(
+					accountId
+				)
+			)
+			.then()
+			.statusCode(200)
+			.extract()
+			.jsonPath();
 
-		ZonedDateTime agree_terms_updated_at_database_old = ZonedDateTime.parse(body.getString("[0].agree_terms_updated_at"));
-		ZonedDateTime notice_privacy_statement_updated_at_database_old = ZonedDateTime.parse(body.getString("[0].notice_privacy_statement_updated_at"));
+		ZonedDateTime agree_terms_updated_at_database_old = ZonedDateTime.parse(
+			body.getString("[0].agree_terms_updated_at")
+		);
+		ZonedDateTime notice_privacy_statement_updated_at_database_old = ZonedDateTime.parse(
+			body.getString("[0].notice_privacy_statement_updated_at")
+		);
 
 		ZonedDateTime agree_terms_updated_at_future = ZonedDateTime.now().plusDays(10);
 		ZonedDateTime notice_privacy_statement_updated_at_future = ZonedDateTime.now().plusMonths(10);
 
-		String patchBody = "{\"agree_terms_updated_at\": \"%s\", \"notice_privacy_statement_updated_at\": \"%s\"}"
-				.formatted(agree_terms_updated_at_future.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME), notice_privacy_statement_updated_at_future.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		String patchBody =
+			"{\"agree_terms_updated_at\": \"%s\", \"notice_privacy_statement_updated_at\": \"%s\"}".formatted(
+				agree_terms_updated_at_future.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME),
+				notice_privacy_statement_updated_at_future.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+			);
 
 		RestAssured.given()
-				.header(user.authHeader)
-				.contentType(ContentType.JSON)
-				.body(patchBody)
-				.when()
-				.patch("account?id=eq.%s".formatted(accountId))
-				.then()
-				.statusCode(204);
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body(patchBody)
+			.when()
+			.patch("account?id=eq.%s".formatted(accountId))
+			.then()
+			.statusCode(204);
 
 		JsonPath bodyNew = RestAssured.given()
-				.header(user.authHeader)
-				.when()
-				.get("account?select=agree_terms_updated_at,notice_privacy_statement_updated_at&id=eq.%s".formatted(accountId))
-				.then()
-				.statusCode(200)
-				.extract()
-				.jsonPath();
+			.header(user.authHeader)
+			.when()
+			.get(
+				"account?select=agree_terms_updated_at,notice_privacy_statement_updated_at&id=eq.%s".formatted(
+					accountId
+				)
+			)
+			.then()
+			.statusCode(200)
+			.extract()
+			.jsonPath();
 
-		ZonedDateTime agree_terms_updated_at_database_new = ZonedDateTime.parse(bodyNew.getString("[0].agree_terms_updated_at"));
-		ZonedDateTime notice_privacy_statement_updated_at_database_new = ZonedDateTime.parse(bodyNew.getString("[0].notice_privacy_statement_updated_at"));
+		ZonedDateTime agree_terms_updated_at_database_new = ZonedDateTime.parse(
+			bodyNew.getString("[0].agree_terms_updated_at")
+		);
+		ZonedDateTime notice_privacy_statement_updated_at_database_new = ZonedDateTime.parse(
+			bodyNew.getString("[0].notice_privacy_statement_updated_at")
+		);
 
 		Assertions.assertEquals(agree_terms_updated_at_database_old, agree_terms_updated_at_database_new);
 		Assertions.assertNotEquals(agree_terms_updated_at_database_old, agree_terms_updated_at_future);
-		Assertions.assertEquals(notice_privacy_statement_updated_at_database_old, notice_privacy_statement_updated_at_database_new);
-		Assertions.assertNotEquals(notice_privacy_statement_updated_at_database_new, notice_privacy_statement_updated_at_future);
+		Assertions.assertEquals(
+			notice_privacy_statement_updated_at_database_old,
+			notice_privacy_statement_updated_at_database_new
+		);
+		Assertions.assertNotEquals(
+			notice_privacy_statement_updated_at_database_new,
+			notice_privacy_statement_updated_at_future
+		);
 	}
 }

--- a/background-services/src/main/java/nl/esciencecenter/rsd/AbstractService.java
+++ b/background-services/src/main/java/nl/esciencecenter/rsd/AbstractService.java
@@ -9,6 +9,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public abstract class AbstractService implements Service {
+
 	protected final Logger LOGGER = LoggerFactory.getLogger(getClass().getName());
 	private final String serviceName;
 

--- a/background-services/src/main/java/nl/esciencecenter/rsd/Main.java
+++ b/background-services/src/main/java/nl/esciencecenter/rsd/Main.java
@@ -8,13 +8,23 @@ package nl.esciencecenter.rsd;
 import java.time.LocalTime;
 
 public class Main {
+
 	public static void main(String[] args) {
 		ServiceManager serviceManager = new ServiceManager();
 
 		String VIEW_NAME_COUNT_SOFTWARE_MENTIONS = "count_software_mentions_cached";
-		Service updateCountSoftwareMentionsCached = ServiceFactory.createPeriodicService("Count Software Mentions Cached Service", 300, 30, "REFRESH MATERIALIZED VIEW CONCURRENTLY %s;".formatted(VIEW_NAME_COUNT_SOFTWARE_MENTIONS));
+		Service updateCountSoftwareMentionsCached = ServiceFactory.createPeriodicService(
+			"Count Software Mentions Cached Service",
+			300,
+			30,
+			"REFRESH MATERIALIZED VIEW CONCURRENTLY %s;".formatted(VIEW_NAME_COUNT_SOFTWARE_MENTIONS)
+		);
 
-		Service deleteExpiredAccessTokens = ServiceFactory.createScheduledService("Delete Expired Access Tokens Service", LocalTime.MIDNIGHT, "SELECT cleanup_expired_token()");
+		Service deleteExpiredAccessTokens = ServiceFactory.createScheduledService(
+			"Delete Expired Access Tokens Service",
+			LocalTime.MIDNIGHT,
+			"SELECT cleanup_expired_token()"
+		);
 
 		serviceManager.registerService(updateCountSoftwareMentionsCached);
 		serviceManager.registerService(deleteExpiredAccessTokens);

--- a/background-services/src/main/java/nl/esciencecenter/rsd/PeriodicService.java
+++ b/background-services/src/main/java/nl/esciencecenter/rsd/PeriodicService.java
@@ -13,6 +13,7 @@ import java.util.concurrent.TimeUnit;
  * PeriodicServices are executed at a fixed rate based on an interval
  */
 public class PeriodicService extends AbstractService {
+
 	private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 	private final int intervalSeconds;
 	private final int initialDelay;
@@ -34,7 +35,13 @@ public class PeriodicService extends AbstractService {
 
 	@Override
 	public void run() {
-		LOGGER.info("Scheduling periodic service %s with %s - %s".formatted(this.getServiceName(), initialDelay, intervalSeconds));
+		LOGGER.info(
+			"Scheduling periodic service %s with %s - %s".formatted(
+				this.getServiceName(),
+				initialDelay,
+				intervalSeconds
+			)
+		);
 		scheduler.scheduleAtFixedRate(this::performTask, initialDelay, intervalSeconds, TimeUnit.SECONDS);
 	}
 

--- a/background-services/src/main/java/nl/esciencecenter/rsd/PostgresRunnable.java
+++ b/background-services/src/main/java/nl/esciencecenter/rsd/PostgresRunnable.java
@@ -9,11 +9,11 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.sql.Statement;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class PostgresRunnable implements Runnable {
+
 	private final String command;
 	protected final Logger LOGGER = LoggerFactory.getLogger(getClass().getName());
 
@@ -30,8 +30,8 @@ public class PostgresRunnable implements Runnable {
 		String dbUsername = System.getenv("POSTGRES_USER");
 		String dbPassword = System.getenv("POSTGRES_PASSWORD");
 		try (
-				Connection connection = DriverManager.getConnection(dbUrl, dbUsername, dbPassword);
-				Statement statement = connection.createStatement()
+			Connection connection = DriverManager.getConnection(dbUrl, dbUsername, dbPassword);
+			Statement statement = connection.createStatement();
 		) {
 			statement.execute(command);
 		} catch (SQLException e) {

--- a/background-services/src/main/java/nl/esciencecenter/rsd/ScheduledService.java
+++ b/background-services/src/main/java/nl/esciencecenter/rsd/ScheduledService.java
@@ -16,6 +16,7 @@ import java.util.concurrent.TimeUnit;
  * ScheduledServices are executed clock time-based
  */
 public class ScheduledService extends AbstractService {
+
 	private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
 	private final LocalTime scheduleTime;
 	private final Runnable task;
@@ -64,5 +65,4 @@ public class ScheduledService extends AbstractService {
 		}
 		return Duration.between(now, nextRun).getSeconds();
 	}
-
 }

--- a/background-services/src/main/java/nl/esciencecenter/rsd/Service.java
+++ b/background-services/src/main/java/nl/esciencecenter/rsd/Service.java
@@ -11,5 +11,3 @@ public interface Service {
 	void run();
 	void terminate();
 }
-
-

--- a/background-services/src/main/java/nl/esciencecenter/rsd/ServiceFactory.java
+++ b/background-services/src/main/java/nl/esciencecenter/rsd/ServiceFactory.java
@@ -9,11 +9,21 @@ import java.time.LocalTime;
 
 public class ServiceFactory {
 
-	public static Service createPeriodicService(String serviceName, int intervalSeconds, int initialDelay, Runnable runnable) {
+	public static Service createPeriodicService(
+		String serviceName,
+		int intervalSeconds,
+		int initialDelay,
+		Runnable runnable
+	) {
 		return new PeriodicService(intervalSeconds, initialDelay, runnable, serviceName);
 	}
 
-	public static Service createPeriodicService(String serviceName, int intervalSeconds, int initialDelay, String command) {
+	public static Service createPeriodicService(
+		String serviceName,
+		int intervalSeconds,
+		int initialDelay,
+		String command
+	) {
 		return new PeriodicService(intervalSeconds, initialDelay, command, serviceName);
 	}
 
@@ -24,5 +34,4 @@ public class ServiceFactory {
 	public static Service createScheduledService(String serviceName, LocalTime scheduledTime, String command) {
 		return new ScheduledService(scheduledTime, command, serviceName);
 	}
-
 }

--- a/background-services/src/main/java/nl/esciencecenter/rsd/ServiceManager.java
+++ b/background-services/src/main/java/nl/esciencecenter/rsd/ServiceManager.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ServiceManager {
+
 	private List<Service> services = new ArrayList<>();
 
 	public void registerService(Service service) {

--- a/data-generation/.prettierignore
+++ b/data-generation/.prettierignore
@@ -1,6 +1,0 @@
-# SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2024 Netherlands eScience Center
-#
-# SPDX-License-Identifier: Apache-2.0
-
-**/*.svg

--- a/data-generation/.prettierrc.license
+++ b/data-generation/.prettierrc.license
@@ -1,4 +1,0 @@
-SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2024 Netherlands eScience Center
-
-SPDX-License-Identifier: Apache-2.0

--- a/data-generation/README.md
+++ b/data-generation/README.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
@@ -19,7 +19,3 @@ To run this locally when you have a running RSD, first install the dependencies 
 -   `PGRST_JWT_SECRET`: This should be the same as set in your `.env` file.
 
 Alternatively, you can also run this with `docker compose` simultaneously with the RSD. It is disabled by default (see the `data-generation` entry at the `docker-compose.yml` file at the root of the project), so you should run `docker compose up --scale data-generation=1` to enable it.
-
-## Contributing
-
-We use [Prettier](https://prettier.io/) for source code formatting. See the file `.prettierrc` for the applied [configuration options](https://prettier.io/docs/en/options) and see the file `.prettierignore` for files that should be [ignored](https://prettier.io/docs/en/ignore) by Prettier. Please make sure your contributions are compliant with Prettier. You can run `npm run format:check` to see which files are not compliant and `npm run format:fix` to fix them. A GitHub workflow runs on every pull request to check if all files are formatted properly.

--- a/data-generation/package-lock.json
+++ b/data-generation/package-lock.json
@@ -11,9 +11,6 @@
 				"@faker-js/faker": "9.8.0",
 				"jsonwebtoken": "9.0.2",
 				"wait-on": "8.0.3"
-			},
-			"devDependencies": {
-				"prettier": "3.3.3"
 			}
 		},
 		"node_modules/@faker-js/faker": {

--- a/data-generation/package.json
+++ b/data-generation/package.json
@@ -8,13 +8,8 @@
 	"version": "1.0.0",
 	"main": "main.js",
 	"scripts": {
-		"start": "node main.js",
-		"format:check": "prettier --check .",
-		"format:fix": "prettier --write ."
+		"start": "node main.js"
 	},
 	"description": "This module generates and stores fake data for the RSD for testing purposes",
-	"type": "module",
-	"devDependencies": {
-		"prettier": "3.3.3"
-	}
+	"type": "module"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,140 @@
+{
+  "name": "RSD-as-a-service",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "prettier": "3.6.2",
+        "prettier-plugin-java": "2.7.1"
+      }
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.0.3.tgz",
+      "integrity": "sha512-BvIKpRLeS/8UbfxXxgC33xOumsacaeCKAjAeLyOn7Pcp95HiRbrpl14S+9vaZLolnbssPIUuiUd8IvgkRyt6NQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "11.0.3",
+        "@chevrotain/types": "11.0.3",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.0.3.tgz",
+      "integrity": "sha512-+qNfcoNk70PyS/uxmj3li5NiECO+2YKZZQMbmjTqRI3Qchu8Hig/Q9vgkHpI3alNjr7M+a2St5pw5w5F6NL5/Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "11.0.3",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.0.3.tgz",
+      "integrity": "sha512-1fMHaBZxLFvWI067AVbGJav1eRY7N8DDvYCTwGBiE/ytKBgP8azTdgyrKyWZ9Mfh09eHWb5PgTSO8wi7U824RA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.0.3.tgz",
+      "integrity": "sha512-gsiM3G8b58kZC2HaWR50gu6Y1440cHiJ+i3JUvcp/35JchYejb2+5MVeJK0iKThYpAa/P2PYFV4hoi44HD+aHQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.0.3.tgz",
+      "integrity": "sha512-YslZMgtJUyuMbZ+aKvfF3x1f5liK4mWNxghFRv7jqRR9C3R3fAOGTTKvxXDa2Y1s9zSbcpuO0cAxDYsc9SrXoQ==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/chevrotain": {
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.0.3.tgz",
+      "integrity": "sha512-ci2iJH6LeIkvP9eJW6gpueU8cnZhv85ELY8w8WiFtNjMHA5ad6pQLaJo9mEly/9qUyCpvqX8/POVUTf18/HFdw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "11.0.3",
+        "@chevrotain/gast": "11.0.3",
+        "@chevrotain/regexp-to-ast": "11.0.3",
+        "@chevrotain/types": "11.0.3",
+        "@chevrotain/utils": "11.0.3",
+        "lodash-es": "4.17.21"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^11.0.0"
+      }
+    },
+    "node_modules/java-parser": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-3.0.1.tgz",
+      "integrity": "sha512-sDIR7u9b7O2JViNUxiZRhnRz7URII/eE7g2B+BmGxDeS6Ex3OYAcCyz5oh0H4LQ+hL/BS8OJTz8apMy9xtGmrQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "chevrotain": "11.0.3",
+        "chevrotain-allstar": "0.3.1",
+        "lodash": "4.17.21"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/prettier-plugin-java": {
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-2.7.1.tgz",
+      "integrity": "sha512-e03KWvC05b3L20t+i/iPlqyivH4WSBK5XQC4buwdfz+xQVyMZzG0zRIz1Tl1wPU/m94HDiZVdldu2y+XKCf3DQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "java-parser": "3.0.1"
+      },
+      "peerDependencies": {
+        "prettier": "^3.0.0"
+      }
+    }
+  }
+}

--- a/package-lock.json.license
+++ b/package-lock.json.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+
+SPDX-License-Identifier: Apache-2.0

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "scripts": {
+    "format:check": "prettier --check .",
+    "format:fix": "prettier --write ."
+  },
+  "devDependencies": {
+    "prettier": "3.6.2",
+    "prettier-plugin-java": "2.7.1"
+  }
+}

--- a/package.json.license
+++ b/package.json.license
@@ -1,0 +1,4 @@
+SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+
+SPDX-License-Identifier: Apache-2.0

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/BibtexParser.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/BibtexParser.java
@@ -5,16 +5,15 @@
 
 package nl.esciencecenter.rsd.scraper;
 
-import nl.esciencecenter.rsd.scraper.doi.Doi;
-import nl.esciencecenter.rsd.scraper.doi.ExternalMentionRecord;
-import nl.esciencecenter.rsd.scraper.doi.MentionType;
-
 import java.io.IOException;
 import java.io.LineNumberReader;
 import java.io.Reader;
 import java.net.URI;
 import java.util.Map;
 import java.util.TreeMap;
+import nl.esciencecenter.rsd.scraper.doi.Doi;
+import nl.esciencecenter.rsd.scraper.doi.ExternalMentionRecord;
+import nl.esciencecenter.rsd.scraper.doi.MentionType;
 
 // https://www.bibtex.org/Format/
 // https://www.bibtex.com/e/entry-types/
@@ -52,7 +51,7 @@ public class BibtexParser {
 		READING_MONTH,
 		READING_INTEGER,
 		READING_VALUE,
-		READING_COMMA
+		READING_COMMA,
 	}
 
 	public static Map<String, ExternalMentionRecord> parse(Reader reader) throws IOException, InvalidInputException {
@@ -96,13 +95,24 @@ public class BibtexParser {
 				case READING_ENTRY_TYPE -> {
 					if (Character.isWhitespace(c) || c == '{') {
 						if (stringBuilder.isEmpty()) {
-							throw new InvalidInputException("READING_ENTRY_TYPE Empty entry type at line %d, column %d".formatted(lineNumberReader.getLineNumber(), column));
+							throw new InvalidInputException(
+								"READING_ENTRY_TYPE Empty entry type at line %d, column %d".formatted(
+									lineNumberReader.getLineNumber(),
+									column
+								)
+							);
 						}
 						entryType = stringBuilder.toString();
 						stringBuilder.setLength(0);
 						state = c == '{' ? ParserState.BEFORE_READING_CITEKEY : ParserState.READING_ENTRY_OUTER_BRACE;
 					} else if (!isAsciiLetter(c)) {
-						throw new InvalidInputException("READING_ENTRY_TYPE Expected a letter but got %c at line %d, column %d".formatted(c, lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"READING_ENTRY_TYPE Expected a letter but got %c at line %d, column %d".formatted(
+								c,
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					} else {
 						stringBuilder.append(c);
 					}
@@ -111,12 +121,24 @@ public class BibtexParser {
 					if (c == '{') {
 						state = ParserState.BEFORE_READING_KEY;
 					} else if (!Character.isWhitespace(c)) {
-						throw new InvalidInputException("READING_ENTRY_OUTER_BRACE Expected { or whitespace but got %c at line %d, column %d".formatted(c, lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"READING_ENTRY_OUTER_BRACE Expected { or whitespace but got %c at line %d, column %d".formatted(
+								c,
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					}
 				}
 				case BEFORE_READING_CITEKEY -> {
 					if (!isValidCitekeyCharacter(c)) {
-						throw new InvalidInputException("BEFORE_READING_CITEKEY Expected an alphanumeric character or - or _ or : but got %c at line %d, column %d".formatted(c, lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"BEFORE_READING_CITEKEY Expected an alphanumeric character or - or _ or : but got %c at line %d, column %d".formatted(
+								c,
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					} else if (!Character.isWhitespace(c)) {
 						stringBuilder.setLength(0);
 						stringBuilder.append(c);
@@ -128,13 +150,24 @@ public class BibtexParser {
 						stringBuilder.append(c);
 					} else if (c == ',') {
 						if (stringBuilder.isEmpty()) {
-							throw new InvalidInputException("READING_CITEKEY Empty citekey at line %d, column %d".formatted(lineNumberReader.getLineNumber(), column));
+							throw new InvalidInputException(
+								"READING_CITEKEY Empty citekey at line %d, column %d".formatted(
+									lineNumberReader.getLineNumber(),
+									column
+								)
+							);
 						}
 						citekey = stringBuilder.toString();
 						stringBuilder.setLength(0);
 						state = ParserState.BEFORE_READING_KEY;
 					} else {
-						throw new InvalidInputException("READING_CITEKEY Expected an alphanumeric character or - or _ or : but got %c at line %d, column %d".formatted(c, lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"READING_CITEKEY Expected an alphanumeric character or - or _ or : but got %c at line %d, column %d".formatted(
+								c,
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					}
 				}
 				case BEFORE_READING_KEY -> {
@@ -146,7 +179,13 @@ public class BibtexParser {
 						stringBuilder.append(c);
 						state = ParserState.READING_KEY;
 					} else if (!Character.isWhitespace(c)) {
-						throw new InvalidInputException("BEFORE_READING_KEY Expected a letter but got %c at line %d, column %d".formatted(c, lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"BEFORE_READING_KEY Expected a letter but got %c at line %d, column %d".formatted(
+								c,
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					}
 				}
 				case READING_KEY -> {
@@ -155,20 +194,37 @@ public class BibtexParser {
 						stringBuilder.append(c);
 					} else if (Character.isWhitespace(c) || c == '=') {
 						if (stringBuilder.isEmpty()) {
-							throw new InvalidInputException("READING_KEY Empty key at line %d, column %d".formatted(lineNumberReader.getLineNumber(), column));
+							throw new InvalidInputException(
+								"READING_KEY Empty key at line %d, column %d".formatted(
+									lineNumberReader.getLineNumber(),
+									column
+								)
+							);
 						}
 						key = stringBuilder.toString();
 						stringBuilder.setLength(0);
 						state = c == '=' ? ParserState.READING_VALUE_DELIMITER : ParserState.READING_EQUALS_SIGN;
 					} else {
-						throw new InvalidInputException("READING_KEY Expected a letter or whitespace or = but got %c at line %d, column %d".formatted(c, lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"READING_KEY Expected a letter or whitespace or = but got %c at line %d, column %d".formatted(
+								c,
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					}
 				}
 				case READING_EQUALS_SIGN -> {
 					if (c == '=') {
 						state = ParserState.READING_VALUE_DELIMITER;
 					} else if (Character.isWhitespace(c)) {
-						throw new InvalidInputException("READING_EQUALS_SIGN Expected whitespace or = but got %c at line %d, column %d".formatted(c, lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"READING_EQUALS_SIGN Expected whitespace or = but got %c at line %d, column %d".formatted(
+								c,
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					}
 				}
 				case READING_VALUE_DELIMITER -> {
@@ -187,7 +243,13 @@ public class BibtexParser {
 						stringBuilder.append(c);
 						state = ParserState.READING_INTEGER;
 					} else if (!Character.isWhitespace(c)) {
-						throw new InvalidInputException("READING_VALUE_DELIMITER Expected whitespace or { or \" but got %c at line %d, column %d".formatted(c, lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"READING_VALUE_DELIMITER Expected whitespace or { or \" but got %c at line %d, column %d".formatted(
+								c,
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					}
 				}
 				case READING_MONTH -> {
@@ -195,18 +257,33 @@ public class BibtexParser {
 						if (stringBuilder.length() < 3) {
 							stringBuilder.append(c);
 						} else {
-							throw new InvalidInputException("READING_MONTH Month literal too long at line %d, column %d".formatted(lineNumberReader.getLineNumber(), column));
+							throw new InvalidInputException(
+								"READING_MONTH Month literal too long at line %d, column %d".formatted(
+									lineNumberReader.getLineNumber(),
+									column
+								)
+							);
 						}
 					} else if (Character.isWhitespace(c) || c == ',') {
 						if (stringBuilder.length() != 3) {
-							throw new InvalidInputException("READING_MONTH Month literal too short at line %d, column %d".formatted(lineNumberReader.getLineNumber(), column));
+							throw new InvalidInputException(
+								"READING_MONTH Month literal too short at line %d, column %d".formatted(
+									lineNumberReader.getLineNumber(),
+									column
+								)
+							);
 						} else {
 							keyValues.put(key, stringBuilder.toString());
 							stringBuilder.setLength(0);
 							state = c == ',' ? ParserState.BEFORE_READING_KEY : ParserState.READING_COMMA;
 						}
 					} else {
-						throw new InvalidInputException("READING_MONTH Illegal month literal at line %d, column %d".formatted(lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"READING_MONTH Illegal month literal at line %d, column %d".formatted(
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					}
 				}
 				case READING_INTEGER -> {
@@ -217,7 +294,12 @@ public class BibtexParser {
 						stringBuilder.setLength(0);
 						state = c == ',' ? ParserState.BEFORE_READING_KEY : ParserState.READING_COMMA;
 					} else {
-						throw new InvalidInputException("READING_INTEGER Illegal integer literal at line %d, column %d".formatted(lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"READING_INTEGER Illegal integer literal at line %d, column %d".formatted(
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					}
 				}
 				case READING_VALUE -> {
@@ -226,7 +308,12 @@ public class BibtexParser {
 					} else if (c == '}') {
 						--openBraceCount;
 						if (openBraceCount < 0 && valueDelimiter != '{') {
-							throw new InvalidInputException("READING_VALUE Unmatched closing brace at line %d, column %d".formatted(lineNumberReader.getLineNumber(), column));
+							throw new InvalidInputException(
+								"READING_VALUE Unmatched closing brace at line %d, column %d".formatted(
+									lineNumberReader.getLineNumber(),
+									column
+								)
+							);
 						} else if (openBraceCount < 0) {
 							keyValues.put(key, stringBuilder.toString());
 							stringBuilder.setLength(0);
@@ -248,14 +335,23 @@ public class BibtexParser {
 						state = ParserState.BETWEEN_ENTRIES;
 						handleEntry(keyValues, entryType, citekey, result);
 					} else if (!Character.isWhitespace(c)) {
-						throw new InvalidInputException("READING_COMMA Expected whitespace or , or } but got %c at line %d, column %d".formatted(c, lineNumberReader.getLineNumber(), column));
+						throw new InvalidInputException(
+							"READING_COMMA Expected whitespace or , or } but got %c at line %d, column %d".formatted(
+								c,
+								lineNumberReader.getLineNumber(),
+								column
+							)
+						);
 					}
 				}
 			}
 		}
 	}
 
-	static Map<String, ExternalMentionRecord> handleEndOfInput(Map<String, ExternalMentionRecord> result, ParserState state) throws InvalidInputException {
+	static Map<String, ExternalMentionRecord> handleEndOfInput(
+		Map<String, ExternalMentionRecord> result,
+		ParserState state
+	) throws InvalidInputException {
 		if (state == ParserState.BETWEEN_ENTRIES) {
 			return result;
 		} else {
@@ -264,17 +360,14 @@ public class BibtexParser {
 	}
 
 	static boolean isValidCitekeyCharacter(char c) {
-		return (c >= 'a' && c <= 'z')
-			||
-			(c >= 'A' && c <= 'Z')
-			||
-			(c >= '0' && c <= '9')
-			||
-			c == '-'
-			||
-			c == '_'
-			||
-			c == ':';
+		return (
+			(c >= 'a' && c <= 'z') ||
+			(c >= 'A' && c <= 'Z') ||
+			(c >= '0' && c <= '9') ||
+			c == '-' ||
+			c == '_' ||
+			c == ':'
+		);
 	}
 
 	static boolean isAsciiLetter(char c) {
@@ -332,4 +425,3 @@ public class BibtexParser {
 		keyValues.clear();
 	}
 }
-

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Config.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Config.java
@@ -9,10 +9,9 @@
 
 package nl.esciencecenter.rsd.scraper;
 
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Optional;
 
 /**
  * Helper class to retrieve various environment variables.
@@ -23,8 +22,7 @@ public class Config {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(Config.class);
 
-	private Config() {
-	}
+	private Config() {}
 
 	/**
 	 * Retrieves the value of the environment variable with the given name. Variable is not allowed to unset, and an Error
@@ -34,7 +32,6 @@ public class Config {
 	 * @return the value of the variable.
 	 */
 	private static String getMandatoryEnv(String name) {
-
 		if (name == null || name.isBlank()) {
 			LOGGER.error("Attempting to retrieve mandatory environment variable without a name!");
 			throw new Error("Attempting to retrieve mandatory environment variable without a name!");
@@ -64,7 +61,6 @@ public class Config {
 	 * @return the value of the variable if set, or empty Optional otherwise.
 	 */
 	private static Optional<String> getOptionalEnv(String name) {
-
 		if (name == null || name.isBlank()) {
 			LOGGER.warn("Attempting to retrieve environment variable without a name!");
 			return Optional.empty();
@@ -88,7 +84,6 @@ public class Config {
 	 * @return the value from the environment of the default value if no value could be obtained
 	 */
 	private static int getIntEnv(String name, int defaultValue) {
-
 		if (name == null || name.isBlank()) {
 			LOGGER.warn("Attempting to retrieve environment variable without a name!");
 			return defaultValue;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Utils.java
@@ -13,9 +13,6 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
@@ -32,6 +29,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.UUID;
 import java.util.function.Function;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Utils {
 
@@ -40,8 +39,7 @@ public class Utils {
 	// Default timeout used for http connections.
 	private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(30);
 
-	private Utils() {
-	}
+	private Utils() {}
 
 	/**
 	 * Base64encode a string.
@@ -73,11 +71,17 @@ public class Utils {
 	 * @throws InterruptedException
 	 * @throws RsdResponseException
 	 */
-	public static String get(String uri, String... headers) throws IOException, InterruptedException, RsdResponseException {
+	public static String get(String uri, String... headers)
+		throws IOException, InterruptedException, RsdResponseException {
 		HttpResponse<String> response = getAsHttpResponse(uri, headers);
 
 		if (response.statusCode() >= 300) {
-			throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Unexpected response");
+			throw new RsdResponseException(
+				response.statusCode(),
+				response.uri(),
+				response.body(),
+				"Unexpected response"
+			);
 		}
 
 		return response.body();
@@ -92,7 +96,8 @@ public class Utils {
 	 * @throws IOException
 	 * @throws InterruptedException
 	 */
-	public static HttpResponse<String> getAsHttpResponse(String uri, String... headers) throws IOException, InterruptedException {
+	public static HttpResponse<String> getAsHttpResponse(String uri, String... headers)
+		throws IOException, InterruptedException {
 		HttpRequest.Builder httpRequestBuilder = HttpRequest.newBuilder()
 			.GET()
 			.timeout(DEFAULT_TIMEOUT)
@@ -136,7 +141,9 @@ public class Utils {
 		}
 
 		if (response.statusCode() >= 300) {
-			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+			throw new RuntimeException(
+				"Error fetching data from endpoint " + uri + " with response: " + response.body()
+			);
 		}
 		return response.body();
 	}
@@ -171,7 +178,9 @@ public class Utils {
 		}
 
 		if (response.statusCode() >= 300) {
-			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+			throw new RuntimeException(
+				"Error fetching data from endpoint " + uri + " with response: " + response.body()
+			);
 		}
 		return response.body();
 	}
@@ -208,7 +217,9 @@ public class Utils {
 		}
 
 		if (response.statusCode() >= 300) {
-			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+			throw new RuntimeException(
+				"Error fetching data from endpoint " + uri + " with response: " + response.body()
+			);
 		}
 		return response.body();
 	}
@@ -237,7 +248,12 @@ public class Utils {
 		postAsAdmin(Config.backendBaseUrl() + "/backend_log", logData.toString());
 	}
 
-	public static void saveExceptionInDatabase(String serviceName, String tableName, UUID referenceId, RsdResponseException e) {
+	public static void saveExceptionInDatabase(
+		String serviceName,
+		String tableName,
+		UUID referenceId,
+		RsdResponseException e
+	) {
 		JsonObject logData = basicData(serviceName, tableName, referenceId, e);
 
 		JsonObject other = new JsonObject();
@@ -250,7 +266,12 @@ public class Utils {
 		postAsAdmin(Config.backendBaseUrl() + "/backend_log", logData.toString());
 	}
 
-	public static void saveExceptionInDatabase(String serviceName, String tableName, UUID referenceId, RsdRateLimitException e) {
+	public static void saveExceptionInDatabase(
+		String serviceName,
+		String tableName,
+		UUID referenceId,
+		RsdRateLimitException e
+	) {
 		JsonObject logData = basicData(serviceName, tableName, referenceId, e);
 
 		JsonObject other = new JsonObject();
@@ -263,7 +284,15 @@ public class Utils {
 		postAsAdmin(Config.backendBaseUrl() + "/backend_log", logData.toString());
 	}
 
-	public static void saveErrorMessageInDatabase(String message, String tableName, String columnName, String primaryKey, String primaryKeyName, ZonedDateTime scrapedAt, String scrapedAtName) {
+	public static void saveErrorMessageInDatabase(
+		String message,
+		String tableName,
+		String columnName,
+		String primaryKey,
+		String primaryKeyName,
+		ZonedDateTime scrapedAt,
+		String scrapedAtName
+	) {
 		JsonObject body = new JsonObject();
 		if (columnName != null) {
 			body.addProperty(columnName, message);
@@ -304,12 +333,15 @@ public class Utils {
 			throw new RuntimeException(e);
 		}
 		if (response.statusCode() >= 300) {
-			throw new RuntimeException("Error fetching data from endpoint " + uri + " with response: " + response.body());
+			throw new RuntimeException(
+				"Error fetching data from endpoint " + uri + " with response: " + response.body()
+			);
 		}
 		return response.body();
 	}
 
-	public static String deleteAsAdmin(String uri, String... extraHeaders) throws IOException, InterruptedException, RsdResponseException {
+	public static String deleteAsAdmin(String uri, String... extraHeaders)
+		throws IOException, InterruptedException, RsdResponseException {
 		String jwtString = adminJwt();
 		HttpRequest.Builder builder = HttpRequest.newBuilder()
 			.method("DELETE", HttpRequest.BodyPublishers.noBody())
@@ -325,7 +357,12 @@ public class Utils {
 			response = client.send(request, HttpResponse.BodyHandlers.ofString());
 		}
 		if (response.statusCode() >= 300) {
-			throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Error deleting data as admin");
+			throw new RsdResponseException(
+				response.statusCode(),
+				response.uri(),
+				response.body(),
+				"Error deleting data as admin"
+			);
 		}
 		return response.body();
 	}
@@ -363,9 +400,9 @@ public class Utils {
 	 * @return the filter.
 	 */
 	public static String atLeastOneHourAgoFilter(String scrapedAtColumnName) {
-		String oneHourAgoEncoded = urlEncode(ZonedDateTime.now()
-			.minusHours(1)
-			.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		String oneHourAgoEncoded = urlEncode(
+			ZonedDateTime.now().minusHours(1).format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+		);
 		return "or=(%s.is.null,%s.lte.%s)".formatted(scrapedAtColumnName, scrapedAtColumnName, oneHourAgoEncoded);
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/aggregator/RemoteRsdConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/aggregator/RemoteRsdConnector.java
@@ -7,12 +7,11 @@ package nl.esciencecenter.rsd.scraper.aggregator;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.StringJoiner;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class RemoteRsdConnector {
 
@@ -38,10 +37,10 @@ public class RemoteRsdConnector {
 		SELECT_LIST = selectListBuilder.toString();
 	}
 
-	private RemoteRsdConnector() {
-	}
+	private RemoteRsdConnector() {}
 
-	public static JsonArray getAllSoftware(URI remoteDomain) throws RsdResponseException, IOException, InterruptedException {
+	public static JsonArray getAllSoftware(URI remoteDomain)
+		throws RsdResponseException, IOException, InterruptedException {
 		String path = "/api/v1/rpc/software_overview?select=" + SELECT_LIST;
 		String url = remoteDomain.toString() + path;
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/aggregator/RemoteRsdData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/aggregator/RemoteRsdData.java
@@ -17,5 +17,4 @@ public record RemoteRsdData(
 	Duration refreshInterval,
 	ZonedDateTime refreshedAt,
 	Collection<UUID> softwareIds
-) {
-}
+) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CitationData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CitationData.java
@@ -12,16 +12,15 @@ import java.util.UUID;
  * Container class for Citation information retrieved from the database.
  */
 public record CitationData(
-		// UUID of this entry in the database
-		UUID id,
+	// UUID of this entry in the database
+	UUID id,
 
-		// DOI of this entry.
-		Doi doi,
+	// DOI of this entry.
+	Doi doi,
 
-		// OpenAlex ID of this entry
-		OpenalexId openalexId,
+	// OpenAlex ID of this entry
+	OpenalexId openalexId,
 
-		// List of known DOIs citing this entry.
-		Collection<Doi> knownDois
-) {
-}
+	// List of known DOIs citing this entry.
+	Collection<Doi> knownDois
+) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
@@ -10,10 +10,6 @@ package nl.esciencecenter.rsd.scraper.doi;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.Config;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
@@ -21,6 +17,9 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import nl.esciencecenter.rsd.scraper.Config;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class CrossrefMention {
 
@@ -68,7 +67,9 @@ public class CrossrefMention {
 	}
 
 	public ExternalMentionRecord mentionData() throws IOException, InterruptedException, RsdResponseException {
-		StringBuilder crossrefUrlBuilder = new StringBuilder("https://api.crossref.org/works/" + Utils.urlEncode(doi.toString()));
+		StringBuilder crossrefUrlBuilder = new StringBuilder(
+			"https://api.crossref.org/works/" + Utils.urlEncode(doi.toString())
+		);
 		Config.crossrefContactEmail().ifPresent(email -> crossrefUrlBuilder.append("?mailto=").append(email));
 		String responseJson = Utils.get(crossrefUrlBuilder.toString());
 		JsonObject jsonTree = JsonParser.parseString(responseJson).getAsJsonObject();
@@ -101,7 +102,9 @@ public class CrossrefMention {
 		String publisher = Utils.stringOrNull(workJson.get("publisher"));
 		Integer publicationYear = null;
 		try {
-			publicationYear = Utils.integerOrNull(workJson.getAsJsonObject("published").getAsJsonArray("date-parts").get(0).getAsJsonArray().get(0));
+			publicationYear = Utils.integerOrNull(
+				workJson.getAsJsonObject("published").getAsJsonArray("date-parts").get(0).getAsJsonArray().get(0)
+			);
 		} catch (RuntimeException e) {
 			//			year not found, we leave it at null, nothing to do
 		}
@@ -115,22 +118,25 @@ public class CrossrefMention {
 			journal = journalBuilder.toString();
 		}
 		String page = Utils.stringOrNull(workJson.get("page"));
-		MentionType mentionType = crossrefTypeMap.getOrDefault(Utils.stringOrNull(workJson.get("type")), MentionType.other);
+		MentionType mentionType = crossrefTypeMap.getOrDefault(
+			Utils.stringOrNull(workJson.get("type")),
+			MentionType.other
+		);
 
 		return new ExternalMentionRecord(
-				this.doi,
-				null,
-				null,
-				mentionUrl,
-				title,
-				authors,
-				publisher,
-				publicationYear,
-				journal,
-				page,
-				mentionType,
-				"Crossref",
-				null
+			this.doi,
+			null,
+			null,
+			mentionUrl,
+			title,
+			authors,
+			publisher,
+			publicationYear,
+			journal,
+			page,
+			mentionType,
+			"Crossref",
+			null
 		);
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataCiteReleaseRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataCiteReleaseRepository.java
@@ -9,15 +9,14 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import nl.esciencecenter.rsd.scraper.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DataCiteReleaseRepository {
 
@@ -39,6 +38,7 @@ public class DataCiteReleaseRepository {
 		  }
 		}
 		""";
+
 	// editorconfig-checker-enable
 
 	public Map<Doi, Collection<ExternalMentionRecord>> getVersionedDois(Collection<Doi> conceptDois) {
@@ -49,7 +49,12 @@ public class DataCiteReleaseRepository {
 		String query = QUERY_UNFORMATTED.formatted(DataciteMentionRepository.joinDoisForGraphqlQuery(conceptDois));
 		JsonObject body = new JsonObject();
 		body.addProperty("query", query);
-		String responseJson = Utils.post("https://api.datacite.org/graphql", body.toString(), "Content-Type", "application/json");
+		String responseJson = Utils.post(
+			"https://api.datacite.org/graphql",
+			body.toString(),
+			"Content-Type",
+			"application/json"
+		);
 		return parseJson(responseJson);
 	}
 
@@ -77,13 +82,19 @@ public class DataCiteReleaseRepository {
 					String relationType = relatedIdentifierObject.getAsJsonPrimitive("relationType").getAsString();
 					if (relationType == null || !relationType.equals("HasVersion")) continue;
 
-					String relatedIdentifierType = relatedIdentifierObject.getAsJsonPrimitive("relatedIdentifierType").getAsString();
+					String relatedIdentifierType = relatedIdentifierObject
+						.getAsJsonPrimitive("relatedIdentifierType")
+						.getAsString();
 					if (relatedIdentifierType == null || !relatedIdentifierType.equals("DOI")) continue;
 
-					String relatedIdentifierDoi = relatedIdentifierObject.getAsJsonPrimitive("relatedIdentifier").getAsString();
+					String relatedIdentifierDoi = relatedIdentifierObject
+						.getAsJsonPrimitive("relatedIdentifier")
+						.getAsString();
 					versionDois.add(Doi.fromString(relatedIdentifierDoi));
 				}
-				Collection<ExternalMentionRecord> versionedMentions = dataciteMentionRepository.mentionData(versionDois);
+				Collection<ExternalMentionRecord> versionedMentions = dataciteMentionRepository.mentionData(
+					versionDois
+				);
 
 				releasesPerConceptDoi.put(conceptDoi, versionedMentions);
 			} catch (RuntimeException e) {

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -9,10 +9,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.net.URI;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
@@ -25,6 +21,9 @@ import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import nl.esciencecenter.rsd.scraper.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class DataciteMentionRepository {
 
@@ -113,9 +112,7 @@ public class DataciteMentionRepository {
 
 	// "10.5281/zenodo.1408128","10.1186/s12859-018-2165-7"
 	static String joinDoisForGraphqlQuery(Collection<Doi> dois) {
-		return dois.stream()
-			.map(Doi::toString)
-			.collect(Collectors.joining("\",\"", "\"", "\""));
+		return dois.stream().map(Doi::toString).collect(Collectors.joining("\",\"", "\"", "\""));
 	}
 
 	static Collection<ExternalMentionRecord> jsonStringToUniqueMentions(String json) {
@@ -165,7 +162,9 @@ public class DataciteMentionRepository {
 		}
 
 		MentionType mentionType;
-		String dataciteResourceTypeGeneral = Utils.stringOrNull(work.getAsJsonObject("types").get("resourceTypeGeneral"));
+		String dataciteResourceTypeGeneral = Utils.stringOrNull(
+			work.getAsJsonObject("types").get("resourceTypeGeneral")
+		);
 		if (dataciteResourceTypeGeneral != null && dataciteResourceTypeGeneral.equals("Text")) {
 			String dataciteResourceType = Utils.stringOrNull(work.getAsJsonObject("types").get("resourceType"));
 			if (dataciteResourceType != null) dataciteResourceType = dataciteResourceType.strip();
@@ -178,9 +177,17 @@ public class DataciteMentionRepository {
 		if (version == null) {
 			JsonArray relatedIdentifiers = work.getAsJsonArray("relatedIdentifiers");
 			for (JsonElement relatedIdentifier : relatedIdentifiers) {
-				String relatedIdentifierString = Utils.stringOrNull(relatedIdentifier.getAsJsonObject().get("relatedIdentifier"));
-				String relatedIdentifierType = Utils.stringOrNull(relatedIdentifier.getAsJsonObject().get("relatedIdentifierType"));
-				if (relatedIdentifierString != null && relatedIdentifierType != null && relatedIdentifierType.equals("URL")) {
+				String relatedIdentifierString = Utils.stringOrNull(
+					relatedIdentifier.getAsJsonObject().get("relatedIdentifier")
+				);
+				String relatedIdentifierType = Utils.stringOrNull(
+					relatedIdentifier.getAsJsonObject().get("relatedIdentifierType")
+				);
+				if (
+					relatedIdentifierString != null &&
+					relatedIdentifierType != null &&
+					relatedIdentifierType.equals("URL")
+				) {
 					Matcher tagMatcher = URL_TREE_TAG_PATTERN.matcher(relatedIdentifierString);
 					if (tagMatcher.find()) {
 						version = tagMatcher.group(1);
@@ -223,7 +230,12 @@ public class DataciteMentionRepository {
 
 		JsonObject body = new JsonObject();
 		body.addProperty("query", QUERY_UNFORMATTED.formatted(joinDoisForGraphqlQuery(dois)));
-		String responseJson = Utils.post("https://api.datacite.org/graphql", body.toString(), "Content-Type", "application/json");
+		String responseJson = Utils.post(
+			"https://api.datacite.org/graphql",
+			body.toString(),
+			"Content-Type",
+			"application/json"
+		);
 		return jsonStringToUniqueMentions(responseJson);
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/Doi.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/Doi.java
@@ -5,10 +5,9 @@
 
 package nl.esciencecenter.rsd.scraper.doi;
 
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.util.Locale;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class Doi {
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/ExternalMentionRecord.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/ExternalMentionRecord.java
@@ -9,18 +9,17 @@ import java.net.URI;
 import java.time.ZonedDateTime;
 
 public record ExternalMentionRecord(
-		Doi doi,
-		ZonedDateTime doiRegistrationDate,
-		OpenalexId openalexId,
-		URI url,
-		String title,
-		String authors,
-		String publisher,
-		Integer publicationYear,
-		String journal,
-		String page,
-		MentionType mentionType,
-		String source,
-		String version
-) {
-}
+	Doi doi,
+	ZonedDateTime doiRegistrationDate,
+	OpenalexId openalexId,
+	URI url,
+	String title,
+	String authors,
+	String publisher,
+	Integer publicationYear,
+	String journal,
+	String page,
+	MentionType mentionType,
+	String source,
+	String version
+) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
@@ -9,11 +9,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.Config;
-import nl.esciencecenter.rsd.scraper.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,19 +19,24 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import nl.esciencecenter.rsd.scraper.Config;
+import nl.esciencecenter.rsd.scraper.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MainMentions {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MainMentions.class);
 
 	public static void main(String[] args) {
-
 		LOGGER.info("Start scraping mentions");
 
 		long t1 = System.currentTimeMillis();
 
 		PostgrestMentionRepository localMentionRepository = new PostgrestMentionRepository(Config.backendBaseUrl());
-		Collection<RsdMentionIds> mentionsToScrape = localMentionRepository.leastRecentlyScrapedMentions(Config.maxRequestsDoi());
+		Collection<RsdMentionIds> mentionsToScrape = localMentionRepository.leastRecentlyScrapedMentions(
+			Config.maxRequestsDoi()
+		);
 		// we will remove successfully scraped mentions from here,
 		// we use this to set scrapedAt even for failed mentions,
 		// to put them back at the scraping queue
@@ -58,11 +58,12 @@ public class MainMentions {
 			}
 		}
 
-		String doisJoined = mentionsToScrape.stream()
-				.map(RsdMentionIds::doi)
-				.filter(Objects::nonNull)
-				.map(Doi::toUrlEncodedString)
-				.collect(Collectors.joining(","));
+		String doisJoined = mentionsToScrape
+			.stream()
+			.map(RsdMentionIds::doi)
+			.filter(Objects::nonNull)
+			.map(Doi::toUrlEncodedString)
+			.collect(Collectors.joining(","));
 		String jsonSources = null;
 		try {
 			jsonSources = Utils.get("https://doi.org/doiRA/" + doisJoined);
@@ -77,17 +78,21 @@ public class MainMentions {
 
 		// DATACITE
 		final String dataciteDoiRaKey = "DataCite";
-		Collection<Doi> dataciteDois = doiToSource.entrySet()
-				.stream()
-				.filter(doiSourceEntry -> doiSourceEntry.getValue().equals(dataciteDoiRaKey))
-				.map(Map.Entry::getKey)
-				.map(Doi::fromString)
-				.toList();
+		Collection<Doi> dataciteDois = doiToSource
+			.entrySet()
+			.stream()
+			.filter(doiSourceEntry -> doiSourceEntry.getValue().equals(dataciteDoiRaKey))
+			.map(Map.Entry::getKey)
+			.map(Doi::fromString)
+			.toList();
 		Collection<ExternalMentionRecord> scrapedDataciteMentions = List.of();
 		try {
 			scrapedDataciteMentions = new DataciteMentionRepository().mentionData(dataciteDois);
 		} catch (RuntimeException e) {
-			Exception exceptionToSave = new Exception("Failed scraping the following DataCite DOIs: " + dataciteDois, e);
+			Exception exceptionToSave = new Exception(
+				"Failed scraping the following DataCite DOIs: " + dataciteDois,
+				e
+			);
 			Utils.saveExceptionInDatabase("DataCite mention scraper", "mention", null, exceptionToSave);
 		}
 		for (ExternalMentionRecord scrapedMention : scrapedDataciteMentions) {
@@ -101,18 +106,18 @@ public class MainMentions {
 				LOGGER.error("Failed to update a DataCite mention with DOI {}", scrapedMention.doi());
 				Utils.saveExceptionInDatabase("Mention scraper", "mention", id, e);
 			}
-
 		}
 		// END DATACITE
 
 		// CROSSREF
 		final String crossrefDoiRaKey = "Crossref";
-		Collection<Doi> crossrefDois = doiToSource.entrySet()
-				.stream()
-				.filter(doiSourceEntry -> doiSourceEntry.getValue().equals(crossrefDoiRaKey))
-				.map(Map.Entry::getKey)
-				.map(Doi::fromString)
-				.toList();
+		Collection<Doi> crossrefDois = doiToSource
+			.entrySet()
+			.stream()
+			.filter(doiSourceEntry -> doiSourceEntry.getValue().equals(crossrefDoiRaKey))
+			.map(Map.Entry::getKey)
+			.map(Doi::fromString)
+			.toList();
 		for (Doi crossrefDoi : crossrefDois) {
 			ExternalMentionRecord scrapedMention;
 			UUID id = doiToId.get(crossrefDoi);
@@ -120,7 +125,10 @@ public class MainMentions {
 				scrapedMention = new CrossrefMention(crossrefDoi).mentionData();
 			} catch (Exception e) {
 				LOGGER.error("Failed to scrape a Crossref mention with DOI {}", crossrefDoi);
-				RuntimeException exceptionWithMessage = new RuntimeException("Failed to scrape a Crossref mention with DOI " + crossrefDoi, e);
+				RuntimeException exceptionWithMessage = new RuntimeException(
+					"Failed to scrape a Crossref mention with DOI " + crossrefDoi,
+					e
+				);
 				Utils.saveExceptionInDatabase("Crossref mention scraper", "mention", id, exceptionWithMessage);
 				continue;
 			}
@@ -129,7 +137,10 @@ public class MainMentions {
 				localMentionRepository.updateMention(mentionToUpdate, false);
 				mentionsFailedToScrape.remove(id);
 			} catch (Exception e) {
-				RuntimeException exceptionWithMessage = new RuntimeException("Failed to update a Crossref mention with DOI " + crossrefDoi, e);
+				RuntimeException exceptionWithMessage = new RuntimeException(
+					"Failed to update a Crossref mention with DOI " + crossrefDoi,
+					e
+				);
 				Utils.saveExceptionInDatabase("Crossref mention scraper", "mention", id, exceptionWithMessage);
 			}
 		}
@@ -139,28 +150,41 @@ public class MainMentions {
 		String email = Config.crossrefContactEmail().orElse(null);
 		Collection<ExternalMentionRecord> scrapedOpenalexMentions = new ArrayList<>();
 		OpenAlexConnector openAlexConnector = new OpenAlexConnector();
-		Collection<String> invalidDoiRas = Set.of(dataciteDoiRaKey, crossrefDoiRaKey, "Invalid DOI", "DOI does not exist", "Unknown");
-		Collection<Doi> europeanPublicationsOfficeDois = doiToSource.entrySet()
-				.stream()
-				.filter(doiSourceEntry -> !invalidDoiRas.contains(doiSourceEntry.getValue()))
-				.map(Map.Entry::getKey)
-				.map(Doi::fromString)
-				.toList();
+		Collection<String> invalidDoiRas = Set.of(
+			dataciteDoiRaKey,
+			crossrefDoiRaKey,
+			"Invalid DOI",
+			"DOI does not exist",
+			"Unknown"
+		);
+		Collection<Doi> europeanPublicationsOfficeDois = doiToSource
+			.entrySet()
+			.stream()
+			.filter(doiSourceEntry -> !invalidDoiRas.contains(doiSourceEntry.getValue()))
+			.map(Map.Entry::getKey)
+			.map(Doi::fromString)
+			.toList();
 		try {
 			scrapedOpenalexMentions.addAll(openAlexConnector.mentionDataByDois(europeanPublicationsOfficeDois, email));
 		} catch (Exception e) {
-			Exception exceptionToSave = new Exception("Failed scraping the following EPO DOIs: " + europeanPublicationsOfficeDois, e);
+			Exception exceptionToSave = new Exception(
+				"Failed scraping the following EPO DOIs: " + europeanPublicationsOfficeDois,
+				e
+			);
 			Utils.saveExceptionInDatabase("OpenAlex mention scraper", "mention", null, exceptionToSave);
 		}
 		Collection<OpenalexId> openalexIdsToScrape = mentionsToScrape
-				.stream()
-				.filter(ids -> ids.doi() == null && ids.openalexId() != null)
-				.map(RsdMentionIds::openalexId)
-				.toList();
+			.stream()
+			.filter(ids -> ids.doi() == null && ids.openalexId() != null)
+			.map(RsdMentionIds::openalexId)
+			.toList();
 		try {
 			scrapedOpenalexMentions.addAll(openAlexConnector.mentionDataByOpenalexIds(openalexIdsToScrape, email));
 		} catch (Exception e) {
-			Exception exceptionToSave = new Exception("Failed scraping the following OpenAlex IDs: " + openalexIdsToScrape, e);
+			Exception exceptionToSave = new Exception(
+				"Failed scraping the following OpenAlex IDs: " + openalexIdsToScrape,
+				e
+			);
 			Utils.saveExceptionInDatabase("OpenAlex mention scraper", "mention", null, exceptionToSave);
 		}
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainReleases.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainReleases.java
@@ -5,16 +5,15 @@
 
 package nl.esciencecenter.rsd.scraper.doi;
 
-import nl.esciencecenter.rsd.scraper.Config;
-import nl.esciencecenter.rsd.scraper.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.time.Instant;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
+import nl.esciencecenter.rsd.scraper.Config;
+import nl.esciencecenter.rsd.scraper.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /*
  * 1. Get the least recently scraped releases from software with a concept DOI. We also check for existing releases that already exist as a mention in the database, so we don't have to (TODO) recreate them later.
@@ -26,26 +25,31 @@ public class MainReleases {
 	private static final Logger LOGGER = LoggerFactory.getLogger(MainReleases.class);
 
 	public static void main(String[] args) {
-
 		LOGGER.info("Start scraping releases");
 
 		long t1 = System.currentTimeMillis();
 
 		PostgrestReleaseRepository releaseRepository = new PostgrestReleaseRepository(Config.backendBaseUrl());
 
-		Collection<ReleaseData> releasesToScrape = releaseRepository.leastRecentlyScrapedReleases(Config.maxRequestsDoi());
+		Collection<ReleaseData> releasesToScrape = releaseRepository.leastRecentlyScrapedReleases(
+			Config.maxRequestsDoi()
+		);
 
-		Collection<Doi> conceptDoisToScrape = releasesToScrape.stream()
-				.map(releaseData -> releaseData.conceptDoi)
-				.toList();
+		Collection<Doi> conceptDoisToScrape = releasesToScrape
+			.stream()
+			.map(releaseData -> releaseData.conceptDoi)
+			.toList();
 
-		Map<Doi, Collection<ExternalMentionRecord>> scrapedReleasesPerConceptDoi = new DataCiteReleaseRepository().getVersionedDois(conceptDoisToScrape);
+		Map<Doi, Collection<ExternalMentionRecord>> scrapedReleasesPerConceptDoi =
+			new DataCiteReleaseRepository().getVersionedDois(conceptDoisToScrape);
 
 		Instant now = Instant.now();
 		PostgrestMentionRepository localMentionRepository = new PostgrestMentionRepository(Config.backendBaseUrl());
-		Collection<ExternalMentionRecord> allMentions = scrapedReleasesPerConceptDoi.values().stream()
-				.flatMap(Collection::stream)
-				.toList();
+		Collection<ExternalMentionRecord> allMentions = scrapedReleasesPerConceptDoi
+			.values()
+			.stream()
+			.flatMap(Collection::stream)
+			.toList();
 		Map<Doi, UUID> doiToId = new HashMap<>();
 		for (ExternalMentionRecord mention : allMentions) {
 			try {

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionType.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MentionType.java
@@ -24,5 +24,5 @@ public enum MentionType {
 	videoRecording,
 	webpage,
 	workshop,
-	other
+	other,
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnector.java
@@ -9,10 +9,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.Utils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpResponse;
@@ -25,6 +21,9 @@ import java.util.UUID;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
+import nl.esciencecenter.rsd.scraper.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 class OpenAlexConnector {
 
@@ -33,16 +32,13 @@ class OpenAlexConnector {
 	static final String DOI_FILTER_URL_UNFORMATTED = "https://api.openalex.org/works?filter=doi:%s";
 	static final String OPENALEX_ID_URL_UNFORMATTED = "https://api.openalex.org/works?filter=ids.openalex:%s";
 
-	public Collection<ExternalMentionRecord> mentionDataByDois(Collection<Doi> dois, String email) throws IOException, InterruptedException {
+	public Collection<ExternalMentionRecord> mentionDataByDois(Collection<Doi> dois, String email)
+		throws IOException, InterruptedException {
 		if (dois == null || dois.isEmpty()) {
 			return Collections.emptyList();
 		}
 
-		String filter = dois
-				.stream()
-				.filter(Objects::nonNull)
-				.map(Doi::toString)
-				.collect(Collectors.joining("|"));
+		String filter = dois.stream().filter(Objects::nonNull).map(Doi::toString).collect(Collectors.joining("|"));
 		// e.g. https://api.openalex.org/works?filter=doi:10.1038%2Fs41598-024-73248-4|10.5194%2Ftc-2022-249-rc1&per-page=200
 		String worksUri = DOI_FILTER_URL_UNFORMATTED.formatted(Utils.urlEncode(filter)) + "&per-page=200";
 
@@ -54,8 +50,7 @@ class OpenAlexConnector {
 		}
 
 		JsonObject tree = JsonParser.parseString(response.body()).getAsJsonObject();
-		JsonArray mentionsArray = tree
-				.getAsJsonArray("results");
+		JsonArray mentionsArray = tree.getAsJsonArray("results");
 
 		Collection<ExternalMentionRecord> mentions = new ArrayList<>();
 		for (JsonElement mention : mentionsArray) {
@@ -72,16 +67,17 @@ class OpenAlexConnector {
 		return mentions;
 	}
 
-	public Collection<ExternalMentionRecord> mentionDataByOpenalexIds(Collection<OpenalexId> openalexIds, String email) throws IOException, InterruptedException {
+	public Collection<ExternalMentionRecord> mentionDataByOpenalexIds(Collection<OpenalexId> openalexIds, String email)
+		throws IOException, InterruptedException {
 		if (openalexIds == null || openalexIds.isEmpty()) {
 			return Collections.emptyList();
 		}
 
 		String filter = openalexIds
-				.stream()
-				.filter(Objects::nonNull)
-				.map(OpenalexId::getOpenalexKey)
-				.collect(Collectors.joining("|"));
+			.stream()
+			.filter(Objects::nonNull)
+			.map(OpenalexId::getOpenalexKey)
+			.collect(Collectors.joining("|"));
 		// e.g. https://api.openalex.org/works?filter=ids.openalex:W4402994101|W4319593220&per-page=200
 		String worksUri = OPENALEX_ID_URL_UNFORMATTED.formatted(Utils.urlEncode(filter)) + "&per-page=200";
 
@@ -93,8 +89,7 @@ class OpenAlexConnector {
 		}
 
 		JsonObject tree = JsonParser.parseString(response.body()).getAsJsonObject();
-		JsonArray mentionsArray = tree
-				.getAsJsonArray("results");
+		JsonArray mentionsArray = tree.getAsJsonArray("results");
 
 		Collection<ExternalMentionRecord> mentions = new ArrayList<>();
 		for (JsonElement mention : mentionsArray) {
@@ -111,15 +106,16 @@ class OpenAlexConnector {
 		return mentions;
 	}
 
-	public Collection<ExternalMentionRecord> citations(OpenalexId openalexId, Doi doi, String email, UUID id) throws IOException, InterruptedException {
+	public Collection<ExternalMentionRecord> citations(OpenalexId openalexId, Doi doi, String email, UUID id)
+		throws IOException, InterruptedException {
 		// This shouldn't happen, but let's check it to prevent unexpected exceptions:
 		if (doi == null && openalexId == null) {
 			return Collections.emptyList();
 		}
 
 		String worksUri = openalexId != null
-				? OPENALEX_ID_URL_UNFORMATTED.formatted(openalexId.toUrlEncodedString())
-				: DOI_FILTER_URL_UNFORMATTED.formatted(doi.toUrlEncodedString());
+			? OPENALEX_ID_URL_UNFORMATTED.formatted(openalexId.toUrlEncodedString())
+			: DOI_FILTER_URL_UNFORMATTED.formatted(doi.toUrlEncodedString());
 
 		Optional<String> optionalCitationsUri = citationsUri(worksUri, email);
 		if (optionalCitationsUri.isEmpty()) {
@@ -139,10 +135,7 @@ class OpenAlexConnector {
 
 		JsonObject tree = JsonParser.parseString(response.body()).getAsJsonObject();
 
-		int count = tree
-				.getAsJsonObject("meta")
-				.getAsJsonPrimitive("count")
-				.getAsInt();
+		int count = tree.getAsJsonObject("meta").getAsJsonPrimitive("count").getAsInt();
 
 		if (count < 1) {
 			LOGGER.warn("No results found for {}: {}", worksUri, count);
@@ -156,11 +149,11 @@ class OpenAlexConnector {
 		String citationsUri = null;
 		try {
 			citationsUri = tree
-					.getAsJsonArray("results")
-					.get(0)
-					.getAsJsonObject()
-					.getAsJsonPrimitive("cited_by_api_url")
-					.getAsString();
+				.getAsJsonArray("results")
+				.get(0)
+				.getAsJsonObject()
+				.getAsJsonPrimitive("cited_by_api_url")
+				.getAsString();
 		} catch (RuntimeException e) {
 			LOGGER.error("Exception parsing cited_by_api_url for %s".formatted(worksUri), e);
 			Utils.saveExceptionInDatabase("OpenAlex citations scraper", null, null, e);
@@ -171,7 +164,8 @@ class OpenAlexConnector {
 
 	// we use cursor paging as that will always work
 	// https://docs.openalex.org/how-to-use-the-api/get-lists-of-entities/paging#cursor-paging
-	static Collection<ExternalMentionRecord> scrapeCitations(String citationsUri, String email, UUID id) throws IOException, InterruptedException {
+	static Collection<ExternalMentionRecord> scrapeCitations(String citationsUri, String email, UUID id)
+		throws IOException, InterruptedException {
 		final int perPage = 200;
 		String cursor = "*";
 
@@ -186,13 +180,9 @@ class OpenAlexConnector {
 			}
 			JsonObject tree = JsonParser.parseString(response.body()).getAsJsonObject();
 
-			cursor = Utils.stringOrNull(tree
-					.getAsJsonObject("meta")
-					.get("next_cursor")
-			);
+			cursor = Utils.stringOrNull(tree.getAsJsonObject("meta").get("next_cursor"));
 
-			JsonArray citationsArray = tree
-					.getAsJsonArray("results");
+			JsonArray citationsArray = tree.getAsJsonArray("results");
 
 			for (JsonElement citation : citationsArray) {
 				ExternalMentionRecord citationAsMention;
@@ -230,17 +220,20 @@ class OpenAlexConnector {
 		String title = Utils.stringOrNull(citationObject.get("title"));
 		if (title == null) {
 			String openAlexId = citationObject.getAsJsonPrimitive("id").getAsString();
-			String message = "The title of the mention with DOI %s and OpenAlex ID %s is null".formatted(doiString, openAlexId);
+			String message = "The title of the mention with DOI %s and OpenAlex ID %s is null".formatted(
+				doiString,
+				openAlexId
+			);
 			throw new RuntimeException(message);
 		}
 
 		JsonArray authorsArray = citationObject.getAsJsonArray("authorships");
 		String authors = StreamSupport.stream(authorsArray.spliterator(), false)
-				.map(JsonElement::getAsJsonObject)
-				.map(jo -> jo.get("raw_author_name"))
-				.filter(Predicate.not(JsonElement::isJsonNull))
-				.map(JsonElement::getAsString)
-				.collect(Collectors.joining(", "));
+			.map(JsonElement::getAsJsonObject)
+			.map(jo -> jo.get("raw_author_name"))
+			.filter(Predicate.not(JsonElement::isJsonNull))
+			.map(JsonElement::getAsString)
+			.collect(Collectors.joining(", "));
 		if (authors.isBlank()) {
 			authors = null;
 		}
@@ -250,26 +243,23 @@ class OpenAlexConnector {
 		String crossrefType = Utils.stringOrNull(citationObject.get("type_crossref"));
 		MentionType mentionType = CrossrefMention.crossrefTypeMap.getOrDefault(crossrefType, MentionType.other);
 
-		String openalexIdString = citationObject
-				.getAsJsonObject("ids")
-				.getAsJsonPrimitive("openalex")
-				.getAsString();
+		String openalexIdString = citationObject.getAsJsonObject("ids").getAsJsonPrimitive("openalex").getAsString();
 		OpenalexId openalexId = OpenalexId.fromString(openalexIdString);
 
 		return new ExternalMentionRecord(
-				doi,
-				null,
-				openalexId,
-				url,
-				title,
-				authors,
-				null,
-				publicationYear,
-				null,
-				null,
-				mentionType,
-				"OpenAlex",
-				null
+			doi,
+			null,
+			openalexId,
+			url,
+			title,
+			authors,
+			null,
+			publicationYear,
+			null,
+			null,
+			mentionType,
+			"OpenAlex",
+			null
 		);
 	}
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/OpenalexId.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/OpenalexId.java
@@ -5,16 +5,17 @@
 
 package nl.esciencecenter.rsd.scraper.doi;
 
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.util.Locale;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 // https://docs.openalex.org/how-to-use-the-api/get-single-entities#the-openalex-id
 public class OpenalexId {
 
-	private static final Pattern OPENALEX_PATTERN = Pattern.compile("^https://openalex\\.org/([WwAaSsIiCcPpFf]\\d{3,13})$");
+	private static final Pattern OPENALEX_PATTERN = Pattern.compile(
+		"^https://openalex\\.org/([WwAaSsIiCcPpFf]\\d{3,13})$"
+	);
 	private static final String OPENALEX_ID_BASE = "https://openalex.org/";
 
 	private final String openalexKey;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/PostgrestCitationRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/PostgrestCitationRepository.java
@@ -9,14 +9,13 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.UUID;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 /**
  * This class provides access to the citation related tables via the Postgrest API.
@@ -38,12 +37,22 @@ public class PostgrestCitationRepository {
 	 */
 	public Collection<CitationData> leastRecentlyScrapedCitations(int limit) {
 		String oneHourAgoFilter = Utils.atLeastOneHourAgoFilter("citations_scraped_at");
-		String uri = backendUrl + "/rpc/reference_papers_to_scrape?order=citations_scraped_at.asc.nullsfirst&limit=" + limit + "&" + oneHourAgoFilter;
+		String uri =
+			backendUrl +
+			"/rpc/reference_papers_to_scrape?order=citations_scraped_at.asc.nullsfirst&limit=" +
+			limit +
+			"&" +
+			oneHourAgoFilter;
 		String data = Utils.getAsAdmin(uri);
 		return parseJson(data);
 	}
 
-	public void saveCitations(String backendUrl, UUID idCitedMention, Collection<UUID> citingMentions, Instant scrapedAt) {
+	public void saveCitations(
+		String backendUrl,
+		UUID idCitedMention,
+		Collection<UUID> citingMentions,
+		Instant scrapedAt
+	) {
 		String jsonPatch = "{\"citations_scraped_at\": \"%s\"}".formatted(scrapedAt.toString());
 		Utils.patchAsAdmin(backendUrl + "/mention?id=eq." + idCitedMention.toString(), jsonPatch);
 
@@ -53,7 +62,6 @@ public class PostgrestCitationRepository {
 		HashSet<String> seen = new HashSet<>();
 
 		for (UUID citingMention : citingMentions) {
-
 			if (citingMention != null) {
 				String citationID = citingMention.toString();
 
@@ -73,7 +81,6 @@ public class PostgrestCitationRepository {
 	}
 
 	private Collection<CitationData> parseJson(String data) {
-
 		JsonArray array = JsonParser.parseString(data).getAsJsonArray();
 		Collection<CitationData> result = new ArrayList<>();
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/ReleaseData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/ReleaseData.java
@@ -17,11 +17,19 @@ public class ReleaseData {
 
 	@Override
 	public String toString() {
-		return "ReleaseData{" +
-				"softwareId=" + softwareId +
-				", slug='" + slug + '\'' +
-				", conceptDoi='" + conceptDoi + '\'' +
-				", versionedDois=" + versionedDois +
-				'}';
+		return (
+			"ReleaseData{" +
+			"softwareId=" +
+			softwareId +
+			", slug='" +
+			slug +
+			'\'' +
+			", conceptDoi='" +
+			conceptDoi +
+			'\'' +
+			", versionedDois=" +
+			versionedDois +
+			'}'
+		);
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/RsdMentionIds.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/RsdMentionIds.java
@@ -7,9 +7,4 @@ package nl.esciencecenter.rsd.scraper.doi;
 
 import java.util.UUID;
 
-public record RsdMentionIds(
-		UUID id,
-		Doi doi,
-		OpenalexId openalexId
-) {
-}
+public record RsdMentionIds(UUID id, Doi doi, OpenalexId openalexId) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/RsdMentionRecord.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/RsdMentionRecord.java
@@ -8,9 +8,4 @@ package nl.esciencecenter.rsd.scraper.doi;
 import java.time.Instant;
 import java.util.UUID;
 
-public record RsdMentionRecord(
-		UUID id,
-		ExternalMentionRecord content,
-		Instant scrapedAt
-) {
-}
+public record RsdMentionRecord(UUID id, ExternalMentionRecord content, Instant scrapedAt) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicGitData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicGitData.java
@@ -11,5 +11,4 @@ public record BasicGitData(
 	Long starCount,
 	Integer forkCount,
 	Integer openIssueCount
-) {
-}
+) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicGitDatabaseData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicGitDatabaseData.java
@@ -8,8 +8,7 @@ package nl.esciencecenter.rsd.scraper.git;
 import java.time.ZonedDateTime;
 
 public record BasicGitDatabaseData(
-		BasicRepositoryData basicData,
-		BasicGitData statsData,
-		ZonedDateTime dataScrapedAt
-) {
-}
+	BasicRepositoryData basicData,
+	BasicGitData statsData,
+	ZonedDateTime dataScrapedAt
+) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicRepositoryData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicRepositoryData.java
@@ -7,5 +7,4 @@ package nl.esciencecenter.rsd.scraper.git;
 
 import java.util.UUID;
 
-public record BasicRepositoryData(UUID software, String url) {
-}
+public record BasicRepositoryData(UUID software, String url) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicRepositoryDataWithHistory.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/BasicRepositoryDataWithHistory.java
@@ -8,5 +8,9 @@ package nl.esciencecenter.rsd.scraper.git;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
-public record BasicRepositoryDataWithHistory(UUID software, String url, ZonedDateTime commitHistoryScrapedAt, CommitsPerWeek commitsPerWeek) {
-}
+public record BasicRepositoryDataWithHistory(
+	UUID software,
+	String url,
+	ZonedDateTime commitHistoryScrapedAt,
+	CommitsPerWeek commitsPerWeek
+) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CodePlatformProvider.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CodePlatformProvider.java
@@ -6,5 +6,9 @@
 package nl.esciencecenter.rsd.scraper.git;
 
 public enum CodePlatformProvider {
-	GITHUB, GITLAB, BITBUCKET, FOURTU, OTHER
+	GITHUB,
+	GITLAB,
+	BITBUCKET,
+	FOURTU,
+	OTHER,
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CommitData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CommitData.java
@@ -11,5 +11,4 @@ public record CommitData(
 	BasicRepositoryData basicData,
 	CommitsPerWeek commitHistory,
 	ZonedDateTime commitHistoryScrapedAt
-) {
-}
+) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeek.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeek.java
@@ -11,7 +11,6 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
-
 import java.time.DayOfWeek;
 import java.time.Instant;
 import java.time.Period;
@@ -31,9 +30,12 @@ public class CommitsPerWeek {
 
 	private final SortedMap<Instant, Long> data = new TreeMap<>();
 	static final Gson gson = new GsonBuilder()
-			.enableComplexMapKeySerialization()
-			.registerTypeAdapter(Instant.class, (JsonSerializer<Instant>) (src, typeOfSrc, context) -> new JsonPrimitive(src.getEpochSecond()))
-			.create();
+		.enableComplexMapKeySerialization()
+		.registerTypeAdapter(
+			Instant.class,
+			(JsonSerializer<Instant>) (src, typeOfSrc, context) -> new JsonPrimitive(src.getEpochSecond())
+		)
+		.create();
 
 	SortedMap<Instant, Long> getData() {
 		return new TreeMap<>(data);
@@ -41,7 +43,10 @@ public class CommitsPerWeek {
 
 	public void addCommits(ZonedDateTime zonedDateTime, long count) {
 		ZonedDateTime utcTime = zonedDateTime.withZoneSameInstant(ZoneOffset.UTC);
-		Instant sundayMidnight = utcTime.truncatedTo(ChronoUnit.DAYS).with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)).toInstant();
+		Instant sundayMidnight = utcTime
+			.truncatedTo(ChronoUnit.DAYS)
+			.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY))
+			.toInstant();
 		data.merge(sundayMidnight, count, Long::sum);
 	}
 
@@ -69,7 +74,11 @@ public class CommitsPerWeek {
 		Instant firstWeek = data.firstKey();
 		Instant lastWeek = data.lastKey();
 
-		for (Instant currentWeek = firstWeek; currentWeek.isBefore(lastWeek); currentWeek = currentWeek.plus(Period.ofWeeks(1))) {
+		for (
+			Instant currentWeek = firstWeek;
+			currentWeek.isBefore(lastWeek);
+			currentWeek = currentWeek.plus(Period.ofWeeks(1))
+		) {
 			data.putIfAbsent(currentWeek, 0L);
 		}
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/ContributorDatabaseData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/ContributorDatabaseData.java
@@ -8,8 +8,7 @@ package nl.esciencecenter.rsd.scraper.git;
 import java.time.ZonedDateTime;
 
 public record ContributorDatabaseData(
-		BasicRepositoryData basicData,
-		Integer contributorCount,
-		ZonedDateTime dataScrapedAt
-) {
-}
+	BasicRepositoryData basicData,
+	Integer contributorCount,
+	ZonedDateTime dataScrapedAt
+) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/FourTuGitScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/FourTuGitScraper.java
@@ -6,14 +6,14 @@
 package nl.esciencecenter.rsd.scraper.git;
 
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.util.Objects;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class FourTuGitScraper implements GitScraper {
+
 	private final String repoUrl;
 
 	public FourTuGitScraper(String repoUrl) {
@@ -31,11 +31,19 @@ public class FourTuGitScraper implements GitScraper {
 		String url = repoUrl + "/languages";
 		HttpResponse<String> response = Utils.getAsHttpResponse(url);
 		return switch (response.statusCode()) {
-			case 404 ->
-					throw new RsdResponseException(404, response.uri(), response.body(), "Not found, is the repository URL correct?");
+			case 404 -> throw new RsdResponseException(
+				404,
+				response.uri(),
+				response.body(),
+				"Not found, is the repository URL correct?"
+			);
 			case 200 -> response.body();
-			default ->
-					throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Unexpected response when downloading 4TU programming languages");
+			default -> throw new RsdResponseException(
+				response.statusCode(),
+				response.uri(),
+				response.body(),
+				"Unexpected response when downloading 4TU programming languages"
+			);
 		};
 	}
 
@@ -45,11 +53,19 @@ public class FourTuGitScraper implements GitScraper {
 		String url = repoUrl + "/contributors";
 		HttpResponse<String> response = Utils.getAsHttpResponse(url);
 		return switch (response.statusCode()) {
-			case 404 ->
-					throw new RsdResponseException(404, response.uri(), response.body(), "Not found, is the repository URL correct?");
+			case 404 -> throw new RsdResponseException(
+				404,
+				response.uri(),
+				response.body(),
+				"Not found, is the repository URL correct?"
+			);
 			case 200 -> GithubScraper.parseCommits(response.body());
-			default ->
-					throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Unexpected response when downloading 4TU commit history");
+			default -> throw new RsdResponseException(
+				response.statusCode(),
+				response.uri(),
+				response.body(),
+				"Unexpected response when downloading 4TU commit history"
+			);
 		};
 	}
 
@@ -59,11 +75,19 @@ public class FourTuGitScraper implements GitScraper {
 		String url = repoUrl + "/contributors";
 		HttpResponse<String> response = Utils.getAsHttpResponse(url);
 		return switch (response.statusCode()) {
-			case 404 ->
-					throw new RsdResponseException(404, response.uri(), response.body(), "Not found, is the repository URL correct?");
+			case 404 -> throw new RsdResponseException(
+				404,
+				response.uri(),
+				response.body(),
+				"Not found, is the repository URL correct?"
+			);
 			case 200 -> JsonParser.parseString(response.body()).getAsJsonArray().size();
-			default ->
-					throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Unexpected response when downloading 4TU commit history");
+			default -> throw new RsdResponseException(
+				response.statusCode(),
+				response.uri(),
+				response.body(),
+				"Unexpected response when downloading 4TU commit history"
+			);
 		};
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitScraper.java
@@ -6,11 +6,9 @@
 package nl.esciencecenter.rsd.scraper.git;
 
 import java.io.IOException;
-
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public interface GitScraper {
-
 	BasicGitData basicData() throws IOException, InterruptedException, RsdResponseException;
 
 	String languages() throws IOException, InterruptedException, RsdResponseException;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/LanguagesData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/LanguagesData.java
@@ -7,9 +7,4 @@ package nl.esciencecenter.rsd.scraper.git;
 
 import java.time.ZonedDateTime;
 
-public record LanguagesData(
-		BasicRepositoryData basicData,
-		String languages,
-		ZonedDateTime languagesScrapedAt
-) {
-}
+public record LanguagesData(BasicRepositoryData basicData, String languages, ZonedDateTime languagesScrapedAt) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainBasicData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainBasicData.java
@@ -5,18 +5,17 @@
 
 package nl.esciencecenter.rsd.scraper.git;
 
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import nl.esciencecenter.rsd.scraper.Config;
 import nl.esciencecenter.rsd.scraper.RsdRateLimitException;
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
 import nl.esciencecenter.rsd.scraper.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.net.URI;
-import java.time.ZonedDateTime;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 public class MainBasicData {
 
@@ -36,7 +35,10 @@ public class MainBasicData {
 	}
 
 	private static void scrapeGitHub() {
-		PostgrestConnector softwareInfoRepository = new PostgrestConnector(Config.backendBaseUrl() + "/repository_url", CodePlatformProvider.GITHUB);
+		PostgrestConnector softwareInfoRepository = new PostgrestConnector(
+			Config.backendBaseUrl() + "/repository_url",
+			CodePlatformProvider.GITHUB
+		);
 		Collection<BasicRepositoryData> dataToScrape = softwareInfoRepository.statsData(Config.maxRequestsGithub());
 		CompletableFuture<?>[] futures = new CompletableFuture[dataToScrape.size()];
 		ZonedDateTime scrapedAt = ZonedDateTime.now();
@@ -48,8 +50,15 @@ public class MainBasicData {
 
 					Optional<GithubScraper> githubScraperOptional = GithubScraper.create(repoUrl);
 					if (githubScraperOptional.isEmpty()) {
-						Utils.saveErrorMessageInDatabase("Not a valid GitHub URL: " + repoUrl, "repository_url", "basic_data_last_error", basicData.software()
-							.toString(), "software", scrapedAt, "basic_data_scraped_at");
+						Utils.saveErrorMessageInDatabase(
+							"Not a valid GitHub URL: " + repoUrl,
+							"repository_url",
+							"basic_data_last_error",
+							basicData.software().toString(),
+							"software",
+							scrapedAt,
+							"basic_data_scraped_at"
+						);
 						return;
 					}
 
@@ -58,17 +67,53 @@ public class MainBasicData {
 					BasicGitDatabaseData updatedData = new BasicGitDatabaseData(basicData, scrapedBasicData, scrapedAt);
 					softwareInfoRepository.saveBasicData(updatedData);
 				} catch (RsdRateLimitException e) {
-					Utils.saveExceptionInDatabase("GitHub basic data scraper", "repository_url", basicData.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "basic_data_last_error", basicData.software()
-						.toString(), "software", null, null);
+					Utils.saveExceptionInDatabase(
+						"GitHub basic data scraper",
+						"repository_url",
+						basicData.software(),
+						e
+					);
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"basic_data_last_error",
+						basicData.software().toString(),
+						"software",
+						null,
+						null
+					);
 				} catch (RsdResponseException e) {
-					Utils.saveExceptionInDatabase("GitHub basic data scraper", "repository_url", basicData.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "basic_data_last_error", basicData.software()
-						.toString(), "software", scrapedAt, "basic_data_scraped_at");
+					Utils.saveExceptionInDatabase(
+						"GitHub basic data scraper",
+						"repository_url",
+						basicData.software(),
+						e
+					);
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"basic_data_last_error",
+						basicData.software().toString(),
+						"software",
+						scrapedAt,
+						"basic_data_scraped_at"
+					);
 				} catch (Exception e) {
-					Utils.saveExceptionInDatabase("GitHub basic data scraper", "repository_url", basicData.software(), e);
-					Utils.saveErrorMessageInDatabase("Unknown error", "repository_url", "basic_data_last_error", basicData.software()
-						.toString(), "software", scrapedAt, "basic_data_scraped_at");
+					Utils.saveExceptionInDatabase(
+						"GitHub basic data scraper",
+						"repository_url",
+						basicData.software(),
+						e
+					);
+					Utils.saveErrorMessageInDatabase(
+						"Unknown error",
+						"repository_url",
+						"basic_data_last_error",
+						basicData.software().toString(),
+						"software",
+						scrapedAt,
+						"basic_data_scraped_at"
+					);
 				}
 			});
 			futures[i] = future;
@@ -78,7 +123,10 @@ public class MainBasicData {
 	}
 
 	private static void scrapeGitLab() {
-		PostgrestConnector softwareInfoRepository = new PostgrestConnector(Config.backendBaseUrl() + "/repository_url", CodePlatformProvider.GITLAB);
+		PostgrestConnector softwareInfoRepository = new PostgrestConnector(
+			Config.backendBaseUrl() + "/repository_url",
+			CodePlatformProvider.GITLAB
+		);
 		Collection<BasicRepositoryData> dataToScrape = softwareInfoRepository.statsData(Config.maxRequestsGitLab());
 		CompletableFuture<?>[] futures = new CompletableFuture[dataToScrape.size()];
 		ZonedDateTime scrapedAt = ZonedDateTime.now();
@@ -96,17 +144,53 @@ public class MainBasicData {
 					BasicGitDatabaseData updatedData = new BasicGitDatabaseData(basicData, scrapedBasicData, scrapedAt);
 					softwareInfoRepository.saveBasicData(updatedData);
 				} catch (RsdRateLimitException e) {
-					Utils.saveExceptionInDatabase("GitLab basic data scraper", "repository_url", basicData.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "basic_data_last_error", basicData.software()
-						.toString(), "software", null, null);
+					Utils.saveExceptionInDatabase(
+						"GitLab basic data scraper",
+						"repository_url",
+						basicData.software(),
+						e
+					);
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"basic_data_last_error",
+						basicData.software().toString(),
+						"software",
+						null,
+						null
+					);
 				} catch (RsdResponseException e) {
-					Utils.saveExceptionInDatabase("GitLab basic data scraper", "repository_url", basicData.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "basic_data_last_error", basicData.software()
-						.toString(), "software", scrapedAt, "basic_data_scraped_at");
+					Utils.saveExceptionInDatabase(
+						"GitLab basic data scraper",
+						"repository_url",
+						basicData.software(),
+						e
+					);
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"basic_data_last_error",
+						basicData.software().toString(),
+						"software",
+						scrapedAt,
+						"basic_data_scraped_at"
+					);
 				} catch (Exception e) {
-					Utils.saveExceptionInDatabase("GitLab basic data scraper", "repository_url", basicData.software(), e);
-					Utils.saveErrorMessageInDatabase("Unknown error", "repository_url", "basic_data_last_error", basicData.software()
-						.toString(), "software", scrapedAt, "basic_data_scraped_at");
+					Utils.saveExceptionInDatabase(
+						"GitLab basic data scraper",
+						"repository_url",
+						basicData.software(),
+						e
+					);
+					Utils.saveErrorMessageInDatabase(
+						"Unknown error",
+						"repository_url",
+						"basic_data_last_error",
+						basicData.software().toString(),
+						"software",
+						scrapedAt,
+						"basic_data_scraped_at"
+					);
 				}
 			});
 			futures[i] = future;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainCommits.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/MainCommits.java
@@ -7,6 +7,11 @@
 
 package nl.esciencecenter.rsd.scraper.git;
 
+import java.net.URI;
+import java.time.ZonedDateTime;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
 import nl.esciencecenter.rsd.scraper.Config;
 import nl.esciencecenter.rsd.scraper.RsdRateLimitException;
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
@@ -14,18 +19,11 @@ import nl.esciencecenter.rsd.scraper.Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.net.URI;
-import java.time.ZonedDateTime;
-import java.util.Collection;
-import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
-
 public class MainCommits {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(MainCommits.class);
 
 	public static void main(String[] args) {
-
 		LOGGER.info("Start scraping commits");
 
 		long t1 = System.currentTimeMillis();
@@ -40,8 +38,13 @@ public class MainCommits {
 	}
 
 	private static void scrapeGitLab() {
-		PostgrestConnector softwareInfoRepository = new PostgrestConnector(Config.backendBaseUrl() + "/repository_url", CodePlatformProvider.GITLAB);
-		Collection<BasicRepositoryDataWithHistory> dataToScrape = softwareInfoRepository.commitDataWithHistory(Config.maxRequestsGitLab());
+		PostgrestConnector softwareInfoRepository = new PostgrestConnector(
+			Config.backendBaseUrl() + "/repository_url",
+			CodePlatformProvider.GITLAB
+		);
+		Collection<BasicRepositoryDataWithHistory> dataToScrape = softwareInfoRepository.commitDataWithHistory(
+			Config.maxRequestsGitLab()
+		);
 		CompletableFuture<?>[] futures = new CompletableFuture[dataToScrape.size()];
 		ZonedDateTime scrapedAt = ZonedDateTime.now();
 		int i = 0;
@@ -56,23 +59,67 @@ public class MainCommits {
 
 					CommitsPerWeek existingCommitsPerWeek = repositoryDataToScrape.commitsPerWeek();
 					ZonedDateTime lastCommitHistoryTimestamp = existingCommitsPerWeek.popLatestTimestamp();
-					CommitsPerWeek scrapedCommits = new GitlabScraper(apiUrl, projectPath, lastCommitHistoryTimestamp, existingCommitsPerWeek).contributions();
+					CommitsPerWeek scrapedCommits = new GitlabScraper(
+						apiUrl,
+						projectPath,
+						lastCommitHistoryTimestamp,
+						existingCommitsPerWeek
+					).contributions();
 
-					BasicRepositoryData basicData = new BasicRepositoryData(repositoryDataToScrape.software(), repositoryDataToScrape.url());
+					BasicRepositoryData basicData = new BasicRepositoryData(
+						repositoryDataToScrape.software(),
+						repositoryDataToScrape.url()
+					);
 					CommitData updatedData = new CommitData(basicData, scrapedCommits, scrapedAt);
 					softwareInfoRepository.saveCommitData(updatedData);
 				} catch (RsdRateLimitException e) {
-					Utils.saveExceptionInDatabase("GitLab commit scraper", "repository_url", repositoryDataToScrape.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "commit_history_last_error", repositoryDataToScrape.software()
-						.toString(), "software", null, null);
+					Utils.saveExceptionInDatabase(
+						"GitLab commit scraper",
+						"repository_url",
+						repositoryDataToScrape.software(),
+						e
+					);
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"commit_history_last_error",
+						repositoryDataToScrape.software().toString(),
+						"software",
+						null,
+						null
+					);
 				} catch (RsdResponseException e) {
-					Utils.saveExceptionInDatabase("GitLab commit scraper", "repository_url", repositoryDataToScrape.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "commit_history_last_error", repositoryDataToScrape.software()
-						.toString(), "software", scrapedAt, "commit_history_scraped_at");
+					Utils.saveExceptionInDatabase(
+						"GitLab commit scraper",
+						"repository_url",
+						repositoryDataToScrape.software(),
+						e
+					);
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"commit_history_last_error",
+						repositoryDataToScrape.software().toString(),
+						"software",
+						scrapedAt,
+						"commit_history_scraped_at"
+					);
 				} catch (Exception e) {
-					Utils.saveExceptionInDatabase("GitLab commit scraper", "repository_url", repositoryDataToScrape.software(), e);
-					Utils.saveErrorMessageInDatabase("Unknown error", "repository_url", "commit_history_last_error", repositoryDataToScrape.software()
-						.toString(), "software", scrapedAt, "commit_history_scraped_at");
+					Utils.saveExceptionInDatabase(
+						"GitLab commit scraper",
+						"repository_url",
+						repositoryDataToScrape.software(),
+						e
+					);
+					Utils.saveErrorMessageInDatabase(
+						"Unknown error",
+						"repository_url",
+						"commit_history_last_error",
+						repositoryDataToScrape.software().toString(),
+						"software",
+						scrapedAt,
+						"commit_history_scraped_at"
+					);
 				}
 			});
 			futures[i] = future;
@@ -82,7 +129,10 @@ public class MainCommits {
 	}
 
 	private static void scrapeGitHub() {
-		PostgrestConnector softwareInfoRepository = new PostgrestConnector(Config.backendBaseUrl() + "/repository_url", CodePlatformProvider.GITHUB);
+		PostgrestConnector softwareInfoRepository = new PostgrestConnector(
+			Config.backendBaseUrl() + "/repository_url",
+			CodePlatformProvider.GITHUB
+		);
 		Collection<BasicRepositoryData> dataToScrape = softwareInfoRepository.commitData(Config.maxRequestsGithub());
 		CompletableFuture<?>[] futures = new CompletableFuture[dataToScrape.size()];
 		ZonedDateTime scrapedAt = ZonedDateTime.now();
@@ -94,8 +144,15 @@ public class MainCommits {
 
 					Optional<GithubScraper> githubScraperOptional = GithubScraper.create(repoUrl);
 					if (githubScraperOptional.isEmpty()) {
-						Utils.saveErrorMessageInDatabase("Not a valid GitHub URL: " + repoUrl, "repository_url", "commit_history_last_error", commitData.software()
-							.toString(), "software", scrapedAt, "commit_history_scraped_at");
+						Utils.saveErrorMessageInDatabase(
+							"Not a valid GitHub URL: " + repoUrl,
+							"repository_url",
+							"commit_history_last_error",
+							commitData.software().toString(),
+							"software",
+							scrapedAt,
+							"commit_history_scraped_at"
+						);
 						return;
 					}
 
@@ -106,16 +163,37 @@ public class MainCommits {
 				} catch (RsdRateLimitException e) {
 					// in case we hit the rate limit, we don't update the scraped_at time, so it gets scraped first next time
 					Utils.saveExceptionInDatabase("GitHub commit scraper", "repository_url", commitData.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "commit_history_last_error", commitData.software()
-						.toString(), "software", null, null);
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"commit_history_last_error",
+						commitData.software().toString(),
+						"software",
+						null,
+						null
+					);
 				} catch (RsdResponseException e) {
 					Utils.saveExceptionInDatabase("GitHub commit scraper", "repository_url", commitData.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "commit_history_last_error", commitData.software()
-						.toString(), "software", scrapedAt, "commit_history_scraped_at");
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"commit_history_last_error",
+						commitData.software().toString(),
+						"software",
+						scrapedAt,
+						"commit_history_scraped_at"
+					);
 				} catch (Exception e) {
 					Utils.saveExceptionInDatabase("GitHub commit scraper", "repository_url", commitData.software(), e);
-					Utils.saveErrorMessageInDatabase("Unknown error", "repository_url", "commit_history_last_error", commitData.software()
-						.toString(), "software", scrapedAt, "commit_history_scraped_at");
+					Utils.saveErrorMessageInDatabase(
+						"Unknown error",
+						"repository_url",
+						"commit_history_last_error",
+						commitData.software().toString(),
+						"software",
+						scrapedAt,
+						"commit_history_scraped_at"
+					);
 				}
 			});
 			futures[i] = future;
@@ -125,7 +203,10 @@ public class MainCommits {
 	}
 
 	private static void scrape4tu() {
-		PostgrestConnector softwareInfoRepository = new PostgrestConnector(Config.backendBaseUrl() + "/repository_url", CodePlatformProvider.FOURTU);
+		PostgrestConnector softwareInfoRepository = new PostgrestConnector(
+			Config.backendBaseUrl() + "/repository_url",
+			CodePlatformProvider.FOURTU
+		);
 		Collection<BasicRepositoryData> dataToScrape = softwareInfoRepository.commitData(Config.maxRequests4tu());
 		CompletableFuture<?>[] futures = new CompletableFuture[dataToScrape.size()];
 		ZonedDateTime scrapedAt = ZonedDateTime.now();
@@ -142,16 +223,37 @@ public class MainCommits {
 				} catch (RsdRateLimitException e) {
 					// in case we hit the rate limit, we don't update the scraped_at time, so it gets scraped first next time
 					Utils.saveExceptionInDatabase("4TU commit scraper", "repository_url", commitData.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "commit_history_last_error", commitData.software()
-						.toString(), "software", null, null);
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"commit_history_last_error",
+						commitData.software().toString(),
+						"software",
+						null,
+						null
+					);
 				} catch (RsdResponseException e) {
 					Utils.saveExceptionInDatabase("4TU commit scraper", "repository_url", commitData.software(), e);
-					Utils.saveErrorMessageInDatabase(e.getMessage(), "repository_url", "commit_history_last_error", commitData.software()
-						.toString(), "software", scrapedAt, "commit_history_scraped_at");
+					Utils.saveErrorMessageInDatabase(
+						e.getMessage(),
+						"repository_url",
+						"commit_history_last_error",
+						commitData.software().toString(),
+						"software",
+						scrapedAt,
+						"commit_history_scraped_at"
+					);
 				} catch (Exception e) {
 					Utils.saveExceptionInDatabase("4TU commit scraper", "repository_url", commitData.software(), e);
-					Utils.saveErrorMessageInDatabase("Unknown error", "repository_url", "commit_history_last_error", commitData.software()
-						.toString(), "software", scrapedAt, "commit_history_scraped_at");
+					Utils.saveErrorMessageInDatabase(
+						"Unknown error",
+						"repository_url",
+						"commit_history_last_error",
+						commitData.software().toString(),
+						"software",
+						scrapedAt,
+						"commit_history_scraped_at"
+					);
 				}
 			});
 			futures[i] = future;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/PostgrestConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/PostgrestConnector.java
@@ -12,8 +12,6 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
@@ -21,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Objects;
 import java.util.UUID;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class PostgrestConnector {
 
@@ -44,7 +43,15 @@ public class PostgrestConnector {
 	 * @return The data corresponding to the git repositories of which the programming languages data were scraped the longest time ago
 	 */
 	public Collection<BasicRepositoryData> languagesData(int limit) {
-		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=software,url&order=languages_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("languages_scraped_at"));
+		String data = Utils.getAsAdmin(
+			backendUrl +
+			"?" +
+			filter +
+			"&select=software,url&order=languages_scraped_at.asc.nullsfirst&limit=" +
+			limit +
+			"&" +
+			Utils.atLeastOneHourAgoFilter("languages_scraped_at")
+		);
 		return parseBasicJsonData(data);
 	}
 
@@ -55,12 +62,28 @@ public class PostgrestConnector {
 	 * @return The data corresponding to the git repositories of which the commit data were scraped the longest time ago
 	 */
 	public Collection<BasicRepositoryData> commitData(int limit) {
-		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=software,url&order=commit_history_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("commit_history_scraped_at"));
+		String data = Utils.getAsAdmin(
+			backendUrl +
+			"?" +
+			filter +
+			"&select=software,url&order=commit_history_scraped_at.asc.nullsfirst&limit=" +
+			limit +
+			"&" +
+			Utils.atLeastOneHourAgoFilter("commit_history_scraped_at")
+		);
 		return parseBasicJsonData(data);
 	}
 
 	public Collection<BasicRepositoryDataWithHistory> commitDataWithHistory(int limit) {
-		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=software,url,commit_history_scraped_at,commit_history&order=commit_history_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("commit_history_scraped_at"));
+		String data = Utils.getAsAdmin(
+			backendUrl +
+			"?" +
+			filter +
+			"&select=software,url,commit_history_scraped_at,commit_history&order=commit_history_scraped_at.asc.nullsfirst&limit=" +
+			limit +
+			"&" +
+			Utils.atLeastOneHourAgoFilter("commit_history_scraped_at")
+		);
 		return parseBasicJsonDataWithHistory(data);
 	}
 
@@ -71,12 +94,28 @@ public class PostgrestConnector {
 	 * @return The data corresponding to the git repositories of which the basic data were scraped the longest time ago
 	 */
 	public Collection<BasicRepositoryData> statsData(int limit) {
-		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=software,url&order=basic_data_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("basic_data_scraped_at"));
+		String data = Utils.getAsAdmin(
+			backendUrl +
+			"?" +
+			filter +
+			"&select=software,url&order=basic_data_scraped_at.asc.nullsfirst&limit=" +
+			limit +
+			"&" +
+			Utils.atLeastOneHourAgoFilter("basic_data_scraped_at")
+		);
 		return parseBasicJsonData(data);
 	}
 
 	public Collection<BasicRepositoryData> contributorData(int limit) {
-		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=software,url&order=contributor_count_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("contributor_count_scraped_at"));
+		String data = Utils.getAsAdmin(
+			backendUrl +
+			"?" +
+			filter +
+			"&select=software,url&order=contributor_count_scraped_at.asc.nullsfirst&limit=" +
+			limit +
+			"&" +
+			Utils.atLeastOneHourAgoFilter("contributor_count_scraped_at")
+		);
 		return parseBasicJsonData(data);
 	}
 
@@ -89,12 +128,17 @@ public class PostgrestConnector {
 			UUID software = UUID.fromString(softwareUuid);
 			String url = jsonObject.getAsJsonPrimitive("url").getAsString();
 			String commitHistoryScrapedAtString = Utils.stringOrNull(jsonObject.get("commit_history_scraped_at"));
-			ZonedDateTime commitHistoryScrapedAt = commitHistoryScrapedAtString == null ? null : ZonedDateTime.parse(commitHistoryScrapedAtString);
+			ZonedDateTime commitHistoryScrapedAt = commitHistoryScrapedAtString == null
+				? null
+				: ZonedDateTime.parse(commitHistoryScrapedAtString);
 			CommitsPerWeek commitsPerWeek = new CommitsPerWeek();
 			if (!jsonObject.get("commit_history").isJsonNull()) {
 				JsonObject commitHistoryJsonObject = jsonObject.getAsJsonObject("commit_history");
 				for (String key : commitHistoryJsonObject.keySet()) {
-					commitsPerWeek.addCommits(Instant.ofEpochSecond(Long.parseLong(key)), commitHistoryJsonObject.getAsJsonPrimitive(key).getAsLong());
+					commitsPerWeek.addCommits(
+						Instant.ofEpochSecond(Long.parseLong(key)),
+						commitHistoryJsonObject.getAsJsonPrimitive(key).getAsLong()
+					);
 				}
 			}
 			result.add(new BasicRepositoryDataWithHistory(software, url, commitHistoryScrapedAt, commitsPerWeek));
@@ -117,20 +161,28 @@ public class PostgrestConnector {
 	}
 
 	public void saveLanguagesData(LanguagesData languagesData) {
-		String json = String.format("{\"languages_last_error\": null, \"languages\": %s, \"languages_scraped_at\": \"%s\"}", languagesData.languages(), languagesData.languagesScrapedAt()
-			.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		String json = String.format(
+			"{\"languages_last_error\": null, \"languages\": %s, \"languages_scraped_at\": \"%s\"}",
+			languagesData.languages(),
+			languagesData.languagesScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+		);
 		Utils.patchAsAdmin(backendUrl + "?software=eq." + languagesData.basicData().software().toString(), json);
 	}
 
 	public void saveCommitData(CommitData commitData) {
 		String json;
 		if (commitData.commitHistory() == null) {
-			json = String.format("{\"commit_history_last_error\": null, \"commit_history_scraped_at\": \"%s\"}", commitData.commitHistoryScrapedAt()
-				.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+			json = String.format(
+				"{\"commit_history_last_error\": null, \"commit_history_scraped_at\": \"%s\"}",
+				commitData.commitHistoryScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+			);
 		} else {
 			commitData.commitHistory().addMissingZeros();
-			json = String.format("{\"commit_history_last_error\": null, \"commit_history\": %s, \"commit_history_scraped_at\": \"%s\"}", commitData.commitHistory()
-				.toJson(), commitData.commitHistoryScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+			json = String.format(
+				"{\"commit_history_last_error\": null, \"commit_history\": %s, \"commit_history_scraped_at\": \"%s\"}",
+				commitData.commitHistory().toJson(),
+				commitData.commitHistoryScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+			);
 		}
 		Utils.patchAsAdmin(backendUrl + "?software=eq." + commitData.basicData().software().toString(), json);
 	}
@@ -138,30 +190,36 @@ public class PostgrestConnector {
 	public void saveBasicData(BasicGitDatabaseData basicData) {
 		JsonObject jsonObject = new JsonObject();
 		jsonObject.add("basic_data_last_error", JsonNull.INSTANCE);
-		jsonObject.addProperty("basic_data_scraped_at", basicData.dataScrapedAt()
-			.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		jsonObject.addProperty(
+			"basic_data_scraped_at",
+			basicData.dataScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+		);
 		jsonObject.addProperty("archived", basicData.statsData().archived());
 		jsonObject.addProperty("license", basicData.statsData().license());
 		jsonObject.addProperty("star_count", basicData.statsData().starCount());
 		jsonObject.addProperty("fork_count", basicData.statsData().forkCount());
 		jsonObject.addProperty("open_issue_count", basicData.statsData().openIssueCount());
 
-		Utils.patchAsAdmin(backendUrl + "?software=eq." + basicData.basicData()
-			.software()
-			.toString(), jsonObject.toString());
+		Utils.patchAsAdmin(
+			backendUrl + "?software=eq." + basicData.basicData().software().toString(),
+			jsonObject.toString()
+		);
 	}
 
 	public void saveContributorCount(ContributorDatabaseData contributorData) {
 		JsonObject jsonObject = new JsonObject();
 		jsonObject.add("contributor_count_last_error", JsonNull.INSTANCE);
-		jsonObject.addProperty("contributor_count_scraped_at", contributorData.dataScrapedAt()
-			.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		jsonObject.addProperty(
+			"contributor_count_scraped_at",
+			contributorData.dataScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+		);
 		if (contributorData.contributorCount() != null) {
 			jsonObject.addProperty("contributor_count", contributorData.contributorCount());
 		}
 
-		Utils.patchAsAdmin(backendUrl + "?software=eq." + contributorData.basicData()
-			.software()
-			.toString(), jsonObject.toString());
+		Utils.patchAsAdmin(
+			backendUrl + "?software=eq." + contributorData.basicData().software().toString(),
+			jsonObject.toString()
+		);
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/license/GitHubSpdxLicenseRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/license/GitHubSpdxLicenseRepository.java
@@ -10,29 +10,33 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.google.gson.reflect.TypeToken;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.io.IOException;
 import java.net.http.HttpResponse;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class GitHubSpdxLicenseRepository {
 
 	private static final Gson gson = new Gson();
 
-	private GitHubSpdxLicenseRepository() {
-	}
+	private GitHubSpdxLicenseRepository() {}
 
-	public static Map<String, SpdxLicense> getLicensesByIdMap() throws IOException, InterruptedException, RsdResponseException {
+	public static Map<String, SpdxLicense> getLicensesByIdMap()
+		throws IOException, InterruptedException, RsdResponseException {
 		String url = "https://raw.githubusercontent.com/spdx/license-list-data/refs/heads/main/json/licenses.json";
 
 		HttpResponse<String> response = Utils.getAsHttpResponse(url);
 		if (response.statusCode() != 200) {
-			throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Unexpected response while getting SPDX licenses");
+			throw new RsdResponseException(
+				response.statusCode(),
+				response.uri(),
+				response.body(),
+				"Unexpected response while getting SPDX licenses"
+			);
 		}
 
 		String json = response.body();
@@ -42,12 +46,9 @@ public class GitHubSpdxLicenseRepository {
 	static Map<String, SpdxLicense> parseLicensesJson(String json) {
 		JsonObject root = JsonParser.parseString(json).getAsJsonObject();
 		JsonArray licensesJsonArray = root.getAsJsonArray("licenses");
-		TypeToken<List<SpdxLicense>> spdxListTypeToken = new TypeToken<>() {
-		};
+		TypeToken<List<SpdxLicense>> spdxListTypeToken = new TypeToken<>() {};
 		List<SpdxLicense> licenses = gson.fromJson(licensesJsonArray, spdxListTypeToken);
 
-		return licenses
-			.stream()
-			.collect(Collectors.toMap(SpdxLicense::licenseId, Function.identity()));
+		return licenses.stream().collect(Collectors.toMap(SpdxLicense::licenseId, Function.identity()));
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/license/SpdxLicense.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/license/SpdxLicense.java
@@ -5,9 +5,4 @@
 
 package nl.esciencecenter.rsd.scraper.license;
 
-public record SpdxLicense(
-		String licenseId,
-		String reference,
-		String name
-) {
-}
+public record SpdxLicense(String licenseId, String reference, String name) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/nassa/NassaReadmeParser.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/nassa/NassaReadmeParser.java
@@ -5,8 +5,6 @@
 
 package nl.esciencecenter.rsd.scraper.nassa;
 
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -14,6 +12,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.Objects;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public class NassaReadmeParser {
 
@@ -27,15 +26,25 @@ public class NassaReadmeParser {
 			return split[1];
 		}
 
-		throw new RsdNassaParseException("Couldn't split description into two parts around expected header, resulting array has size %d instead of 2".formatted(split.length));
+		throw new RsdNassaParseException(
+			"Couldn't split description into two parts around expected header, resulting array has size %d instead of 2".formatted(
+				split.length
+			)
+		);
 	}
 
-	public static String downloadAndReturnDescriptionFromReadme(URI readmeUri, HttpClient client) throws IOException, InterruptedException, RsdResponseException, RsdNassaParseException {
+	public static String downloadAndReturnDescriptionFromReadme(URI readmeUri, HttpClient client)
+		throws IOException, InterruptedException, RsdResponseException, RsdNassaParseException {
 		HttpRequest request = HttpRequest.newBuilder(readmeUri).build();
 
 		HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 		if (response.statusCode() >= 300) {
-			throw new RsdResponseException(response.statusCode(), readmeUri, response.body(), "Unexpected response getting NASSA README");
+			throw new RsdResponseException(
+				response.statusCode(),
+				readmeUri,
+				response.body(),
+				"Unexpected response getting NASSA README"
+			);
 		}
 
 		return getLongDescriptionFromReadme(response.body());

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/nassa/NassaSoftwareEntry.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/nassa/NassaSoftwareEntry.java
@@ -8,13 +8,6 @@ package nl.esciencecenter.rsd.scraper.nassa;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
-import nl.esciencecenter.rsd.scraper.doi.ExternalMentionRecord;
-import nl.esciencecenter.rsd.scraper.doi.PostgrestMentionRepository;
-import nl.esciencecenter.rsd.scraper.license.SpdxLicense;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.yaml.snakeyaml.Yaml;
-
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -22,6 +15,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import nl.esciencecenter.rsd.scraper.doi.ExternalMentionRecord;
+import nl.esciencecenter.rsd.scraper.doi.PostgrestMentionRepository;
+import nl.esciencecenter.rsd.scraper.license.SpdxLicense;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.yaml.snakeyaml.Yaml;
 
 public class NassaSoftwareEntry {
 
@@ -162,7 +161,10 @@ public class NassaSoftwareEntry {
 		root.addProperty("slug", id.toLowerCase());
 		root.addProperty("brand_name", title);
 		root.addProperty("description", descriptionWithInputsAndOutputs());
-		root.addProperty("short_statement", shortDescription.length() > 300 ? shortDescription.substring(0, 297) + "..." : shortDescription);
+		root.addProperty(
+			"short_statement",
+			shortDescription.length() > 300 ? shortDescription.substring(0, 297) + "..." : shortDescription
+		);
 		root.addProperty("get_started_url", gitHtmlUrl + "/" + docsDir);
 		root.addProperty("repository_url", gitHtmlUrl);
 
@@ -242,7 +244,11 @@ public class NassaSoftwareEntry {
 		if (implementations != null) {
 			JsonArray languagesJson = new JsonArray();
 			for (Map<String, Object> implementation : implementations) {
-				if (implementation != null && implementation.get("language") != null && implementation.get("language") instanceof String lang) {
+				if (
+					implementation != null &&
+					implementation.get("language") != null &&
+					implementation.get("language") instanceof String lang
+				) {
 					languagesJson.add(lang);
 				}
 			}
@@ -257,19 +263,23 @@ public class NassaSoftwareEntry {
 
 		Collection<ExternalMentionRecord> regularMentions = new ArrayList<>();
 		if (references != null && references.get("moduleReferences") != null) {
-			references.get("moduleReferences").forEach(citekey -> {
-				if (mentions.get(citekey) != null) {
-					regularMentions.add(mentions.get(citekey));
-				}
-			});
+			references
+				.get("moduleReferences")
+				.forEach(citekey -> {
+					if (mentions.get(citekey) != null) {
+						regularMentions.add(mentions.get(citekey));
+					}
+				});
 		}
 
 		if (references != null && references.get("useExampleReferences") != null) {
-			references.get("useExampleReferences").forEach(citekey -> {
-				if (mentions.get(citekey) != null) {
-					regularMentions.add(mentions.get(citekey));
-				}
-			});
+			references
+				.get("useExampleReferences")
+				.forEach(citekey -> {
+					if (mentions.get(citekey) != null) {
+						regularMentions.add(mentions.get(citekey));
+					}
+				});
 		}
 		root.add("regular_mentions", PostgrestMentionRepository.toRsdJsonArray(regularMentions));
 
@@ -323,6 +333,7 @@ public class NassaSoftwareEntry {
 }
 
 class NassaContributor {
+
 	final String givenName;
 	final String familyName;
 	final String emailAddress;
@@ -357,13 +368,6 @@ class NassaContributor {
 		String emailAddress = (String) map.get("email");
 		String orcid = (String) map.get("orcid");
 
-		return new NassaContributor(
-			givenName,
-			familyName,
-			emailAddress,
-			roles,
-			orcid,
-			position
-		);
+		return new NassaContributor(givenName, familyName, emailAddress, roles, orcid, position);
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/BasicPackageManagerData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/BasicPackageManagerData.java
@@ -7,9 +7,4 @@ package nl.esciencecenter.rsd.scraper.package_manager;
 
 import java.util.UUID;
 
-public record BasicPackageManagerData(
-		UUID id,
-		String url,
-		PackageManagerType type
-) {
-}
+public record BasicPackageManagerData(UUID id, String url, PackageManagerType type) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PackageManagerType.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PackageManagerType.java
@@ -20,5 +20,5 @@ public enum PackageManagerType {
 	pixi,
 	pypi,
 	sonatype,
-	other
+	other,
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/PostgrestConnector.java
@@ -11,8 +11,6 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
@@ -21,6 +19,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
 import java.util.UUID;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class PostgrestConnector {
 
@@ -50,17 +49,33 @@ public class PostgrestConnector {
 		String packageManagerFilter = PostgrestConnector.joinPackageManagersAsFilter(downloadEnabledPackageManagers);
 
 		String filter = "download_count_scraping_disabled_reason=is.null&" + packageManagerFilter;
-		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=id,url,package_manager&order=download_count_scraped_at.asc.nullsfirst&limit=" + limit
-			+ "&" + Utils.atLeastOneHourAgoFilter("download_count_scraped_at")
+		String data = Utils.getAsAdmin(
+			backendUrl +
+			"?" +
+			filter +
+			"&select=id,url,package_manager&order=download_count_scraped_at.asc.nullsfirst&limit=" +
+			limit +
+			"&" +
+			Utils.atLeastOneHourAgoFilter("download_count_scraped_at")
 		);
 		return parseBasicJsonData(data);
 	}
 
 	public Collection<BasicPackageManagerData> oldestReverseDependencyCounts(int limit) {
-		String packageManagerFilter = PostgrestConnector.joinPackageManagersAsFilter(reverseDependencyEnabledPackageManagers);
+		String packageManagerFilter = PostgrestConnector.joinPackageManagersAsFilter(
+			reverseDependencyEnabledPackageManagers
+		);
 
 		String filter = "reverse_dependency_count_scraping_disabled_reason=is.null&" + packageManagerFilter;
-		String data = Utils.getAsAdmin(backendUrl + "?" + filter + "&select=id,url,package_manager&order=reverse_dependency_count_scraped_at.asc.nullsfirst&limit=" + limit + "&" + Utils.atLeastOneHourAgoFilter("reverse_dependency_count_scraped_at"));
+		String data = Utils.getAsAdmin(
+			backendUrl +
+			"?" +
+			filter +
+			"&select=id,url,package_manager&order=reverse_dependency_count_scraped_at.asc.nullsfirst&limit=" +
+			limit +
+			"&" +
+			Utils.atLeastOneHourAgoFilter("reverse_dependency_count_scraped_at")
+		);
 		return parseBasicJsonData(data);
 	}
 
@@ -75,12 +90,20 @@ public class PostgrestConnector {
 	}
 
 	public void saveDownloadCount(UUID id, Long count, ZonedDateTime scrapedAt) {
-		String json = "{\"download_count\": %s, \"download_count_scraped_at\": \"%s\", \"download_count_last_error\": null}".formatted(count, scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		String json =
+			"{\"download_count\": %s, \"download_count_scraped_at\": \"%s\", \"download_count_last_error\": null}".formatted(
+				count,
+				scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+			);
 		Utils.patchAsAdmin(backendUrl + "?id=eq." + id, json);
 	}
 
 	public void saveReverseDependencyCount(UUID id, Integer count, ZonedDateTime scrapedAt) {
-		String json = "{\"reverse_dependency_count\": %s, \"reverse_dependency_count_scraped_at\": \"%s\", \"reverse_dependency_count_last_error\": null}".formatted(count, scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		String json =
+			"{\"reverse_dependency_count\": %s, \"reverse_dependency_count_scraped_at\": \"%s\", \"reverse_dependency_count_last_error\": null}".formatted(
+				count,
+				scrapedAt.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+			);
 		Utils.patchAsAdmin(backendUrl + "?id=eq." + id, json);
 	}
 
@@ -92,8 +115,9 @@ public class PostgrestConnector {
 			String idString = jsonObject.getAsJsonPrimitive("id").getAsString();
 			UUID id = UUID.fromString(idString);
 			String url = jsonObject.getAsJsonPrimitive("url").getAsString();
-			PackageManagerType type = PackageManagerType.valueOf(jsonObject.getAsJsonPrimitive("package_manager")
-				.getAsString());
+			PackageManagerType type = PackageManagerType.valueOf(
+				jsonObject.getAsJsonPrimitive("package_manager").getAsString()
+			);
 
 			result.add(new BasicPackageManagerData(id, url, type));
 		}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/AnacondaScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/AnacondaScraper.java
@@ -7,13 +7,11 @@ package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-
 import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public class AnacondaScraper implements PackageManagerScraper {
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CranScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CranScraper.java
@@ -7,19 +7,23 @@ package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-
 import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public class CranScraper implements PackageManagerScraper {
 
 	final String packageName;
-	private static final Pattern urlPattern1 = Pattern.compile("https://cran\\.r-project\\.org/web/packages/([^/\\s]+)/?(index\\.html/?)?", Pattern.CASE_INSENSITIVE);
-	private static final Pattern urlPattern2 = Pattern.compile("https://cran\\.r-project\\.org/package=([^/\\s]+)/?", Pattern.CASE_INSENSITIVE);
+	private static final Pattern urlPattern1 = Pattern.compile(
+		"https://cran\\.r-project\\.org/web/packages/([^/\\s]+)/?(index\\.html/?)?",
+		Pattern.CASE_INSENSITIVE
+	);
+	private static final Pattern urlPattern2 = Pattern.compile(
+		"https://cran\\.r-project\\.org/package=([^/\\s]+)/?",
+		Pattern.CASE_INSENSITIVE
+	);
 
 	public CranScraper(String url) {
 		Objects.requireNonNull(url);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CratesScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CratesScraper.java
@@ -7,12 +7,11 @@ package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-
 import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public class CratesScraper implements PackageManagerScraper {
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/DockerHubScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/DockerHubScraper.java
@@ -6,8 +6,6 @@
 package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -17,6 +15,7 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public class DockerHubScraper implements PackageManagerScraper {
 
@@ -40,19 +39,19 @@ public class DockerHubScraper implements PackageManagerScraper {
 		String url;
 		if (owner.equals("_")) url = "https://hub.docker.com/v2/repositories/library/" + packageName;
 		else url = "https://hub.docker.com/v2/repositories/" + owner + "/" + packageName;
-		HttpClient client = HttpClient.newBuilder()
-				.followRedirects(HttpClient.Redirect.NORMAL)
-				.build();
-		HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-				.timeout(Duration.ofSeconds(30))
-				.build();
+		HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
+		HttpRequest request = HttpRequest.newBuilder(URI.create(url)).timeout(Duration.ofSeconds(30)).build();
 		String json;
 		try {
 			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 			json = switch (response.statusCode()) {
 				case 200 -> response.body();
-				default ->
-						throw new RsdResponseException(response.statusCode(), request.uri(), response.body(), "Unexpected response");
+				default -> throw new RsdResponseException(
+					response.statusCode(),
+					request.uri(),
+					response.body(),
+					"Unexpected response"
+				);
 			};
 		} catch (InterruptedException e) {
 			Thread.currentThread().interrupt();

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/FourTuScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/FourTuScraper.java
@@ -5,11 +5,11 @@
 
 package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
+import java.io.IOException;
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
-import java.io.IOException;
-
 public class FourTuScraper implements PackageManagerScraper {
+
 	@Override
 	public Long downloads() throws IOException, RsdResponseException {
 		throw new UnsupportedOperationException();

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/GoScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/GoScraper.java
@@ -7,13 +7,12 @@ package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class GoScraper implements PackageManagerScraper {
 
@@ -41,7 +40,9 @@ public class GoScraper implements PackageManagerScraper {
 	// Example URL: https://libraries.io/api/go/google.golang.org%2Fgrpc
 	@Override
 	public Integer reverseDependencies() throws IOException, InterruptedException, RsdResponseException {
-		String data = PackageManagerScraper.doLibrariesIoRequest("https://libraries.io/api/go/" + Utils.urlEncode(packageName));
+		String data = PackageManagerScraper.doLibrariesIoRequest(
+			"https://libraries.io/api/go/" + Utils.urlEncode(packageName)
+		);
 		JsonElement tree = JsonParser.parseString(data);
 		return tree.getAsJsonObject().getAsJsonPrimitive("dependents_count").getAsInt();
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/InvalidPackageManagerUrlException.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/InvalidPackageManagerUrlException.java
@@ -6,6 +6,7 @@
 package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 public class InvalidPackageManagerUrlException extends Exception {
+
 	public InvalidPackageManagerUrlException(String message) {
 		super(message);
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/JuliaScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/JuliaScraper.java
@@ -6,8 +6,6 @@
 package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -17,12 +15,15 @@ import java.time.Duration;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public class JuliaScraper implements PackageManagerScraper {
 
 	private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
 	private final String packageName;
-	private static final Pattern generalRegistryPattern = Pattern.compile("^https://github\\.com/JuliaRegistries/General/tree/master/[A-Z]/(\\w+)$");
+	private static final Pattern generalRegistryPattern = Pattern.compile(
+		"^https://github\\.com/JuliaRegistries/General/tree/master/[A-Z]/(\\w+)$"
+	);
 	private static final Pattern ownRepoPattern = Pattern.compile("^https://github\\.com/[^/]+/(\\w+)\\.jl\\.git$");
 
 	public JuliaScraper(String url) throws InvalidPackageManagerUrlException {
@@ -53,7 +54,12 @@ public class JuliaScraper implements PackageManagerScraper {
 			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 
 			if (response.statusCode() != 200) {
-				throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Unexpected response getting Julia downloads for package: " + packageName);
+				throw new RsdResponseException(
+					response.statusCode(),
+					response.uri(),
+					response.body(),
+					"Unexpected response getting Julia downloads for package: " + packageName
+				);
 			}
 
 			String numberAsString = JsonParser.parseString(response.body())

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraper.java
@@ -7,20 +7,20 @@ package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-
 import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public class MavenScraper implements PackageManagerScraper {
 
 	final String groupId;
 	final String artifactId;
 	private static final Pattern mvnPattern = Pattern.compile("https://mvnrepository\\.com/artifact/([^/]+)/([^/]+)/?");
-	private static final Pattern sonatypePattern = Pattern.compile("https://central\\.sonatype\\.com/artifact/([^/]+)/([^/]+)/?");
+	private static final Pattern sonatypePattern = Pattern.compile(
+		"https://central\\.sonatype\\.com/artifact/([^/]+)/([^/]+)/?"
+	);
 
 	public MavenScraper(String url) {
 		Objects.requireNonNull(url);
@@ -50,7 +50,9 @@ public class MavenScraper implements PackageManagerScraper {
 	// Example URL: https://libraries.io/api/maven/io.github.sanctuuary:APE
 	@Override
 	public Integer reverseDependencies() throws IOException, InterruptedException, RsdResponseException {
-		String data = PackageManagerScraper.doLibrariesIoRequest("https://libraries.io/api/maven/" + groupId + ":" + artifactId);
+		String data = PackageManagerScraper.doLibrariesIoRequest(
+			"https://libraries.io/api/maven/" + groupId + ":" + artifactId
+		);
 		JsonElement tree = JsonParser.parseString(data);
 		return tree.getAsJsonObject().getAsJsonPrimitive("dependents_count").getAsInt();
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/NpmScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/NpmScraper.java
@@ -7,14 +7,12 @@ package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class NpmScraper implements PackageManagerScraper {
 
@@ -38,7 +36,9 @@ public class NpmScraper implements PackageManagerScraper {
 
 	@Override
 	public Integer reverseDependencies() throws IOException, InterruptedException, RsdResponseException {
-		String data = PackageManagerScraper.doLibrariesIoRequest("https://libraries.io/api/npm/" + Utils.urlEncode(packageName));
+		String data = PackageManagerScraper.doLibrariesIoRequest(
+			"https://libraries.io/api/npm/" + Utils.urlEncode(packageName)
+		);
 		JsonElement tree = JsonParser.parseString(data);
 		return tree.getAsJsonObject().getAsJsonPrimitive("dependents_count").getAsInt();
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PackageManagerScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PackageManagerScraper.java
@@ -5,10 +5,6 @@
 
 package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
-import nl.esciencecenter.rsd.scraper.Config;
-import nl.esciencecenter.rsd.scraper.RsdRateLimitException;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-
 import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -16,9 +12,11 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.time.Duration;
 import java.util.Optional;
+import nl.esciencecenter.rsd.scraper.Config;
+import nl.esciencecenter.rsd.scraper.RsdRateLimitException;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public interface PackageManagerScraper {
-
 	Long downloads() throws IOException, InterruptedException, RsdResponseException;
 
 	Integer reverseDependencies() throws IOException, InterruptedException, RsdResponseException;
@@ -27,22 +25,29 @@ public interface PackageManagerScraper {
 		Optional<String> optionalApiKey = Config.librariesIoKey();
 		if (optionalApiKey.isPresent()) url += "?api_key=" + optionalApiKey.get();
 
-
-		HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-			.timeout(Duration.ofSeconds(30))
-			.build();
-		try (HttpClient client = HttpClient.newBuilder()
-			.followRedirects(HttpClient.Redirect.NORMAL)
-			.build()) {
+		HttpRequest request = HttpRequest.newBuilder(URI.create(url)).timeout(Duration.ofSeconds(30)).build();
+		try (HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build()) {
 			HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
 			return switch (response.statusCode()) {
-				case 429 ->
-					throw new RsdRateLimitException(429, request.uri(), response.body(), "Rate limit reached for libraries.io");
-				case 404 ->
-					throw new RsdResponseException(404, request.uri(), response.body(), "Not found, is the URL correct?");
+				case 429 -> throw new RsdRateLimitException(
+					429,
+					request.uri(),
+					response.body(),
+					"Rate limit reached for libraries.io"
+				);
+				case 404 -> throw new RsdResponseException(
+					404,
+					request.uri(),
+					response.body(),
+					"Not found, is the URL correct?"
+				);
 				case 200 -> response.body();
-				default ->
-					throw new RsdResponseException(response.statusCode(), response.uri(), response.body(), "Unexpected response");
+				default -> throw new RsdResponseException(
+					response.statusCode(),
+					response.uri(),
+					response.body(),
+					"Unexpected response"
+				);
 			};
 		}
 	}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PixiScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PixiScraper.java
@@ -5,15 +5,13 @@
 
 package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
-import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import nl.esciencecenter.rsd.scraper.RsdResponseException;
 import nl.esciencecenter.rsd.scraper.Utils;
 
@@ -36,23 +34,33 @@ public class PixiScraper implements PackageManagerScraper {
 
 	@Override
 	public Long downloads() throws RsdResponseException {
-		String graphqlQuery = String.format("""
-				{
-					package(channelName: "%s", name: "%s") {
-						downloadCounts {
-							version
-							count
-						}
+		String graphqlQuery = String.format(
+			"""
+			{
+				package(channelName: "%s", name: "%s") {
+					downloadCounts {
+						version
+						count
 					}
 				}
-				""",
-				channelName,
-				packageName);
+			}
+			""",
+			channelName,
+			packageName
+		);
 		JsonObject body = new JsonObject();
 		body.addProperty("query", graphqlQuery);
-		String response = Utils.post("https://prefix.dev/api/graphql", body.toString(), "Content-Type", "application/json");
+		String response = Utils.post(
+			"https://prefix.dev/api/graphql",
+			body.toString(),
+			"Content-Type",
+			"application/json"
+		);
 		JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
-		JsonArray countItems = jsonObject.getAsJsonObject("data").getAsJsonObject("package").getAsJsonArray("downloadCounts");
+		JsonArray countItems = jsonObject
+			.getAsJsonObject("data")
+			.getAsJsonObject("package")
+			.getAsJsonArray("downloadCounts");
 
 		long downloadsSum = 0;
 		for (JsonElement item : countItems) {
@@ -67,5 +75,4 @@ public class PixiScraper implements PackageManagerScraper {
 	public Integer reverseDependencies() {
 		throw new UnsupportedOperationException();
 	}
-
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PypiScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/PypiScraper.java
@@ -7,13 +7,11 @@ package nl.esciencecenter.rsd.scraper.package_manager.scrapers;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-
 import java.io.IOException;
 import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
 
 public class PypiScraper implements PackageManagerScraper {
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/OrganisationDatabaseData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/OrganisationDatabaseData.java
@@ -10,10 +10,4 @@ package nl.esciencecenter.rsd.scraper.ror;
 import java.time.ZonedDateTime;
 import java.util.UUID;
 
-public record OrganisationDatabaseData(
-	UUID id,
-	RorId rorId,
-	ZonedDateTime rorScrapedAt,
-	RorData data
-) {
-}
+public record OrganisationDatabaseData(UUID id, RorId rorId, ZonedDateTime rorScrapedAt, RorData data) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorData.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorData.java
@@ -15,5 +15,4 @@ public record RorData(
 	List<String> rorNames,
 	Double lat,
 	Double lon
-) {
-}
+) {}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorId.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorId.java
@@ -22,7 +22,9 @@ public class RorId {
 	private static final String ROR_BASE_URL = "https://ror.org/";
 	// https://ror.org/blog/2024-04-15-announcing-ror-v2/
 	private static final String ROR_BASE_API_V1_URL = "https://api.ror.org/v1/organizations/";
-	private static final Pattern ROR_URL_PATTERN = Pattern.compile("^https://ror\\.org/(0[a-hj-km-np-tv-z|\\d]{6}\\d{2})$");
+	private static final Pattern ROR_URL_PATTERN = Pattern.compile(
+		"^https://ror\\.org/(0[a-hj-km-np-tv-z|\\d]{6}\\d{2})$"
+	);
 
 	private final String id;
 

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorPostgrestConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorPostgrestConnector.java
@@ -12,16 +12,16 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.Config;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import nl.esciencecenter.rsd.scraper.Config;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class RorPostgrestConnector {
+
 	private final String backendUrl;
 
 	public RorPostgrestConnector() {
@@ -29,7 +29,8 @@ public class RorPostgrestConnector {
 	}
 
 	public Collection<OrganisationDatabaseData> organisationsWithoutLocation(int limit) {
-		String filter = "organisation?ror_id=not.is.null&order=ror_scraped_at.asc.nullsfirst&select=id,ror_id&limit=" + limit;
+		String filter =
+			"organisation?ror_id=not.is.null&order=ror_scraped_at.asc.nullsfirst&select=id,ror_id&limit=" + limit;
 		String data = Utils.getAsAdmin(backendUrl + "/" + filter);
 		return parseBasicJsonData(data);
 	}
@@ -73,8 +74,10 @@ public class RorPostgrestConnector {
 		jsonObject.addProperty("lat", organisationData.data().lat());
 		jsonObject.addProperty("lon", organisationData.data().lon());
 
-		jsonObject.addProperty("ror_scraped_at", organisationData.rorScrapedAt()
-			.format(DateTimeFormatter.ISO_OFFSET_DATE_TIME));
+		jsonObject.addProperty(
+			"ror_scraped_at",
+			organisationData.rorScrapedAt().format(DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+		);
 		jsonObject.add("ror_last_error", JsonNull.INSTANCE);
 
 		Utils.patchAsAdmin(backendUrl + "/organisation?id=eq." + organisationData.id(), jsonObject.toString());

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorScraper.java
@@ -9,14 +9,13 @@ package nl.esciencecenter.rsd.scraper.ror;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
-import nl.esciencecenter.rsd.scraper.RsdResponseException;
-import nl.esciencecenter.rsd.scraper.Utils;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
+import nl.esciencecenter.rsd.scraper.RsdResponseException;
+import nl.esciencecenter.rsd.scraper.Utils;
 
 public class RorScraper {
 
@@ -40,85 +39,85 @@ public class RorScraper {
 		JsonElement jsonElement = JsonParser.parseString(json);
 		final String addressesKey = "addresses";
 
-		String country = Utils.safelyGetOrNull(jsonElement, j -> j
-			.getAsJsonObject()
-			.getAsJsonObject("country")
-			.getAsJsonPrimitive("country_name")
-			.getAsString());
-		String city = Utils.safelyGetOrNull(jsonElement, j -> j
-			.getAsJsonObject()
-			.getAsJsonArray(addressesKey)
-			.get(0)
-			.getAsJsonObject()
-			.getAsJsonPrimitive("city")
-			.getAsString());
-		String wikipediaUrl = Utils.safelyGetOrNull(jsonElement, j -> {
-			JsonElement wikiElement = j
+		String country = Utils.safelyGetOrNull(jsonElement, j ->
+			j.getAsJsonObject().getAsJsonObject("country").getAsJsonPrimitive("country_name").getAsString()
+		);
+		String city = Utils.safelyGetOrNull(jsonElement, j ->
+			j
 				.getAsJsonObject()
-				.get("wikipedia_url");
+				.getAsJsonArray(addressesKey)
+				.get(0)
+				.getAsJsonObject()
+				.getAsJsonPrimitive("city")
+				.getAsString()
+		);
+		String wikipediaUrl = Utils.safelyGetOrNull(jsonElement, j -> {
+			JsonElement wikiElement = j.getAsJsonObject().get("wikipedia_url");
 			return wikiElement.isJsonPrimitive() ? wikiElement.getAsString() : null;
 		});
 		if (wikipediaUrl != null && wikipediaUrl.isBlank()) {
 			wikipediaUrl = null;
 		}
-		List<String> rorTypes = Utils.safelyGetOrNull(jsonElement, j -> j
-			.getAsJsonObject()
-			.getAsJsonArray("types")
-			.asList()
-			.stream()
-			.map(JsonElement::getAsString)
-			.toList()
+		List<String> rorTypes = Utils.safelyGetOrNull(jsonElement, j ->
+			j.getAsJsonObject().getAsJsonArray("types").asList().stream().map(JsonElement::getAsString).toList()
 		);
 
 		List<String> rorNames = new ArrayList<>();
-		List<String> rorAliases = Utils.safelyGetOrNull(jsonElement, j -> j
-			.getAsJsonObject()
-			.getAsJsonArray("aliases")
-			.asList()
-			.stream()
-			.map(alias -> alias.getAsJsonPrimitive().getAsString())
-			.toList()
+		List<String> rorAliases = Utils.safelyGetOrNull(jsonElement, j ->
+			j
+				.getAsJsonObject()
+				.getAsJsonArray("aliases")
+				.asList()
+				.stream()
+				.map(alias -> alias.getAsJsonPrimitive().getAsString())
+				.toList()
 		);
 		if (rorAliases != null) {
 			rorNames.addAll(rorAliases);
 		}
-		List<String> rorAcronyms = Utils.safelyGetOrNull(jsonElement, j -> j
-			.getAsJsonObject()
-			.getAsJsonArray("acronyms")
-			.asList()
-			.stream()
-			.map(acronym -> acronym.getAsJsonPrimitive().getAsString())
-			.toList()
+		List<String> rorAcronyms = Utils.safelyGetOrNull(jsonElement, j ->
+			j
+				.getAsJsonObject()
+				.getAsJsonArray("acronyms")
+				.asList()
+				.stream()
+				.map(acronym -> acronym.getAsJsonPrimitive().getAsString())
+				.toList()
 		);
 		if (rorAcronyms != null) {
 			rorNames.addAll(rorAcronyms);
 		}
-		List<String> rorLabels = Utils.safelyGetOrNull(jsonElement, j -> j
-			.getAsJsonObject()
-			.getAsJsonArray("labels")
-			.asList()
-			.stream()
-			.map(label -> label.getAsJsonObject().getAsJsonPrimitive("label").getAsString())
-			.toList()
+		List<String> rorLabels = Utils.safelyGetOrNull(jsonElement, j ->
+			j
+				.getAsJsonObject()
+				.getAsJsonArray("labels")
+				.asList()
+				.stream()
+				.map(label -> label.getAsJsonObject().getAsJsonPrimitive("label").getAsString())
+				.toList()
 		);
 		if (rorLabels != null) {
 			rorNames.addAll(rorLabels);
 		}
 
-		Double lat = Utils.safelyGetOrNull(jsonElement, j -> j
-			.getAsJsonObject()
-			.getAsJsonArray(addressesKey)
-			.get(0)
-			.getAsJsonObject()
-			.getAsJsonPrimitive("lat")
-			.getAsDouble());
-		Double lon = Utils.safelyGetOrNull(jsonElement, j -> j
-			.getAsJsonObject()
-			.getAsJsonArray(addressesKey)
-			.get(0)
-			.getAsJsonObject()
-			.getAsJsonPrimitive("lng")
-			.getAsDouble());
+		Double lat = Utils.safelyGetOrNull(jsonElement, j ->
+			j
+				.getAsJsonObject()
+				.getAsJsonArray(addressesKey)
+				.get(0)
+				.getAsJsonObject()
+				.getAsJsonPrimitive("lat")
+				.getAsDouble()
+		);
+		Double lon = Utils.safelyGetOrNull(jsonElement, j ->
+			j
+				.getAsJsonObject()
+				.getAsJsonArray(addressesKey)
+				.get(0)
+				.getAsJsonObject()
+				.getAsJsonPrimitive("lng")
+				.getAsDouble()
+		);
 
 		return new RorData(
 			country,

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/BibtexParserTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/BibtexParserTest.java
@@ -5,13 +5,12 @@
 
 package nl.esciencecenter.rsd.scraper;
 
-import nl.esciencecenter.rsd.scraper.doi.ExternalMentionRecord;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.io.IOException;
 import java.io.StringReader;
 import java.util.Map;
+import nl.esciencecenter.rsd.scraper.doi.ExternalMentionRecord;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class BibtexParserTest {
 
@@ -53,8 +52,10 @@ class BibtexParserTest {
 
 		Assertions.assertEquals(3, result.size());
 		Assertions.assertEquals("Brughmans, Tom", result.get("Brughmans2018").authors());
-		Assertions.assertEquals("Network structures and assembling code in Netlogo, Tutorial", result.get("Brughmans2018")
-			.title());
+		Assertions.assertEquals(
+			"Network structures and assembling code in Netlogo, Tutorial",
+			result.get("Brughmans2018").title()
+		);
 		Assertions.assertEquals(2018, result.get("Brughmans2018").publicationYear());
 	}
 
@@ -79,8 +80,10 @@ class BibtexParserTest {
 
 		Assertions.assertEquals(1, result.size());
 		Assertions.assertEquals("Romanowska, Iza", result.get("romanowska_agent-based_2021").authors());
-		Assertions.assertEquals("Agent-Based Modeling for Archaeology", result.get("romanowska_agent-based_2021")
-			.title());
+		Assertions.assertEquals(
+			"Agent-Based Modeling for Archaeology",
+			result.get("romanowska_agent-based_2021").title()
+		);
 		Assertions.assertEquals("10.37911/9781947864382", result.get("romanowska_agent-based_2021").doi().toString());
 		Assertions.assertEquals(2021, result.get("romanowska_agent-based_2021").publicationYear());
 	}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/UtilsIT.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/UtilsIT.java
@@ -27,9 +27,7 @@ class UtilsIT {
 	@Test
 	void getWrongUri() {
 		final String wrongUri = gitHubApiUrl + "/repos/research-software-directory/wrongRepo";
-		Exception thrown = Assertions.assertThrows(
-			Exception.class, () -> Utils.get(wrongUri)
-		);
+		Exception thrown = Assertions.assertThrows(Exception.class, () -> Utils.get(wrongUri));
 		Assertions.assertTrue(thrown.getMessage().startsWith("Error fetching data"));
 	}
 

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepositoryTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepositoryTest.java
@@ -5,11 +5,10 @@
 
 package nl.esciencecenter.rsd.scraper.doi;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.util.Collection;
 import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class DataciteMentionRepositoryTest {
 

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/DoiTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/DoiTest.java
@@ -13,7 +13,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 class DoiTest {
 
 	@ParameterizedTest
-	@ValueSource(strings = {
+	@ValueSource(
+		strings = {
 			"10.2533/chimia.2024.525",
 			"10.1017/9781108881425",
 			"10.3390/photonics11070630",
@@ -21,14 +22,16 @@ class DoiTest {
 			"10.1007/978-3-030-83508-8_2",
 			"10.22541/essoar.171500959.99365288/v1",
 			"10.1016/j.eswa.2023.120561",
-	})
+		}
+	)
 	void givenValidDoi_whenInstanceCreated_thenNoExceptionThrown(String validDoi) {
 		Doi doi = Assertions.assertDoesNotThrow(() -> Doi.fromString(validDoi));
 		Assertions.assertNotNull(doi);
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
+	@ValueSource(
+		strings = {
 			"10.2533",
 			"10.2533/",
 			"https://doi.org/10.2533/chimia.2024.525",
@@ -36,7 +39,8 @@ class DoiTest {
 			"10.3390/photonics11070630 ",
 			"11.1016/j.eswa.2023.120561",
 			"",
-	})
+		}
+	)
 	void givenInValidDoi_whenCreatingInstance_thenExceptionThrown(String invalidDoi) {
 		Assertions.assertThrows(RuntimeException.class, () -> Doi.fromString(invalidDoi));
 	}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/MainMentionsTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/MainMentionsTest.java
@@ -5,13 +5,11 @@
 
 package nl.esciencecenter.rsd.scraper.doi;
 
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-import java.util.Map;
-
 class MainMentionsTest {
-
 
 	@Test
 	void givenValidDoiSourceData_whenParsing_thenMapReturned() {

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnectorTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnectorTest.java
@@ -7,12 +7,11 @@ package nl.esciencecenter.rsd.scraper.doi;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.net.URI;
 import java.util.Collection;
 import java.util.Collections;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class OpenAlexConnectorTest {
 
@@ -34,10 +33,14 @@ class OpenAlexConnectorTest {
 	void givenEmptyCollection_whenGettingData_thenEmptyCollectionReturned() {
 		OpenAlexConnector openAlexConnector = new OpenAlexConnector();
 
-		Collection<ExternalMentionRecord> doiMentions = Assertions.assertDoesNotThrow(() -> openAlexConnector.mentionDataByDois(Collections.emptyList(), null));
+		Collection<ExternalMentionRecord> doiMentions = Assertions.assertDoesNotThrow(() ->
+			openAlexConnector.mentionDataByDois(Collections.emptyList(), null)
+		);
 		Assertions.assertTrue(doiMentions.isEmpty());
 
-		Collection<ExternalMentionRecord> openalexMentions = Assertions.assertDoesNotThrow(() -> openAlexConnector.mentionDataByOpenalexIds(Collections.emptyList(), null));
+		Collection<ExternalMentionRecord> openalexMentions = Assertions.assertDoesNotThrow(() ->
+			openAlexConnector.mentionDataByOpenalexIds(Collections.emptyList(), null)
+		);
 		Assertions.assertTrue(openalexMentions.isEmpty());
 	}
 }

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenalexIdTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenalexIdTest.java
@@ -13,25 +13,27 @@ import org.junit.jupiter.params.provider.ValueSource;
 class OpenalexIdTest {
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-			"https://openalex.org/W3160330321",
-			"https://openalex.org/w3160330321",
-			"https://openalex.org/W152867311",
-	})
+	@ValueSource(
+		strings = {
+			"https://openalex.org/W3160330321", "https://openalex.org/w3160330321", "https://openalex.org/W152867311",
+		}
+	)
 	void givenValidOpenalexId_whenInstanceCreated_thenNoExceptionThrown(String validId) {
 		OpenalexId openalexId = Assertions.assertDoesNotThrow(() -> OpenalexId.fromString(validId));
 		Assertions.assertNotNull(openalexId);
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
+	@ValueSource(
+		strings = {
 			"http://openalex.org/W3160330321",
 			"https://openalex.org/3160330321",
 			"https://openalex.org/W3160330321/",
 			"https://openalex.org/works/W3160330321",
 			"W3160330321",
 			"",
-	})
+		}
+	)
 	void givenInValidOpenalexId_whenCreatingInstance_thenExceptionThrown(String invalidId) {
 		Assertions.assertThrows(RuntimeException.class, () -> OpenalexId.fromString(invalidId));
 	}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeekTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/CommitsPerWeekTest.java
@@ -11,13 +11,12 @@ import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonDeserializer;
 import com.google.gson.reflect.TypeToken;
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.time.Duration;
 import java.time.Instant;
 import java.time.Period;
 import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class CommitsPerWeekTest {
 
@@ -34,7 +33,6 @@ class CommitsPerWeekTest {
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight1));
 		Assertions.assertEquals(10, underlyingMap.get(sundayMidnight1));
 
-
 		commitsPerWeek.addCommits(sundayMidnight1, 20);
 
 		underlyingMap = commitsPerWeek.getData();
@@ -42,8 +40,8 @@ class CommitsPerWeekTest {
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight1));
 		Assertions.assertEquals(30, underlyingMap.get(sundayMidnight1));
 
-
-		Instant smallTimeAfterSundayMidnight1 = sundayMidnight1.plus(Duration.ofDays(3))
+		Instant smallTimeAfterSundayMidnight1 = sundayMidnight1
+			.plus(Duration.ofDays(3))
 			.plus(Duration.ofSeconds(12345));
 		commitsPerWeek.addCommits(smallTimeAfterSundayMidnight1, 10);
 
@@ -51,7 +49,6 @@ class CommitsPerWeekTest {
 		Assertions.assertEquals(1, underlyingMap.size());
 		Assertions.assertTrue(underlyingMap.containsKey(sundayMidnight1));
 		Assertions.assertEquals(40, underlyingMap.get(sundayMidnight1));
-
 
 		Instant sundayMidnight2 = sundayMidnight1.plus(Period.ofWeeks(5));
 		commitsPerWeek.addCommits(sundayMidnight2, 5);
@@ -62,7 +59,6 @@ class CommitsPerWeekTest {
 		Assertions.assertEquals(5, underlyingMap.get(sundayMidnight2));
 		Assertions.assertEquals(40, underlyingMap.get(sundayMidnight1));
 
-
 		commitsPerWeek.addMissingZeros();
 		underlyingMap = commitsPerWeek.getData();
 		Assertions.assertEquals(6, underlyingMap.size());
@@ -72,16 +68,18 @@ class CommitsPerWeekTest {
 		Assertions.assertEquals(0, underlyingMap.get(sundayMidnight1.plus(Period.ofWeeks(4))));
 		Assertions.assertEquals(40, underlyingMap.get(sundayMidnight1));
 		Assertions.assertEquals(5, underlyingMap.get(sundayMidnight2));
-
 	}
 
 	@Test
 	void givenInstance_whenValidOperations_thenCorrectJsonProduced() {
 		Gson gson = new GsonBuilder()
-			.registerTypeAdapter(Instant.class, (JsonDeserializer<Instant>) (json, typeOfT, context) -> Instant.ofEpochSecond(Long.parseLong(json.getAsString())))
+			.registerTypeAdapter(
+				Instant.class,
+				(JsonDeserializer<Instant>) (json, typeOfT, context) ->
+					Instant.ofEpochSecond(Long.parseLong(json.getAsString()))
+			)
 			.create();
-		TypeToken<Map<Instant, Long>> mapTypeToken = new TypeToken<>() {
-		};
+		TypeToken<Map<Instant, Long>> mapTypeToken = new TypeToken<>() {};
 		CommitsPerWeek commitsPerWeek = new CommitsPerWeek();
 
 		Map<Instant, Long> shouldBeEmptyMap = gson.fromJson(commitsPerWeek.toJson(), mapTypeToken.getType());
@@ -91,13 +89,13 @@ class CommitsPerWeekTest {
 		commitsPerWeek.addCommits(sundayMidnight1, 10);
 		commitsPerWeek.addCommits(sundayMidnight1, 20);
 
-		Instant smallTimeAfterSundayMidnight1 = sundayMidnight1.plus(Duration.ofDays(3))
+		Instant smallTimeAfterSundayMidnight1 = sundayMidnight1
+			.plus(Duration.ofDays(3))
 			.plus(Duration.ofSeconds(12345));
 		commitsPerWeek.addCommits(smallTimeAfterSundayMidnight1, 10);
 
 		Instant sundayMidnight2 = sundayMidnight1.plus(Period.ofWeeks(5));
 		commitsPerWeek.addCommits(sundayMidnight2, 5);
-
 
 		Map<Instant, Long> dataFromJson = gson.fromJson(commitsPerWeek.toJson(), mapTypeToken.getType());
 		Assertions.assertEquals(2, dataFromJson.size());
@@ -105,8 +103,7 @@ class CommitsPerWeekTest {
 		Assertions.assertEquals(5, dataFromJson.get(sundayMidnight2));
 
 		commitsPerWeek.addMissingZeros();
-		dataFromJson = gson.fromJson(commitsPerWeek.toJson(), new TypeToken<Map<Instant, Long>>() {
-		}.getType());
+		dataFromJson = gson.fromJson(commitsPerWeek.toJson(), new TypeToken<Map<Instant, Long>>() {}.getType());
 		Assertions.assertEquals(6, dataFromJson.size());
 		Assertions.assertEquals(0, dataFromJson.get(sundayMidnight1.plus(Period.ofWeeks(1))));
 		Assertions.assertEquals(0, dataFromJson.get(sundayMidnight1.plus(Period.ofWeeks(2))));

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperTest.java
@@ -7,11 +7,10 @@
 
 package nl.esciencecenter.rsd.scraper.git;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class GithubScraperTest {
 
@@ -23,11 +22,16 @@ class GithubScraperTest {
 
 	@Test
 	void givenListWithLastPageHeader_whenParsing_thenCorrectPageReturned() {
-		List<String> singleLinkList = List.of("<https://api.github.com/repositories/413814951/contributors?per_page=1&page=2>; rel=\"next\", <https://api.github.com/repositories/413814951/contributors?per_page=1&page=9>; rel=\"last\"");
+		List<String> singleLinkList = List.of(
+			"<https://api.github.com/repositories/413814951/contributors?per_page=1&page=2>; rel=\"next\", <https://api.github.com/repositories/413814951/contributors?per_page=1&page=9>; rel=\"last\""
+		);
 
 		String[] lastPageData = GithubScraper.lastPageFromLinkHeader(singleLinkList);
 		Assertions.assertEquals(2, lastPageData.length);
-		Assertions.assertEquals("https://api.github.com/repositories/413814951/contributors?per_page=1&page=9", lastPageData[0]);
+		Assertions.assertEquals(
+			"https://api.github.com/repositories/413814951/contributors?per_page=1&page=9",
+			lastPageData[0]
+		);
 		Assertions.assertEquals("9", lastPageData[1]);
 	}
 

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GitlabScraperIT.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GitlabScraperIT.java
@@ -11,8 +11,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-
 class GitlabScraperIT {
+
 	private final String baseApiUrl = "https://git.gfz-potsdam.de/api";
 	private final String repo = "swc-bb/swc-templates/swc-l/python";
 	private final GitlabScraper scraper = new GitlabScraper(baseApiUrl, repo);

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/PostgrestConnectorTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/PostgrestConnectorTest.java
@@ -5,11 +5,10 @@
 
 package nl.esciencecenter.rsd.scraper.git;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
-
 import java.util.Collection;
 import java.util.UUID;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 class PostgrestConnectorTest {
 
@@ -50,12 +49,14 @@ class PostgrestConnectorTest {
 				}
 			]""";
 
-		Assertions.assertThrowsExactly(IllegalArgumentException.class, () -> PostgrestConnector.parseBasicJsonData(invalidUuidJson));
+		Assertions.assertThrowsExactly(IllegalArgumentException.class, () ->
+			PostgrestConnector.parseBasicJsonData(invalidUuidJson)
+		);
 	}
 
 	@Test
 	void givenInvalidJson_whenParsingJsonData_thenExceptionThrown() {
-//		missing comma after software UUID
+		//		missing comma after software UUID
 		String invalidJson = """
 			[
 				{
@@ -76,7 +77,9 @@ class PostgrestConnectorTest {
 				}
 			]""";
 
-		Assertions.assertThrows(RuntimeException.class, () -> PostgrestConnector.parseBasicJsonData(missingSoftwareJson));
+		Assertions.assertThrows(RuntimeException.class, () ->
+			PostgrestConnector.parseBasicJsonData(missingSoftwareJson)
+		);
 
 		String missingUrlJson = """
 			[

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/license/GitHubSpdxLicenseRepositoryTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/license/GitHubSpdxLicenseRepositoryTest.java
@@ -5,10 +5,9 @@
 
 package nl.esciencecenter.rsd.scraper.license;
 
+import java.util.Map;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.util.Map;
 
 class GitHubSpdxLicenseRepositoryTest {
 
@@ -63,7 +62,9 @@ class GitHubSpdxLicenseRepositoryTest {
 			}""";
 		// editorconfig-checker-enable
 
-		Map<String, SpdxLicense> licenseMap = Assertions.assertDoesNotThrow(() -> GitHubSpdxLicenseRepository.parseLicensesJson(json));
+		Map<String, SpdxLicense> licenseMap = Assertions.assertDoesNotThrow(() ->
+			GitHubSpdxLicenseRepository.parseLicensesJson(json)
+		);
 		Assertions.assertEquals(3, licenseMap.size());
 		Assertions.assertTrue(licenseMap.containsKey("0BSD"));
 		Assertions.assertTrue(licenseMap.containsKey("MIT"));

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/nassa/NassaSoftwareEntryTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/nassa/NassaSoftwareEntryTest.java
@@ -5,10 +5,9 @@
 
 package nl.esciencecenter.rsd.scraper.nassa;
 
+import java.io.StringReader;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
-
-import java.io.StringReader;
 
 class NassaSoftwareEntryTest {
 
@@ -54,7 +53,11 @@ class NassaSoftwareEntryTest {
 			""";
 		// editorconfig-checker-enable
 
-		NassaSoftwareEntry entry = NassaSoftwareEntry.fromYaml(new StringReader(validYaml), "https://github.com/Archaeology-ABM/NASSA-modules/tree/main/2022-Verhagen-001", null);
+		NassaSoftwareEntry entry = NassaSoftwareEntry.fromYaml(
+			new StringReader(validYaml),
+			"https://github.com/Archaeology-ABM/NASSA-modules/tree/main/2022-Verhagen-001",
+			null
+		);
 
 		Assertions.assertNotNull(entry);
 		Assertions.assertEquals("Determine fertility rates for use in a demographic simulation.", entry.title);

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CranScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CranScraperTest.java
@@ -14,22 +14,28 @@ import org.junit.jupiter.params.provider.ValueSource;
 class CranScraperTest {
 
 	@ParameterizedTest
-	@CsvSource({
+	@CsvSource(
+		{
 			"https://CRAN.R-project.org/package=TIMP,TIMP",
 			"https://CRAN.R-project.org/package=TIMP/,TIMP",
 			"https://cran.r-project.org/package=splithalfr,splithalfr",
 			"https://cran.r-project.org/web/packages/GGIR,GGIR",
 			"https://cran.r-project.org/web/packages/GGIR/,GGIR",
 			"https://cran.r-project.org/web/packages/GGIR/index.html,GGIR",
-			"https://cran.r-project.org/web/packages/GGIR/index.html/,GGIR"
-	})
-	void givenValidCranUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNamesCorrect(String url, String expectedPackageName) {
+			"https://cran.r-project.org/web/packages/GGIR/index.html/,GGIR",
+		}
+	)
+	void givenValidCranUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNamesCorrect(
+		String url,
+		String expectedPackageName
+	) {
 		CranScraper cranScraper = Assertions.assertDoesNotThrow(() -> new CranScraper(url));
 		Assertions.assertEquals(expectedPackageName, cranScraper.packageName);
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
+	@ValueSource(
+		strings = {
 			"https://cran.r-project.org/web/packages/",
 			"https://cran.r-project.org/web/packages/GG IR",
 			"https://cran.r-project.org/web/packages/GGIR ",
@@ -39,8 +45,9 @@ class CranScraperTest {
 			"https://CRAN.R-project.org/package=TI MP ",
 			"https://CRAN.R-project.org/package=TIMP /",
 			"https://www.example.com",
-			""
-	})
+			"",
+		}
+	)
 	void givenInvalidCranUrl_whenCallingConstructor_thenExceptionThrown(String url) {
 		Assertions.assertThrowsExactly(RuntimeException.class, () -> new CranScraper(url));
 	}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CratesScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/CratesScraperTest.java
@@ -13,10 +13,7 @@ import org.junit.jupiter.params.provider.NullSource;
 class CratesScraperTest {
 
 	@ParameterizedTest
-	@CsvSource({
-		"https://crates.io/crates/tokio,tokio",
-		"https://crates.io/crates/tokio/,tokio",
-	})
+	@CsvSource({ "https://crates.io/crates/tokio,tokio", "https://crates.io/crates/tokio/,tokio" })
 	void givenValidCratesUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNamesCorrect(
 		String url,
 		String expectedPackageName

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/GoScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/GoScraperTest.java
@@ -13,12 +13,14 @@ import org.junit.jupiter.params.provider.NullSource;
 class GoScraperTest {
 
 	@ParameterizedTest
-	@CsvSource({
-		"https://pkg.go.dev/github.com/gin-gonic/gin,github.com/gin-gonic/gin",
-		"https://pkg.go.dev/github.com/gin-gonic/gin/,github.com/gin-gonic/gin",
-		"https://pkg.go.dev/google.golang.org/grpc,google.golang.org/grpc",
-		"https://pkg.go.dev/google.golang.org/grpc/,google.golang.org/grpc",
-	})
+	@CsvSource(
+		{
+			"https://pkg.go.dev/github.com/gin-gonic/gin,github.com/gin-gonic/gin",
+			"https://pkg.go.dev/github.com/gin-gonic/gin/,github.com/gin-gonic/gin",
+			"https://pkg.go.dev/google.golang.org/grpc,google.golang.org/grpc",
+			"https://pkg.go.dev/google.golang.org/grpc/,google.golang.org/grpc",
+		}
+	)
 	void givenValidGoUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNameCorrect(
 		String url,
 		String expectedPackageName

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/package_manager/scrapers/MavenScraperTest.java
@@ -14,12 +14,14 @@ import org.junit.jupiter.params.provider.ValueSource;
 class MavenScraperTest {
 
 	@ParameterizedTest
-	@CsvSource({
-		"https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle,org.openscience.cdk,cdk-bundle",
-		"https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle/,org.openscience.cdk,cdk-bundle",
-		"https://mvnrepository.com/artifact/io.github.sanctuuary/APE,io.github.sanctuuary,APE",
-		"https://mvnrepository.com/artifact/io.github.sanctuuary/APE/,io.github.sanctuuary,APE",
-	})
+	@CsvSource(
+		{
+			"https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle,org.openscience.cdk,cdk-bundle",
+			"https://central.sonatype.com/artifact/org.openscience.cdk/cdk-bundle/,org.openscience.cdk,cdk-bundle",
+			"https://mvnrepository.com/artifact/io.github.sanctuuary/APE,io.github.sanctuuary,APE",
+			"https://mvnrepository.com/artifact/io.github.sanctuuary/APE/,io.github.sanctuuary,APE",
+		}
+	)
 	void givenValidMavenOrSonatypeUrl_whenCallingConstructor_thenNoExceptionThrownAndPackageNameCorrect(
 		String url,
 		String expectedGroupId,
@@ -31,15 +33,17 @@ class MavenScraperTest {
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-		"https://central.sonatype.com/artifact",
-		"https://mvnrepository.com/artifact/",
-		"https://central.sonatype.com/artifact/org.openscience.cdk",
-		"https://mvnrepository.com/artifact/io.github.sanctuuary/",
-		"https://www.example.com",
-		"https://www.example.com/artifact/org.openscience.cdk/cdk-bundle",
-		""
-	})
+	@ValueSource(
+		strings = {
+			"https://central.sonatype.com/artifact",
+			"https://mvnrepository.com/artifact/",
+			"https://central.sonatype.com/artifact/org.openscience.cdk",
+			"https://mvnrepository.com/artifact/io.github.sanctuuary/",
+			"https://www.example.com",
+			"https://www.example.com/artifact/org.openscience.cdk/cdk-bundle",
+			"",
+		}
+	)
 	void givenInvalidUrl_whenCallingConstructor_thenExceptionThrown(String url) {
 		Assertions.assertThrowsExactly(RuntimeException.class, () -> new MavenScraper(url));
 	}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ror/RorIdTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ror/RorIdTest.java
@@ -5,71 +5,78 @@
 
 package nl.esciencecenter.rsd.scraper.ror;
 
+import java.net.URI;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.net.URI;
-
 class RorIdTest {
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-		"https://ror.org/14tsk2644", // ID should start with 0
-		"https://ror.org/0ltsk2644", // character 'l' not allowed
-		"https://ror.org/04tsk26444", // ID longer than 9 characters
-		"https://ror.org/04tsk264", // // ID shorter than 9 characters
-		"ror.org/04tsk2644", // should start with https://
-		"",
-	})
+	@ValueSource(
+		strings = {
+			"https://ror.org/14tsk2644", // ID should start with 0
+			"https://ror.org/0ltsk2644", // character 'l' not allowed
+			"https://ror.org/04tsk26444", // ID longer than 9 characters
+			"https://ror.org/04tsk264", // // ID shorter than 9 characters
+			"ror.org/04tsk2644", // should start with https://
+			"",
+		}
+	)
 	void givenInvalidRorIds_whenTesting_thenFalseReturned(String url) {
 		Assertions.assertFalse(RorId.isValidRorUrl(url));
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-		"https://ror.org/14tsk2644", // ID should start with 0
-		"https://ror.org/0ltsk2644", // character 'l' not allowed
-		"https://ror.org/04tsk26444", // ID longer than 9 characters
-		"https://ror.org/04tsk264", // // ID shorter than 9 characters
-		"ror.org/04tsk2644", // should start with https://
-		"",
-	})
+	@ValueSource(
+		strings = {
+			"https://ror.org/14tsk2644", // ID should start with 0
+			"https://ror.org/0ltsk2644", // character 'l' not allowed
+			"https://ror.org/04tsk26444", // ID longer than 9 characters
+			"https://ror.org/04tsk264", // // ID shorter than 9 characters
+			"ror.org/04tsk2644", // should start with https://
+			"",
+		}
+	)
 	void givenInvalidRorIds_whenCreatingInstance_thenExceptionThrown(String url) {
 		Assertions.assertThrows(IllegalArgumentException.class, () -> RorId.fromUrlString(url));
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-		"https://ror.org/04tsk2644",
-		"https://ror.org/05qghxh33",
-		"https://ror.org/01e6qks80",
-		"https://ror.org/00wjc7c48",
-		"https://ror.org/01swzsf04",
-		"https://ror.org/02jbv0t02",
-		"https://ror.org/05grdyy37",
-		"https://ror.org/05f950310",
-		"https://ror.org/04ke6ht85",
-		"https://ror.org/018dfmf50",
-	})
+	@ValueSource(
+		strings = {
+			"https://ror.org/04tsk2644",
+			"https://ror.org/05qghxh33",
+			"https://ror.org/01e6qks80",
+			"https://ror.org/00wjc7c48",
+			"https://ror.org/01swzsf04",
+			"https://ror.org/02jbv0t02",
+			"https://ror.org/05grdyy37",
+			"https://ror.org/05f950310",
+			"https://ror.org/04ke6ht85",
+			"https://ror.org/018dfmf50",
+		}
+	)
 	void givenValidRorIds_whenTesting_thenTrueReturned(String url) {
 		Assertions.assertTrue(RorId.isValidRorUrl(url));
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-		"https://ror.org/04tsk2644",
-		"https://ror.org/05qghxh33",
-		"https://ror.org/01e6qks80",
-		"https://ror.org/00wjc7c48",
-		"https://ror.org/01swzsf04",
-		"https://ror.org/02jbv0t02",
-		"https://ror.org/05grdyy37",
-		"https://ror.org/05f950310",
-		"https://ror.org/04ke6ht85",
-		"https://ror.org/018dfmf50",
-	})
+	@ValueSource(
+		strings = {
+			"https://ror.org/04tsk2644",
+			"https://ror.org/05qghxh33",
+			"https://ror.org/01e6qks80",
+			"https://ror.org/00wjc7c48",
+			"https://ror.org/01swzsf04",
+			"https://ror.org/02jbv0t02",
+			"https://ror.org/05grdyy37",
+			"https://ror.org/05f950310",
+			"https://ror.org/04ke6ht85",
+			"https://ror.org/018dfmf50",
+		}
+	)
 	void givenValidRorIds_whenCreatingInstance_thenNoExceptionThrown(String url) {
 		RorId rorId = Assertions.assertDoesNotThrow(() -> RorId.fromUrlString(url));
 		Assertions.assertNotNull(rorId);

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ror/RorPostgrestConnectorTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ror/RorPostgrestConnectorTest.java
@@ -7,19 +7,19 @@
 
 package nl.esciencecenter.rsd.scraper.ror;
 
-import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.util.Collection;
 import java.util.UUID;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
+import org.junit.jupiter.api.Test;
 
 class RorPostgrestConnectorTest {
 
 	@Test
 	void testParseBasicJsonData() {
-		String data = "[{\"id\":\"52b13a36-334b-429a-9cbb-5215264b36d2\",\"parent\":null,\"primary_maintainer\":\"22f87e87-7fd9-4716-9dc6-e790372cac4c\",\"slug\":\"gfz\",\"name\":\"Helmholtz Centre Potsdam GFZ German Research Centre for Geosciences\",\"ror_id\":\"https://ror.org/04z8jg394\",\"website\":\"https://www.gfz-potsdam.de\",\"is_tenant\":true,\"created_at\":\"2022-07-26T19:34:55.173342+00:00\",\"updated_at\":\"2023-05-17T06:11:51.338233+00:00\",\"description\":\"# About GFZ Potsdam\n\nThe GFZ is Germany’s national research center for the solid Earth Sciences. Our mission is to deepen the knowledge of the dynamics of the solid Earth, and to develop solutions for grand challenges facing society. These challenges include anticipating the hazards arising from the Earth’s dynamic systems and mitigating the associated risks to society; securing our habitat under the pressure of global change; and supplying energy and mineral resources for a rapidly growing population in a sustainable manner and without harming the environment. \n\n## Research Software at GFZ\n\nTo learn more about the research software policy at GFZ, visit [gfz-potsdam.de/en/software](https://www.gfz-potsdam.de/en/software).\n\n\",\"logo_id\":\"da40b40113fdfb1d3ce40f58ecb784fe33ba40bb\",\"country\":null,\"city\":null,\"short_description\":null}]";
+		String data =
+			"[{\"id\":\"52b13a36-334b-429a-9cbb-5215264b36d2\",\"parent\":null,\"primary_maintainer\":\"22f87e87-7fd9-4716-9dc6-e790372cac4c\",\"slug\":\"gfz\",\"name\":\"Helmholtz Centre Potsdam GFZ German Research Centre for Geosciences\",\"ror_id\":\"https://ror.org/04z8jg394\",\"website\":\"https://www.gfz-potsdam.de\",\"is_tenant\":true,\"created_at\":\"2022-07-26T19:34:55.173342+00:00\",\"updated_at\":\"2023-05-17T06:11:51.338233+00:00\",\"description\":\"# About GFZ Potsdam\n\nThe GFZ is Germany’s national research center for the solid Earth Sciences. Our mission is to deepen the knowledge of the dynamics of the solid Earth, and to develop solutions for grand challenges facing society. These challenges include anticipating the hazards arising from the Earth’s dynamic systems and mitigating the associated risks to society; securing our habitat under the pressure of global change; and supplying energy and mineral resources for a rapidly growing population in a sustainable manner and without harming the environment. \n\n## Research Software at GFZ\n\nTo learn more about the research software policy at GFZ, visit [gfz-potsdam.de/en/software](https://www.gfz-potsdam.de/en/software).\n\n\",\"logo_id\":\"da40b40113fdfb1d3ce40f58ecb784fe33ba40bb\",\"country\":null,\"city\":null,\"short_description\":null}]";
 
 		Collection<OrganisationDatabaseData> result = RorPostgrestConnector.parseBasicJsonData(data);
 		assertEquals(1, result.size());

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ror/RorScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ror/RorScraperTest.java
@@ -7,36 +7,35 @@
 
 package nl.esciencecenter.rsd.scraper.ror;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 
-import java.util.List;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-
-
 class RorScraperTest {
-
 
 	@Test
 	void testLocations() {
-		String completeJsonResponse = "{\"id\":\"https://ror.org/04z8jg394\",\"name\":\"Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences\",\"email_address\":\"\",\"ip_addresses\":[],\"established\":1992,\"types\":[\"Facility\"],\"relationships\":[{\"label\":\"Helmholtz Association of German Research Centres\",\"type\":\"Parent\",\"id\":\"https://ror.org/0281dp749\"}],\"addresses\":[{\"lat\":52.39886,\"lng\":13.06566,\"state\":null,\"state_code\":null,\"city\":\"Potsdam\",\"geonames_city\":{\"id\":2852458,\"city\":\"Potsdam\",\"geonames_admin1\":{\"name\":\"Brandenburg\",\"id\":2945356,\"ascii_name\":\"Brandenburg\",\"code\":\"DE.11\"},\"geonames_admin2\":{\"name\":null,\"id\":null,\"ascii_name\":null,\"code\":\"DE.11.00\"},\"license\":{\"attribution\":\"Data from geonames.org under a CC-BY 3.0 license\",\"license\":\"http://creativecommons.org/licenses/by/3.0/\"},\"nuts_level1\":{\"name\":null,\"code\":null},\"nuts_level2\":{\"name\":null,\"code\":null},\"nuts_level3\":{\"name\":null,\"code\":null}},\"postcode\":null,\"primary\":false,\"line\":null,\"country_geonames_id\":2921044}],\"links\":[\"https://www.gfz-potsdam.de\"],\"aliases\":[],\"acronyms\":[\"GFZ\"],\"status\":\"active\",\"wikipedia_url\":\"https://en.wikipedia.org/wiki/GFZ_German_Research_Centre_for_Geosciences\",\"labels\":[{\"label\":\"Helmholtz-Zentrum Potsdam - Deutsches GeoForschungsZentrum GFZ\",\"iso639\":\"de\"}],\"country\":{\"country_name\":\"Germany\",\"country_code\":\"DE\"},\"external_ids\":{\"ISNI\":{\"preferred\":null,\"all\":[\"0000 0000 9195 2461\"]},\"FundRef\":{\"preferred\":\"501100010956\",\"all\":[\"501100010956\"]},\"Wikidata\":{\"preferred\":null,\"all\":[\"Q1205654\"]},\"GRID\":{\"preferred\":\"grid.23731.34\",\"all\":\"grid.23731.34\"}}}";
+		String completeJsonResponse =
+			"{\"id\":\"https://ror.org/04z8jg394\",\"name\":\"Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences\",\"email_address\":\"\",\"ip_addresses\":[],\"established\":1992,\"types\":[\"Facility\"],\"relationships\":[{\"label\":\"Helmholtz Association of German Research Centres\",\"type\":\"Parent\",\"id\":\"https://ror.org/0281dp749\"}],\"addresses\":[{\"lat\":52.39886,\"lng\":13.06566,\"state\":null,\"state_code\":null,\"city\":\"Potsdam\",\"geonames_city\":{\"id\":2852458,\"city\":\"Potsdam\",\"geonames_admin1\":{\"name\":\"Brandenburg\",\"id\":2945356,\"ascii_name\":\"Brandenburg\",\"code\":\"DE.11\"},\"geonames_admin2\":{\"name\":null,\"id\":null,\"ascii_name\":null,\"code\":\"DE.11.00\"},\"license\":{\"attribution\":\"Data from geonames.org under a CC-BY 3.0 license\",\"license\":\"http://creativecommons.org/licenses/by/3.0/\"},\"nuts_level1\":{\"name\":null,\"code\":null},\"nuts_level2\":{\"name\":null,\"code\":null},\"nuts_level3\":{\"name\":null,\"code\":null}},\"postcode\":null,\"primary\":false,\"line\":null,\"country_geonames_id\":2921044}],\"links\":[\"https://www.gfz-potsdam.de\"],\"aliases\":[],\"acronyms\":[\"GFZ\"],\"status\":\"active\",\"wikipedia_url\":\"https://en.wikipedia.org/wiki/GFZ_German_Research_Centre_for_Geosciences\",\"labels\":[{\"label\":\"Helmholtz-Zentrum Potsdam - Deutsches GeoForschungsZentrum GFZ\",\"iso639\":\"de\"}],\"country\":{\"country_name\":\"Germany\",\"country_code\":\"DE\"},\"external_ids\":{\"ISNI\":{\"preferred\":null,\"all\":[\"0000 0000 9195 2461\"]},\"FundRef\":{\"preferred\":\"501100010956\",\"all\":[\"501100010956\"]},\"Wikidata\":{\"preferred\":null,\"all\":[\"Q1205654\"]},\"GRID\":{\"preferred\":\"grid.23731.34\",\"all\":\"grid.23731.34\"}}}";
 		RorData rorData = RorScraper.parseData(completeJsonResponse);
 
 		assertEquals("Potsdam", rorData.city());
 		assertEquals("Germany", rorData.country());
 		assertEquals(List.of("Facility"), rorData.rorTypes());
-
 	}
 
 	@ParameterizedTest
-	@ValueSource(strings = {
-		"{\"addresses\": [{\"city\": null}], \"country\": {\"country_name\": null}}",
-		"{\"addresses\": [],\"country\": {}}",
-		"{}",
-	})
+	@ValueSource(
+		strings = {
+			"{\"addresses\": [{\"city\": null}], \"country\": {\"country_name\": null}}",
+			"{\"addresses\": [],\"country\": {}}",
+			"{}",
+		}
+	)
 	void testNullLocationsOrEmptyLocationOrEmptyResponse(String jsonBody) {
 		RorData rorData = RorScraper.parseData(jsonBody);
 


### PR DESCRIPTION
## Expand Prettier to Java files

### Changes proposed in this pull request

* Expand the existing Prettier setup from the data-generation module and move it to the root to include all Java files
* Adapt the GitHub action that checks for correct formatting

### How to test

* Install Prettier in the root of the project (`npm install`) for future contributions
* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Test if the RSD still works
* Check the first commit of this PR

Note that the config can still be overridden with different options for other directories

Part of #915

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [ ] Tests
