### PR TITLE
feat: organisation overview as card grid or list view

### DIFF
--- a/frontend/__tests__/OrganisationsOverview.test.tsx
+++ b/frontend/__tests__/OrganisationsOverview.test.tsx
@@ -1,23 +1,25 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {render, screen} from '@testing-library/react'
 
-import OrganisationsOverviewPage, {getServerSideProps} from '../pages/organisations/index'
-import {mockResolvedValue} from '../utils/jest/mockFetch'
-
+import OrganisationsOverviewPage, {getServerSideProps} from 'pages/organisations/index'
+import {mockResolvedValue} from '~/utils/jest/mockFetch'
 import {WithAppContext} from '~/utils/jest/WithAppContext'
 import organisationsOverview from './__mocks__/organisationsOverview.json'
+import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
+import {OrganisationList} from '~/types/Organisation'
 
 const mockProps = {
   count: 408,
   page: 1,
   rows: 12,
-  organisations: organisationsOverview as any
+  organisations: organisationsOverview as OrganisationList[],
+  layout: 'grid' as LayoutType
 }
 
 describe('pages/organisations/index.tsx', () => {
@@ -38,6 +40,7 @@ describe('pages/organisations/index.tsx', () => {
       props:{
         // count is extracted from response header
         count:200,
+        layout: 'grid',
         // default query param values
         page:1,
         rows:12,

--- a/frontend/components/organisation/overview/OrganisationList.tsx
+++ b/frontend/components/organisation/overview/OrganisationList.tsx
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import NoContent from '~/components/layout/NoContent'
+
+import {OrganisationForOverview} from '~/types/Organisation'
+import OrganisationListItem from '~/components/user/organisations/OrganisationListItem'
+
+export default function OrganisationList({organisations}:Readonly<{organisations: OrganisationForOverview[]}>) {
+  if (typeof organisations == 'undefined' || organisations.length===0){
+    return <NoContent />
+  }
+  return (
+    <section
+      data-testid="organisation-overview-list"
+      className="flex-1 my-12 flex flex-col gap-2">
+      {organisations.map((item) => (
+        <OrganisationListItem key={item.rsd_path} organisation={item} />
+      ))}
+    </section>
+  )
+}

--- a/frontend/pages/communities/index.tsx
+++ b/frontend/pages/communities/index.tsx
@@ -11,7 +11,10 @@ import Pagination from '@mui/material/Pagination'
 import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
-import {getUserSettings, setDocumentCookie} from '~/utils/userSettings'
+import {useSession} from '~/auth'
+import {getRsdModules} from '~/config/getSettingsServerSide'
+import {useUserSettings} from '~/config/UserSettingsContext'
+import {getUserSettings} from '~/utils/userSettings'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
 import PageMeta from '~/components/seo/PageMeta'
 import PageBackground from '~/components/layout/PageBackground'
@@ -23,12 +26,9 @@ import useSearchParams from '~/components/search/useSearchParams'
 import SelectRows from '~/components/software/overview/search/SelectRows'
 import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
 import ViewToggleGroup,{ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
-
 import CommunitiesList from '~/components/communities/overview/CommunitiesList'
 import CommunitiesGrid from '~/components/communities/overview/CommunitiesGrid'
 import {CommunityListProps, getCommunityList} from '~/components/communities/apiCommunities'
-import {useSession} from '~/auth'
-import {getRsdModules} from '~/config/getSettingsServerSide'
 
 const pageTitle = `Communities | ${app.title}`
 const pageDesc = 'List of RSD communities.'
@@ -42,7 +42,6 @@ type CommunitiesOverviewProps={
   communities: CommunityListProps[]
 }
 
-
 export default function CommunitiesOverview({count,page,rows,layout,search,communities}:CommunitiesOverviewProps) {
   const {user} = useSession()
   if (user?.role !== 'rsd_admin') {
@@ -54,6 +53,7 @@ export default function CommunitiesOverview({count,page,rows,layout,search,commu
   const initView = layout === 'masonry' ? 'grid' : layout
   const [view, setView] = useState<ProjectLayoutType>(initView)
   const numPages = Math.ceil(count / rows)
+  const {setPageLayout} = useUserSettings()
 
   // console.group('CommunitiesOverview')
   // console.log('count...', count)
@@ -68,8 +68,8 @@ export default function CommunitiesOverview({count,page,rows,layout,search,commu
   function setLayout(view: ProjectLayoutType) {
     // update local view
     setView(view)
-    // save to cookie
-    setDocumentCookie(view,'rsd_page_layout')
+    // save change to user context and cookie
+    setPageLayout(view)
   }
 
   return (

--- a/frontend/pages/organisations/index.tsx
+++ b/frontend/pages/organisations/index.tsx
@@ -6,36 +6,39 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {MouseEvent, ChangeEvent} from 'react'
+import {useState} from 'react'
 import {GetServerSidePropsContext} from 'next/types'
 import Link from 'next/link'
-import TablePagination from '@mui/material/TablePagination'
 import Pagination from '@mui/material/Pagination'
 import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
 import {getRsdModules} from '~/config/getSettingsServerSide'
-import PageTitle from '~/components/layout/PageTitle'
-import Searchbox from '~/components/form/Searchbox'
-import {OrganisationList} from '~/types/Organisation'
-import {rowsPerPageOptions} from '~/config/pagination'
+import {useUserSettings} from '~/config/UserSettingsContext'
+import {OrganisationForOverview} from '~/types/Organisation'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
-import {getOrganisationsList} from '~/components/organisation/apiOrganisations'
+import {getUserSettings} from '~/utils/userSettings'
 import PageMeta from '~/components/seo/PageMeta'
 import AppFooter from '~/components/AppFooter'
 import AppHeader from '~/components/AppHeader'
-import {getUserSettings} from '~/utils/userSettings'
 import useSearchParams from '~/components/search/useSearchParams'
 import OrganisationGrid from '~/components/organisation/overview/OrganisationGrid'
 import PageBackground from '~/components/layout/PageBackground'
 import CanonicalUrl from '~/components/seo/CanonicalUrl'
 import MainContent from '~/components/layout/MainContent'
+import SearchInput from '~/components/search/SearchInput'
+import ViewToggleGroup, {ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
+import SelectRows from '~/components/software/overview/search/SelectRows'
+import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
+import {getOrganisationsList} from '~/components/organisation/apiOrganisations'
+import OrganisationListView from '~/components/organisation/overview/OrganisationList'
 
 type OrganisationsOverviewPageProps = {
   count: number,
   page: number,
   rows: number,
-  organisations: OrganisationList[],
+  layout: LayoutType,
+  organisations: OrganisationForOverview[],
   search?: string,
 }
 
@@ -43,35 +46,27 @@ const pageTitle = `Organisations | ${app.title}`
 const pageDesc = 'List of organizations involved in the development of research software.'
 
 export default function OrganisationsOverviewPage({
-  organisations = [], count, page, rows, search
+  organisations = [], count, page, rows, search, layout
 }: OrganisationsOverviewPageProps) {
   const {handleQueryChange,createUrl} = useSearchParams('organisations')
+  const initView = layout === 'masonry' ? 'grid' : layout
+  const [view, setView] = useState<ProjectLayoutType>(initView)
   const numPages = Math.ceil(count / rows)
+  const {setPageLayout} = useUserSettings()
 
   // console.group('OrganisationsOverviewPage')
   // console.log('search...', search)
   // console.log('page...', page)
   // console.log('rows...', rows)
+  // console.log('view...', view)
   // console.log('organisations...', organisations)
   // console.groupEnd()
 
-  // next/previous page button
-  function handleTablePageChange(
-    event: MouseEvent<HTMLButtonElement> | null,
-    newPage: number,
-  ) {
-    // Pagination component starts counting from 0, but we need to start from 1
-    handleQueryChange('page',(newPage + 1).toString())
-  }
-  // change number of cards per page
-  function handleItemsPerPage(
-    event: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-  ) {
-    handleQueryChange('rows', event.target.value)
-  }
-
-  function handleSearch(searchFor: string) {
-    handleQueryChange('search',searchFor)
+  function setLayout(view: ProjectLayoutType) {
+    // update local view
+    setView(view)
+    // save change to user context and cookie
+    setPageLayout(view)
   }
 
   return (
@@ -89,36 +84,35 @@ export default function OrganisationsOverviewPage({
 
         <MainContent className="py-4">
           {/* Page title with search and pagination */}
-          <div className="px-4 rounded-lg bg-base-100 lg:sticky top-0 border border-base-200 z-9">
-            <PageTitle title="Organisations">
-              <div className="md:flex flex-wrap justify-end">
-                <div className="flex items-center lg:ml-4">
-                  <Searchbox
-                    placeholder='Find organisation'
-                    onSearch={handleSearch}
-                    defaultValue={search}
-                  />
-                </div>
-                <TablePagination
-                  component="nav"
-                  count={count}
-                  // uses 0 based index
-                  page={page>0 ? page-1 : 0}
-                  labelRowsPerPage="Items"
-                  onPageChange={handleTablePageChange}
-                  rowsPerPage={rows}
-                  rowsPerPageOptions={rowsPerPageOptions}
-                  onRowsPerPageChange={handleItemsPerPage}
-                />
-              </div>
-            </PageTitle>
+          <div className="flex flex-wrap py-8 px-4 rounded-lg bg-base-100 lg:sticky top-0 border border-base-200 z-11">
+            <h1 className="mr-4 lg:flex-1">
+              Organisations
+            </h1>
+            <div className="flex-2 flex min-w-[20rem]">
+              <SearchInput
+                placeholder="Search organisation by name, ROR name or website"
+                onSearch={(search: string) => handleQueryChange('search', search)}
+                defaultValue={search ?? ''}
+              />
+              <ViewToggleGroup
+                layout={view}
+                onSetView={setLayout}
+                sx={{
+                  marginLeft:'0.5rem'
+                }}
+              />
+              <SelectRows
+                rows={rows}
+                handleQueryChange={handleQueryChange}
+              />
+            </div>
           </div>
-
           {/* Organizations cards */}
-          <OrganisationGrid
-            organisations={organisations}
-          />
-
+          {view === 'list' ?
+            <OrganisationListView organisations={organisations}/>
+            :
+            <OrganisationGrid organisations={organisations}/>
+          }
           {/* Pagination */}
           {numPages > 1 &&
             <div className="flex flex-wrap justify-center mb-10">
@@ -165,7 +159,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
     }
   }
   // extract user settings from cookie
-  const {rsd_page_rows} = getUserSettings(context.req)
+  const {rsd_page_rows,rsd_page_layout} = getUserSettings(context.req)
   // use url param if present else user settings
   const page_rows = rows ?? rsd_page_rows
 
@@ -190,6 +184,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
       page,
       rows: page_rows,
       organisations: data,
+      layout: rsd_page_layout
     }
   }
 }


### PR DESCRIPTION
# Organisations view as grid and list

Closes #1566

Changes proposed in this pull request:
* Align organisation layout and functionality with communities overview pages
* User can change page layout between grid and list as on the other pages. The settings is shared with other pages

How to test:
* `make start` to build solution and generate test data
* visit organisation overiew. Change layout and confirm it works
* test search, it should work as previously
* test pagination, it should work as previously

## Example organisation overview as grid
<img width="1593" height="1190" alt="image" src="https://github.com/user-attachments/assets/14d1fb4f-06ec-43a5-9f17-0de0aef68610" />

## Example organisation overview as list
<img width="1574" height="1268" alt="image" src="https://github.com/user-attachments/assets/1fb1f40d-39dc-49d8-a821-fa9e4d448dc5" />


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
