### PR TITLE
Clean up unused env variables

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -54,7 +54,6 @@ The default index.css and settings.json are already in the frontend image. If yo
       - POSTGREST_URL
       - PGRST_JWT_SECRET
       - RSD_AUTH_URL
-      - RSD_AUTH_COUPLE_PROVIDERS
       - RSD_AUTH_PROVIDERS
       - MATOMO_URL
       - MATOMO_ID

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -67,7 +67,6 @@ services:
       # it uses values from .env file
       - RSD_ENVIRONMENT
       - POSTGREST_URL
-      - RSD_AUTH_COUPLE_PROVIDERS
       - RSD_AUTH_PROVIDERS
       - SURFCONEXT_CLIENT_ID
       - SURFCONEXT_WELL_KNOWN_URL
@@ -130,11 +129,8 @@ services:
       - CROSSREF_CONTACT_EMAIL
       - MATOMO_URL
       - MATOMO_ID
-      # link your orcid account
-      - RSD_AUTH_COUPLE_PROVIDERS
       - ORCID_CLIENT_ID
       - ORCID_WELL_KNOWN_URL
-      # link your linkedin account
       - LINKEDIN_CLIENT_ID
       - LINKEDIN_WELL_KNOWN_URL
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,6 @@ services:
       # it uses values from .env file
       - RSD_ENVIRONMENT
       - POSTGREST_URL
-      - RSD_AUTH_COUPLE_PROVIDERS
       - RSD_AUTH_PROVIDERS
       - SURFCONEXT_CLIENT_ID
       - SURFCONEXT_WELL_KNOWN_URL
@@ -139,11 +138,8 @@ services:
       - CROSSREF_CONTACT_EMAIL
       - MATOMO_URL
       - MATOMO_ID
-      # link your orcid account
-      - RSD_AUTH_COUPLE_PROVIDERS
       - ORCID_CLIENT_ID
       - ORCID_WELL_KNOWN_URL
-      # link your linkedin account
       - LINKEDIN_CLIENT_ID
       - LINKEDIN_WELL_KNOWN_URL
     expose:


### PR DESCRIPTION
This PR removes all references to the unused env variable `RSD_AUTH_COUPLE_PROVIDERS`.

closes #1627