### PR TITLE
fix: don't require requested_at to be not null in software_for_commun…

### DIFF
--- a/database/008-create-community-table.sql
+++ b/database/008-create-community-table.sql
@@ -1,7 +1,6 @@
 -- SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+-- SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 -- SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
--- SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 -- SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 --
@@ -347,7 +346,7 @@ CREATE TABLE software_for_community (
 	software UUID REFERENCES software (id),
 	community UUID REFERENCES community (id),
 	status request_status NOT NULL DEFAULT 'pending',
-	requested_at TIMESTAMPTZ NOT NULL,
+	requested_at TIMESTAMPTZ,
 	PRIMARY KEY (software, community)
 );
 


### PR DESCRIPTION
This makes the `requested_at` column not required for the `software_for_community` table, to make it consistent with the `v4.1.0` release. We removed the requirement there, as all existing rows don't have a value there and adding a arbitrary non-null value would be incorrect semantically.