### PR TITLE
Upgrade publisher dependencies

### DIFF
--- a/publisher/requirements.txt
+++ b/publisher/requirements.txt
@@ -1,4 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+# SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -9,8 +11,8 @@ Flask-JWT-Extended==4.6.0
 Flask-Migrate==4.0.7
 Flask-SQLAlchemy==3.1.1
 gunicorn==23.0.0
-Jinja2==3.1.4
+Jinja2==3.1.6
 pika==1.3.2
 python-dotenv==1.0.1
-requests==2.32.3
+requests==2.32.5
 psycopg[binary]>=3.1


### PR DESCRIPTION
## Upgrade publisher dependencies

### Changes proposed in this pull request

* Upgrade publisher dependencies to close Dependabot security alerts

### How to test

* Follow the instructions in #1525 to see if emails still get sent
* Alternatively, if this breaks production, we will hear back soon enough from Helmholtz
* The [Jinja release notes](https://github.com/pallets/jinja/releases) indicate that no breaking changes should have been introduced
* The [Requests release notes](https://requests.readthedocs.io/en/latest/community/updates/) indicate that no applicable breaking changes should have been introduced

closes #1596 (other alerts should have dedicated issues)

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests