### PR TITLE
feat: add image to open graph for software, project and news page

### DIFF
--- a/frontend/app/(container)/search/page.tsx
+++ b/frontend/app/(container)/search/page.tsx
@@ -35,7 +35,7 @@ function groupResultsBySource(results: GlobalSearchResults[]) {
 export default async function SearchResultsPage({
   searchParams
 }:Readonly<{
-  searchParams: Promise<{ [key: string]: string | string[] | undefined }>
+  searchParams: Promise<{[key: string]: string | string[] | undefined}>
 }>) {
   // extract params and user settings
   const [params, {token}] = await Promise.all([

--- a/frontend/components/seo/apiMetadata.ts
+++ b/frontend/components/seo/apiMetadata.ts
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {Metadata} from 'next/types'
+import {app} from '~/config/app'
+
+type MetadataProps={
+  domain: string
+  page_title: string
+  description: string
+  url: string | URL
+  image_url: string[]
+  other?: {[name: string]: string | number | (string | number)[]}
+}
+
+export function createMetadata({domain,page_title,description,url,image_url,other}:MetadataProps){
+  const meta:Metadata = {
+    title: `${page_title} | ${app.title}`,
+    description,
+    openGraph:{
+      type: 'website',
+      siteName: app.title,
+      title: page_title,
+      description,
+      url,
+    },
+    other:{
+      // add RSD website logo
+      'og:logo':`https://${domain}/android-chrome-512x512.png`,
+      ...other
+    }
+  }
+  if (image_url?.length > 0 && meta.openGraph){
+    const images:{url:string}[] = []
+    // add all logo/images to openGraph
+    image_url.forEach(url=>{
+      images.push({url})
+    })
+    if (images.length > 0){
+      meta.openGraph['images'] = images
+    }
+  }
+  return meta
+}


### PR DESCRIPTION
# Add image to OpenGraph

Closes #1650

Changes proposed in this pull request:
* Add software image to OpenGraph metadata, if exists, to software page
* Add project image to OpenGraph metadata on the project page
* Add news card image to OpenGraph metadata on the news page
* Add OpenGraph metadata to organisation page.
* Add OpenGraph metadata to community page.
* The image to url is "fixed" to secure site (https://)

**Note! Although the validation tests are successful it seems that SVG image, defined in OpenGraph metadata, is not shown/loaded in the social media post (I tested LinkedIn and X). The SVG image is of XML format and can contain JavaScript code. For the security reasons the social media platforms seem to ignore SVG image defined in OpenGraph metadata, while validation tools will show it.**

How to test:
* `make start` to build project and generate test data
* navigate to software page. Examine page head, use F12 to open debugger and search for "twitter:image", "og:image" props. Confirm that image url is added including domain.
* repeat this check on project and news item page.

The proper confirmation that OpenGraph image works can be only performed with the real domain (not locally with localhost). I have put this PR on our [dev](https://research-software.dev/) to test metadata tags using [open graph validator](https://orcascan.com/tools/open-graph-validator).

## Results open graph validation
<img width="1020" height="1213" alt="image" src="https://github.com/user-attachments/assets/ac7cdaca-8c32-4fe1-9eaa-90f428898060" />


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
