### PR TITLE
fix: organisation and community settings dynamic routes

### DIFF
--- a/frontend/components/communities/settings/SettingsNav.tsx
+++ b/frontend/components/communities/settings/SettingsNav.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,10 +11,12 @@ import ListItemText from '@mui/material/ListItemText'
 
 import {editMenuItemButtonSx} from '~/config/menuItems'
 import {settingsMenu} from './SettingsNavItems'
+import {useCommunityContext} from '../context'
 
 export default function CommunitySettingsNav() {
   const router = useRouter()
   const tab = router.query['tab'] ?? 'general'
+  const {community:{slug}} = useCommunityContext()
   // console.group('CommunitySettingsNav')
   // console.log('description...', organisation.description)
   // console.groupEnd()
@@ -27,18 +29,14 @@ export default function CommunitySettingsNav() {
     >
       {settingsMenu.map((item, pos) => {
         const selected = tab === settingsMenu[pos].id
+        const url = `${router.pathname.replace('[slug]',slug)}?tab=${item.id}`
         return (
           <ListItemButton
-            data-testid="organisation-settings-nav-item"
+            data-testid="community-settings-nav-item"
             key={`step-${pos}`}
             selected={selected}
             onClick={() => {
-              router.push({
-                query: {
-                  ...router.query,
-                  tab: item.id
-                }
-              },{},{scroll:false})
+              router.push(url,url,{scroll:false})
             }}
             sx={editMenuItemButtonSx}
           >

--- a/frontend/components/organisation/settings/OrganisationSettingsIndex.test.tsx
+++ b/frontend/components/organisation/settings/OrganisationSettingsIndex.test.tsx
@@ -17,6 +17,23 @@ import mockOrganisation from '../__mocks__/mockOrganisation'
 // mock user agreement call
 jest.mock('~/components/user/settings/agreements/useUserAgreements')
 
+// MOCK page useRouter (next/router)
+jest.mock('next/router', () => ({
+  useRouter: jest.fn(()=>{
+    return {
+      pathname: {
+        replace:jest.fn()
+      },
+      asPath: 'test-path',
+      // ... whatever else you call on `router`
+      query: {
+        test: 'query',
+        slug: 'test-slug'
+      }
+    }
+  }),
+}))
+
 const mockProps = {
   organisation: mockOrganisation,
   isMaintainer: false

--- a/frontend/components/organisation/settings/SettingsNav.tsx
+++ b/frontend/components/organisation/settings/SettingsNav.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,10 +13,12 @@ import ListItemText from '@mui/material/ListItemText'
 
 import {editMenuItemButtonSx} from '~/config/menuItems'
 import {settingsMenu} from './SettingsNavItems'
+import useOrganisationContext from '../context/useOrganisationContext'
 
 export default function OrganisationSettingsNav() {
   const router = useRouter()
   const settings = router.query['settings'] ?? 'general'
+  const {rsd_path} = useOrganisationContext()
   // console.group('OrganisationNav')
   // console.log('description...', organisation.description)
   // console.groupEnd()
@@ -29,19 +31,14 @@ export default function OrganisationSettingsNav() {
     >
       {settingsMenu.map((item, pos) => {
         const selected = settings === settingsMenu[pos].id
-        // const selected = router.query['id'] ?? organisationMenu[0].id
+        const url = `${router.pathname.replace('[...slug]',rsd_path ?? '')}?tab=settings&settings=${item.id}`
         return (
           <ListItemButton
             data-testid="organisation-settings-nav-item"
             key={`step-${pos}`}
             selected={selected}
             onClick={() => {
-              router.push({
-                query: {
-                  ...router.query,
-                  settings:item.id
-                }
-              },{},{scroll:false})
+              router.push(url,url,{scroll:false})
             }}
             sx={editMenuItemButtonSx}
           >

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,7 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
 /// <reference types="next/navigation-types/compat/navigation" />
+/// <reference path="./.next/types/routes.d.ts" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rsd-frontend",
-  "version": "4.1.0",
+  "version": "5.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rsd-frontend",
-      "version": "4.1.0",
+      "version": "5.2.0",
       "dependencies": {
         "@bprogress/next": "3.2.12",
         "@dnd-kit/core": "6.3.1",


### PR DESCRIPTION
# Fix dynamic slug routes

Closes #1637

Changes proposed in this pull request:
* Calculate dynamic slug routes for organisation and communities settings pages. It seems that "old" way does not function properly with the curent next version and combination of app and page routers.    

How to test:
* `make start` to build and generate test data
* navigate to organisation and test all routes, in particular settings routes when you logged in as maintainer
* navigate to communities and test all routes, in particular settings routes when you logged in as maintainer

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
