### PR TITLE
Fix restoring database backups

### DIFF
--- a/database/104-software-views.sql
+++ b/database/104-software-views.sql
@@ -117,15 +117,15 @@ SELECT
 		reference_paper_for_software.mention
 	) AS reference_paper
 FROM
-	reference_paper_for_software
+	public.reference_paper_for_software
 INNER JOIN
-	citation_for_mention ON citation_for_mention.mention = reference_paper_for_software.mention
+	public.citation_for_mention ON citation_for_mention.mention = reference_paper_for_software.mention
 INNER JOIN
-	mention ON mention.id = citation_for_mention.citation
+	public.mention ON mention.id = citation_for_mention.citation
 --EXCLUDE reference papers items from citations
 WHERE
 	mention.id NOT IN (
-		SELECT mention FROM reference_paper_for_software
+		SELECT mention FROM public.reference_paper_for_software
 	)
 GROUP BY
 	reference_paper_for_software.software,
@@ -168,9 +168,9 @@ WITH mentions_and_citations AS (
 		mention.mention_type,
 		mention.source
 	FROM
-		mention
+		public.mention
 	INNER JOIN
-		mention_for_software ON mention_for_software.mention = mention.id
+		public.mention_for_software ON mention_for_software.mention = mention.id
 	-- does not deduplicate identical entries, but we will do so below with DISTINCT
 	-- from scraped citations
 	UNION ALL
@@ -190,7 +190,7 @@ WITH mentions_and_citations AS (
 		mention_type,
 		source
 	FROM
-		citation_by_software()
+		public.citation_by_software()
 )
 SELECT DISTINCT ON (mentions_and_citations.software, mentions_and_citations.id) * FROM mentions_and_citations;
 $$;
@@ -201,7 +201,7 @@ $$
 	SELECT
 		mentions_by_software.software, COUNT(mentions_by_software.id) AS mention_cnt
 	FROM
-		mentions_by_software()
+		public.mentions_by_software()
 	GROUP BY
 		mentions_by_software.software;
 $$;


### PR DESCRIPTION
## Fix restoring database backups

### Changes proposed in this pull request

* Fix restoring database backups by using fully qualified names in the materialized view

### How to test

Run the following:

```bash
docker compose down --volumes
docker compose build --parallel

#it might take a few seconds before you see any output and some more time before it exits
docker compose up --scale scrapers=0 --scale data-generation=1 --attach data-generation

docker compose exec database pg_dump --format=tar --file=db_backup.tar --username=rsd --dbname=rsd-db
docker compose cp database:/db_backup.tar ./

docker compose down --volumes
docker compose up --scale scrapers=0 --scale data-generation=0 --detach

#to ensure database is ready
sleep 15s

docker compose cp ./db_backup.tar database:/
docker compose exec database bash -c 'pg_restore --username=rsd --dbname=rsd-db --clean /db_backup.tar'

#removes backup from your file system
rm ./db_backup.tar
```

The database should be restored without any errors

closes #1499

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
