### PR TITLE
chore: fix frontend debugging in docker container

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-# SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+# SPDX-FileCopyrightText: 2024 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+# SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -14,6 +14,7 @@ services:
       - DGID
   ports:
     - "9229:9229"
+    - "9230:9230"
   volumes:
     - ./frontend:/app
     # Replace the follwoing directory with the custom deployment directory

--- a/frontend/next.rewrites.ts
+++ b/frontend/next.rewrites.ts
@@ -19,24 +19,7 @@ import {Rewrite} from 'next/dist/lib/load-custom-routes'
 
 let rewritesConfig: Rewrite[] = [] // NOSONAR
 
-if (process.env.NODE_ENV === 'docker' as any) {
-  // proxies for frontend-dev service
-  // developing using node docker container
-  rewritesConfig = [
-    {
-      source: '/image/:path*',
-      destination: 'http://nginx/image/:path*', // NOSONAR
-    },
-    {
-      source: '/api/v1/:path*',
-      destination: 'http://nginx/api/v1/:path*',// NOSONAR
-    },
-    {
-      source: '/auth/login/local',
-      destination: 'http://nginx/auth/login/local', // NOSONAR
-    }
-  ]
-} else if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'development') {
   rewritesConfig = [
     {
       source: '/image/:path*',

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbo",
     "dev:wp": "next dev",
-    "dev:docker": "NODE_ENV=docker next dev  # backup: NODE_ENV=docker NODE_OPTIONS='--inspect=0.0.0.0:9229' next dev",
+    "dev:docker": "NODE_OPTIONS='--inspect=0.0.0.0:9229' next dev",
     "build": "next build",
     "build:turbo": "next build --turbopack",
     "start": "next start",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev --turbo",
     "dev:wp": "next dev",
-    "dev:docker": "NODE_OPTIONS='--inspect=0.0.0.0:9229' next dev",
+    "dev:docker": "NODE_OPTIONS='--inspect=0.0.0.0:9229' next dev --turbo",
     "build": "next build",
     "build:turbo": "next build --turbopack",
     "start": "next start",

--- a/frontend/package.json.license
+++ b/frontend/package.json.license
@@ -4,6 +4,8 @@ SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
Changes proposed in this pull request:

* Fix frontend debugging for nextjs 15

How to test (vscode only):

* create a new job in `launch.json`:

```
{
    "name": "Docker: nextjs",
    "type": "node",
    "request": "attach",
    "address": "localhost",
    "port": 9230,
    "localRoot": "${workspaceFolder}/frontend",
    "remoteRoot": "/app",
    "sourceMaps": true,
    "smartStep": true,
    "trace": true,
    "outputCapture": "console",
}
```

* run `make frontend-dev`, the docker output should notify that the debugger is listening

```
frontend-1             | Debugger listening on ws://0.0.0.0:9229/5b6e8aea-d33b-4113-9d80-2162eec23cf8
frontend-1             | For help, see: https://nodejs.org/en/docs/inspector
frontend-1             | Debugger listening on ws://0.0.0.0:9230/b700d934-b196-4f9d-bd64-d9412d8f1d4f
frontend-1             | For help, see: https://nodejs.org/en/docs/inspector
frontend-1             |    the --inspect option was detected, the Next.js router server should be inspected at 0.0.0.0:9230.
frontend-1             |    ▲ Next.js 15.3.5
frontend-1             |    - Local:        http://localhost:3000
frontend-1             |    - Network:      http://172.18.0.9:3000
frontend-1             |    - Environments: .env.local
```

* run the debug job in vscode

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
