### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,8 @@ jobs:
           skip-git-pull: true
           # skip tag push - it will not push but it will tag
           git-push: false
+          # (hopefully) also complete a release when no fix or feat (but e.g. only chore) commits were made
+          skip-on-empty: false
 
   log_release_tag:
     needs: release_tag


### PR DESCRIPTION
## Fix release workflow

### Changes proposed in this pull request

* By setting `skip-on-empty` to `false`, the release workflow hopefully also fully runs when no `feat` or `fix` commits where made (see the [workflow documentation](https://github.com/TriPSs/conventional-changelog-action) for more info)

### How to test


* N/A

closes #1611

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests