### PR TITLE
Show ID and comment for account invites

### DIFF
--- a/database/002-create-account-table.sql
+++ b/database/002-create-account-table.sql
@@ -107,6 +107,7 @@ CREATE TABLE admin_account (
 CREATE TABLE account_invite (
 	id UUID PRIMARY KEY,
 	uses_left INTEGER, --NULL means bulk (i.e. infinite use) invite
+	comment VARCHAR(50),
 	expires_at TIMESTAMPTZ NOT NULL,
 	created_at TIMESTAMPTZ NOT NULL,
 	updated_at TIMESTAMPTZ NOT NULL

--- a/frontend/components/admin/rsd-invites/CreateRsdInvite.tsx
+++ b/frontend/components/admin/rsd-invites/CreateRsdInvite.tsx
@@ -28,6 +28,12 @@ export default function CreateRsdInvite({createInvite}:CreateRsdInviteProps) {
     getYearMonthDay(getDateFromNow(7)) ?? ''
   )
 
+  const [comment, setComment] = useState<string>('')
+  const trimmedComment: string = comment.trim().replaceAll(/\s+/g, ' ')
+  const trimmedCommentLength: number = trimmedComment.length
+  const maxCommentLength = 50
+  const isCommentValid: boolean = trimmedCommentLength <= maxCommentLength
+
   // console.group('CreateRsdInvite')
   // console.log('users...',users)
   // console.log('expires...',expires)
@@ -36,10 +42,12 @@ export default function CreateRsdInvite({createInvite}:CreateRsdInviteProps) {
   function onCreateInvite(){
     const invite:NewAccountInvite={
       uses_left: users,
-      expires_at: expires
+      expires_at: expires,
+      comment: trimmedComment.length ? trimmedComment : null
     }
     createInvite(invite)
   }
+
 
   return (
     <>
@@ -62,6 +70,9 @@ export default function CreateRsdInvite({createInvite}:CreateRsdInviteProps) {
               setUsers(parseInt(target.value))
             }
           }}
+          sx={{
+            flex: 1
+          }}
         />
         <TextField
           type="date"
@@ -71,10 +82,28 @@ export default function CreateRsdInvite({createInvite}:CreateRsdInviteProps) {
           onChange={({target})=>{
             setExpires(target.value)
           }}
+          sx={{
+            flex: 1
+          }}
         />
       </div>
+      <TextField
+        type="text"
+        label="Comment"
+        value={comment}
+        error={!isCommentValid}
+        helperText={
+          <span className="line-clamp-1" title={`Max comment length is ${maxCommentLength}`}>{`${trimmedCommentLength} / ${maxCommentLength}`}</span>
+        }
+        onChange={({target})=>{
+          setComment(target.value)
+        }}
+        sx={{
+          width: '100%'
+        }}
+      />
       <Button
-        disabled={expires===''}
+        disabled={expires==='' || !isCommentValid}
         variant='contained'
         sx={{
           margin: '1rem 0rem',

--- a/frontend/components/admin/rsd-invites/apiRsdInvite.ts
+++ b/frontend/components/admin/rsd-invites/apiRsdInvite.ts
@@ -10,6 +10,7 @@ import logger from '~/utils/logger'
 export type NewAccountInvite = {
   // null means unlimited number of users
   uses_left: number | null
+  comment: string | null
   // data formatted YYYY-MM-DD
   expires_at: string
 }
@@ -97,31 +98,5 @@ export async function deleteRsdInvite({id, token}: { id: string, token: string }
       status: 500,
       message: e?.message
     }
-  }
-}
-
-export async function getRsdInvite(id: string) {
-  try {
-    const query = `id=eq.${id}`
-    const url = `${getBaseUrl()}/account_invite?${query}`
-
-    const resp = await fetch(url, {
-      method: 'GET',
-      headers: createJsonHeaders()
-    })
-
-    if (resp.status === 200) {
-      const json: AccountInvite[] = await resp.json()
-      if (json.length === 1) {
-        return json[0]
-      }
-      return null
-    }
-    // ERRORS
-    logger(`getRsdInvite: ${resp.status}:${resp.statusText}`, 'warn')
-    return null
-  } catch (e: any) {
-    logger(`getRsdInvite: ${e?.message}`, 'error')
-    return null
   }
 }

--- a/frontend/components/admin/rsd-invites/index.tsx
+++ b/frontend/components/admin/rsd-invites/index.tsx
@@ -6,10 +6,12 @@
 
 import Alert from '@mui/material/Alert'
 
-import InvitationList from '~/components/maintainers/InvitationList'
+import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
 import ContentLoader from '~/components/layout/ContentLoader'
 import CreateRsdInvite from './CreateRsdInvite'
 import {useRsdInvite} from './useRsdInvite'
+
+const extraLineGenerators: ((inv: Invitation) => string)[] = [inv => inv.id, inv => inv.comment ?? '']
 
 export default function RsdInvites() {
   const {loading,activeInvites,createInvite,deleteInvite} = useRsdInvite()
@@ -44,7 +46,7 @@ export default function RsdInvites() {
               invitations={activeInvites}
               onDelete={deleteInvite}
               showTitle={false}
-              extraLineGenerators={[inv => inv.id]}
+              extraLineGenerators={extraLineGenerators}
             />
         }
       </div>

--- a/frontend/components/admin/rsd-invites/index.tsx
+++ b/frontend/components/admin/rsd-invites/index.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -43,6 +44,7 @@ export default function RsdInvites() {
               invitations={activeInvites}
               onDelete={deleteInvite}
               showTitle={false}
+              extraLineGenerators={[inv => inv.id]}
             />
         }
       </div>

--- a/frontend/components/admin/rsd-invites/useRsdInvite.tsx
+++ b/frontend/components/admin/rsd-invites/useRsdInvite.tsx
@@ -1,4 +1,5 @@
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -27,7 +28,8 @@ export function useRsdInvite(){
             created_at: item.created_at,
             expires_at: item.expires_at,
             type: 'rsd' as InvitationType,
-            uses_left: item.uses_left
+            uses_left: item.uses_left,
+            comment: item.comment
           }
         })
         setActiveInvites(invitations)

--- a/frontend/components/maintainers/InvitationList.tsx
+++ b/frontend/components/maintainers/InvitationList.tsx
@@ -17,7 +17,7 @@ import ListItemText from '@mui/material/ListItemText'
 import copyToClipboard from '~/utils/copyToClipboard'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import EditSectionTitle from '~/components/layout/EditSectionTitle'
-import Stack from '@mui/material/Stack'
+import {Fragment} from 'react'
 
 export type InvitationType = 'software' | 'project' | 'organisation' | 'community' | 'rsd'
 
@@ -26,7 +26,8 @@ export type Invitation = {
     created_at: string,
     expires_at: string,
     type: InvitationType,
-    uses_left?: number | null
+    uses_left?: number | null,
+    comment?: string | null
 }
 
 type InvitationListProps=Readonly<{
@@ -77,6 +78,22 @@ function getInviteText(invite: Invitation): {expiredText: string, usesLeftText: 
     usesLeftText,
     linkIsValid
   }
+}
+
+function ExtraSecondaryLines({invitation, extraLineGenerators}: Readonly<{invitation: Invitation, extraLineGenerators: ((invitation: Invitation) => string)[]}>) {
+  if (extraLineGenerators.length === 0) {
+    return null
+  }
+
+  const lines: string[] = []
+  for (const extraLineGenerator of extraLineGenerators) {
+    const generatedLineTrimmed: string = extraLineGenerator(invitation).trim()
+    if (generatedLineTrimmed.length > 0) {
+      lines.push(generatedLineTrimmed)
+    }
+  }
+
+  return lines.map(line => <Fragment key={line}><br/>{line}</Fragment>)
 }
 
 export default function InvitationList({
@@ -149,15 +166,13 @@ export default function InvitationList({
               <ListItemText
                 primary={`Created on ${new Date(inv.created_at).toLocaleString()} [${expiredText}]`}
                 secondary={
-                  <Stack className="font-medium leading-[2rem]" spacing={-1}>
-                    <>
-                      {usesLeftText ?
-                        <span >{usesLeftText}</span>
-                        :
-                        <span>{currentLink}</span>}
-                      {extraLineGenerators.length ? extraLineGenerators.map(extraLineGenerator => <span key={extraLineGenerator.toString()}> {extraLineGenerator(inv)} </span>) : null}
-                    </>
-                  </Stack>
+                  <>
+                    {usesLeftText ?
+                      <span className="font-medium leading-[2rem]">{usesLeftText}</span>
+                      :
+                      <span>{currentLink}</span>}
+                    <ExtraSecondaryLines invitation={inv} extraLineGenerators={extraLineGenerators}/>
+                  </>
                 }
               />
             </ListItem>


### PR DESCRIPTION
## Show ID and comment for account invites

### Changes proposed in this pull request

* Show the ID of account invites
* Allow to add a comment to account invites and show them

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin, go to RSD invites in the admin menu
* Create an invite without comment, the ID should be visible
* Create an invite with a comment, the ID and the comment should be visible
* Check that other types of invites still work properly

closes #1522
closes #1573

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests
