### PR TITLE
feat: use lock account modal for lock info

### DIFF
--- a/frontend/components/admin/rsd-users/LockUserModal.tsx
+++ b/frontend/components/admin/rsd-users/LockUserModal.tsx
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Button from '@mui/material/Button'
+import Dialog from '@mui/material/Dialog'
+import DialogTitle from '@mui/material/DialogTitle'
+import DialogContent from '@mui/material/DialogContent'
+import DialogActions from '@mui/material/DialogActions'
+import useMediaQuery from '@mui/material/useMediaQuery'
+
+import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
+import {useForm} from 'react-hook-form'
+import TextFieldWithCounter from '~/components/form/TextFieldWithCounter'
+import ControlledSwitch from '~/components/form/ControlledSwitch'
+
+export type LockAccountProps= {
+  id: string
+  lock_account: boolean
+  admin_facing_reason: string|null
+  user_facing_reason: string|null
+}
+
+type LockUserModalProps = {
+  account: LockAccountProps,
+  onCancel: () => void,
+  onSubmit: (item:LockAccountProps) => void
+}
+
+const config={
+  formId: 'lock-user-form',
+  modalTitle:'Lock account',
+  lock:{
+    label: 'Lock account',
+  },
+  admin_facing_reason:{
+    label: 'Admin facing reason',
+    help: 'Type the reason for locking this account',
+    validation:{
+      required: 'The reason for locking is required',
+      minLength: {value: 10, message: 'Minimum length is 10'},
+      maxLength: {value: 100, message: 'Maximum length is 100'},
+    }
+  },
+  user_facing_reason:{
+    label: 'User facing reason',
+    help: 'Type message to show to user',
+    validation:{
+      required: 'The message to user is required',
+      minLength: {value: 10, message: 'Minimum length is 10'},
+      maxLength: {value: 100, message: 'Maximum length is 100'},
+    }
+  }
+}
+
+export default function LockUserModal({account,onCancel,onSubmit}:LockUserModalProps) {
+  const smallScreen = useMediaQuery('(max-width:600px)')
+  const {register, handleSubmit,formState,watch, control} = useForm<LockAccountProps>({
+    mode: 'onChange',
+    defaultValues: account
+  })
+  const {errors, isValid} = formState
+  const [admin_facing_reason,user_facing_reason,lock_account] = watch(['admin_facing_reason','user_facing_reason','lock_account'])
+
+  function handleCancel(e:any,reason: 'backdropClick' | 'escapeKeyDown') {
+    // close only on escape, not if user clicks outside of the modal
+    if (reason==='escapeKeyDown') onCancel()
+  }
+
+  return (
+    <Dialog
+      // use fullScreen modal for small screens (< 600px)
+      fullScreen={smallScreen}
+      open={true}
+      onClose={handleCancel}
+    >
+      <DialogTitle sx={{
+        fontSize: '1.5rem',
+        borderBottom: '1px solid',
+        borderColor: 'divider',
+        color: 'primary.main',
+        fontWeight: 500
+      }}>
+        {config.modalTitle}
+      </DialogTitle>
+      <form
+        id={config.formId}
+        onSubmit={handleSubmit(onSubmit)}
+        className="w-full">
+
+        {/* hidden inputs */}
+        <input type="hidden"
+          {...register('id')}
+        />
+
+        <DialogContent sx={{
+          width: ['100%', '37rem'],
+          padding: '2rem 1.5rem 2.5rem'
+        }}>
+
+
+          <ControlledSwitch
+            label={config.lock.label}
+            name="lock_account"
+            control={control}
+            defaultValue={account.lock_account}
+          />
+          <div className="py-4" />
+          <TextFieldWithCounter
+            options={{
+              error: errors.admin_facing_reason?.message !== undefined,
+              label: config.admin_facing_reason.label,
+              helperTextMessage: errors?.admin_facing_reason?.message ?? config.admin_facing_reason.help,
+              helperTextCnt: `${admin_facing_reason?.length || 0}/${config.admin_facing_reason.validation.maxLength.value}`,
+              variant:'outlined',
+              disabled: !lock_account
+            }}
+            register={register('admin_facing_reason', {
+              ...config.admin_facing_reason.validation
+            })}
+          />
+          <div className="py-4" />
+          <TextFieldWithCounter
+            options={{
+              error: errors.user_facing_reason?.message !== undefined,
+              label: config.user_facing_reason.label,
+              helperTextMessage: errors?.user_facing_reason?.message ?? config.user_facing_reason.help,
+              helperTextCnt: `${user_facing_reason?.length || 0}/${config.user_facing_reason.validation.maxLength.value}`,
+              variant:'outlined',
+              disabled: !lock_account
+            }}
+            register={register('user_facing_reason', {
+              ...config.user_facing_reason.validation
+            })}
+          />
+
+        </DialogContent>
+        <DialogActions sx={{
+          padding: '1rem 1.5rem',
+          borderTop: '1px solid',
+          borderColor: 'divider'
+        }}>
+          <Button
+            onClick={onCancel}
+            color="secondary"
+            sx={{marginRight:'2rem'}}
+          >
+            Cancel
+          </Button>
+          <SubmitButtonWithListener
+            formId={config.formId}
+            disabled={isValid===false}
+          />
+        </DialogActions>
+      </form>
+    </Dialog>
+  )
+}

--- a/frontend/components/admin/rsd-users/RsdAccountItem.tsx
+++ b/frontend/components/admin/rsd-users/RsdAccountItem.tsx
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -17,174 +17,62 @@ import {RsdAccountInfo} from './useRsdAccounts'
 import RsdRoleSwitch from './RsdRoleSwitch'
 import Box from '@mui/material/Box'
 import LockPersonIcon from '@mui/icons-material/LockPerson'
-import {useState} from 'react'
-import Stack from '@mui/material/Stack'
-import TextField from '@mui/material/TextField'
-import Button from '@mui/material/Button'
-import Switch from '@mui/material/Switch'
-import FormControlLabel from '@mui/material/FormControlLabel'
-import useSnackbar from '~/components/snackbar/useSnackbar'
-import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
 
 type RsdUserItemProps = {
   account: RsdAccountInfo,
   onDelete: (id:string)=>void,
-  onMutation: () => void
+  onLock: (account:RsdAccountInfo) => void
 }
 
-const maxLengthLockedFields = 100
-
-export default function RsdAccountItem({account, onDelete, onMutation}: Readonly<RsdUserItemProps>) {
-  const {user, token} = useSession()
-  const {showErrorMessage} = useSnackbar()
-
-  const [showLockForm, setShowLockForm] = useState<boolean>(false)
-
-  const [doingAsyncRequest, setDoingAsyncRequest] = useState<boolean>(false)
-
-  const [newLockStatus, setNewLockStatus] = useState<boolean>(account.locked_account !== null)
-
-  const [newAdminReason, setNewAdminReason] = useState<string | null>(account.locked_account?.admin_facing_reason ?? null)
-  const isAdminReasonValid: boolean = (newAdminReason?.length ?? 0) <= maxLengthLockedFields
-
-  const [newUserReason, setNewUserReason] = useState<string | null>(account.locked_account?.user_facing_reason ?? null)
-  const isUserReasonValid: boolean = (newUserReason?.length ?? 0) <= maxLengthLockedFields
-
-  const buttonsEnabled: boolean = !doingAsyncRequest && isAdminReasonValid && isUserReasonValid
-
-  function closeLockFormWithoutSaving() {
-    setNewLockStatus(account.locked_account !== null)
-    setNewAdminReason(account.locked_account?.admin_facing_reason ?? null)
-    setNewUserReason(account.locked_account?.user_facing_reason ?? null)
-    setShowLockForm(false)
-  }
-
-  async function saveLockAccountAndClose() {
-    const tableName = 'locked_account'
-    const query = `${tableName}?account_id=eq.${account.id}`
-    const url = `${getBaseUrl()}/${query}`
-
-    const headers = createJsonHeaders(token)
-
-    setDoingAsyncRequest(true)
-
-    try {
-      if (!newLockStatus) {
-        const resp = await fetch(url, {method: 'DELETE', headers: headers})
-        if (!resp.ok) {
-          showErrorMessage(await resp.text())
-        } else {
-          setNewAdminReason(null)
-          setNewUserReason(null)
-          setShowLockForm(false)
-          onMutation()
-        }
-      } else {
-        const body = JSON.stringify({
-          account_id: account.id,
-          admin_facing_reason: newAdminReason === '' ? null : newAdminReason,
-          user_facing_reason: newUserReason === '' ? null : newUserReason,
-        })
-
-        const resp = await fetch(url, {
-          method: 'PUT',
-          headers: {...headers, 'Prefer': 'resolution=merge-duplicates'},
-          body: body,
-        })
-        if (!resp.ok) {
-          showErrorMessage(await resp.text())
-        } else {
-          setShowLockForm(false)
-          onMutation()
-        }
-      }
-    } catch (e: any) {
-      showErrorMessage(e)
-    } finally {
-      setDoingAsyncRequest(false)
-    }
-  }
+export default function RsdAccountItem({account, onDelete, onLock}: Readonly<RsdUserItemProps>) {
+  const {user} = useSession()
 
   return (
-    <Stack spacing={2}>
-      <ListItem
-        data-testid="account-item"
-        key={account.id}
-        secondaryAction={
-          <div className="flex gap-2">
-            <RsdRoleSwitch
-              id={account.id}
-              admin_account={account.admin_account}
-              disabled={user?.account === account.id}
-            />
-            <IconButton
-              aria-label="lock account"
-              title="Show user locking form"
-              onClick={() => {
-                setShowLockForm(true)
-              }}
-            >
-              <LockPersonIcon color={account.locked_account === null ? 'action' : 'primary'} />
-            </IconButton>
-            <IconButton
-              disabled={user?.account === account.id}
-              edge="end"
-              aria-label="delete"
-              onClick={() => {
-                onDelete(account.id)
-              }}
-            >
-              <DeleteIcon />
-            </IconButton>
-          </div>
-        }
-        sx={{
-        // this makes space for buttons
-          paddingRight:'8.5rem',
-          '&:hover': {
-            backgroundColor:'grey.100'
-          }
-        }}
-      >
-        <ListItemText>
-          <div className="text-base-content-disabled">{account.id}</div>
-          {account.locked_account ? <Box sx={{color: 'error.main'}}>{`Locked since ${new Date(account.locked_account.created_at).toUTCString()}`}</Box> : null}
-          <RsdLoginList logins={account.login_for_account} />
-        </ListItemText>
-      </ListItem>
 
-      {showLockForm && (
-        <form>
-          <Stack direction="row" spacing={2} sx={{alignItems: 'baseline'}}>
-            <FormControlLabel
-              label="Lock account"
-              control={<Switch
-                defaultChecked={account.locked_account !== null}
-                onChange={e => setNewLockStatus(e.target.checked)}
-              />}
-            />
-            <TextField
-              label="Admin facing reason"
-              helperText={`${newAdminReason?.length ?? 0} / ${maxLengthLockedFields}`}
-              error={!isAdminReasonValid}
-              disabled={!newLockStatus}
-              defaultValue={account.locked_account?.admin_facing_reason}
-              onChange={e => setNewAdminReason(e.target.value)}
-            />
-            <TextField
-              label="User facing reason"
-              helperText={`${newUserReason?.length ?? 0} / ${maxLengthLockedFields}`}
-              error={!isUserReasonValid}
-              disabled={!newLockStatus}
-              defaultValue={account.locked_account?.user_facing_reason}
-              onChange={e => setNewUserReason(e.target.value)}
-            />
-            <Button variant="outlined" disabled={!buttonsEnabled} onClick={closeLockFormWithoutSaving}>Cancel</Button>
-            <Button variant="contained" disabled={!buttonsEnabled} onClick={saveLockAccountAndClose}>Save</Button>
-          </Stack>
-        </form>
-      )}
-    </Stack>
+    <ListItem
+      data-testid="account-item"
+      key={account.id}
+      secondaryAction={
+        <div className="flex gap-2">
+          <RsdRoleSwitch
+            id={account.id}
+            admin_account={account.admin_account}
+            disabled={user?.account === account.id}
+          />
+          <IconButton
+            aria-label="lock account"
+            title="Show user locking form"
+            onClick={()=>onLock(account)}
+          >
+            <LockPersonIcon color={account.locked_account === null ? 'action' : 'error'} />
+          </IconButton>
+          <IconButton
+            disabled={user?.account === account.id}
+            edge="end"
+            aria-label="delete"
+            onClick={() => {
+              onDelete(account.id)
+            }}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </div>
+      }
+      sx={{
+        // this makes space for buttons
+        paddingRight:'8.5rem',
+        '&:hover': {
+          backgroundColor:'grey.100'
+        }
+      }}
+    >
+      <ListItemText>
+        <div className="text-base-content-disabled">{account.id}</div>
+        {account.locked_account ? <Box sx={{color: 'error.main'}}>{`Locked since ${new Date(account.locked_account.created_at).toUTCString()}`}</Box> : null}
+        <RsdLoginList logins={account.login_for_account} />
+      </ListItemText>
+    </ListItem>
+
   )
 
 }

--- a/frontend/components/admin/rsd-users/RsdUsersList.tsx
+++ b/frontend/components/admin/rsd-users/RsdUsersList.tsx
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -17,19 +17,31 @@ import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
 import ContentLoader from '~/components/layout/ContentLoader'
 import RsdAccountItem from './RsdAccountItem'
 import useRsdAccounts, {RsdAccountInfo} from './useRsdAccounts'
+import LockUserModal from './LockUserModal'
 
-export type DeleteAccountModal = {
-  open: boolean,
-  account?: RsdAccountInfo
+export type AccountModal = {
+  delete:{
+    open: boolean,
+    account?: RsdAccountInfo
+  },
+  lock:{
+    open: boolean,
+    account?: RsdAccountInfo
+  }
 }
 
 export default function RsdUsersList({adminsOnly, lockedOnly, inactiveDays}: {adminsOnly: boolean, lockedOnly: boolean, inactiveDays: number}) {
   const {token} = useSession()
   // meaningless toggle to be able to force getting fresh data
   const [toggle, setToggle] = useState<boolean>(false)
-  const {loading, accounts, deleteAccount} = useRsdAccounts(token, adminsOnly, lockedOnly, inactiveDays, toggle)
-  const [modal, setModal] = useState<DeleteAccountModal>({
-    open: false
+  const {loading, accounts, lockAccount,deleteAccount} = useRsdAccounts(token, adminsOnly, lockedOnly, inactiveDays, toggle)
+  const [modal, setModal] = useState<AccountModal>({
+    delete:{
+      open: false
+    },
+    lock:{
+      open: false
+    }
   })
 
   // console.group('RsdUsersList')
@@ -53,8 +65,27 @@ export default function RsdUsersList({adminsOnly, lockedOnly, inactiveDays}: {ad
   function onDeleteAccount(account:RsdAccountInfo) {
     if (account) {
       setModal({
-        open: true,
-        account
+        delete:{
+          open: true,
+          account
+        },
+        lock:{
+          open:false
+        }
+      })
+    }
+  }
+
+  function onLockAccount(account:RsdAccountInfo) {
+    if (account) {
+      setModal({
+        delete:{
+          open: false,
+        },
+        lock:{
+          open:true,
+          account
+        }
       })
     }
   }
@@ -71,37 +102,66 @@ export default function RsdUsersList({adminsOnly, lockedOnly, inactiveDays}: {ad
                 key={item.id}
                 account={item}
                 onDelete={()=>onDeleteAccount(item)}
-                onMutation={() => {setToggle(!toggle)}}
+                onLock={onLockAccount}
               />
             )
           })
         }
       </List>
-      <ConfirmDeleteModal
-        open={modal.open}
-        title="Remove account"
-        body={
-          <>
-            <p>
-              Are you sure you want to delete the account <strong>{modal?.account?.id}</strong>?
-            </p>
-            <p className="mt-4">
+      {modal.delete.open ?
+        <ConfirmDeleteModal
+          open={modal.delete.open}
+          title="Remove account"
+          body={
+            <>
+              <p>
+              Are you sure you want to delete the account <strong>{modal.delete?.account?.id}</strong>?
+              </p>
+              <p className="mt-4">
               The user will lose all maintainer rights and all unused maintainer invites created by this user will be deleted.
-            </p>
-          </>
-        }
-        onCancel={() => {
-          setModal({
-            open: false
-          })
-        }}
-        onDelete={() => {
-          deleteAccount(modal?.account?.id ?? '')
-          setModal({
-            open: false
-          })
-        }}
-      />
+              </p>
+            </>
+          }
+          onCancel={() => {
+            setModal({
+              delete:{open: false},
+              lock:{open: false},
+            })
+          }}
+          onDelete={() => {
+            deleteAccount(modal?.delete.account?.id ?? '')
+            setModal({
+              delete:{open: false},
+              lock:{open: false},
+            })
+          }}
+        />
+        :null
+      }
+      {modal.lock.open && modal.lock.account ?
+        <LockUserModal
+          account={{
+            id: modal.lock?.account.id,
+            lock_account: modal?.lock?.account.locked_account ? true : false,
+            admin_facing_reason: modal?.lock?.account.locked_account?.admin_facing_reason ?? null,
+            user_facing_reason: modal?.lock?.account.locked_account?.user_facing_reason ?? null,
+          }}
+          onCancel={()=>
+            setModal({
+              delete:{open: false},
+              lock:{open: false},
+            })
+          }
+          onSubmit={(account)=>{
+            lockAccount(account)
+            setModal({
+              delete:{open: false},
+              lock:{open: false},
+            })
+          }}
+        />
+        : null
+      }
     </>
   )
 }

--- a/frontend/components/admin/rsd-users/RsdUsersPage.test.tsx
+++ b/frontend/components/admin/rsd-users/RsdUsersPage.test.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +24,7 @@ jest.mock('~/components/admin/rsd-users/apiRsdUsers')
 
 describe('components/admin/rsd-users/index.tsx', () => {
 
-  it('shows progressbar initialy', () => {
+  it('shows progressbar initially', () => {
     render(
       <WithAppContext options={{session: testSession}}>
         <RsdUsersPage />
@@ -61,18 +61,36 @@ describe('components/admin/rsd-users/index.tsx', () => {
 
     const deleteBtn = within(rows[0]).getByRole('button',{name:'delete'})
     fireEvent.click(deleteBtn)
+    // get confirm delete
+    const confirmDelete = screen.getByRole('dialog')
+    // confirm first account from list - listed twice in modal
+    screen.getAllByText(mockAccounts[0].id)
+    // confirm remove
+    const removeBtn = within(confirmDelete).getByRole('button', {name: 'Remove'})
+    fireEvent.click(removeBtn)
+  })
 
-    await waitFor(async() => {
-      // get confirm delete
-      const confirmDelete = screen.getByRole('dialog')
-      // confirm first account from list - listed twice in modal
-      screen.getAllByText(mockAccounts[0].id)
-      // confirm remove
-      const removeBtn = within(confirmDelete).getByRole('button', {name: 'Remove'})
-      fireEvent.click(removeBtn)
-      await waitForElementToBeRemoved(confirmDelete)
-      // screen.debug(confirmDelete)
-    })
+  it('shows lock modal of first account', async() => {
+    render(
+      <WithAppContext options={{session: testSession}}>
+        <RsdUsersPage />
+      </WithAppContext>
+    )
+    // wait for loader to be removed
+    await waitForElementToBeRemoved(screen.getByRole('progressbar'))
+
+    const rows = screen.getAllByTestId('account-item')
+    expect(rows.length).toEqual(mockAccounts.length)
+
+    const deleteBtn = within(rows[0]).getByRole('button',{name:'lock account'})
+    fireEvent.click(deleteBtn)
+    // get confirm delete
+    const confirmDelete = screen.getByRole('dialog')
+    // confirm first account from list - listed twice in modal
+    screen.getAllByText(mockAccounts[0].id)
+    // confirm remove
+    const removeBtn = within(confirmDelete).getByRole('button', {name: 'Cancel'})
+    fireEvent.click(removeBtn)
   })
 })
 

--- a/frontend/components/admin/rsd-users/apiRsdUsers.ts
+++ b/frontend/components/admin/rsd-users/apiRsdUsers.ts
@@ -11,6 +11,7 @@ import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetch
 import logger from '~/utils/logger'
 import {paginationUrlParams} from '~/utils/postgrestUrl'
 import {RsdAccountInfo} from './useRsdAccounts'
+import {LockAccountProps} from './LockUserModal'
 
 type getLoginApiParams = {
   token: string,
@@ -140,6 +141,54 @@ export async function removeRsdAdmin({id,token}:{ id: string, token: string }){
       method: 'DELETE',
       headers: createJsonHeaders(token)
     })
+    return await extractReturnMessage(resp)
+  } catch (e:any) {
+    logger(`removeRsdAdmin: ${e.message}`,'error')
+    return {
+      status: 500,
+      message: e.message
+    }
+  }
+}
+
+export async function lockRsdAcount({
+  account,token
+}:{
+  account:LockAccountProps, token: string
+}){
+  try {
+    if (!account.id) return {
+      status: 400,
+      message: 'User account_id not provided'
+    }
+
+    const tableName = 'locked_account'
+    const query = `${tableName}?account_id=eq.${account.id}`
+    const url = `${getBaseUrl()}/${query}`
+
+    let resp
+
+    if (account.lock_account===true){
+      resp = await fetch(url, {
+        method: 'PUT',
+        headers: {
+          ...createJsonHeaders(token),
+          'Prefer': 'resolution=merge-duplicates'
+        },
+        body: JSON.stringify({
+          account_id: account.id,
+          admin_facing_reason: account.admin_facing_reason,
+          user_facing_reason: account.user_facing_reason,
+        }),
+      })
+    } else {
+      resp = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          ...createJsonHeaders(token)
+        }
+      })
+    }
     return await extractReturnMessage(resp)
   } catch (e:any) {
     logger(`removeRsdAdmin: ${e.message}`,'error')

--- a/frontend/components/admin/rsd-users/useRsdAccounts.tsx
+++ b/frontend/components/admin/rsd-users/useRsdAccounts.tsx
@@ -1,13 +1,14 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useEffect, useState} from 'react'
+import {useCallback, useEffect, useState} from 'react'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import usePaginationWithSearch from '~/utils/usePaginationWithSearch'
-import {deleteRsdAccount, getRsdAccounts} from './apiRsdUsers'
+import {deleteRsdAccount, getRsdAccounts, lockRsdAcount} from './apiRsdUsers'
+import {LockAccountProps} from './LockUserModal'
 
 export type RsdAccount = {
   id: string,
@@ -38,23 +39,25 @@ export default function useRsdAccounts(token: string, adminsOnly: boolean, locke
   // show loading only on initial load
   const [loading, setLoading] = useState(true)
 
+  const getAccountList = useCallback(async()=>{
+    const {accounts, count} = await getRsdAccounts({
+      token,
+      searchFor,
+      page,
+      rows,
+      adminsOnly,
+      lockedOnly,
+      inactiveDays
+    })
+    setAccounts(accounts)
+    setCount(count)
+    setLoading(false)
+
+  },[token,searchFor,page,rows,adminsOnly,lockedOnly,inactiveDays])
+
   useEffect(() => {
-    async function getLogins() {
-      const {accounts, count} = await getRsdAccounts({
-        token,
-        searchFor,
-        page,
-        rows,
-        adminsOnly,
-        lockedOnly,
-        inactiveDays
-      })
-      setAccounts(accounts)
-      setCount(count)
-      setLoading(false)
-    }
     if (token) {
-      getLogins()
+      getAccountList()
     }
   // we do not include setCount in order to avoid loop
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -67,16 +70,30 @@ export default function useRsdAccounts(token: string, adminsOnly: boolean, locke
       token
     })
     if (resp.status===200) {
-      const newList = accounts.filter(item => item.id !== id)
-      setAccounts(newList)
+      // reload account list
+      getAccountList()
     } else {
       showErrorMessage(`Failed to remove account ${id}. ${resp.message}`)
+    }
+  }
+
+  async function lockAccount(account:LockAccountProps){
+    const resp = await lockRsdAcount({
+      account,
+      token
+    })
+    if (resp.status===200) {
+      // reload account list
+      getAccountList()
+    } else {
+      showErrorMessage(`Failed to ${account.lock_account? 'lock' : 'unlock'} account ${account.id}. ${resp.message}`)
     }
   }
 
   return {
     loading,
     accounts,
+    lockAccount,
     deleteAccount
   }
 }


### PR DESCRIPTION
# Use Lock account modal

Changes proposed in this pull request:
* Show modal when lock button is clicked to change account lock status
* Validation on lock input is set to min 10 chars and max 100 chart. 
* Providing reasons when account is locked is required
* When account is locked the lock icon is red  

How to test:
* `make start` to build and generate test data
* login as rsd admin and navigate to rsd users section
* Try to lock and unlock an account

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
