### PR TITLE
Throttle requests to OpenAlex

### DIFF
--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Throttler.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/Throttler.java
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * A thread safe throttler which will never allow more than N invocations per X time units.
+ * It only accounts for the start of an action, not the duration of the action.
+ * Actions that go over the limit are not rejected but delayed and executed when possible.
+ */
+public class Throttler {
+
+	private final Semaphore semaphore;
+	private final long xTimeUnits;
+	private final TimeUnit timeUnit;
+	private final ScheduledExecutorService scheduledExecutorService = Executors.newSingleThreadScheduledExecutor(
+		runnable -> {
+			ThreadFactory defaultFactory = Executors.defaultThreadFactory();
+			Thread t = defaultFactory.newThread(runnable);
+			t.setDaemon(true);
+			return t;
+		}
+	);
+
+	/**
+	 * Create a new Throttler that will allow N invocations per X time units, in accordance with the supplied arguments.
+	 *
+	 * @param amountPerXTimeUnits the amount of invocations per X time units
+	 * @param xTimeUnits          how many time units can contain N invocations
+	 * @param timeUnit            the time unit of this throttler
+	 */
+	public Throttler(int amountPerXTimeUnits, long xTimeUnits, TimeUnit timeUnit) {
+		semaphore = new Semaphore(amountPerXTimeUnits, true);
+		this.xTimeUnits = xTimeUnits;
+		this.timeUnit = timeUnit;
+	}
+
+	/**
+	 * A blocking call that will return when you can do an action according to this throttler.
+	 * It is up to the caller to take the action afterwards as soon as possible.
+	 *
+	 * @throws InterruptedException when interrupted while waiting
+	 */
+	public void awaitPermission() throws InterruptedException {
+		semaphore.acquire();
+		releaseFuturePermit();
+	}
+
+	/**
+	 * A non-blocking call that will run the submitted action as soon as this throttler allows for it.
+	 *
+	 * @param task            the action that should be throttled
+	 * @param executorService the thread pool in which the action should run
+	 * @param <V>             the return type of the action
+	 * @return the Future representing the running action
+	 */
+	public <V> Future<V> runThrottledTask(Callable<V> task, ExecutorService executorService) {
+		Callable<V> wrappedTask = () -> {
+			semaphore.acquire();
+			releaseFuturePermit();
+			return task.call();
+		};
+
+		return executorService.submit(wrappedTask);
+	}
+
+	private void releaseFuturePermit() {
+		scheduledExecutorService.schedule(() -> semaphore.release(), xTimeUnits, timeUnit);
+	}
+}

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/MainMentions.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -147,7 +147,6 @@ public class MainMentions {
 		// END CROSSREF
 
 		// OPENALEX (other DOI registry agents)
-		String email = Config.crossrefContactEmail().orElse(null);
 		Collection<ExternalMentionRecord> scrapedOpenalexMentions = new ArrayList<>();
 		OpenAlexConnector openAlexConnector = new OpenAlexConnector();
 		Collection<String> invalidDoiRas = Set.of(
@@ -165,7 +164,7 @@ public class MainMentions {
 			.map(Doi::fromString)
 			.toList();
 		try {
-			scrapedOpenalexMentions.addAll(openAlexConnector.mentionDataByDois(europeanPublicationsOfficeDois, email));
+			scrapedOpenalexMentions.addAll(openAlexConnector.mentionDataByDois(europeanPublicationsOfficeDois));
 		} catch (Exception e) {
 			Exception exceptionToSave = new Exception(
 				"Failed scraping the following EPO DOIs: " + europeanPublicationsOfficeDois,
@@ -179,7 +178,7 @@ public class MainMentions {
 			.map(RsdMentionIds::openalexId)
 			.toList();
 		try {
-			scrapedOpenalexMentions.addAll(openAlexConnector.mentionDataByOpenalexIds(openalexIdsToScrape, email));
+			scrapedOpenalexMentions.addAll(openAlexConnector.mentionDataByOpenalexIds(openalexIdsToScrape));
 		} catch (Exception e) {
 			Exception exceptionToSave = new Exception(
 				"Failed scraping the following OpenAlex IDs: " + openalexIdsToScrape,

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ThrottlerTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/ThrottlerTest.java
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter.rsd.scraper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+class ThrottlerTest {
+
+	@Test
+	void givenThrottlerWithFixedDelay_whenGettingTwoPermission_thenMinimumTimeRespected() throws InterruptedException {
+		int millisecondsBetweenPermissions = 100;
+		Throttler throttler = new Throttler(1, millisecondsBetweenPermissions, TimeUnit.MILLISECONDS);
+
+		long tik = System.nanoTime();
+		throttler.awaitPermission();
+		throttler.awaitPermission();
+		long tok = System.nanoTime();
+
+		Assertions.assertTrue((tok - tik) / 1_000_000 >= millisecondsBetweenPermissions);
+	}
+
+	@Test
+	void givenThrottlerWithRandomDelay_whenGettingTwoPermission_thenMinimumTimeRespected() throws InterruptedException {
+		int min = 10;
+		int max = 500;
+		Random random = new Random();
+
+		for (int i = 0; i < 10; i++) {
+			int millisecondsBetweenPermissions = random.nextInt(max - min) + min;
+			Throttler throttler = new Throttler(1, millisecondsBetweenPermissions, TimeUnit.MILLISECONDS);
+
+			long tik = System.nanoTime();
+			throttler.awaitPermission();
+			throttler.awaitPermission();
+			long tok = System.nanoTime();
+
+			Assertions.assertTrue((tok - tik) / 1_000_000 >= millisecondsBetweenPermissions);
+		}
+	}
+
+	@Disabled("This is for playing around with the Throttler class using prints, not for automated testing.")
+	@Test
+	void testThrottlerFuturesWithPrintStatements() {
+		Throttler throttler = new Throttler(3, 1000, TimeUnit.MILLISECONDS);
+		ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+		List<Future<Integer>> futures = new ArrayList<>();
+		for (int i = 0; i < 10; i++) {
+			int finalI = i;
+			Future<Integer> task = throttler.runThrottledTask(() -> finalI, executorService);
+			futures.add(task);
+		}
+
+		futures.forEach(f -> {
+			try {
+				System.out.println(f.get());
+			} catch (InterruptedException | ExecutionException e) {
+				throw new RuntimeException(e);
+			}
+		});
+	}
+}

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnectorTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnectorTest.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -34,12 +34,12 @@ class OpenAlexConnectorTest {
 		OpenAlexConnector openAlexConnector = new OpenAlexConnector();
 
 		Collection<ExternalMentionRecord> doiMentions = Assertions.assertDoesNotThrow(() ->
-			openAlexConnector.mentionDataByDois(Collections.emptyList(), null)
+			openAlexConnector.mentionDataByDois(Collections.emptyList())
 		);
 		Assertions.assertTrue(doiMentions.isEmpty());
 
 		Collection<ExternalMentionRecord> openalexMentions = Assertions.assertDoesNotThrow(() ->
-			openAlexConnector.mentionDataByOpenalexIds(Collections.emptyList(), null)
+			openAlexConnector.mentionDataByOpenalexIds(Collections.emptyList())
 		);
 		Assertions.assertTrue(openalexMentions.isEmpty());
 	}


### PR DESCRIPTION
## Throttle requests to OpenAlex

### Changes proposed in this pull request

* Throttle HTTP request to the OpenAlex API so there is at least (a little more than) one second between two consecutive requests

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation-1`
* Run the citation scraper a few times: `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations`
* There should be no related errors in the Docker logs or the admin logs, unless your run overlaps with a run by the cron job
* (optional) play around with the disabled test in the `ThrottlerTest` class to see if it works as expected

closes #1640

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests