### PR TITLE
fix: open community page after admin creation

### DIFF
--- a/frontend/components/admin/communities/index.tsx
+++ b/frontend/components/admin/communities/index.tsx
@@ -1,9 +1,12 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useState,useContext} from 'react'
+import {useRouter} from 'next/router'
 import Button from '@mui/material/Button'
 import AddIcon from '@mui/icons-material/Add'
 
@@ -18,13 +21,14 @@ export default function AdminCommunities() {
   const [modal, setModal] = useState(false)
   const {pagination:{page}} = useContext(PaginationContext)
   const {loading, communities, addCommunity, deleteCommunity} = useAdminCommunities()
+  const router = useRouter()
 
   async function onAddCommunity(data:EditCommunityProps){
     // add community
-    const ok = await addCommunity(data)
-    // if all ok close the modal
+    const [ok, slug] = await addCommunity(data)
+    // if all ok redirect to community page
     // on error snackbar will be shown and we leave modal open for possible corrections
-    if (ok===true) setModal(false)
+    if (ok===true) router.push(`/communities/${slug}/settings`)
   }
 
   return (

--- a/frontend/components/admin/communities/useAdminCommunities.tsx
+++ b/frontend/components/admin/communities/useAdminCommunities.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -61,7 +63,7 @@ export function useAdminCommunities(){
         } else {
           data.logo_id = null
           showErrorMessage(`Failed to upload image. ${upload.message}`)
-          return false
+          return [false, null]
         }
       }
       // remove temp props
@@ -76,15 +78,15 @@ export function useAdminCommunities(){
       if (resp.status === 200) {
         // return created item
         loadCommunities()
-        return true
+        return [true, resp.message['slug']]
       } else {
         // show error
         showErrorMessage(`Failed to add community. Error: ${resp.message}`)
-        return false
+        return [false, null]
       }
     }catch(e:any){
       showErrorMessage(`Failed to add community. Error: ${e.message}`)
-      return false
+      return [false, null]
     }
   // we do not include showErrorMessage in order to avoid loop
   // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
Fixes #1511 

Changes proposed in this pull request:

* after clicking `Save` on the `Add community` modal in the admin view, redirect to the community page of the community that was created

How to test:

* Log into RSD as admin
* In the admin view, create a new community
* You should be redirected to the page of the newly created community after saving

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
