### PR TITLE
 Properly show software when remote RSD name contains special character

### DIFF
--- a/frontend/components/filter/RsdHostFilter.tsx
+++ b/frontend/components/filter/RsdHostFilter.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,8 +29,8 @@ type RsdSourceFilterProps = Readonly<{
 export default function RsdHostFilter({rsd_host,hostsList,handleQueryChange,title='RSD Host'}: RsdSourceFilterProps) {
 
   // console.group('RsdSourceFilter')
-  // console.log('source...',source)
-  // console.log('sourceList...',sourceList)
+  // console.log('rsd_host...',rsd_host)
+  // console.log('hostsList...',hostsList)
   // console.groupEnd()
 
   return (

--- a/frontend/components/software/overview/filters/index.tsx
+++ b/frontend/components/software/overview/filters/index.tsx
@@ -3,8 +3,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -54,9 +54,8 @@ export default function SoftwareFilters({
   // console.log('categoryList...', categoryList)
   // console.groupEnd()
 
-  function clearDisabled() {
-    if (filterCnt && filterCnt > 0) return false
-    return true
+  function clearDisabled(): boolean {
+    return !filterCnt
   }
 
   return (

--- a/frontend/pages/software/index.tsx
+++ b/frontend/pages/software/index.tsx
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -239,7 +239,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   const settings = await getRsdSettings()
   const activeModules = activeModulesKeys(settings.modules)
   // do not show software overview if module is not enabled
-  if (activeModules.includes('software')===false){
+  if (!activeModules.includes('software')){
     return {
       notFound: true
     }
@@ -260,7 +260,7 @@ export async function getServerSideProps(context: GetServerSidePropsContext) {
   // default order
   let softwareOrder = order ?? 'mention_cnt'
   // remove order key if NOT in list of allowed
-  if (order && allowedOrderings.includes(order)===false) {
+  if (order && !allowedOrderings.includes(order)) {
     softwareOrder = 'mention_cnt'
   }
 

--- a/frontend/utils/extractQueryParam.ts
+++ b/frontend/utils/extractQueryParam.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +25,7 @@ export function encodeQueryValue(value: EncodeQueryValue) {
   try {
     if (typeof value === 'string' || typeof value === 'number') {
       return encodeURIComponent(value)
-    } else if (Array.isArray(value) === true && (value as any)?.length > 0) {
+    } else if (Array.isArray(value) && (value as any[]).length > 0) {
       // arrays are stringified
       return encodeURIComponent(JSON.stringify(value))
     }
@@ -33,7 +34,7 @@ export function encodeQueryValue(value: EncodeQueryValue) {
   }
 }
 
-export function encodeQueryParam({param, value}: EncodeQueryParamProps) {
+function encodeQueryParam({param, value}: EncodeQueryParamProps) {
   try {
     // encode value
     const encoded = encodeQueryValue(value)
@@ -47,20 +48,30 @@ export function encodeQueryParam({param, value}: EncodeQueryParamProps) {
   }
 }
 
-// encode filters into url query parameters
+/**
+ *
+ * @param query the existing query
+ * @param param the query parameter key to be appended
+ * @param value the query parameter value to be appended
+ *
+ * @returns The query to which the param and value are appended in the form '&param=value', of which the value is URL encoded.
+ * If the query was empty, the leading '&' is omitted.
+ */
 export function encodeUrlQuery({query, param, value}: BuildUrlQueryProps) {
-  // if there is no value we return "" for query=no query
+  // if there is no value we return the query
   if (typeof value === 'undefined' || value === '' || value === null) return query
+
   // encode value
   const encoded = encodeQueryParam({param, value})
   // if nothing is encoded return query
   if (encoded === '' || encoded === null) return query
+
   // handle string value
   if (query) {
-    query += `&${encoded}`
-  } else {
-    query += encoded
+    query += '&'
   }
+
+  query += encoded
   // return build query
   return query
 }

--- a/frontend/utils/extractQueryParam.ts
+++ b/frontend/utils/extractQueryParam.ts
@@ -99,7 +99,7 @@ export function decodeQueryParam({query,param,castToType='string',defaultValue}:
       // debugger
       const rawVal = query[param]
       // if value is not "actionable" we return default value
-      if (typeof rawVal == 'undefined' || rawVal === '' || rawVal === null) return defaultValue
+      if (rawVal === undefined || rawVal === '' || rawVal === null) return defaultValue
       // if cast to type is not defined we return raw value
       if (typeof castToType === 'undefined') return rawVal
       // convert to specific type
@@ -111,11 +111,7 @@ export function decodeQueryParam({query,param,castToType='string',defaultValue}:
           logger(`decodeQueryParam: query param ${param} NOT a string. Returning defaultValue`, 'warn')
           return defaultValue
         case 'string':
-          if (typeof rawVal === 'string'){
-            return decodeURIComponent(rawVal)
-          }else{
-            return decodeURIComponent(rawVal?.toString())
-          }
+          return rawVal.toString()
         case 'json-encoded':
           if (typeof rawVal === 'string') {
             const json = decodeJsonParam(rawVal,defaultValue)

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -286,18 +286,19 @@ export function baseQueryString(props: baseQueryStringProps) {
   }
   // RSD Host
   if (rsd_host !== undefined) {
+    const rsd_host_encoded = encodeURIComponent(rsd_host)
     if (query) {
       // the null value is passed as string in url query
-      if (rsd_host === 'null') {
+      if (rsd_host_encoded === 'null') {
         query = `${query}&rsd_host=is.null`
       } else {
-        query = `${query}&rsd_host=eq.${rsd_host}`
+        query = `${query}&rsd_host=eq.${rsd_host_encoded}`
       }
-    } else if (rsd_host === 'null' || rsd_host === null) {
+    } else if (rsd_host_encoded === 'null' || rsd_host_encoded === null) {
       // the null value is passed as string in url query
       query = 'rsd_host=is.null'
     } else {
-      query = `rsd_host=eq.${rsd_host}`
+      query = `rsd_host=eq.${rsd_host_encoded}`
     }
   }
   if (organisations !== undefined &&
@@ -369,7 +370,7 @@ export function softwareListUrl(props: PostgrestParams) {
     const encodedSearch = encodeURIComponent(search)
     // search query is performed in aggregated_software_search RPC
     // we search in title,subtitle,slug,keywords_text and prog_lang
-    // check rpc in 105-project-views.sql for exact filtering
+    // check rpc in 124-aggregated-software-views.sql for exact filtering
     query += `&search=${encodedSearch}`
 
     url = `${baseUrl}/rpc/aggregated_software_search`


### PR DESCRIPTION
## Properly show software when remote RSD name contains special character

### Changes proposed in this pull request

* When a remote RSD host contains any special characters, when filtering on that host, software will be shown properly

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin
* Add a remote RSD, like `https://helmholtz.software/`
* Wait a minute for the scraper to run
* On the software overview page, when selecting this RSD, software should be shown
* Change the name of the remote RSD to include special characters (test the plus sign)
* The software overview page should still work correctly
* Change the name to `%20`
* The software overview page should still work correctly, the name should be shown instead of a space
* Try other filters, also on other overview pages, they should still work correctly

closes #1572

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests