### PR TITLE
Add categories to project metadata overview

### DIFF
--- a/frontend/components/user/project-quality/apiProjectQuality.tsx
+++ b/frontend/components/user/project-quality/apiProjectQuality.tsx
@@ -1,6 +1,6 @@
+// SPDX-FileCopyrightText: 2023 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -29,6 +29,7 @@ export type ProjectQualityProps = {
   research_domain_cnt: number,
   impact_cnt: number,
   output_cnt: number,
+  category_cnt: number,
   score: number
 }
 
@@ -53,8 +54,9 @@ realLabels.set('keyword_cnt', {'label': 'Keywords', 'type': 'number'})
 realLabels.set('research_domain_cnt', {'label': 'Research domains', 'type': 'number'})
 realLabels.set('impact_cnt', {'label': 'Impact', 'type': 'number'})
 realLabels.set('output_cnt', {'label': 'Output', 'type': 'number'})
+realLabels.set('category_cnt', {'label': 'Categories', 'type': 'number'})
 
-async function fetchProjectQuality(showAll: boolean, token:string) {
+async function fetchProjectQuality(showAll: boolean, token:string): Promise<ProjectQualityProps[]> {
   try {
     const url = getBaseUrl() + `/rpc/project_quality?show_all=${showAll}`
     const resp = await fetch(url, {
@@ -64,8 +66,7 @@ async function fetchProjectQuality(showAll: boolean, token:string) {
     })
     if (resp.status === 200) {
       const json:ProjectQualityProps[] = await resp.json()
-      const data = handleData(json)
-      return data
+      return handleData(json)
     }
     logger(`fetchProjectQuality...${resp.status}: ${resp.statusText}`)
     return []
@@ -75,20 +76,23 @@ async function fetchProjectQuality(showAll: boolean, token:string) {
   }
 }
 
-function handleData(data: ProjectQualityProps[]) {
+function handleData(data: ProjectQualityProps[]): ProjectQualityProps[] {
   data.forEach(element => {
     element.score = calculateScore(element)
   })
   return data
 }
 
-function calculateScore(element:ProjectQualityProps) {
+function calculateScore(element:ProjectQualityProps): number {
   let score = 0
   let kpiCount = 0
 
   const keys = Object.keys(element) as ProjectQualityKeys[]
   keys.forEach((key) => {
-    if (key === 'title' || key === 'slug' || key === 'score') return
+    if (key === 'title' || key === 'slug' || key === 'score') {
+      return
+    }
+
     const value = element[key]
     if (typeof value !== 'undefined' && (value === true || (Number.isInteger(value) && value as number > 0) || typeof value === 'string')){
       score += 1


### PR DESCRIPTION
## Add categories to project metadata overview

### Changes proposed in this pull request

* Add categories to project metadata overview, it counts assigned incidental leaf nodes (nodes that can have children but of which no child is assigned to the project)

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin, look at the project metadata overview, the final columns should show the category count
* Create a new project, add an organisation with categories to it and assign one category to the project
* When saving the category, you will see that all parents are also saved in the dev tools of your browser (F12, network tab), but in the project metadata overview, it should be counted as one (this should also be the case whan assigning a category that does have children, but of which you don't assign any children)
* Check for other project pages if the category count makes sense

closes #1596

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests