### PR TITLE
feat: allow to send slug as query parameter in editSoftwareNav plugin slot

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -128,7 +128,7 @@ services:
       # dockerfile to use for build
       dockerfile: Dockerfile
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:3.3.0
+    image: rsd/frontend:4.1.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL
@@ -215,7 +215,7 @@ services:
       context: ./documentation
       # dockerfile to use for build
       dockerfile: Dockerfile
-    image: rsd/documentation:3.0.0
+    image: rsd/documentation:4.1.0
     expose:
       - "80"
     networks:

--- a/documentation/docs/04-contribute/06-plugin-development.md
+++ b/documentation/docs/04-contribute/06-plugin-development.md
@@ -18,6 +18,12 @@ and at the bottom of the software edit navbar:
 
 ![Plugin slot in the software edit navigation sidebar](img/softwareNavPlugin.png)
 
+Plugin slots may define placeholders that are allowed in the `href` content. The placeholders will be replaced by Next.js. Their use is optional. The available placeholders per plugin slot are listed in the following table:
+
+| Plugin slot     | Placeholder | Description                                  |
+|-----------------|-------------|----------------------------------------------|
+| editSoftwareNav | `{slug}`    | Replaced by the slug of the edited software. |
+
 ## How plugins work
 
 1) Next.js performs GET requests to all registered plugins, to the endpoints `<baseUrl>/plugin/<plugin>/api/v1/config`. The `baseUrl` is determined by the plugin name in `settings.json`. If a user is signed it, the token is sent in the header for authentication. The token contains a `data` attribute which can be used to determine which links should be displayed for each user. Users logged in via HelmholtzID have their [`eduPersonEntitlements`](https://hifis.net/doc/helmholtz-aai/attributes/#group-membership-information) delivered within the `data` attribute.

--- a/documentation/docs/04-contribute/06-plugin-development.md.license
+++ b/documentation/docs/04-contribute/06-plugin-development.md.license
@@ -1,6 +1,7 @@
-SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2024 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+SPDX-FileCopyrightText: 2025 PERFACCT GmbH
 
 SPDX-License-Identifier: CC-BY-4.0

--- a/documentation/package.json
+++ b/documentation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-documentation",
-  "version": "3.0.0",
+  "version": "4.1.0",
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",

--- a/frontend/components/software/edit/EditSoftwareNav.tsx
+++ b/frontend/components/software/edit/EditSoftwareNav.tsx
@@ -59,7 +59,7 @@ export default function EditSoftwareNav({slug,pageId}:{slug:string,pageId:string
             const url = pluginSlot.href ? pluginSlot.href.replace('{slug}', slug) : '#'
             return (
               <ListItemButton
-                data-testid="edit-software-nav-item"
+                data-testid="edit-software-plugin-item"
                 key={pluginSlot.title}
                 selected={false}
                 onClick={() => {

--- a/frontend/components/software/edit/EditSoftwareNav.tsx
+++ b/frontend/components/software/edit/EditSoftwareNav.tsx
@@ -3,9 +3,10 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2024 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+// SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 PERFACCT GmbH
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -55,13 +56,14 @@ export default function EditSoftwareNav({slug,pageId}:{slug:string,pageId:string
         })}
         {
           pluginSlots.map((pluginSlot) => {
+            const url = pluginSlot.href ? pluginSlot.href.replace('{slug}', slug) : '#'
             return (
               <ListItemButton
                 data-testid="edit-software-nav-item"
                 key={pluginSlot.title}
                 selected={false}
                 onClick={() => {
-                  router.push(pluginSlot.href || '#')
+                  router.push(url)
                 }}
                 sx={editMenuItemButtonSx}
               >

--- a/frontend/config/getPlugins.ts
+++ b/frontend/config/getPlugins.ts
@@ -1,7 +1,7 @@
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -60,13 +60,26 @@ async function getPlugin({pluginName, token}:{pluginName: string, token?: string
 export default async function getPlugins(
   {plugins,token}: {plugins?: string[], token?: string}
 ) {
-  if (!plugins) {
+  try{
+    if (!plugins) {
+      return []
+    }
+    // create all requests
+    const promises = plugins?.map(pluginName=>getPlugin({pluginName,token}))
+    // execute all requests
+    const pluginSlots = await Promise.all(promises)
+    // flatten arrays into one array
+    const pluginList = pluginSlots.flat()
+
+    // console.group('getPlugins')
+    // console.log('plugins...', plugins)
+    // console.log('pluginSlots...', pluginSlots)
+    // console.log('pluginList...', pluginList)
+    // console.groupEnd()
+
+    return pluginList
+  }catch(e:any){
+    logger(`Failed to load plugins. ${e?.message}`,'warn')
     return []
   }
-  // create all requests
-  const promises = plugins?.map(pluginName=>getPlugin({pluginName,token}))
-  // execute all requests
-  const pluginSlots = await Promise.all(promises)
-  // flatten definitions
-  return pluginSlots.flat()
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "3.4.0",
+  "version": "4.1.0",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",


### PR DESCRIPTION
# Enhance editSoftwareNav plugin slot

Changes proposed in this pull request:

* add the ability to append the software slug as query parameter to the link url of the editSoftwareNav plugin slot
* if a plugin adds `{slug}` to the url, NextJS will replace it with the slug of the software that is currently edited

How to test:

* in a plugin (for example the [RSD-plugin-example](https://github.com/research-software-directory/RSD-plugin-example)), add `{slug}` to the [href](https://github.com/research-software-directory/RSD-plugin-example/blob/85a52500f40b2021c0f76a72eea95663b552dcb0/plugin-01/backend/main.py#L43) field, e.g.

```tsx
        PluginSlot(
            slot="editSoftwareNav",
            icon="",
            href="http://localhost/plugin/plugin-01/{slug}",
            title="Plugin 01 link",
            subtitle="",
        ),
```

* open a software edit view and click on the plugin slot, `{slug}` must be replaced by the slug of the software

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
