### PR TITLE
Don't expose unpublished meta pages in API

### DIFF
--- a/backend-tests/README.md
+++ b/backend-tests/README.md
@@ -1,6 +1,6 @@
 <!--
-SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+SPDX-FileCopyrightText: 2023 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 
 SPDX-License-Identifier: CC-BY-4.0
 -->
@@ -26,7 +26,7 @@ Tests should be written taking the following principles in account:
 
 ## Contributing
 
-This module uses [EditorConfig](https://editorconfig.org/) for basic formatting. Please check if your editor [already supports EditorConfig](https://editorconfig.org/#pre-installed) or if you need to [install a plugin](https://editorconfig.org/#download). A GitHub workflow is run on every PR to check if any files violate the formatting settings.
+This module uses [Prettier](https://prettier.io/) for code formatting. Please make sure your contributions comply with Prettier. A GitHub workflow is run on every PR to check if any files violate the formatting settings.
 
 ## Writing tests
 

--- a/backend-tests/pom.xml
+++ b/backend-tests/pom.xml
@@ -70,7 +70,7 @@ SPDX-License-Identifier: Apache-2.0
 		<dependency>
 			<groupId>io.rest-assured</groupId>
 			<artifactId>rest-assured</artifactId>
-			<version>5.5.5</version>
+			<version>5.5.6</version>
 			<scope>test</scope>
 		</dependency>
 

--- a/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
@@ -121,7 +121,7 @@ public class AuthenticationIntegrationTest {
 			.statusCode(204);
 
 		String getStartedUrl = "https://www.example.com";
-		List response = RestAssured.given()
+		List<?> response = RestAssured.given()
 			.header(user.authHeader)
 			.header(new Header("Prefer", "return=representation"))
 			.contentType(ContentType.JSON)
@@ -159,7 +159,7 @@ public class AuthenticationIntegrationTest {
 			.then()
 			.statusCode(201);
 
-		List response = RestAssured.when()
+		List<?> response = RestAssured.when()
 			.get("software?slug=eq." + slug)
 			.then()
 			.statusCode(200)
@@ -247,7 +247,7 @@ public class AuthenticationIntegrationTest {
 
 		// check if category IDs appear in proper location of result (=CategoryPath[])
 		JsonArray jsonArray = JsonParser.parseString(response).getAsJsonArray();
-		Assertions.assertEquals(jsonArray.size(), 2);
+		Assertions.assertEquals(2, jsonArray.size());
 		for (JsonElement jsonElement : jsonArray) {
 			JsonArray categoryPath = jsonElement.getAsJsonArray();
 			String shortName = categoryPath.get(1).getAsJsonObject().getAsJsonPrimitive("short_name").getAsString();

--- a/backend-tests/src/test/java/nl/esciencecenter/MetaPagesIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/MetaPagesIntegrationTest.java
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({ SetupAllTests.class })
+public class MetaPagesIntegrationTest {
+
+	@Test
+	void givenUnpublishedMetaPage_whenQueryingAnonymously_thenNothingFound() {
+		String unpublishedMetaPageSlug = Commons.createUUID();
+		RestAssured.given()
+			.header(SetupAllTests.adminAuthHeader)
+			.contentType(ContentType.JSON)
+			.body(
+				"{\"slug\": \"%s\", \"is_published\": false, \"title\": \"test meta page %s\"}".formatted(
+					unpublishedMetaPageSlug,
+					unpublishedMetaPageSlug
+				)
+			)
+			.when()
+			.post("meta_page")
+			.then()
+			.statusCode(201);
+
+		List<?> anonymousResponse = RestAssured.get("meta_page?slug=eq." + unpublishedMetaPageSlug)
+			.then()
+			.statusCode(200)
+			.extract()
+			.body()
+			.as(List.class);
+		Assertions.assertTrue(anonymousResponse.isEmpty());
+
+		List<?> adminResponse = RestAssured.given()
+			.header(SetupAllTests.adminAuthHeader)
+			.get("meta_page?slug=eq." + unpublishedMetaPageSlug)
+			.then()
+			.statusCode(200)
+			.extract()
+			.body()
+			.as(List.class);
+		Assertions.assertEquals(1, adminResponse.size());
+	}
+}

--- a/backend-tests/src/test/java/nl/esciencecenter/UserDeletingItemsIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/UserDeletingItemsIntegrationTest.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,7 +22,7 @@ public class UserDeletingItemsIntegrationTest {
 			.header(Commons.requestEntry)
 			.contentType(ContentType.JSON)
 			.body(
-				"{\"slug\":  \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug)
+				"{\"slug\": \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug)
 			)
 			.when()
 			.post("software")
@@ -56,7 +56,7 @@ public class UserDeletingItemsIntegrationTest {
 			.header(Commons.requestEntry)
 			.contentType(ContentType.JSON)
 			.body(
-				"{\"slug\":  \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug)
+				"{\"slug\": \"%s\", \"is_published\": true, \"brand_name\": \"test software\"}".formatted(softwareSlug)
 			)
 			.when()
 			.post("software")
@@ -90,7 +90,7 @@ public class UserDeletingItemsIntegrationTest {
 			.header(user.authHeader)
 			.header(Commons.requestEntry)
 			.contentType(ContentType.JSON)
-			.body("{\"slug\":  \"%s\", \"is_published\": true, \"title\": \"test project\"}".formatted(projectSlug))
+			.body("{\"slug\": \"%s\", \"is_published\": true, \"title\": \"test project\"}".formatted(projectSlug))
 			.when()
 			.post("project")
 			.then()
@@ -123,7 +123,7 @@ public class UserDeletingItemsIntegrationTest {
 			.header(user.authHeader)
 			.header(Commons.requestEntry)
 			.contentType(ContentType.JSON)
-			.body("{\"slug\":  \"%s\", \"name\": \"test organisation\"}".formatted(organisationSlug))
+			.body("{\"slug\": \"%s\", \"name\": \"test organisation\"}".formatted(organisationSlug))
 			.when()
 			.post("organisation")
 			.then()
@@ -154,7 +154,7 @@ public class UserDeletingItemsIntegrationTest {
 			.header(SetupAllTests.adminAuthHeader)
 			.header(Commons.requestEntry)
 			.contentType(ContentType.JSON)
-			.body("{\"slug\":  \"%s\", \"name\": \"test community\"}".formatted(communitySlug))
+			.body("{\"slug\": \"%s\", \"name\": \"test community\"}".formatted(communitySlug))
 			.when()
 			.post("community")
 			.then()

--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -1260,7 +1260,7 @@ const globalCategoryPromise = Promise.all([softwarePromise, categoryPromise])
 	.then(() => 'global categories for software done');
 globalPromises.push(globalCategoryPromise);
 
-const metaPagesPromise = postToBackend('/meta_pages', generateMetaPages()).then(() => console.log('meta pages done'));
+const metaPagesPromise = postToBackend('/meta_page', generateMetaPages()).then(() => console.log('meta pages done'));
 globalPromises.push(metaPagesPromise);
 
 const newsPromise = imageIdsPromise.then(imageIds =>

--- a/database/017-meta-pages.sql
+++ b/database/017-meta-pages.sql
@@ -1,5 +1,5 @@
--- SPDX-FileCopyrightText: 2021 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2021 - 2024 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2021 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2021 - 2025 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 dv4all
 --
@@ -8,7 +8,7 @@
 -- CUSTOM META PAGES TO BE ADDED TO RSD
 -- THE PAGES ARE LISTED IN THE FOOTER
 
-CREATE TABLE meta_pages (
+CREATE TABLE meta_page (
 	id UUID DEFAULT gen_random_uuid() PRIMARY KEY,
 	slug VARCHAR(100) UNIQUE NOT NULL CHECK (slug ~ '^[a-z0-9]+(-[a-z0-9]+)*$'),
 	title VARCHAR(100) NOT NULL,
@@ -20,7 +20,7 @@ CREATE TABLE meta_pages (
 );
 
 
-CREATE FUNCTION sanitise_insert_meta_pages() RETURNS TRIGGER LANGUAGE plpgsql AS
+CREATE FUNCTION sanitise_insert_meta_page() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = gen_random_uuid();
@@ -30,11 +30,11 @@ BEGIN
 END
 $$;
 
-CREATE TRIGGER sanitise_insert_meta_pages BEFORE INSERT ON meta_pages
-	FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_meta_pages();
+CREATE TRIGGER sanitise_insert_meta_page BEFORE INSERT ON meta_page
+	FOR EACH ROW EXECUTE PROCEDURE sanitise_insert_meta_page();
 
 
-CREATE FUNCTION sanitise_update_meta_pages() RETURNS TRIGGER LANGUAGE plpgsql AS
+CREATE FUNCTION sanitise_update_meta_page() RETURNS TRIGGER LANGUAGE plpgsql AS
 $$
 BEGIN
 	NEW.id = OLD.id;
@@ -52,5 +52,5 @@ BEGIN
 END
 $$;
 
-CREATE TRIGGER sanitise_update_meta_pages BEFORE UPDATE ON meta_pages
-	FOR EACH ROW EXECUTE PROCEDURE sanitise_update_meta_pages();
+CREATE TRIGGER sanitise_update_meta_page BEFORE UPDATE ON meta_page
+	FOR EACH ROW EXECUTE PROCEDURE sanitise_update_meta_page();

--- a/database/017-meta-pages.sql
+++ b/database/017-meta-pages.sql
@@ -54,3 +54,14 @@ $$;
 
 CREATE TRIGGER sanitise_update_meta_page BEFORE UPDATE ON meta_page
 	FOR EACH ROW EXECUTE PROCEDURE sanitise_update_meta_page();
+
+
+-- row level security
+ALTER TABLE meta_page ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY anyone_can_read ON meta_page FOR SELECT TO rsd_web_anon, rsd_user
+	USING (is_published);
+
+CREATE POLICY admin_all_rights ON meta_page TO rsd_admin
+	USING (TRUE)
+	WITH CHECK (TRUE);

--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -793,12 +793,12 @@ CREATE POLICY admin_all_rights ON project_for_organisation TO rsd_admin
 
 
 -- meta-pages
-ALTER TABLE meta_pages ENABLE ROW LEVEL SECURITY;
+ALTER TABLE meta_page ENABLE ROW LEVEL SECURITY;
 
-CREATE POLICY anyone_can_read ON meta_pages FOR SELECT TO rsd_web_anon, rsd_user
+CREATE POLICY anyone_can_read ON meta_page FOR SELECT TO rsd_web_anon, rsd_user
 	USING (TRUE);
 
-CREATE POLICY admin_all_rights ON meta_pages TO rsd_admin
+CREATE POLICY admin_all_rights ON meta_page TO rsd_admin
 	USING (TRUE)
 	WITH CHECK (TRUE);
 

--- a/database/020-row-level-security.sql
+++ b/database/020-row-level-security.sql
@@ -792,16 +792,6 @@ CREATE POLICY admin_all_rights ON project_for_organisation TO rsd_admin
 	WITH CHECK (TRUE);
 
 
--- meta-pages
-ALTER TABLE meta_page ENABLE ROW LEVEL SECURITY;
-
-CREATE POLICY anyone_can_read ON meta_page FOR SELECT TO rsd_web_anon, rsd_user
-	USING (TRUE);
-
-CREATE POLICY admin_all_rights ON meta_page TO rsd_admin
-	USING (TRUE)
-	WITH CHECK (TRUE);
-
 
 -- backend logs
 ALTER TABLE backend_log ENABLE ROW LEVEL SECURITY;

--- a/frontend/components/admin/pages/saveMarkdownPage.test.ts
+++ b/frontend/components/admin/pages/saveMarkdownPage.test.ts
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,7 +28,7 @@ beforeEach(() => {
 })
 
 it('addMarkdownPage', async() => {
-  const expectUrl = '/api/v1/meta_pages'
+  const expectUrl = '/api/v1/meta_page'
   const expectBody = {
     'body': '{"id":null,"slug":"test-slug","title":"Test title 1","description":null,"is_published":false,"position":1}',
     'headers': {
@@ -66,7 +67,7 @@ it('addMarkdownPage', async() => {
 it('saveMarkdownPage', async () => {
   mockParams.page.id = 'test-page-id'
 
-  const expectUrl = `/api/v1/meta_pages?id=eq.${mockParams.page.id}`
+  const expectUrl = `/api/v1/meta_page?id=eq.${mockParams.page.id}`
   const expectBody = {
     'body': '{"id":"test-page-id","slug":"test-slug","title":"Test title 1","description":null,"is_published":false,"position":1}',
     'headers': {
@@ -121,7 +122,7 @@ it('deleteMarkdownPage', async() => {
     token: 'TEST-TOKEN'
   }
 
-  const expectedUrl = `/api/v1/meta_pages?slug=eq.${params.slug}`
+  const expectedUrl = `/api/v1/meta_page?slug=eq.${params.slug}`
   const expectBody = {
     'headers': {
       'Authorization': `Bearer ${params.token}`,

--- a/frontend/components/admin/pages/saveMarkdownPage.ts
+++ b/frontend/components/admin/pages/saveMarkdownPage.ts
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +13,7 @@ import {MarkdownPage} from './useMarkdownPages'
 
 export async function addMarkdownPage({page,token}:{page:MarkdownPage,token:string}) {
   try {
-    const query = 'meta_pages'
+    const query = 'meta_page'
     const url = `/api/v1/${query}`
 
     const resp = await fetch(url,{
@@ -43,7 +45,7 @@ export async function addMarkdownPage({page,token}:{page:MarkdownPage,token:stri
 
 export async function saveMarkdownPage({page,token}:{page:MarkdownPage,token:string}) {
   try {
-    const query = `meta_pages?id=eq.${page.id}`
+    const query = `meta_page?id=eq.${page.id}`
     const url = `/api/v1/${query}`
 
     const resp = await fetch(url,{
@@ -111,7 +113,7 @@ export async function updatePagePositions({items,token}:{items:RsdLink[],token:s
 
 export async function patchMarkdownData({id,data,token}:{id:string,data:any,token:string}) {
   try {
-    const query = `meta_pages?id=eq.${id}`
+    const query = `meta_page?id=eq.${id}`
     const url = `/api/v1/${query}`
 
     const resp = await fetch(url,{
@@ -134,7 +136,7 @@ export async function patchMarkdownData({id,data,token}:{id:string,data:any,toke
 
 export async function deleteMarkdownPage({slug,token}:{slug:string,token:string}) {
   try {
-    const query = `meta_pages?slug=eq.${slug}`
+    const query = `meta_page?slug=eq.${slug}`
     const url = `/api/v1/${query}`
 
     const resp = await fetch(url,{

--- a/frontend/components/admin/pages/useMarkdownPages.ts
+++ b/frontend/components/admin/pages/useMarkdownPages.ts
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -61,7 +62,7 @@ export async function getMarkdownPage(props:UseMarkdownpageProps) {
     // use server side when available
     const baseUrl = getBaseUrl()
     // construct query string
-    let query = `meta_pages?slug=eq.${slug}`
+    let query = `meta_page?slug=eq.${slug}`
     if (is_published) {
       // only published
       query+='&is_published=eq.true'
@@ -109,7 +110,7 @@ export async function getPageLinks({is_published = true,token}: {is_published?: 
     // use server side when available
     const baseUrl = getBaseUrl()
     // get published meta pages ordered by position
-    let query = 'meta_pages?select=id,slug,title,position,is_published&order=position'
+    let query = 'meta_page?select=id,slug,title,position,is_published&order=position'
     if (is_published) {
       query += '&is_published=eq.true'
     }
@@ -138,7 +139,7 @@ export async function getPageLinks({is_published = true,token}: {is_published?: 
 
 export async function validPageSlug({slug, token}: { slug: string, token: string }) {
   // get published meta pages ordered by position
-  const query = `meta_pages?select=slug,is_published&slug=eq.${slug}`
+  const query = `meta_page?select=slug,is_published&slug=eq.${slug}`
   const url = `${getBaseUrl()}/${query}`
 
   // get page


### PR DESCRIPTION
## Don't expose unpublished meta pages in API

### Changes proposed in this pull request

* Change row level security so only published meta pages are exposed in the API
* Rename the table from `meta_pages` to `meta_page`
* Patch upgrade of REST Assured

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin
* Create an unpublished meta page (called "Public page" in the admin interface)
* It should not be shown at http://localhost/api/v1/meta_page when visiting in your browser
* Publish it
* It should now be present at the API
* Check if the new test does what it is supposed to do
* Check if the RLS is correct

closes #1604

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [x] Tests