### PR TITLE
Prevent scraping of citations of one mention in parallel

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainCitations.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainCitations.java
@@ -28,87 +28,89 @@ public class MainCitations {
 		long start = System.currentTimeMillis();
 
 		try {
-			// Connect to the database to retrieve the reference papers to scrape
-
-			String backendUrl = Config.backendBaseUrl();
-			PostgrestCitationRepository localCitationRepository = new PostgrestCitationRepository(backendUrl);
-
-			Collection<CitationData> referencePapersToScrape = localCitationRepository.leastRecentlyScrapedCitations(
-				Config.maxCitationSourcesToScrape()
-			);
-
-			localCitationRepository.updateScrapedAtTime(
-				referencePapersToScrape.stream().map(CitationData::id).toList(),
-				Instant.now()
-			);
-
-			OpenAlexConnector openAlexConnector = new OpenAlexConnector();
-			PostgrestMentionRepository localMentionRepository = new PostgrestMentionRepository(backendUrl);
-			String email = Config.crossrefContactEmail().orElse(null);
-			Instant now = Instant.now();
-
-			for (CitationData citationData : referencePapersToScrape) {
-				long t1 = System.currentTimeMillis();
-
-				LOGGER.info("Scraping for DOI {}, OpenAlex ID {}", citationData.doi(), citationData.openalexId());
-
-				Collection<ExternalMentionRecord> citingMentions = openAlexConnector.citations(
-					citationData.openalexId(),
-					citationData.doi(),
-					email,
-					citationData.id()
-				);
-				// we don't update mentions that have a DOI in the database with OpenAlex data, as they can already be
-				// scraped through Crossref or DataCite
-
-				long t2 = System.currentTimeMillis();
-
-				citingMentions.removeIf(
-					mention -> mention.doi() != null && citationData.knownDois().contains(mention.doi())
-				);
-				Collection<RsdMentionIds> savedIds = new ArrayList<>(citingMentions.size());
-				for (ExternalMentionRecord citingMention : citingMentions) {
-					try {
-						RsdMentionIds ids = localMentionRepository.createOrUpdateMentionWithOpenalexId(
-							citingMention,
-							now
-						);
-						savedIds.add(ids);
-					} catch (Exception e) {
-						LOGGER.error("Unable to save exception with OpenAlex ID {}", citingMention.openalexId());
-						Utils.saveExceptionInDatabase("Citation scraper", "mention", null, e);
-					}
-				}
-
-				Collection<UUID> citingMentionIds = new ArrayList<>();
-				for (RsdMentionIds ids : savedIds) {
-					citingMentionIds.add(ids.id());
-				}
-
-				long t3 = System.currentTimeMillis();
-
-				localCitationRepository.saveCitations(backendUrl, citationData.id(), citingMentionIds);
-
-				long t4 = System.currentTimeMillis();
-
-				LOGGER.info(
-					"Scraping for {} done. OpenAlex: {} ms. Saving mentions {} ms. Saving citations {} ms. Total {} ms.",
-					citationData.doi(),
-					(t2 - t1),
-					(t3 - t2),
-					(t4 - t3),
-					(t4 - t1)
-				);
-			}
-		} catch (IOException | InterruptedException e) {
+			scrapeCitations();
+		} catch (RuntimeException | IOException e) {
+			LOGGER.error("Exception while scraping citations", e);
 			Utils.saveExceptionInDatabase("Citation scraper", null, null, e);
-
-			if (e instanceof InterruptedException) {
-				Thread.currentThread().interrupt();
-			}
+		} catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			LOGGER.warn("Got interrupted scraping citations, exiting");
+			return;
 		}
 
 		long time = System.currentTimeMillis() - start;
 		LOGGER.info("Done scraping citations ({} ms.)", time);
+	}
+
+	private static void scrapeCitations() throws IOException, InterruptedException {
+		// Connect to the database to retrieve the reference papers to scrape
+		String backendUrl = Config.backendBaseUrl();
+		PostgrestCitationRepository localCitationRepository = new PostgrestCitationRepository(backendUrl);
+
+		Collection<CitationData> referencePapersToScrape = localCitationRepository.leastRecentlyScrapedCitations(
+			Config.maxCitationSourcesToScrape()
+		);
+
+		// already update the citations_scraped_at fields to prevent them being scraped by a second process if this one takes too long
+		localCitationRepository.updateScrapedAtTime(
+			referencePapersToScrape.stream().map(CitationData::id).toList(),
+			Instant.now()
+		);
+
+		OpenAlexConnector openAlexConnector = new OpenAlexConnector();
+		PostgrestMentionRepository localMentionRepository = new PostgrestMentionRepository(backendUrl);
+		String email = Config.crossrefContactEmail().orElse(null);
+		Instant now = Instant.now();
+
+		for (CitationData citationData : referencePapersToScrape) {
+			long t1 = System.currentTimeMillis();
+
+			LOGGER.info("Scraping for DOI {}, OpenAlex ID {}", citationData.doi(), citationData.openalexId());
+
+			Collection<ExternalMentionRecord> citingMentions = openAlexConnector.citations(
+				citationData.openalexId(),
+				citationData.doi(),
+				email,
+				citationData.id()
+			);
+			// we don't update mentions that have a DOI in the database with OpenAlex data, as they can already be
+			// scraped through Crossref or DataCite
+
+			long t2 = System.currentTimeMillis();
+
+			citingMentions.removeIf(
+				mention -> mention.doi() != null && citationData.knownDois().contains(mention.doi())
+			);
+			Collection<RsdMentionIds> savedIds = new ArrayList<>(citingMentions.size());
+			for (ExternalMentionRecord citingMention : citingMentions) {
+				try {
+					RsdMentionIds ids = localMentionRepository.createOrUpdateMentionWithOpenalexId(citingMention, now);
+					savedIds.add(ids);
+				} catch (Exception e) {
+					LOGGER.error("Unable to save exception with OpenAlex ID {}", citingMention.openalexId());
+					Utils.saveExceptionInDatabase("Citation scraper", "mention", null, e);
+				}
+			}
+
+			Collection<UUID> citingMentionIds = new ArrayList<>();
+			for (RsdMentionIds ids : savedIds) {
+				citingMentionIds.add(ids.id());
+			}
+
+			long t3 = System.currentTimeMillis();
+
+			localCitationRepository.saveCitations(backendUrl, citationData.id(), citingMentionIds);
+
+			long t4 = System.currentTimeMillis();
+
+			LOGGER.info(
+				"Scraping for {} done. OpenAlex: {} ms. Saving mentions {} ms. Saving citations {} ms. Total {} ms.",
+				citationData.doi(),
+				(t2 - t1),
+				(t3 - t2),
+				(t4 - t3),
+				(t4 - t1)
+			);
+		}
 	}
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainCitations.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainCitations.java
@@ -36,6 +36,12 @@ public class MainCitations {
 			Collection<CitationData> referencePapersToScrape = localCitationRepository.leastRecentlyScrapedCitations(
 				Config.maxCitationSourcesToScrape()
 			);
+
+			localCitationRepository.updateScrapedAtTime(
+				referencePapersToScrape.stream().map(CitationData::id).toList(),
+				Instant.now()
+			);
+
 			OpenAlexConnector openAlexConnector = new OpenAlexConnector();
 			PostgrestMentionRepository localMentionRepository = new PostgrestMentionRepository(backendUrl);
 			String email = Config.crossrefContactEmail().orElse(null);
@@ -81,7 +87,7 @@ public class MainCitations {
 
 				long t3 = System.currentTimeMillis();
 
-				localCitationRepository.saveCitations(backendUrl, citationData.id(), citingMentionIds, now);
+				localCitationRepository.saveCitations(backendUrl, citationData.id(), citingMentionIds);
 
 				long t4 = System.currentTimeMillis();
 


### PR DESCRIPTION
## Prevent scraping of citations of one mention in parallel

### Changes proposed in this pull request

* When scraping citations, first update the respective `citations_scraped_at` columns so that if it takes very long, a second process won't scrape citations of the same mention
* Refactor out a method from the main method in `MainCitations`

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin, create a software page
* Add as reference paper `10.1038/nature14539`
* Visit http://localhost/api/v1/mention?select=title,citations_scraped_at, the date should be `null`
* Run the citation scraper: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations`
* This should take very long (unless it was already started in the container before you had the chance), continue to next step without waiting
* Visit http://localhost/api/v1/mention?select=title,citations_scraped_at again, the date should be now
* Run the same scraper in a new terminal again
* The second scraper should terminate very quickly
* (Terminate the first scraper)
* There should be no error logs
* Remove the reference paper, add a new one `10.1103/physreve.99.043309`
* Repeat the previous steps, this has only 6 citations so you can check if the process completes normally

closes #1379

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests