### PR TITLE
feat!: extend modules definitions in settings.json

### DIFF
--- a/documentation/docs/03-rsd-instance/02-configurations.md
+++ b/documentation/docs/03-rsd-instance/02-configurations.md
@@ -159,7 +159,6 @@ The `host` section of settings.json defines following settings. **Most of them s
 - `privacy_statement_url`: the link to your privacy statement page. Used on the user profile page to let user accept the privacy statement.
 - `software_highlights`: the definitions for the software highlights section on the top of the software overview page. You can specify title and the number of items loaded in the carousel. The default values are shown below.
 - `orcid_search`: should ORCID api be used when searching for contributors or team members? By default ORCID search api is enabled and the entries from RSD and ORCID are combined in the search result. If you want your users to be able to search only within the existing RSD entries set this value to false.
-- `modules`: defines RSD "modules" displayed in the main menu in the page header. Possible values are: software, projects, organisations, communities and persons.
 
 ```json
 ...
@@ -183,18 +182,67 @@ The `host` section of settings.json defines following settings. **Most of them s
       "limit": 5,
       "description": null
     },
-    "orcid_search": true,
-    "modules":["software","projects","organisations","communities","persons"]
+    "orcid_search": true
   }
 ...
 ```
 
-:::tip host modules
+## RSD modules
 
-- Note that the communities module is included in the default settings definitions.
-- Note that disabled module pages still can be accessed when "proper" url is used.
-- You can enable it by adding "communities" into the modules array and the menu option will appear.
-  :::
+RSD consist of following modules: software, projects, organisations, communities, persons and news. Each of the modules can be enabled and the main menu item label can be adapted. By default following modules are enabled: software, projects, organisations, communities and news (persons module is disabled/inactive by default). The keys of the modules property correspond to module names: software, projects, organisations, communities, persons and news.
+
+- To disable an module set `active` flag to false (see module persons in the example below).
+- To change menu item entry label edit `menuItem` (see module project in the example below).
+- To hide main menu item while module is enabled set `menuItem` to `null` (see news module in the example below).
+
+:::info
+The state/values of the module properties is cached in production in order to reduce the number of requests.
+After you changed properties in the modules you should restart RSD (docker compose down && docker compose up).
+:::
+
+```json
+...
+"modules":{
+  "software":{
+    "active":true,
+    "name":"software",
+    "menuItem":"Software"
+  },
+  "projects":{
+    "active":true,
+    "name":"projects",
+    "menuItem":"Custom Projects Menu Item"
+  },
+  "organisations":{
+    "active":true,
+    "name":"organisations",
+    "menuItem":"Organisations"
+  },
+  "communities": {
+    "active":true,
+    "name":"communities",
+    "menuItem":"Communities"
+  },
+  "persons": {
+    "active":false,
+    "name":"persons",
+    "menuItem":"Persons"
+  },
+  "news": {
+    "active":true,
+    "name":"news",
+    "menuItem":null
+  }
+},
+...
+```
+
+:::warning modules
+
+- The communities module is included in the default settings definitions. If you disable software module the communities menu option will be omitted because communities module is dependent on software module.
+- The pages of inactive/disabled module cannot be accessed, 404 page will be shown.
+- Note that module
+:::
 
 ## UI theming
 
@@ -251,7 +299,7 @@ RSD uses default settings.json if alternative is not mounted into `/app/public/d
       "url": "rsd@esciencecenter.nl",
       "issues_page_url": "https://github.com/research-software-directory/RSD-as-a-service/issues"
     },
-    "login_info_url": "https://research-software-directory.github.io/documentation/getting-access.html",
+    "login_info_url":"https://research-software-directory.github.io/documentation/getting-access.html",
     "terms_of_service_url": "/page/terms-of-service/",
     "privacy_statement_url": "/page/privacy-statement/",
     "software_highlights": {
@@ -259,8 +307,39 @@ RSD uses default settings.json if alternative is not mounted into `/app/public/d
       "limit": 5,
       "description": null
     },
-    "orcid_search": true,
-    "modules": ["software", "projects", "organisations"]
+    "orcid_search":true
+  },
+  "modules":{
+    "software":{
+      "active":false,
+      "name":"software",
+      "menuItem":"Software"
+    },
+    "projects":{
+      "active":true,
+      "name":"projects",
+      "menuItem":"Projects"
+    },
+    "organisations":{
+      "active":true,
+      "name":"organisations",
+      "menuItem":"Organisations"
+    },
+    "communities": {
+      "active":true,
+      "name":"communities",
+      "menuItem":"Communities"
+    },
+    "persons": {
+      "active":false,
+      "name":"persons",
+      "menuItem":"Persons"
+    },
+    "news": {
+      "active":true,
+      "name":"news",
+      "menuItem":"News"
+    }
   },
   "links": [
     {

--- a/frontend/__tests__/ProjectEditPage.test.tsx
+++ b/frontend/__tests__/ProjectEditPage.test.tsx
@@ -146,7 +146,7 @@ describe('pages/projects/[slug]/edit/index.tsx', () => {
   it('does not show related-software when no software module in settings', async () => {
     mockProps.page='information'
     // remove software module from settings
-    mockSettings.host.modules = ['projects','organisations','news']
+    mockSettings.modules.software.active=false
     // return isMaintainer
     mockIsMaintainer.mockResolvedValue(true)
 

--- a/frontend/__tests__/SoftwareEditPage.test.tsx
+++ b/frontend/__tests__/SoftwareEditPage.test.tsx
@@ -137,14 +137,18 @@ describe('pages/software/[slug]/edit/[page].tsx', () => {
   it('does not render communities menu option', async () => {
     // return isMaintainer
     mockIsMaintainer.mockResolvedValueOnce(true)
+
     // module list without "communities"
-    defaultSettings.host.modules = ['software','projects','organisations']
+    const settings = {
+      ...defaultSettings
+    }
+    settings.modules.communities.active=false
 
     // render components
     render(
       <WithAppContext options={{
         session: mockSession,
-        settings: defaultSettings as RsdSettingsState
+        settings: settings as RsdSettingsState
       }}>
         <WithFormContext>
           <WithSoftwareContext state={softwareState}>
@@ -167,14 +171,17 @@ describe('pages/software/[slug]/edit/[page].tsx', () => {
   it('does not render related-projects menu option', async () => {
     // return isMaintainer
     mockIsMaintainer.mockResolvedValueOnce(true)
-    // module list without "communities"
-    defaultSettings.host.modules = ['software','organisations','communities']
+    // module list without "projects"
+    const settings = {
+      ...defaultSettings
+    }
+    settings.modules.projects.active = false
 
     // render components
     render(
       <WithAppContext options={{
         session: mockSession,
-        settings: defaultSettings as RsdSettingsState
+        settings: settings as RsdSettingsState
       }}>
         <WithFormContext>
           <WithSoftwareContext state={softwareState}>

--- a/frontend/components/AppHeader/AddMenu.test.tsx
+++ b/frontend/components/AppHeader/AddMenu.test.tsx
@@ -27,7 +27,6 @@ it('should render AddMenu',()=>{
 })
 
 it('all menu options for rsd-admin',async()=>{
-  mockSettings.host.modules = ['software','projects','news']
   // admin should have more items
   if (mockSession.user) mockSession.user.role='rsd_admin'
 
@@ -44,13 +43,12 @@ it('all menu options for rsd-admin',async()=>{
   fireEvent.click(menuButton as HTMLElement)
   // select all menu options
   const menuOptions = screen.queryAllByTestId('add-menu-option')
-  // assert only 1 item
-  expect(menuOptions.length).toEqual(mockSettings.host.modules.length)
+  // assert 3 menu options [software,projects,news]
+  expect(menuOptions.length).toEqual(3)
   // screen.debug()
 })
 
 it('no news option for rsd-user',async()=>{
-  mockSettings.host.modules = ['software','projects','news']
   // admin should have more items
   if (mockSession.user) mockSession.user.role='rsd_user'
 
@@ -67,7 +65,7 @@ it('no news option for rsd-user',async()=>{
   fireEvent.click(menuButton as HTMLElement)
   // select all menu options
   const menuOptions = screen.queryAllByTestId('add-menu-option')
-  // assert only 1 item
-  expect(menuOptions.length).toEqual(mockSettings.host.modules.length-1)
+  // assert 2 menu options [software,projects]
+  expect(menuOptions.length).toEqual(2)
   // screen.debug()
 })

--- a/frontend/components/AppHeader/AppHeader.test.tsx
+++ b/frontend/components/AppHeader/AppHeader.test.tsx
@@ -45,7 +45,8 @@ it('renders AppHeader with links to defined modules and logo link', () => {
   // has searchbox
   const links = screen.getAllByRole('link')
   // menu items defined in modules + logo link + feedback link
-  expect(links).toHaveLength(defaultSettings.host.modules.length + 2)
+  const moduleLinks = Object.keys(defaultSettings.modules)
+  expect(links).toHaveLength(moduleLinks.length + 2)
   // screen.debug()
 })
 

--- a/frontend/components/AppHeader/__mocks__/useAddItemMenu.tsx
+++ b/frontend/components/AppHeader/__mocks__/useAddItemMenu.tsx
@@ -46,10 +46,10 @@ export const addItemMenu:AddItemMenuItem[]=[{
 
 function useAddItemMenu(){
   const {user} = useSession()
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
 
   const menuItems = addItemMenu.filter(item=>{
-    return item.active({role: user?.role, modules: host.modules}) ?? false
+    return item.active({role: user?.role, modules:activeModules}) ?? false
   })
 
   // console.group('useAddItemMenu')

--- a/frontend/components/AppHeader/useAddItemMenu.tsx
+++ b/frontend/components/AppHeader/useAddItemMenu.tsx
@@ -11,6 +11,7 @@ import TerminalIcon from '@mui/icons-material/Terminal'
 import ListAltIcon from '@mui/icons-material/ListAlt'
 import NewspaperIcon from '@mui/icons-material/Newspaper'
 import useRsdSettings from '~/config/useRsdSettings'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 
 type AddItemMenuItem={
   type: 'link' | 'divider'
@@ -26,13 +27,13 @@ const addItemMenu:AddItemMenuItem[]=[{
   label: 'New Software',
   icon: <TerminalIcon/>,
   path: '/add/software',
-  active: ({modules})=>modules.includes('software')
+  active: ({modules}:{modules:RsdModuleName[]})=>modules.includes('software')
 },{
   type: 'link',
   label: 'New Project',
   icon: <ListAltIcon/>,
   path: '/add/project',
-  active: ({modules})=>modules.includes('projects')
+  active: ({modules}:{modules:RsdModuleName[]})=>modules.includes('projects')
 },{
   type: 'link',
   label: 'Add News',
@@ -46,10 +47,10 @@ const addItemMenu:AddItemMenuItem[]=[{
 
 function useAddItemMenu(){
   const {user} = useSession()
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
 
   const menuItems = addItemMenu.filter(item=>{
-    return item.active({role: user?.role, modules: host.modules}) ?? false
+    return item.active({role: user?.role, modules:activeModules}) ?? false
   })
 
   // console.group('useAddItemMenu')

--- a/frontend/components/GlobalSearchAutocomplete/GlobalSearchAutocomplete.test.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/GlobalSearchAutocomplete.test.tsx
@@ -45,7 +45,7 @@ it('renders component with testid global-search', async() => {
 it('shows navigation option on focus based on modules defined', async () => {
   mockUseHasRemotes.mockReturnValue({hasRemotes:false})
   // filter out news as these are not in global search
-  const expectedMenuOptions = defaultRsdSettings.host.modules?.filter(item=>item!=='news')
+  const expectedMenuOptions = Object.keys(defaultRsdSettings.modules).filter(key=>key!=='news')
   // render component with session
   render(WrappedComponentWithProps(GlobalSearchAutocomplete))
   // find input

--- a/frontend/components/GlobalSearchAutocomplete/SearchItemIcon.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/SearchItemIcon.tsx
@@ -8,10 +8,11 @@ import ListAltIcon from '@mui/icons-material/ListAlt'
 import BusinessIcon from '@mui/icons-material/Business'
 import Diversity3Icon from '@mui/icons-material/Diversity3'
 import AccountCircleIcon from '@mui/icons-material/AccountCircle'
+import CalendarViewMonthIcon from '@mui/icons-material/CalendarViewMonth'
 
-import {RsdModule} from '~/config/rsdSettingsReducer'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 
-export default function SearchItemIcon({source}:Readonly<{source:RsdModule}>) {
+export default function SearchItemIcon({source}:Readonly<{source:RsdModuleName}>) {
   switch (source){
     case 'software':
       return <TerminalIcon/>
@@ -21,6 +22,8 @@ export default function SearchItemIcon({source}:Readonly<{source:RsdModule}>) {
       return <BusinessIcon/>
     case 'communities':
       return <Diversity3Icon/>
+    case 'news':
+      return <CalendarViewMonthIcon />
     case 'persons':
       return <AccountCircleIcon/>
     default:

--- a/frontend/components/GlobalSearchAutocomplete/apiGlobalSearch.ts
+++ b/frontend/components/GlobalSearchAutocomplete/apiGlobalSearch.ts
@@ -8,7 +8,7 @@
 
 import logger from '~/utils/logger'
 import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
-import {RsdModule} from '~/config/rsdSettingsReducer'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 
 // export type GlobalSearchResultsSource = 'software' | 'projects' | 'organisations' | 'communities' | 'persons'
 
@@ -17,7 +17,7 @@ export type GlobalSearchResults = {
   domain: string | null
   slug: string,
   name: string,
-  source: RsdModule,
+  source: RsdModuleName,
   is_published?: boolean,
   search_text?: string
 }

--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -33,7 +33,7 @@ type Props = {
 export default function GlobalSearchAutocomplete(props: Props) {
   const {session} = useAuth()
   const router = useRouter()
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
   const {showErrorMessage} = useSnackbar()
   const [isOpen, setOpen] = useState(false)
   const [inputValue, setInputValue] = useState('')
@@ -99,7 +99,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
     // Fetch api
     let data: GlobalSearchResults[]
     try {
-      data = await getGlobalSearch(search, session.token, host.modules) || []
+      data = await getGlobalSearch(search, session.token, activeModules) || []
     } catch (e: any) {
       logger(e?.message, 'error')
       showErrorMessage('Something went wrong getting the search results')
@@ -186,21 +186,25 @@ export default function GlobalSearchAutocomplete(props: Props) {
   }
 
   // do not show searchbar if no modules defined
-  if (host?.modules?.length === 0) return null
+  if (activeModules?.length === 0) return null
 
-  if (host.modules?.includes('software')) {
+  if (activeModules?.includes('software')) {
     defaultValues.push({name: 'Go to Software page', slug: '', source: 'software', domain: null, rsd_host: null})
   }
-  if (host.modules?.includes('projects')) {
+  if (activeModules?.includes('projects')) {
     defaultValues.push({name: 'Go to Projects page', slug: '', source: 'projects', domain: null, rsd_host: null})
   }
-  if (host.modules?.includes('organisations')) {
+  if (activeModules?.includes('organisations')) {
     defaultValues.push({name: 'Go to Organisations page', slug: '', source: 'organisations', domain: null, rsd_host: null})
   }
-  if (host.modules?.includes('communities')) {
+  if (activeModules?.includes('communities')) {
     defaultValues.push({name: 'Go to Communities page', slug: '', source: 'communities', domain: null, rsd_host: null})
   }
-  if (host.modules?.includes('persons')) {
+  // TODO! Add news to global search?
+  // if (activeModules?.includes('news')) {
+  //   defaultValues.push({name: 'Go to News page', slug: '', source: 'news', domain: null, rsd_host: null})
+  // }
+  if (activeModules?.includes('persons')) {
     defaultValues.push({name: 'Go to Persons page', slug: '', source: 'persons', domain: null, rsd_host: null})
   }
 

--- a/frontend/components/admin/AdminNav.tsx
+++ b/frontend/components/admin/AdminNav.tsx
@@ -34,7 +34,7 @@ import InfoIcon from '@mui/icons-material/Info'
 import PersonAddIcon from '@mui/icons-material/PersonAdd'
 
 import {editMenuItemButtonSx} from '~/config/menuItems'
-import {RsdModule} from '~/config/rsdSettingsReducer'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 import useRsdSettings from '~/config/useRsdSettings'
 
 export type AdminMenuItemProps={
@@ -58,7 +58,7 @@ export const adminPages = {
     subtitle: '',
     icon: <FluorescentIcon />,
     path: '/admin/software-highlights',
-    active: ({modules}:{modules:RsdModule[]}) => modules?.includes('software'),
+    active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('software'),
   },
   rsd_invites:{
     title: 'RSD invites',
@@ -86,28 +86,28 @@ export const adminPages = {
     subtitle: '',
     icon: <TerminalIcon />,
     path: '/admin/software',
-    active: ({modules}:{modules:RsdModule[]}) => modules?.includes('software'),
+    active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('software'),
   },
   projects: {
     title: 'Projects',
     subtitle: '',
     icon: <ListAltIcon />,
     path: '/admin/projects',
-    active: ({modules}:{modules:RsdModule[]}) => modules?.includes('projects'),
+    active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('projects'),
   },
   organisations: {
     title: 'Organisations',
     subtitle: '',
     icon: <DomainAddIcon />,
     path: '/admin/organisations',
-    active: ({modules}:{modules:RsdModule[]}) => modules?.includes('organisations'),
+    active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('organisations'),
   },
   communities: {
     title: 'Communities',
     subtitle: '',
     icon: <Diversity3Icon />,
     path: '/admin/communities',
-    active: ({modules}:{modules:RsdModule[]}) => modules?.includes('communities') && modules?.includes('software'),
+    active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('communities') && modules?.includes('software'),
   },
   keywords:{
     title: 'Keywords',
@@ -166,7 +166,7 @@ export type AdminPageTypes = keyof typeof adminPages
 export default function AdminNav() {
   const router = useRouter()
   const items = Object.keys(adminPages)
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
 
   // console.group("AdminNav")
   // console.log("items...",items)
@@ -180,7 +180,7 @@ export default function AdminNav() {
       }}>
         {items.map((key, pos) => {
           const item:AdminMenuItemProps = adminPages[key as AdminPageTypes]
-          if (item.active({modules:host?.modules})===true){
+          if (item.active({modules:activeModules})===true){
             return (
               <ListItemButton
                 data-testid="admin-nav-item"

--- a/frontend/components/layout/UserMenu.test.tsx
+++ b/frontend/components/layout/UserMenu.test.tsx
@@ -38,5 +38,6 @@ it('show userMenu options based on modules defined',async()=>{
   // select all menu options
   const menuOptions = screen.queryAllByTestId('user-menu-option')
   // based on default user session the menu should have 5 items
-  expect(menuOptions.length).toEqual(defaultRsdSettings?.host?.modules?.length)
+  const expectOptions = Object.keys(defaultRsdSettings?.modules)
+  expect(menuOptions.length).toEqual(expectOptions.length)
 })

--- a/frontend/components/organisation/overview/card/OrganisationCardMetrics.tsx
+++ b/frontend/components/organisation/overview/card/OrganisationCardMetrics.tsx
@@ -40,19 +40,19 @@ function ProjectsCounter({project_cnt}:Readonly<{project_cnt: number | null}>){
 
 
 export default function OrganisationCardMetrics({software_cnt,project_cnt}:OrganisationMetricsProps) {
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
   return (
     <>
       {/* Software counter if module enabled */}
       {
-        host?.modules?.includes('software') ?
+        activeModules?.includes('software') ?
           <SoftwareCounter software_cnt={software_cnt} />
           : null
       }
 
       {/* Projects counter if modules is enabled */}
       {
-        host?.modules?.includes('projects') ?
+        activeModules?.includes('projects') ?
           <ProjectsCounter project_cnt={project_cnt} />
           : null
       }

--- a/frontend/components/organisation/tabs/OrganisationTabItems.tsx
+++ b/frontend/components/organisation/tabs/OrganisationTabItems.tsx
@@ -15,12 +15,12 @@ import SettingsIcon from '@mui/icons-material/Settings'
 import StyleOutlinedIcon from '@mui/icons-material/StyleOutlined'
 
 import {OrganisationForOverview} from '~/types/Organisation'
-import {RsdModule} from '~/config/rsdSettingsReducer'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 
 
 type IsVisibleProps = Partial<OrganisationForOverview> & {
   isMaintainer: boolean
-  modules: RsdModule[]
+  modules: RsdModuleName[]
 }
 
 export type OrganisationTabItemProps = {
@@ -45,19 +45,19 @@ export const organisationTabItems:OrganisationTabProps = {
     id:'software',
     label:({software_cnt})=>`Software (${software_cnt ?? 0})`,
     icon: <TerminalIcon />,
-    isVisible: ({modules}) => modules?.includes('software')
+    isVisible: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('software')
   },
   projects:{
     id:'projects',
     label: ({project_cnt})=>`Projects (${project_cnt ?? 0})`,
     icon: <ListAltIcon />,
-    isVisible: ({modules}) => modules?.includes('projects')
+    isVisible: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('projects')
   },
   releases: {
     id:'releases',
     label:({release_cnt})=>`Releases (${release_cnt ?? 0})`,
     icon: <StyleOutlinedIcon />,
-    isVisible: ({modules}) => modules?.includes('software')
+    isVisible: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('software')
   },
   units:{
     id:'units',

--- a/frontend/components/organisation/tabs/OrganisationTabs.tsx
+++ b/frontend/components/organisation/tabs/OrganisationTabs.tsx
@@ -18,7 +18,7 @@ const tabItems = Object.keys(organisationTabItems) as TabKey[]
 
 export default function OrganisationTabs({tab_id}:{tab_id:TabKey|null}) {
   const router = useRouter()
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
   const select_tab = useSelectedTab(tab_id)
   const {
     description, software_cnt,
@@ -29,7 +29,7 @@ export default function OrganisationTabs({tab_id}:{tab_id:TabKey|null}) {
   // console.group('OrganisationTabs')
   // console.log('tab...', tab_id)
   // console.log('select_tab...', select_tab)
-  // console.log('modules...', host?.modules)
+  // console.log('activeModules...', activeModules)
   // console.groupEnd()
 
   return (
@@ -57,7 +57,7 @@ export default function OrganisationTabs({tab_id}:{tab_id:TabKey|null}) {
           project_cnt,
           children_cnt,
           description,
-          modules: host?.modules ?? []
+          modules: activeModules
         })) {
           return <TabAsLink
             icon={item.icon}

--- a/frontend/components/profile/overview/PersonMetrics.tsx
+++ b/frontend/components/profile/overview/PersonMetrics.tsx
@@ -16,7 +16,7 @@ type PersonMetricsProps = {
 }
 
 export default function PersonMetrics({software_cnt,project_cnt}:PersonMetricsProps) {
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
 
   function softwareMessage(){
     if (software_cnt && software_cnt === 1) {
@@ -35,7 +35,7 @@ export default function PersonMetrics({software_cnt,project_cnt}:PersonMetricsPr
   return (
     <>
       {
-        host.modules?.includes('software') ?
+        activeModules?.includes('software') ?
           <Tooltip title={softwareMessage()} placement="top">
             <div className="flex gap-2 items-center text-base-content-secondary">
               <TerminalIcon sx={{width:20}} />
@@ -45,7 +45,7 @@ export default function PersonMetrics({software_cnt,project_cnt}:PersonMetricsPr
           :null
       }
       {
-        host.modules?.includes('projects') ?
+        activeModules?.includes('projects') ?
           <Tooltip title={projectMessage()} placement="top">
             <div className="flex gap-2 items-center text-base-content-secondary">
               <ListAltIcon sx={{width:20}} />

--- a/frontend/components/profile/tabs/index.tsx
+++ b/frontend/components/profile/tabs/index.tsx
@@ -23,13 +23,13 @@ const tabItems = Object.keys(profileTabItems) as ProfileTabKey[]
 
 export default function ProfileTabs({tab_id, isMaintainer}:ProfileTabsProps) {
   const router = useRouter()
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
   const {software_cnt,project_cnt} = useProfileContext()
 
   // if only one module active we do not show tabs
   if (
-    host?.modules?.includes('software')===false ||
-    host?.modules?.includes('projects')===false
+    activeModules.includes('software')===false ||
+    activeModules.includes('projects')===false
   ){
     return (
       <div className="my-2"></div>
@@ -50,7 +50,7 @@ export default function ProfileTabs({tab_id, isMaintainer}:ProfileTabsProps) {
       >
         {tabItems.map(key => {
           const item = profileTabItems[key]
-          if (item.isVisible({isMaintainer,modules:host?.modules ?? []})===true){
+          if (item.isVisible({isMaintainer,modules:activeModules})===true){
             return (
               <TabAsLink
                 key={key}

--- a/frontend/components/projects/edit/EditProjectNav.tsx
+++ b/frontend/components/projects/edit/EditProjectNav.tsx
@@ -19,7 +19,7 @@ import {EditProjectPageId} from './EditProjectPageContent'
 import {editProjectMenuItems} from './editProjectMenuItems'
 
 export default function EditProjectNav({slug,pageId}:Readonly<{slug:string,pageId:EditProjectPageId}>) {
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
   return (
     <nav>
       <List sx={{
@@ -27,7 +27,7 @@ export default function EditProjectNav({slug,pageId}:Readonly<{slug:string,pageI
       }}>
         {editProjectMenuItems.map((item, pos) => {
           // show only "active" mention options
-          if (item.active({modules: host.modules})===true){
+          if (item.active({modules: activeModules})===true){
             return (
               <ListItemButton
                 data-testid="edit-project-nav-item"

--- a/frontend/components/projects/edit/editProjectMenuItems.tsx
+++ b/frontend/components/projects/edit/editProjectMenuItems.tsx
@@ -13,7 +13,7 @@ import TerminalIcon from '@mui/icons-material/Terminal'
 import JoinInnerIcon from '@mui/icons-material/JoinInner'
 import AddCommentIcon from '@mui/icons-material/AddComment'
 import ThreePIcon from '@mui/icons-material/ThreeP'
-import {RsdModule} from '~/config/rsdSettingsReducer'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 
 export type EditProjectMenuItemProps = {
   id: string,
@@ -42,7 +42,7 @@ export const editProjectMenuItems: EditProjectMenuItemProps[] = [
     id: 'organisations',
     label: 'Organisations',
     icon: <BusinessIcon />,
-    active: ({modules}:{modules:RsdModule[]}) => modules?.includes('organisations'),
+    active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('organisations'),
     status: ''
   },
   {
@@ -70,7 +70,7 @@ export const editProjectMenuItems: EditProjectMenuItemProps[] = [
     id: 'related-software',
     label: 'Related software',
     icon: <TerminalIcon />,
-    active: ({modules}:{modules:RsdModule[]}) => modules?.includes('software'),
+    active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('software'),
     status: ''
   },
   {

--- a/frontend/components/search/useSearchParams.tsx
+++ b/frontend/components/search/useSearchParams.tsx
@@ -8,7 +8,7 @@ import {useRouter} from 'next/router'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
 import {QueryParams,buildFilterUrl} from '~/utils/postgrestUrl'
 import {useUserSettings} from '~/config/UserSettingsContext'
-import {RsdModule} from '~/config/rsdSettingsReducer'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 
 
 /**
@@ -17,7 +17,7 @@ import {RsdModule} from '~/config/rsdSettingsReducer'
  * @param view the route of the overview page (organisations | communities | news)
  * @returns handleQueryChange and resetFilters methods.
  */
-export default function useSearchParams(view:RsdModule){
+export default function useSearchParams(view:RsdModuleName){
   const router = useRouter()
   const {rsd_page_rows, setPageRows} = useUserSettings()
 

--- a/frontend/components/software/CommunitiesSection.tsx
+++ b/frontend/components/software/CommunitiesSection.tsx
@@ -21,11 +21,11 @@ type CommunitiesSectionProps=Readonly<{
 
 
 export default function CommunitiesSection({communities = []}: CommunitiesSectionProps) {
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
   // do not render section if no data
   if (communities?.length === 0) return null
   // do not render section if module is not enabled
-  if (host?.modules?.includes('communities')===false) return null
+  if (activeModules.includes('communities')===false) return null
 
   return (
     <PageContainer className="py-12 px-4 lg:grid lg:grid-cols-[1fr_4fr]">

--- a/frontend/components/software/edit/EditSoftwareNav.tsx
+++ b/frontend/components/software/edit/EditSoftwareNav.tsx
@@ -25,7 +25,7 @@ import {editSoftwareMenuItems} from './editSoftwareMenuItems'
 
 export default function EditSoftwareNav({slug,pageId}:{slug:string,pageId:string}) {
   const router = useRouter()
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
   // get edit software plugins
   const pluginSlots = usePluginSlots('editSoftwareNav')
 
@@ -35,7 +35,7 @@ export default function EditSoftwareNav({slug,pageId}:{slug:string,pageId:string
         width:['100%','100%','15rem']
       }}>
         {editSoftwareMenuItems.map(item => {
-          if (item.active({modules:host.modules})===true){
+          if (item.active({modules:activeModules})===true){
             return (
               <ListItemButton
                 data-testid="edit-software-nav-item"

--- a/frontend/components/software/edit/editSoftwareMenuItems.tsx
+++ b/frontend/components/software/edit/editSoftwareMenuItems.tsx
@@ -17,7 +17,7 @@ import JoinInnerIcon from '@mui/icons-material/JoinInner'
 import DonutLargeIcon from '@mui/icons-material/DonutLarge'
 import ArticleIcon from '@mui/icons-material/Article'
 import Diversity3Icon from '@mui/icons-material/Diversity3'
-import {RsdModule} from '~/config/rsdSettingsReducer'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 
 
 export type EditSoftwareMenuItemsProps = {
@@ -50,7 +50,7 @@ export const editSoftwareMenuItems:EditSoftwareMenuItemsProps[] = [{
   id: 'organisations',
   label: 'Organisations',
   icon: <BusinessIcon />,
-  active: ({modules}:{modules:RsdModule[]}) => modules?.includes('organisations'),
+  active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('organisations'),
   status: ''
 },{
   id: 'mentions',
@@ -74,7 +74,7 @@ export const editSoftwareMenuItems:EditSoftwareMenuItemsProps[] = [{
   id: 'communities',
   label: 'Communities',
   icon: <Diversity3Icon />,
-  active: ({modules}:{modules:RsdModule[]}) => modules?.includes('communities'),
+  active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('communities'),
   status: ''
 },{
   id: 'related-software',
@@ -86,7 +86,7 @@ export const editSoftwareMenuItems:EditSoftwareMenuItemsProps[] = [{
   id: 'related-projects',
   label: 'Related projects',
   icon: <DonutLargeIcon />,
-  active: ({modules}:{modules:RsdModule[]}) => modules?.includes('projects'),
+  active: ({modules}:{modules:RsdModuleName[]}) => modules?.includes('projects'),
   status: ''
 },{
   id: 'maintainers',

--- a/frontend/components/user/tabs/UserTabs.tsx
+++ b/frontend/components/user/tabs/UserTabs.tsx
@@ -33,7 +33,7 @@ export type UserTabsProps=Readonly<{
 
 export default function UserTabs({tab,counts}:UserTabsProps) {
   const select_tab = useSelectedTab(tab)
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
   const {user} = useSession()
   const {profile} = useUserContext()
   // rsd_admin and your own profile
@@ -54,7 +54,7 @@ export default function UserTabs({tab,counts}:UserTabsProps) {
       {tabItems.map(key => {
         const item = userTabItems[key]
         if (item.isVisible({
-          modules: host.modules,
+          modules: activeModules,
           isMaintainer
         })) {
           return <TabAsLink

--- a/frontend/config/defaultSettings.json
+++ b/frontend/config/defaultSettings.json
@@ -18,8 +18,39 @@
       "limit": 3,
       "description": null
     },
-    "orcid_search": true,
-    "modules":["software","projects","organisations","communities","persons","news"]
+    "orcid_search": true
+  },
+  "modules":{
+    "software":{
+      "active":true,
+      "name":"software",
+      "menuItem":"Software"
+    },
+    "projects":{
+      "active":true,
+      "name":"projects",
+      "menuItem":"Projects"
+    },
+    "organisations":{
+      "active":true,
+      "name":"organisations",
+      "menuItem":"Organisations"
+    },
+    "communities": {
+      "active":true,
+      "name":"communities",
+      "menuItem":"Communities"
+    },
+    "persons": {
+      "active":true,
+      "name":"persons",
+      "menuItem":"Persons"
+    },
+    "news": {
+      "active":true,
+      "name":"news",
+      "menuItem":"News"
+    }
   },
   "links": [
     {

--- a/frontend/config/menuItems.tsx
+++ b/frontend/config/menuItems.tsx
@@ -19,7 +19,9 @@ import Logout from '@mui/icons-material/Logout'
 import CalendarViewMonthIcon from '@mui/icons-material/CalendarViewMonth'
 import Diversity3Icon from '@mui/icons-material/Diversity3'
 
-import {RsdModule} from './rsdSettingsReducer'
+import {RsdModuleName} from './rsdSettingsReducer'
+
+export type MenuModules = RsdModuleName | 'user'
 
 export type MenuItemType = {
   type?: 'link' | 'function' |'divider' | 'pluginSlot'
@@ -35,54 +37,61 @@ export type MenuItemType = {
   // than path
   fn?: (props:any)=>void,
   // enables filtering of menuItems for the instance (defined in settings.json)
-  module?: RsdModule
+  module?: MenuModules
 }
+
+export type MenuItemProps = {
+  // optional key values
+  // [Key in RsdModule as string]:MenuItemType
+  [K in RsdModuleName]:MenuItemType
+}
+
 // routes defined for nav/menu
 // used in components/AppHeader
-export const menuItems:MenuItemType[] = [
-  {
-    path: '/software',
+export const menuItems:MenuItemProps = {
+  software:{
+    path:'/software',
     match:'/software',
     label:'Software',
     module:'software',
-    active:({modules}:{modules:RsdModule[]})=>modules?.includes('software')
+    active:({modules}:{modules:RsdModuleName[]})=>modules.includes('software')
   },
-  {
+  projects:{
     path: '/projects',
     match: '/projects',
     label: 'Projects',
     module:'projects',
-    active:({modules}:{modules:RsdModule[]})=>modules.includes('projects')
+    active:({modules}:{modules:RsdModuleName[]})=>modules.includes('projects')
   },
-  {
+  organisations: {
     path: '/organisations',
     match: '/organisations',
     label: 'Organisations',
     module:'organisations',
-    active:({modules}:{modules:RsdModule[]})=>modules.includes('organisations')
+    active:({modules}:{modules:RsdModuleName[]})=>modules.includes('organisations')
   },
-  {
+  communities:{
     path: '/communities',
     match: '/communities',
     label: 'Communities',
     module:'communities',
-    active:({modules}:{modules:RsdModule[]})=>modules.includes('software') && modules.includes('communities')
+    active:({modules}:{modules:RsdModuleName[]})=>modules.includes('software') && modules.includes('communities')
   },
-  {
+  persons:{
     path: '/persons',
     match: '/persons',
     label: 'Persons',
     module:'persons',
-    active:({modules}:{modules:RsdModule[]})=>modules.includes('persons')
+    active:({modules}:{modules:RsdModuleName[]})=>modules.includes('persons')
   },
-  {
+  news:{
     path: '/news',
     match: '/news',
     label: 'News',
     module:'news',
-    active:({modules}:{modules:RsdModule[]})=>modules.includes('news')
+    active:({modules}:{modules:RsdModuleName[]})=>modules.includes('news')
   }
-]
+}
 
 // ListItemButton styles for menus used on the edit pages
 export const editMenuItemButtonSx={

--- a/frontend/config/rsdSettingsReducer.ts
+++ b/frontend/config/rsdSettingsReducer.ts
@@ -12,15 +12,26 @@ import logger from '~/utils/logger'
 import {RsdTheme} from '~/styles/rsdMuiTheme'
 import defaultSettings from '~/config/defaultSettings.json'
 
+// export type RsdModule= 'software'| 'projects' | 'organisations' | 'communities' | 'news' | 'user' | 'persons'
+export type RsdModuleName= 'software'| 'projects' | 'organisations' | 'communities' | 'news' | 'persons'
+export type RsdModule={
+  active: boolean,
+  name: RsdModuleName,
+  // if omitted/undefined or null menu item will not be shown
+  menuItem?: string | null
+}
+export type RsdModules={
+  [K in RsdModuleName]:RsdModule
+}
+
 export type RsdSettingsState = {
   host: RsdHost,
+  modules: RsdModules,
   theme: RsdTheme,
   links?: CustomLink[]
   pages?: RsdLink[]
   announcement?: string | null
 }
-
-export type RsdModule= 'software'| 'projects' | 'organisations' | 'communities' | 'news' | 'user' | 'persons'
 
 export type RsdHost = {
   name: string,
@@ -42,7 +53,6 @@ export type RsdHost = {
     limit: number,
     description?: string | null
   },
-  modules?: RsdModule[],
   plugins?: string[],
   orcid_search?: boolean
 }
@@ -74,7 +84,7 @@ export type RsdSettingsAction = {
 
 export type RsdSettingsDispatch = (action: RsdSettingsAction)=>void
 
-export const defaultRsdSettings = defaultSettings as RsdSettingsState
+export const defaultRsdSettings = defaultSettings as unknown as RsdSettingsState
 
 export function rsdSettingsReducer(state: RsdSettingsState, action: RsdSettingsAction) {
   // console.group('rsdSettingsReducer')
@@ -100,5 +110,18 @@ export function rsdSettingsReducer(state: RsdSettingsState, action: RsdSettingsA
     default:
       logger(`rsdSettingsReducer UNKNOWN ACTION TYPE ${action.type}`, 'warn')
       return state
+  }
+}
+
+export function activeModulesKeys(modules:RsdModules){
+  try{
+    // filter out active modules (keys)
+    const keys = Object.keys(modules) as RsdModuleName []
+    const activeModules = keys
+      .filter(key=>modules[key].active)
+    return activeModules
+  }catch(e:any){
+    logger(`activeModulesKeys error: ${e.message}`, 'warn')
+    return []
   }
 }

--- a/frontend/config/useMenuItems.tsx
+++ b/frontend/config/useMenuItems.tsx
@@ -3,22 +3,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {menuItems} from '~/config/menuItems'
+import {menuItems, MenuItemType} from '~/config/menuItems'
 import useRsdSettings from './useRsdSettings'
 
 export default function useMenuItems(){
   // get host settings
-  const {host} = useRsdSettings()
-  // filter menu items for this RSD instance
-  const items = menuItems.filter(item=> {
-    // if modules are defined in settings.json and in menuItems
-    if (Array.isArray(host?.modules)===true && item.active){
-      // include only options defined for this RSD host
-      return item.active({modules:host?.modules})
-    }
-    // else all menuItems are allowed by default
-    return true
-  })
+  const {modules,activeModules} = useRsdSettings()
+  const items:MenuItemType[] = []
+
+  // loop active modules from settings to get menuItems order
+  activeModules
+    .forEach(name=>{
+      // if there is menuItem for this module key=module
+      if (menuItems.hasOwnProperty(name)){
+        const item = menuItems[name]
+        const rsdModule = modules[name]
+        // we check if menu item should be shown based on settings.json
+        if (rsdModule.hasOwnProperty('menuItem') && rsdModule.menuItem!==null){
+          // we use custom label
+          item.label = rsdModule.menuItem as string
+          // we check if menu item should be shown based on menu active logic
+          if (item.active && item?.active({modules:activeModules})){
+            items.push(item)
+          }
+        }
+      }
+    })
+
+  // console.group('useMenuItems')
+  // console.log('items...', items)
+  // console.groupEnd()
 
   return items
+
 }

--- a/frontend/config/useRsdSettings.tsx
+++ b/frontend/config/useRsdSettings.tsx
@@ -1,18 +1,19 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useContext} from 'react'
 import {RsdTheme} from '~/styles/rsdMuiTheme'
 import {RsdSettingsContext} from './RsdSettingsContext'
-import {RsdActionType, RsdLink, RsdHost} from './rsdSettingsReducer'
-
+import {RsdActionType, RsdLink, RsdHost, activeModulesKeys} from './rsdSettingsReducer'
 
 export default function useRsdSettings() {
   const {state, dispatch} = useContext(RsdSettingsContext)
+  // filter out active modules (keys)
+  const activeModules = activeModulesKeys(state.modules)
 
   function setRsdLinks(links: RsdLink) {
     dispatch({
@@ -37,6 +38,8 @@ export default function useRsdSettings() {
 
   return {
     host: state.host,
+    modules: state.modules,
+    activeModules,
     pages: state.pages,
     links: state.links,
     theme: state.theme,

--- a/frontend/config/useUserMenuItems.tsx
+++ b/frontend/config/useUserMenuItems.tsx
@@ -13,14 +13,14 @@ import {usePluginSlots} from './RsdPluginContext'
 
 export default function useUserMenuItems(){
   const {user} = useSession()
-  const {host} = useRsdSettings()
+  const {activeModules} = useRsdSettings()
   // get user menu plugins
   const pluginSlots = usePluginSlots('userMenu')
   // construct menu items
   const items: MenuItemType[] = []
 
   userMenuItems.forEach( (item) => {
-    if (item.active?.({role: user?.role, modules: host.modules})){
+    if (item.active?.({role: user?.role, modules:activeModules})){
       items.push(item)
     } else if (item.type == 'pluginSlot') {
       // add plugins to user menu

--- a/frontend/pages/add/news.tsx
+++ b/frontend/pages/add/news.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import RsdAdminContent from '~/auth/RsdAdminContent'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import AppFooter from '~/components/AppFooter'
 import AppHeader from '~/components/AppHeader'
 import PageContainer from '~/components/layout/PageContainer'
@@ -28,7 +28,7 @@ export default function AddNews() {
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps() {
   // check module is active
-  const modules = await getRsdModules()
+  const modules = await getActiveModuleNames()
   // do not show software overview if module is not enabled
   if (modules?.includes('news')===false){
     return {

--- a/frontend/pages/add/project.tsx
+++ b/frontend/pages/add/project.tsx
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import ProtectedContent from '~/auth/ProtectedContent'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import AppHeader from '~/components/AppHeader'
 import AppFooter from '~/components/AppFooter'
 import PageContainer from '~/components/layout/PageContainer'
@@ -38,7 +38,7 @@ export default function AddProject() {
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps() {
   // check module is active
-  const modules = await getRsdModules()
+  const modules = await getActiveModuleNames()
 
   // do not show software overview if module is not enabled
   if (modules?.includes('projects')===false){

--- a/frontend/pages/add/software.tsx
+++ b/frontend/pages/add/software.tsx
@@ -8,7 +8,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import ProtectedContent from '~/auth/ProtectedContent'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import AppHeader from '~/components/AppHeader'
 import PageContainer from '~/components/layout/PageContainer'
 import AppFooter from '~/components/AppFooter'
@@ -38,7 +38,7 @@ export default function AddSoftware() {
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps() {
   // check module is active
-  const modules = await getRsdModules()
+  const modules = await getActiveModuleNames()
   // do not show software overview if module is not enabled
   if (modules?.includes('software')===false){
     return {

--- a/frontend/pages/communities/index.tsx
+++ b/frontend/pages/communities/index.tsx
@@ -8,7 +8,7 @@ import {GetServerSidePropsContext} from 'next/types'
 
 import {app} from '~/config/app'
 import {useSession} from '~/auth'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {useUserSettings} from '~/config/UserSettingsContext'
 import {getUserSettings} from '~/utils/userSettings'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
@@ -127,7 +127,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     const {req} = context
     const {search, rows, page} = ssrBasicParams(context.query)
     const token = req?.cookies['rsd_token']
-    const modules = await getRsdModules()
+    const modules = await getActiveModuleNames()
     // show 404 page if communities OR software module is not enabled
     // NOTE! communities are currently only for software
     if (modules?.includes('communities')===false || modules?.includes('software')===false){

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -7,7 +7,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {app} from '~/config/app'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import useRsdSettings from '~/config/useRsdSettings'
 import {getHomepageCounts} from '~/components/home/getHomepageCounts'
 import HelmholtzHome from '~/components/home/helmholtz'
@@ -78,7 +78,7 @@ export async function getServerSideProps() {
     getHomepageCounts(),
     // get top 3 (most recent) news items
     getTopNews(3),
-    getRsdModules()
+    getActiveModuleNames()
   ])
   // provide props to home component
   return {

--- a/frontend/pages/news/index.tsx
+++ b/frontend/pages/news/index.tsx
@@ -6,7 +6,7 @@
 import {GetServerSidePropsContext} from 'next/types'
 
 import {app} from '~/config/app'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
 import {getUserSettings} from '~/utils/userSettings'
 import PageMeta from '~/components/seo/PageMeta'
@@ -121,7 +121,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     const {req} = context
     const {search, rows, page} = ssrBasicParams(context.query)
     const token = req?.cookies['rsd_token']
-    const modules = await getRsdModules()
+    const modules = await getActiveModuleNames()
 
     // show 404 page if module is not enabled
     if (modules?.includes('news')===false){

--- a/frontend/pages/organisations/index.tsx
+++ b/frontend/pages/organisations/index.tsx
@@ -9,7 +9,7 @@
 import {GetServerSidePropsContext} from 'next/types'
 
 import {app} from '~/config/app'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {useUserSettings} from '~/config/UserSettingsContext'
 import {OrganisationForOverview} from '~/types/Organisation'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
@@ -124,7 +124,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const {req} = context
   const {search, rows, page} = ssrBasicParams(context.query)
   const token = req?.cookies['rsd_token']
-  const modules = await getRsdModules()
+  const modules = await getActiveModuleNames()
   // show 404 page if module is not enabled
   if (modules?.includes('organisations')===false){
     return {

--- a/frontend/pages/persons/[id]/[tab].tsx
+++ b/frontend/pages/persons/[id]/[tab].tsx
@@ -4,15 +4,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {GetServerSidePropsContext} from 'next'
+
 import {app} from '~/config/app'
 import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
 import {ProjectListItem} from '~/types/Project'
 import {getUserSettings} from '~/utils/userSettings'
 import {isOrcid} from '~/utils/getORCID'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 import PageMeta from '~/components/seo/PageMeta'
 import CanonicalUrl from '~/components/seo/CanonicalUrl'
 import BackgroundAndLayout from '~/components/layout/BackgroundAndLayout'
-
 import {getProfileProjects,getProfileSoftware} from '~/components/profile/apiProfile'
 import ProfileMetadata from '~/components/profile/metadata'
 import ProfileTabs from '~/components/profile/tabs'
@@ -20,8 +22,6 @@ import ProfileTabContent from '~/components/profile/tabs/ProfileTabContent'
 import {ProfileContextProvider} from '~/components/profile/context/ProfileContext'
 import {ProfileTabKey} from '~/components/profile/tabs/ProfileTabItems'
 import {getPublicUserProfile, PublicUserProfile} from '~/components/user/settings/profile/apiUserProfile'
-import {getRsdModules} from '~/config/getSettingsServerSide'
-import {RsdModule} from '~/config/rsdSettingsReducer'
 
 type PublicProfilePageProps=Readonly<{
   orcid: string
@@ -101,9 +101,9 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     } else {
       account = params?.id.toString()
     }
-    const [publicProfile, modules] = await Promise.all([
+    const [publicProfile, activeModules] = await Promise.all([
       getPublicUserProfile({orcid,account}),
-      getRsdModules()
+      getActiveModuleNames()
     ])
 
     // 404 if profile is null (not found in public_user_profile)
@@ -124,14 +124,14 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     // select tab
     let tab = ''
     if (params?.tab){
-      if (modules.includes(params.tab.toString() as RsdModule)===true){
+      if (activeModules.includes(params.tab.toString() as RsdModuleName)===true){
         tab = params?.tab.toString()
       }
     }else{
       // default tab based no enabled modules
-      if (modules.includes('software')===true) {
+      if (activeModules.includes('software')===true) {
         tab='software'
-      } else if (modules.includes('projects')===true){
+      } else if (activeModules.includes('projects')===true){
         tab='projects'
       }
     }

--- a/frontend/pages/persons/[id]/index.tsx
+++ b/frontend/pages/persons/[id]/index.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {GetServerSidePropsContext} from 'next/types'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 
 export default function Profile() {
   return (
@@ -20,7 +20,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     const id = params?.id as string
 
     // determine active modules
-    const modules = await getRsdModules()
+    const modules = await getActiveModuleNames()
     // default tab is software
     let tab = ''
     if (modules?.includes('software')){

--- a/frontend/pages/persons/index.tsx
+++ b/frontend/pages/persons/index.tsx
@@ -9,7 +9,7 @@ import Pagination from '@mui/material/Pagination'
 import PaginationItem from '@mui/material/PaginationItem'
 
 import {app} from '~/config/app'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {useUserSettings} from '~/config/UserSettingsContext'
 import {getUserSettings} from '~/utils/userSettings'
 import {ssrBasicParams} from '~/utils/extractQueryParam'
@@ -130,7 +130,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
     const {req} = context
     const {search, rows, page} = ssrBasicParams(context.query)
     const token = req?.cookies['rsd_token']
-    const modules = await getRsdModules()
+    const modules = await getActiveModuleNames()
 
     // show 404 page if module is not enabled
     if (modules.includes('persons')===false){

--- a/frontend/pages/projects/[slug]/edit/[page].tsx
+++ b/frontend/pages/projects/[slug]/edit/[page].tsx
@@ -12,7 +12,7 @@ import {GetServerSidePropsContext} from 'next/types'
 import Head from 'next/head'
 
 import {app} from '~/config/app'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import ProtectedContent from '~/auth/ProtectedContent'
 import {getProjectItem} from '~/utils/getProjects'
 import DefaultLayout from '~/components/layout/DefaultLayout'
@@ -77,7 +77,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   const page = params?.page?.toString() ?? ''
 
   // show 404 page if module is not enabled
-  const modules = await getRsdModules()
+  const modules = await getActiveModuleNames()
   if (modules.includes('projects')===false){
     return {
       notFound: true,

--- a/frontend/pages/projects/index.tsx
+++ b/frontend/pages/projects/index.tsx
@@ -12,7 +12,7 @@ import useMediaQuery from '@mui/material/useMediaQuery'
 
 import {app} from '~/config/app'
 import {useUserSettings} from '~/config/UserSettingsContext'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {ProjectListItem} from '~/types/Project'
 import {getUserSettings} from '~/utils/userSettings'
 import {getProjectList} from '~/utils/getProjects'
@@ -203,7 +203,7 @@ export default function ProjectsOverviewPage({
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   let offset=0
-  const modules = await getRsdModules()
+  const modules = await getActiveModuleNames()
   // show 404 page if module is not enabled
   if (modules?.includes('projects')===false){
     return {

--- a/frontend/pages/robots.txt.tsx
+++ b/frontend/pages/robots.txt.tsx
@@ -6,8 +6,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {GetServerSidePropsContext} from 'next'
-import {getRsdModules} from '~/config/getSettingsServerSide'
-import {RsdModule} from '~/config/rsdSettingsReducer'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
+import {RsdModuleName} from '~/config/rsdSettingsReducer'
 import {getDomain} from '~/utils/getDomain'
 
 export default function RobotsTxt() {
@@ -15,7 +15,7 @@ export default function RobotsTxt() {
 }
 
 
-async function generateRobotsFile(domain:string, modules: RsdModule[]) {
+async function generateRobotsFile(domain:string, modules: RsdModuleName[]) {
   // base body
   let robots = `User-agent: *
 
@@ -69,9 +69,9 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // console.log('getServerSideProps...req.headers...', req)
   // extract domain info from request headers
   const domain = getDomain(req)
-  const modules = await getRsdModules()
+  const activeModules = await getActiveModuleNames()
   // We generate the XML sitemap with the posts data
-  const content = await generateRobotsFile(domain,modules)
+  const content = await generateRobotsFile(domain,activeModules)
 
   res.setHeader('Content-Type', 'text/plain; charset=UTF-8')
   res.setHeader('x-generator', 'custom-next-script')

--- a/frontend/pages/sitemap/communities.xml.tsx
+++ b/frontend/pages/sitemap/communities.xml.tsx
@@ -8,7 +8,7 @@
 import {GetServerSidePropsContext} from 'next'
 
 import {getDomain} from '~/utils/getDomain'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {getCommunitiesSitemap} from '~/components/seo/getCommunitiesSitemap'
 
 export default function RobotsTxt() {
@@ -24,7 +24,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // generate the XML sitemap for software
   const [content, modules]= await Promise.all([
     getCommunitiesSitemap(domain),
-    getRsdModules()
+    getActiveModuleNames()
   ])
 
   // return 404 if module is not defined

--- a/frontend/pages/sitemap/news.xml.tsx
+++ b/frontend/pages/sitemap/news.xml.tsx
@@ -7,7 +7,7 @@
 
 import {GetServerSidePropsContext} from 'next'
 import {getDomain} from '~/utils/getDomain'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {getNewsSitemap} from '~/components/seo/getNewsSitemap'
 
 export default function RobotsTxt() {
@@ -23,7 +23,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // generate the XML sitemap for software
   const [content, modules]= await Promise.all([
     getNewsSitemap(domain),
-    getRsdModules()
+    getActiveModuleNames()
   ])
 
   // return 404 if module is not defined

--- a/frontend/pages/sitemap/organisations.xml.tsx
+++ b/frontend/pages/sitemap/organisations.xml.tsx
@@ -8,7 +8,7 @@
 import {GetServerSidePropsContext} from 'next'
 
 import {getDomain} from '~/utils/getDomain'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {getOrganisationSitemap} from '~/components/seo/getOrganisationSitemap'
 
 export default function RobotsTxt() {
@@ -24,7 +24,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // generate the XML sitemap for software
   const [content, modules]= await Promise.all([
     getOrganisationSitemap(domain),
-    getRsdModules()
+    getActiveModuleNames()
   ])
 
   // return 404 if module is not defined

--- a/frontend/pages/sitemap/persons.xml.tsx
+++ b/frontend/pages/sitemap/persons.xml.tsx
@@ -9,7 +9,7 @@ import {GetServerSidePropsContext} from 'next'
 
 import {getDomain} from '~/utils/getDomain'
 import {getPublicProfileSitemap} from '~/components/seo/getPersonsSitemap'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 
 export default function RobotsTxt() {
   // getServerSideProps will create response
@@ -24,7 +24,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // generate the XML sitemap for software
   const [content, modules]= await Promise.all([
     getPublicProfileSitemap(domain),
-    getRsdModules()
+    getActiveModuleNames()
   ])
 
   // return 404 if module is not defined

--- a/frontend/pages/sitemap/projects.xml.tsx
+++ b/frontend/pages/sitemap/projects.xml.tsx
@@ -8,7 +8,7 @@
 import {GetServerSidePropsContext} from 'next'
 
 import {getDomain} from '~/utils/getDomain'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {getProjectsSitemap} from '~/components/seo/getProjectsSitemap'
 
 export default function RobotsTxt() {
@@ -23,7 +23,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // generate the XML sitemap for software
   const [content, modules]= await Promise.all([
     getProjectsSitemap(domain),
-    getRsdModules()
+    getActiveModuleNames()
   ])
 
   // return 404 if module is not defined

--- a/frontend/pages/sitemap/software.xml.tsx
+++ b/frontend/pages/sitemap/software.xml.tsx
@@ -8,7 +8,7 @@
 import {GetServerSidePropsContext} from 'next'
 
 import {getDomain} from '~/utils/getDomain'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {getSoftwareSitemap} from '~/components/seo/getSoftwareSitemap'
 
 export default function RobotsTxt() {
@@ -23,7 +23,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   // generate the XML sitemap for software
   const [content, modules]= await Promise.all([
     getSoftwareSitemap(domain),
-    getRsdModules()
+    getActiveModuleNames()
   ])
 
   // return 404 if module is not defined

--- a/frontend/pages/software/[slug]/edit/[page].tsx
+++ b/frontend/pages/software/[slug]/edit/[page].tsx
@@ -12,7 +12,7 @@ import {GetServerSidePropsContext} from 'next/types'
 import Head from 'next/head'
 
 import {app} from '~/config/app'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import ProtectedContent from '~/auth/ProtectedContent'
 import {getSoftwareToEdit} from '~/utils/editSoftware'
 import DefaultLayout from '~/components/layout/DefaultLayout'
@@ -77,7 +77,7 @@ export async function getServerSideProps(context:GetServerSidePropsContext) {
   const page = params?.page?.toString() ?? ''
 
   // show 404 page if module is not enabled
-  const modules = await getRsdModules()
+  const modules = await getActiveModuleNames()
   if (modules.includes('software')===false){
     return {
       notFound: true,

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -53,6 +53,7 @@ import {softwareOrderOptions} from '~/components/software/overview/filters/Order
 import {HostsFilterOption} from '~/components/filter/RsdHostFilter'
 import {getRemoteRsd} from '~/components/admin/remote-rsd/apiRemoteRsd'
 import {CategoryOption} from '~/components/filter/CategoriesFilter'
+import {activeModulesKeys} from '~/config/rsdSettingsReducer'
 
 
 type SoftwareOverviewProps = {
@@ -236,8 +237,9 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   let offset=0
   // extract rsd settings
   const settings = await getRsdSettings()
+  const activeModules = activeModulesKeys(settings.modules)
   // do not show software overview if module is not enabled
-  if (settings.host?.modules?.includes('software')===false){
+  if (activeModules.includes('software')===false){
     return {
       notFound: true
     }

--- a/frontend/pages/spotlights/index.tsx
+++ b/frontend/pages/spotlights/index.tsx
@@ -20,7 +20,7 @@ import {getSoftwareList} from '~/utils/getSoftware'
 import {getUserSettings} from '~/utils/userSettings'
 import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
 import useRsdSettings from '~/config/useRsdSettings'
-import {getRsdModules} from '~/config/getSettingsServerSide'
+import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {useUserSettings} from '~/config/UserSettingsContext'
 import MainContent from '~/components/layout/MainContent'
 import PageBackground from '~/components/layout/PageBackground'
@@ -211,7 +211,7 @@ export default function SpotlightsOverviewPage({
 // see documentation https://nextjs.org/docs/basic-features/data-fetching#getserversideprops-server-side-rendering
 export async function getServerSideProps(context: GetServerSidePropsContext) {
   let orderBy='slug.asc', offset=0
-  const modules = await getRsdModules()
+  const modules = await getActiveModuleNames()
   // show 404 page if software module is not enabled
   if (modules?.includes('software')===false){
     return {

--- a/frontend/public/data/settings.json
+++ b/frontend/public/data/settings.json
@@ -19,8 +19,39 @@
       "limit": 5,
       "description": null
     },
-    "orcid_search":true,
-    "modules":["software","projects","organisations","communities","news"]
+    "orcid_search":true
+  },
+  "modules":{
+    "software":{
+      "active":true,
+      "name":"software",
+      "menuItem":"Software"
+    },
+    "projects":{
+      "active":true,
+      "name":"projects",
+      "menuItem":"Projects"
+    },
+    "organisations":{
+      "active":true,
+      "name":"organisations",
+      "menuItem":"Organisations"
+    },
+    "communities": {
+      "active":true,
+      "name":"communities",
+      "menuItem":"Communities"
+    },
+    "persons": {
+      "active":false,
+      "name":"persons",
+      "menuItem":"Persons"
+    },
+    "news": {
+      "active":true,
+      "name":"news",
+      "menuItem":"News"
+    }
   },
   "links": [
     {


### PR DESCRIPTION
# Extend modules definition in settings.json

Closes #1582

Question
The news module is not included in global search while all other modules are. I assume this is because the content of the news item is different from other modules, however the question is do we want to include news in global search and what would be optimal approach?

Changes proposed in this pull request:
* Remove modules array from host definition
* Introduce new `modules` definition that enables customization of active modules and main menu items label
* Update documentation about changes in settings.json
* Active module values are cached on the frontend in the production mode.

How to test:
* `make start` to build and generate test data.
* Default modules you should see are: software, projects, organisations, communities and news
* Change values in settings.json. 
   * Disable software module. Restart docker (docker compose down && docker compose up). Confirm that software and communities modules are not shown and not accessible (you should see 404 page when visiting software and communities routes). Login to rsd and confirm that menu option add software is not visible.
   * Disable projects module. Restart docker. Confirm that projects overview is not accessible (404 page). Confirm that add projects option is not available.
   * Hide news module menu item by settings menuItem to null. Confirm that news menu option is not shown but the news route can be accessed. Login as rsd admin and confim news option is available. Confirm add news option is available. On default RSD homepage, top 3 news items should be shown. In the rsd-admin news option should be enabled. 
   * Disable news module and confirm that add news option is not available.
* Change the order of menu items by changing order of the entries in the settings.json. For example place organisations at the first place and confirm that organisation is the first menu item.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [x] Tests
