### PR TITLE
Fix citations harvester

### DIFF
--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnectorTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnectorTest.java
@@ -43,4 +43,19 @@ class OpenAlexConnectorTest {
 		);
 		Assertions.assertTrue(openalexMentions.isEmpty());
 	}
+
+	@Test
+	void givenOpenAlexId_whenConvertingToCitationsUrl_thenCorrectUrlReturned() {
+		String openAlexKey = "W12345";
+		OpenalexId openalexId = OpenalexId.fromString("https://openalex.org/" + openAlexKey);
+
+		String citationsUrl = OpenAlexConnector.citationsUri(openalexId);
+
+		Assertions.assertEquals("https://api.openalex.org/works?filter=cites:" + openAlexKey, citationsUrl);
+	}
+
+	@Test
+	void givenNullOpenAlexId_whenConvertingToCitationsUrl_thenNullPointerThrown() {
+		Assertions.assertThrowsExactly(NullPointerException.class, () -> OpenAlexConnector.citationsUri(null));
+	}
 }


### PR DESCRIPTION
## Fix citations harvester

### Changes proposed in this pull request

* Fix the OpenAlex citations harvester by manually constructing the citations URL for a given work
* If a mention on the RSD database doesn't have a DOI, we try to get its OpenAlex ID first

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, add software
* Add as a reference paper `10.5194/gmd-16-315-2023`
* Wait for the citation scraper to run or run `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations`
* Twelve citations should have been added, in accordance with the count of [the OpenAlex API](https://api.openalex.org/works?filter=cites:W4315649142) (the OpenAlex ID can be found at [this URL](https://api.openalex.org/works/https://doi.org/10.5194%2Fgmd-16-315-2023))
* Try this out with other mentions as well, also as project output

closes #1654

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests
