### PR TITLE
Use v1 of ROR API

### DIFF
--- a/e2e/helpers/organisations.ts
+++ b/e2e/helpers/organisations.ts
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,11 +14,11 @@ export async function addFundingOrganisation(page: Page, organisation: string) {
   const fundingInput = page.getByRole('combobox', {name: 'Find funding organisation'})
 
   // we mock ror api response
-  await listenForRoRCalls(page, organisation)
+  await listenForRorCalls(page, organisation)
 
   // await page.pause()
   await Promise.all([
-    page.waitForResponse(/api.ror.org\/organizations/),
+    page.waitForResponse(/api\.ror\.org\/v1\/organizations/),
     page.waitForLoadState('networkidle'),
     fundingInput.fill(organisation)
   ])
@@ -76,11 +77,11 @@ export async function addOrganisation(page, organisation: Organisation, apiUrl) 
   }
 
   // we mock ror api response
-  await listenForRoRCalls(page, organisation.name)
+  await listenForRorCalls(page, organisation.name)
 
   // if not exists we search
   await Promise.all([
-    page.waitForResponse(/api.ror.org\/organizations/),
+    page.waitForResponse(/api\.ror\.org\/v1\/organizations/),
     page.waitForLoadState('networkidle'),
     findOrganisation.fill(organisation.name)
   ])
@@ -142,10 +143,10 @@ export async function addOrganisation(page, organisation: Organisation, apiUrl) 
 }
 
 
-async function listenForRoRCalls(page, input: string) {
+async function listenForRorCalls(page, input: string) {
   // monitor api calls
   // console.log('input...', input)
-  await page.route(`https://api.ror.org/organizations?query=${encodeURIComponent(input)}`, async route => {
+  await page.route(`https://api.ror.org/v1/organizations?query=${encodeURIComponent(input)}`, async route => {
     // const url = route.request().url()
     // console.log('api.ror.org...url...', url)
     const filename = `mocks/data/ror_${generateFileName(input)}.json`
@@ -157,7 +158,7 @@ async function listenForRoRCalls(page, input: string) {
 export async function generateJsonFromApiCalls(page, input: string) {
   // monitor api calls
   // console.log('input...', input)
-  await page.route(`https://api.ror.org/organizations?query=${encodeURIComponent(input)}`, async route => {
+  await page.route(`https://api.ror.org/v1/organizations?query=${encodeURIComponent(input)}`, async route => {
     // const url = route.request().url()
     // console.log('doi.org...url...', url)
     const resp = await route.fetch()
@@ -193,7 +194,7 @@ export async function saveOrganisation(page, input: string) {
 
   // if not exists we search
   await Promise.all([
-    page.waitForResponse(/api.ror.org\/organizations/),
+    page.waitForResponse(/api\.ror\.org\/v1\/organizations/),
     page.waitForLoadState('networkidle'),
     findOrganisation.fill(input)
   ])

--- a/frontend/utils/getROR.test.ts
+++ b/frontend/utils/getROR.test.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2024 dv4all
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -66,7 +67,7 @@ it('findInROR calls fetch with search param and json header', async () => {
 
   expect(mockFetch).toHaveBeenCalledTimes(1)
   expect(mockFetch).toHaveBeenCalledWith(
-    `https://api.ror.org/organizations?query=${searchFor}`,
+    `https://api.ror.org/v1/organizations?query=${searchFor}`,
     {'headers': {'Content-Type': 'application/json'}}
   )
 })

--- a/frontend/utils/getROR.ts
+++ b/frontend/utils/getROR.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,7 +15,7 @@ import logger from './logger'
 export async function findInROR({searchFor}:{searchFor:string}) {
   try {
     // this query will match organisation by name or website values
-    const url = `https://api.ror.org/organizations?query=${encodeURIComponent(searchFor)}`
+    const url = `https://api.ror.org/v1/organizations?query=${encodeURIComponent(searchFor)}`
 
     // make request
     const resp = await fetch(url, {

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorId.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorId.java
@@ -21,6 +21,7 @@ public class RorId {
 
 	private static final String ROR_BASE_URL = "https://ror.org/";
 	// https://ror.org/blog/2024-04-15-announcing-ror-v2/
+	// https://ror.readme.io/changelog/2025-07-01-sunset-of-version-1
 	private static final String ROR_BASE_API_V1_URL = "https://api.ror.org/v1/organizations/";
 	private static final Pattern ROR_URL_PATTERN = Pattern.compile(
 		"^https://ror\\.org/(0[a-hj-km-np-tv-z|\\d]{6}\\d{2})$"

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/ror/RorScraper.java
@@ -26,7 +26,7 @@ public class RorScraper {
 	}
 
 	private String getFromApi() throws IOException, InterruptedException, RsdResponseException {
-		// e.g https://api.ror.org/organizations/04tsk2644
+		// e.g https://api.ror.org/v1/organizations/04tsk2644
 		return Utils.get(rorId.asApiV1Url().toString());
 	}
 


### PR DESCRIPTION
## Use v1 of ROR API

### Changes proposed in this pull request

* Use v1 of the ROR API, since the default version is [v2 now](https://ror.readme.io/changelog/2025-07-01-sunset-of-version-1), we will later switch to v2

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in
* Add organisations to software, projects and directly as admin, this should work again

part of #1597

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests