### PR TITLE
chore: upgrade Postgres from 15.13 to 17.6

### DIFF
--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgres:15.13
+FROM postgres:17.6
 RUN chmod a+rwx /docker-entrypoint-initdb.d
 COPY --chown=postgres:postgres *.sh /docker-entrypoint-initdb.d/
 COPY --chown=postgres:postgres *.sql /docker-entrypoint-initdb.d/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,7 @@ version: "2.1"
 services:
   database:
     build: ./database
-    image: rsd/database:3.0.0
+    image: rsd/database:4.0.0
     ports:
       # enable connection from outside (development mode)
       - "5432:5432"


### PR DESCRIPTION
## Upgrade to Postgres 17

### Changes proposed in this pull request

* Upgrade Postgres from version 15.13 to 17.6

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Check if everything still works, both anonymously, as an admin and as a regular user
* All tests in the CI/CD pipeline should still pass

**Important**

When this is released, a dump and restore or `pg_upgrade` is needed, see [the documentation](https://www.postgresql.org/docs/current/upgrading.html).

closes #1561

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests