### PR TITLE
fix: pagination previous and next buttons

### DIFF
--- a/frontend/__tests__/OrganisationsOverview.test.tsx
+++ b/frontend/__tests__/OrganisationsOverview.test.tsx
@@ -11,7 +11,6 @@ import OrganisationsOverviewPage, {getServerSideProps} from 'pages/organisations
 import {mockResolvedValue} from '~/utils/jest/mockFetch'
 import {WithAppContext} from '~/utils/jest/WithAppContext'
 import organisationsOverview from './__mocks__/organisationsOverview.json'
-import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
 import {OrganisationList} from '~/types/Organisation'
 
 const mockProps = {
@@ -19,7 +18,6 @@ const mockProps = {
   page: 1,
   rows: 12,
   organisations: organisationsOverview as OrganisationList[],
-  layout: 'grid' as LayoutType
 }
 
 describe('pages/organisations/index.tsx', () => {
@@ -40,7 +38,6 @@ describe('pages/organisations/index.tsx', () => {
       props:{
         // count is extracted from response header
         count:200,
-        layout: 'grid',
         // default query param values
         page:1,
         rows:12,

--- a/frontend/components/communities/overview/CommunitiesGrid.tsx
+++ b/frontend/components/communities/overview/CommunitiesGrid.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,7 @@ export default function CommunitiesGrid({items}:{items:CommunityListProps[]}) {
   return (
     <section
       data-testid="communities-overview-list"
-      className="my-12 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 auto-rows-[27rem]">
+      className="flex-1 my-12 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 auto-rows-[27rem]">
       {items.map((item) => (
         <CommunityCard key={item.slug} community={item} />
       ))}

--- a/frontend/components/layout/PaginationLink.tsx
+++ b/frontend/components/layout/PaginationLink.tsx
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+import Pagination from '@mui/material/Pagination'
+import PaginationItem from '@mui/material/PaginationItem'
+
+type PaginationLinkProps={
+  createUrl: (key: string, value: string | string[]) => string
+  count?: number
+  page?: number
+  className?: string
+}
+
+export default function PaginationLink({createUrl,count,page,className}:PaginationLinkProps) {
+  // do not show if no page count
+  if (!count) return null
+
+  return (
+    <div className={`flex flex-wrap justify-center ${className ?? ''}`}>
+      <Pagination
+        count={count}
+        page={page}
+        renderItem={item => {
+          if (item.disabled === false && item?.page) {
+            return (
+              <Link href={createUrl('page', item.page.toString())}>
+                <PaginationItem {...item}/>
+              </Link>
+            )
+          } else {
+            return (
+              <PaginationItem {...item}/>
+            )
+          }
+        }}
+      />
+    </div>
+  )
+}

--- a/frontend/components/news/overview/NewsGrid.tsx
+++ b/frontend/components/news/overview/NewsGrid.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -22,7 +22,7 @@ export default function NewsGrid({news}: NewsGridProps) {
   return (
     <section
       data-testid="news-overview-grid"
-      className="my-12 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 auto-rows-[27rem]">
+      className="flex-1 my-12 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 auto-rows-[27rem]">
       {news.map((news) => (
         <NewsCard key={`${news.publication_date}/${news.slug}`} item={news} />
       ))}

--- a/frontend/components/organisation/overview/OrganisationGrid.tsx
+++ b/frontend/components/organisation/overview/OrganisationGrid.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -21,7 +21,7 @@ export default function OrganisationGrid({organisations}: OrganisationGridProps)
   return (
     <section
       data-testid="organisation-overview-grid"
-      className="my-12 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 auto-rows-[27rem]">
+      className="flex-1 my-12 grid md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-8 auto-rows-[27rem]">
       {organisations.map((organisation) => (
         <OrganisationCard
           key={organisation.id}

--- a/frontend/components/projects/overview/cards/ProjectOverviewGrid.tsx
+++ b/frontend/components/projects/overview/cards/ProjectOverviewGrid.tsx
@@ -12,7 +12,7 @@ export default function ProjectOverviewGrid({children}: { children: JSX.Element 
   return (
     <section
       data-testid="project-overview-grid"
-      className="mt-4 grid gap-8 lg:grid-cols-2 xl:grid-cols-3 auto-rows-[30rem]"
+      className="flex-1 mt-4 grid gap-8 lg:grid-cols-2 xl:grid-cols-3 auto-rows-[30rem]"
     >
       {children}
     </section>

--- a/frontend/components/software/overview/SoftwareOverviewContent.tsx
+++ b/frontend/components/software/overview/SoftwareOverviewContent.tsx
@@ -61,23 +61,24 @@ export default function SoftwareOverviewContent({layout, software, hasRemotes}: 
           // remove rsd_host if remotes are not present
           item.rsd_host = getRsdHost({hasRemotes,rsd_host:item.rsd_host})
           return (
-            <Link
-              data-testid="software-list-item"
+            <OverviewListItem
               key={listKey}
-              href={pageUrl}
-              className='flex-1 flex hover:text-inherit group'
-              title={item.brand_name}
-              target={item.domain ? '_blank' : '_self'}
-            >
-              <OverviewListItem className="pr-4">
+              className="pr-4">
+              <Link
+                data-testid="software-list-item"
+                href={pageUrl}
+                className='flex-1 flex hover:text-inherit group'
+                title={item.brand_name}
+                target={item.domain ? '_blank' : '_self'}
+              >
                 <SoftwareListItemContent
                   statusBanner={
                     <RsdHostBanner rsd_host={item?.rsd_host} domain={item?.domain}/>
                   }
                   {...item}
                 />
-              </OverviewListItem>
-            </Link>
+              </Link>
+            </OverviewListItem>
           )
         })}
       </SoftwareOverviewList>

--- a/frontend/components/software/overview/cards/SoftwareOverviewGrid.tsx
+++ b/frontend/components/software/overview/cards/SoftwareOverviewGrid.tsx
@@ -21,7 +21,7 @@ export default function SoftwareOverviewGrid({children,fullWidth=false}: {
   return (
     <section
       data-testid="software-overview-grid"
-      className={`mt-4 grid gap-8 md:grid-cols-${md} lg:grid-cols-${lg} xl:grid-cols-${xl} auto-rows-[28rem]`}
+      className={`flex-1 mt-4 grid gap-8 md:grid-cols-${md} lg:grid-cols-${lg} xl:grid-cols-${xl} auto-rows-[28rem]`}
     >
       {children}
     </section>

--- a/frontend/components/software/overview/list/OverviewListItem.tsx
+++ b/frontend/components/software/overview/list/OverviewListItem.tsx
@@ -16,7 +16,7 @@ export default function OverviewListItem({
   className=''
 }: OverviewListItemProps) {
   return (
-    <div className={`flex-1 flex items-center transition shadow-xs border bg-base-100 rounded-sm hover:shadow-lg ${className ?? ''}`}
+    <div className={`flex items-center transition shadow-xs border bg-base-100 rounded-sm hover:shadow-lg ${className ?? ''}`}
     >
       {children}
     </div>

--- a/frontend/config/UserSettingsContext.tsx
+++ b/frontend/config/UserSettingsContext.tsx
@@ -57,6 +57,9 @@ export function useUserSettings(){
   const {user,setUser} = useContext(UserSettingsContext)
 
   function setPageLayout(layout:LayoutType='grid'){
+    // ignore null value - click on "same" button
+    if (layout===null) return
+    // console.log('layout...',layout)
     // save to cookie
     setDocumentCookie(layout,'rsd_page_layout')
     // save to state

--- a/frontend/pages/news/index.tsx
+++ b/frontend/pages/news/index.tsx
@@ -3,28 +3,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useState} from 'react'
 import {GetServerSidePropsContext} from 'next/types'
-import Pagination from '@mui/material/Pagination'
-import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
 import {getRsdModules} from '~/config/getSettingsServerSide'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
-import {getUserSettings, setDocumentCookie} from '~/utils/userSettings'
+import {getUserSettings} from '~/utils/userSettings'
 import PageMeta from '~/components/seo/PageMeta'
-import PageBackground from '~/components/layout/PageBackground'
 import AppHeader from '~/components/AppHeader'
-import MainContent from '~/components/layout/MainContent'
 import AppFooter from '~/components/AppFooter'
+import PageBackground from '~/components/layout/PageBackground'
+import MainContent from '~/components/layout/MainContent'
+import PaginationLink from '~/components/layout/PaginationLink'
 import SearchInput from '~/components/search/SearchInput'
 import useSearchParams from '~/components/search/useSearchParams'
 import SelectRows from '~/components/software/overview/search/SelectRows'
 import {LayoutType} from '~/components/software/overview/search/ViewToggleGroup'
-import ViewToggleGroup,{ProjectLayoutType} from '~/components/projects/overview/search/ViewToggleGroup'
+import ViewToggleGroup from '~/components/projects/overview/search/ViewToggleGroup'
 import NewsGrid from '~/components/news/overview/NewsGrid'
 import {NewsListItem, getNewsList} from '~/components/news/apiNews'
 import NewsList from '~/components/news/overview/list'
+import {useUserSettings} from '~/config/UserSettingsContext'
 
 const pageTitle = `News | ${app.title}`
 const pageDesc = 'List of RSD news.'
@@ -38,10 +37,11 @@ type NewsOverviewProps={
   news: NewsListItem[]
 }
 
-export default function NewsOverview({count,page,rows,layout,search,news}:NewsOverviewProps) {
+export default function NewsOverview({count,page,rows,search,news}:NewsOverviewProps) {
   const {handleQueryChange,createUrl} = useSearchParams('news')
-  const initView = layout === 'masonry' ? 'grid' : layout
-  const [view, setView] = useState<ProjectLayoutType>(initView)
+  const {rsd_page_layout,setPageLayout} = useUserSettings()
+  // if masonry we change to grid
+  const view = rsd_page_layout === 'masonry' ? 'grid' : rsd_page_layout
   const numPages = Math.ceil(count / rows)
 
   // console.group('NewsOverview')
@@ -53,13 +53,6 @@ export default function NewsOverview({count,page,rows,layout,search,news}:NewsOv
   // console.log('search...', search)
   // console.log('news...', news)
   // console.groupEnd()
-
-  function setLayout(view: ProjectLayoutType) {
-    // update local view
-    setView(view)
-    // save to cookie
-    setDocumentCookie(view,'rsd_page_layout')
-  }
 
   return (
     <>
@@ -86,7 +79,7 @@ export default function NewsOverview({count,page,rows,layout,search,news}:NewsOv
               />
               <ViewToggleGroup
                 layout={view}
-                onSetView={setLayout}
+                onSetView={setPageLayout}
                 sx={{
                   marginLeft:'0.5rem'
                 }}
@@ -106,27 +99,12 @@ export default function NewsOverview({count,page,rows,layout,search,news}:NewsOv
           }
 
           {/* Pagination */}
-          {numPages > 1 &&
-            <div className="flex flex-wrap justify-center mb-10">
-              <Pagination
-                count={numPages}
-                page={page}
-                renderItem={item => {
-                  if (item.page !== null) {
-                    return (
-                      <a href={createUrl('page', item.page.toString())}>
-                        <PaginationItem {...item}/>
-                      </a>
-                    )
-                  } else {
-                    return (
-                      <PaginationItem {...item}/>
-                    )
-                  }
-                }}
-              />
-            </div>
-          }
+          <PaginationLink
+            count={numPages}
+            page={page}
+            createUrl={createUrl}
+            className="mb-10"
+          />
         </MainContent>
 
         {/* App footer */}

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -8,11 +8,7 @@
 
 import {useState} from 'react'
 import {GetServerSidePropsContext} from 'next'
-
-import Pagination from '@mui/material/Pagination'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import Link from 'next/link'
-import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
 import {useUserSettings} from '~/config/UserSettingsContext'
@@ -26,10 +22,11 @@ import {getBaseUrl} from '~/utils/fetchHelpers'
 import AppHeader from '~/components/AppHeader'
 import AppFooter from '~/components/AppFooter'
 import MainContent from '~/components/layout/MainContent'
+import PageBackground from '~/components/layout/PageBackground'
+import PaginationLink from '~/components/layout/PaginationLink'
 import PageMeta from '~/components/seo/PageMeta'
 import CanonicalUrl from '~/components/seo/CanonicalUrl'
 import useProjectOverviewParams from '~/components/projects/overview/useProjectOverviewParams'
-import PageBackground from '~/components/layout/PageBackground'
 import FiltersPanel from '~/components/filter/FiltersPanel'
 import {KeywordFilterOption} from '~/components/filter/KeywordsFilter'
 import {OrganisationOption} from '~/components/filter/OrganisationsFilter'
@@ -152,7 +149,7 @@ export default function ProjectsOverviewPage({
               </FiltersPanel>
             }
             {/* Search & main content section */}
-            <div className="flex-1">
+            <div className="flex-1 flex flex-col">
               <ProjectSearchSection
                 page={page}
                 rows={rows}
@@ -169,27 +166,12 @@ export default function ProjectsOverviewPage({
                 projects={projects}
               />
               {/* Pagination */}
-              {numPages > 1 &&
-                <div className="flex flex-wrap justify-center mt-8">
-                  <Pagination
-                    count={numPages}
-                    page={page}
-                    renderItem={item => {
-                      if (item.page !== null) {
-                        return (
-                          <Link href={createUrl('page', item.page.toString())}>
-                            <PaginationItem {...item}/>
-                          </Link>
-                        )
-                      } else {
-                        return (
-                          <PaginationItem {...item}/>
-                        )
-                      }
-                    }}
-                  />
-                </div>
-              }
+              <PaginationLink
+                count={numPages}
+                page={page}
+                createUrl={createUrl}
+                className="mt-8"
+              />
             </div>
           </div>
         </MainContent>

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -11,9 +11,6 @@
 import {useState} from 'react'
 import {GetServerSidePropsContext} from 'next/types'
 import useMediaQuery from '@mui/material/useMediaQuery'
-import Pagination from '@mui/material/Pagination'
-import Link from 'next/link'
-import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
 import {getRsdSettings} from '~/config/getSettingsServerSide'
@@ -26,6 +23,7 @@ import {getUserSettings} from '~/utils/userSettings'
 import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
 import MainContent from '~/components/layout/MainContent'
 import PageBackground from '~/components/layout/PageBackground'
+import PaginationLink from '~/components/layout/PaginationLink'
 import FiltersPanel from '~/components/filter/FiltersPanel'
 import AppHeader from '~/components/AppHeader'
 import AppFooter from '~/components/AppFooter'
@@ -55,6 +53,7 @@ import {softwareOrderOptions} from '~/components/software/overview/filters/Order
 import {HostsFilterOption} from '~/components/filter/RsdHostFilter'
 import {getRemoteRsd} from '~/components/admin/remote-rsd/apiRemoteRsd'
 import {CategoryOption} from '~/components/filter/CategoriesFilter'
+
 
 type SoftwareOverviewProps = {
   search?: string | null
@@ -177,7 +176,7 @@ export default function SoftwareOverviewPage({
               </FiltersPanel>
             }
             {/* Search & main content section */}
-            <div className="flex-1">
+            <div className="flex-1 flex flex-col">
               <SoftwareSearchSection
                 page={page}
                 rows={rows}
@@ -195,28 +194,12 @@ export default function SoftwareOverviewPage({
                 hasRemotes={hasRemotes}
               />
               {/* Pagination */}
-              <div className="flex justify-center mt-8">
-                {numPages > 1 &&
-                  <Pagination
-                    count={numPages}
-                    page={page}
-                    renderItem={item => {
-                      if (item.page !== null) {
-                        const url = createUrl('page', item.page.toString())
-                        return (
-                          <Link href={url}>
-                            <PaginationItem {...item}/>
-                          </Link>
-                        )
-                      } else {
-                        return (
-                          <PaginationItem {...item}/>
-                        )
-                      }
-                    }}
-                  />
-                }
-              </div>
+              <PaginationLink
+                count={numPages}
+                page={page}
+                createUrl={createUrl}
+                className="mt-8"
+              />
             </div>
           </div>
         </MainContent>


### PR DESCRIPTION
# Pagination previous and next button at start/end

Closes #1505

Changes proposed in this pull request:
* Created PaginationLink component to use as pagination component on all overview pages
* Fixed back/next button active on first and last page that produced "out of range" pages like -1 or max+1 page
* Fixed layout view toggle button. Clicking on same view button produced "null" value
* Applied PaginationLink component to all overview pages: software, highlights, projects, organisations, communities and news overviews.  
* Applied useUserSettings hook to all overview pages to obtain and save preferred view type
* Minor layout fix: the pagination component is kept at the bottom of the page even when few items (1-3) are displayed (on the last page).

How to test:
* `make start` to build app and generate test data. You might need to edit data in order to test pagination in all overviews.
* Test software overview page:
    * Confirm that previous button is disabled when on first page. 
    * Confirm that next button is disabled on the last page.
    * Confirm that multiple click on "same" view button will not toggle/change the view
* Repeat these tests for other overview pages: highlights, projects, organisations, communities and news. Note! Organisation software/project overview pages do not use this component yet.

## Example disabled prev button on the first page
<img width="1577" height="576" alt="image" src="https://github.com/user-attachments/assets/f7035fac-1363-4295-8bf6-698c58a0ad76" />

## Examlple disabled next button on the last page
<img width="1612" height="974" alt="image" src="https://github.com/user-attachments/assets/315c2003-39ed-4c8d-9bb7-f056edf5d41a" />


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
