### PR TITLE
Additional functionality for user software and projects overviews

### DIFF
--- a/database/104-software-views.sql
+++ b/database/104-software-views.sql
@@ -1,6 +1,6 @@
--- SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 -- SPDX-FileCopyrightText: 2023 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+-- SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2023 dv4all
 -- SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
@@ -796,38 +796,40 @@ $$
 $$;
 
 -- SOFTWARE BY MAINTAINER
--- NOTE! one software is shown multiple times in this view
--- we filter this view at least by organisation uuid
+-- NOTE! depends on software_overview RPC
 CREATE FUNCTION software_by_maintainer(maintainer_id UUID) RETURNS TABLE (
 	id UUID,
 	slug VARCHAR,
 	brand_name VARCHAR,
 	short_statement VARCHAR,
-	is_published BOOLEAN,
 	image_id VARCHAR,
+	is_published BOOLEAN,
 	updated_at TIMESTAMPTZ,
 	contributor_cnt BIGINT,
-	mention_cnt BIGINT
+	mention_cnt BIGINT,
+	keywords CITEXT[],
+	prog_lang TEXT[],
+	licenses VARCHAR[]
 ) LANGUAGE sql STABLE AS
 $$
 	SELECT
-		software.id,
-		software.slug,
-		software.brand_name,
-		software.short_statement,
-		software.is_published,
-		software.image_id,
-		software.updated_at,
-		count_software_contributors.contributor_cnt,
-		count_software_mentions.mention_cnt
+		software_overview.id,
+		software_overview.slug,
+		software_overview.brand_name,
+		software_overview.short_statement,
+		software_overview.image_id,
+		software_overview.is_published,
+		software_overview.updated_at,
+		software_overview.contributor_cnt,
+		software_overview.mention_cnt,
+		software_overview.keywords,
+		software_overview.prog_lang,
+		software_overview.licenses
 	FROM
-		software
-	LEFT JOIN
-		count_software_contributors() ON software.id=count_software_contributors.software
-	LEFT JOIN
-		count_software_mentions() ON software.id=count_software_mentions.software
+		software_overview()
 	INNER JOIN
-		maintainer_for_software ON software.id=maintainer_for_software.software
+		maintainer_for_software ON software_overview.id=maintainer_for_software.software
 	WHERE
 		maintainer_for_software.maintainer=maintainer_id;
 $$;
+

--- a/frontend/components/cards/KeywordList.tsx
+++ b/frontend/components/cards/KeywordList.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -15,7 +15,7 @@ export default function KeywordList({keywords=[], visibleNumberOfKeywords = 3}: 
   if (!keywords || keywords.length===0) return null
 
   return (
-    <ul className="flex flex-wrap items-start gap-2 text-base-content text-xs">
+    <ul className="flex flex-wrap items-start gap-1 text-base-content text-xs">
       {// limits the keywords to 'visibleNumberOfKeywords' per software.
         keywords?.slice(0, visibleNumberOfKeywords)
           .map((keyword:string) => (

--- a/frontend/components/software/overview/cards/SoftwareCardContent.tsx
+++ b/frontend/components/software/overview/cards/SoftwareCardContent.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,8 +17,8 @@ type SoftwareCardContentProps = {
   brand_name: string
   short_statement: string
   image_id: string | null
-  keywords: string[],
-  prog_lang: string[],
+  keywords: string[] | null,
+  prog_lang: string[] | null,
   contributor_cnt: number | null
   mention_cnt: number | null
   downloads?: number
@@ -62,7 +62,7 @@ export default function SoftwareCardContent(item:SoftwareCardContentProps) {
         <div className="flex gap-2 justify-between mt-4">
           {/* Languages */}
           <ProgrammingLanguageList
-            prog_lang={item.prog_lang}
+            prog_lang={item.prog_lang ?? undefined}
             visibleNumberOfProgLang={item.visibleProgLang ?? 3}
           />
           {/* Metrics */}

--- a/frontend/components/software/overview/cards/SoftwareGridCard.tsx
+++ b/frontend/components/software/overview/cards/SoftwareGridCard.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -10,14 +10,14 @@ import {getPageUrl,visibleNumberOfKeywords,visibleNumberOfProgLang} from '../use
 import SoftwareCardContent from './SoftwareCardContent'
 import ExternalLinkIcon from './ExternalLinkIcon'
 
-type SoftwareCardProps = {
+export type SoftwareCardProps = {
   id: string
   slug: string
   brand_name: string
   short_statement: string
   image_id: string | null
-  keywords: string[],
-  prog_lang: string[],
+  keywords: string[] | null,
+  prog_lang: string[] | null,
   contributor_cnt: number | null
   mention_cnt: number | null
   downloads?: number

--- a/frontend/components/user/project/UserProjectGridCard.tsx
+++ b/frontend/components/user/project/UserProjectGridCard.tsx
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+
+import ProjectCardContent from '~/components/projects/overview/cards/ProjectCardContent'
+import StatusBanner from '~/components/cards/StatusBanner'
+import IconBtnMenuOnAction from '~/components/menu/IconBtnMenuOnAction'
+import useUserProjectActions from './useUserProjectActions'
+import {ProjectByMaintainer} from './useUserProjects'
+
+
+export default function UserProjectGridCard({item}:Readonly<{item:ProjectByMaintainer}>) {
+  const {project,menuOptions, onAction} = useUserProjectActions({item})
+
+  // console.group('UserProjectGridCard')
+  // console.log('refresh...', refresh)
+  // console.log('id...', project.id)
+  // console.log('is_published...', project.is_published)
+  // console.log('status...', project.status)
+  // console.groupEnd()
+
+  return (
+    <div
+      data-testid="admin-project-grid-card"
+      className="relative h-full"
+    >
+      {/* standard project card with link */}
+      <Link
+        data-testid="project-grid-card"
+        href={`/projects/${project.slug}`}
+        className="h-full hover:text-inherit"
+      >
+        <ProjectCardContent
+          visibleKeywords={3}
+          {...project}
+        />
+      </Link>
+
+      {/* menu and status icons - at the top of the card */}
+      <div className="w-full flex items-start absolute top-0 pt-2 pr-2 opacity-50 hover:opacity-100 z-10">
+        <div className="flex-1 flex flex-col">
+          <div className="flex flex-col items-start gap-1 pt-2 text-xs">
+            <StatusBanner
+              status="approved"
+              is_featured={false}
+              is_published={project.is_published}
+              borderRadius='0 0.75rem 0.75rem 0'
+            />
+          </div>
+        </div>
+        <div className="bg-base-100 rounded-[50%]">
+          <IconBtnMenuOnAction
+            options={menuOptions}
+            onAction={onAction}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/user/project/UserProjectListItem.tsx
+++ b/frontend/components/user/project/UserProjectListItem.tsx
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+
+import IconBtnMenuOnAction from '~/components/menu/IconBtnMenuOnAction'
+import OverviewListItem from '~/components/software/overview/list/OverviewListItem'
+import ProjectListItemContent from '~/components/projects/overview/list/ProjectListItemContent'
+import StatusBanner from '~/components/cards/StatusBanner'
+import {ProjectByMaintainer} from './useUserProjects'
+import useUserProjectActions from './useUserProjectActions'
+
+
+export default function UserProjectListItem({item}:Readonly<{item:ProjectByMaintainer}>) {
+  const {project,menuOptions, onAction} = useUserProjectActions({item})
+
+  // console.group('UserProjectListItem')
+  // console.log('id...', project.id)
+  // console.log('is_published...', project.is_published)
+  // console.log('status...', project.status)
+  // console.groupEnd()
+
+  return (
+    <OverviewListItem>
+      {/* standard project list item with link */}
+      <Link
+        data-testid="admin-project-list-item"
+        key={project.id}
+        href={`/projects/${project.slug}`}
+        className='flex-1 flex hover:text-inherit'
+      >
+        <ProjectListItemContent
+          statusBanner={
+            <StatusBanner
+              status="approved"
+              is_featured={false}
+              is_published={project.is_published}
+              width='auto'
+              borderRadius='0.125rem'
+            />
+          }
+          {...project}
+        />
+      </Link>
+      {/* admin menu */}
+      <div className="flex mx-2">
+        <IconBtnMenuOnAction
+          options={menuOptions}
+          onAction={onAction}
+        />
+      </div>
+    </OverviewListItem>
+  )
+}

--- a/frontend/components/user/project/UserProjectsOverview.tsx
+++ b/frontend/components/user/project/UserProjectsOverview.tsx
@@ -1,19 +1,16 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
-
-import Link from 'next/link'
 
 import NoContent from '~/components/layout/NoContent'
 import GridOverview from '~/components/layout/GridOverview'
 import CardSkeleton from '~/components/cards/CardSkeleton'
 import {ProjectLayoutType} from '~/components/search/ToggleViewGroup'
-import OverviewListItem from '~/components/software/overview/list/OverviewListItem'
-import ProjectCardContent from '~/components/projects/overview/cards/ProjectCardContent'
 import ProjectOverviewList from '~/components/projects/overview/list/ProjectOverviewList'
-import ProjectListItemContent from '~/components/projects/overview/list/ProjectListItemContent'
 import {ProjectByMaintainer} from './useUserProjects'
+import UserProjectGridCard from './UserProjectGridCard'
+import UserProjectListItem from './UserProjectListItem'
 
 type UserProjectsOverviewProps=Readonly<{
   layout: ProjectLayoutType
@@ -37,19 +34,7 @@ export default function UserProjectsOverview({loading,skeleton_items,layout,proj
     return (
       <ProjectOverviewList>
         {projects.map(item => {
-          return (
-            <Link
-              data-testid="project-list-item"
-              key={item.id}
-              href={`/projects/${item.slug}`}
-              className='flex-1 hover:text-inherit'
-              title={item.title}
-            >
-              <OverviewListItem className='pr-4'>
-                <ProjectListItemContent key={item.id} {...item as any} />
-              </OverviewListItem>
-            </Link>
-          )
+          return <UserProjectListItem key={item.id} item={item} />
         })}
       </ProjectOverviewList>
     )
@@ -60,19 +45,7 @@ export default function UserProjectsOverview({loading,skeleton_items,layout,proj
   return (
     <GridOverview fullWidth={true}>
       {projects.map((item) => {
-        return (
-          <Link
-            key={item.id}
-            data-testid="project-grid-card"
-            href={`/projects/${item.slug}`}
-            className="h-full hover:text-inherit"
-          >
-            <ProjectCardContent
-              visibleKeywords={3}
-              {...item as any}
-            />
-          </Link>
-        )
+        return <UserProjectGridCard key={item.id} item={item} />
       })}
     </GridOverview>
   )

--- a/frontend/components/user/project/useUserMenuOptions.tsx
+++ b/frontend/components/user/project/useUserMenuOptions.tsx
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import EditIcon from '@mui/icons-material/Edit'
+import ArticleIcon from '@mui/icons-material/Article'
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff'
+import VisibilityIcon from '@mui/icons-material/Visibility'
+
+import {IconBtnMenuOption} from '~/components/menu/IconBtnMenuOnAction'
+
+export type UserMenuAction = {
+  type: 'VIEW' | 'EDIT' | 'PUBLISH' | 'UNPUBLISH',
+  payload?: string
+}
+
+type UseUserMenuOptionsProps=Readonly<{
+  is_published:boolean
+}>
+
+export default function useUserMenuOptions({is_published}:UseUserMenuOptionsProps) {
+  const menuOptions:IconBtnMenuOption<UserMenuAction>[]=[{
+    type: 'action',
+    key:'edit',
+    label:'Edit',
+    icon: <EditIcon />,
+    action:{
+      type: 'EDIT'
+    }
+  },{
+    type: 'action',
+    key:'view',
+    label:'View',
+    icon: <ArticleIcon />,
+    action:{
+      type: 'VIEW'
+    }
+  }]
+
+  if (is_published===true){
+    menuOptions.push({
+      type: 'action',
+      key:'unpublish',
+      label:'Unpublish',
+      icon: <VisibilityOffIcon />,
+      action:{
+        type: 'UNPUBLISH'
+      }
+    })
+  }else{
+    menuOptions.push({
+      type: 'action',
+      key:'publish',
+      label:'Publish',
+      icon: <VisibilityIcon />,
+      action:{
+        type: 'PUBLISH'
+      }
+    })
+  }
+
+  return menuOptions
+}

--- a/frontend/components/user/project/useUserProjectActions.tsx
+++ b/frontend/components/user/project/useUserProjectActions.tsx
@@ -1,0 +1,76 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import {useState} from 'react'
+import {useRouter} from 'next/navigation'
+
+import {useSession} from '~/auth/AuthProvider'
+import logger from '~/utils/logger'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {patchProjectTable} from '~/components/projects/edit/information/patchProjectInfo'
+import useUserMenuOptions, {UserMenuAction} from './useUserMenuOptions'
+import {ProjectByMaintainer} from './useUserProjects'
+
+export default function useUserProjectActions({item}:{item:ProjectByMaintainer}) {
+  const router = useRouter()
+  const {token} = useSession()
+  const {showErrorMessage} = useSnackbar()
+  const [project, setProject] = useState(item)
+  // dynamic menu options
+  const menuOptions = useUserMenuOptions({
+    is_published: project.is_published
+  })
+
+  async function publishProject({is_published}:{is_published:boolean}){
+    const resp = await patchProjectTable({
+      id: project.id,
+      data:{
+        is_published
+      },
+      token
+    })
+
+    if (resp.status===200){
+      // update local project object
+      setProject({
+        ...project,
+        is_published
+      })
+    }else{
+      showErrorMessage(`Failed to update ${project.title}. ${resp.message}`)
+    }
+  }
+
+  function onAction(action: UserMenuAction){
+    switch(action.type){
+      case 'VIEW':
+        router.push(`/projects/${project.slug}`)
+        break
+      case 'EDIT':
+        router.push(`/projects/${project.slug}/edit`)
+        break
+      case 'PUBLISH':
+        publishProject({
+          is_published: true
+        })
+        break
+      case 'UNPUBLISH':
+        publishProject({
+          is_published: false
+        })
+        break
+      default:
+        logger(`Action type ${action.type} NOT SUPPORTED. Check your spelling.`, 'warn')
+    }
+  }
+
+  return {
+    project,
+    menuOptions,
+    onAction,
+  }
+}

--- a/frontend/components/user/project/useUserProjects.tsx
+++ b/frontend/components/user/project/useUserProjects.tsx
@@ -10,6 +10,7 @@
 import {useEffect,useState} from 'react'
 
 import {useSession} from '~/auth/AuthProvider'
+import {ProjectStatusKey} from '~/types/Project'
 import {extractCountFromHeader} from '~/utils/extractCountFromHeader'
 import {createJsonHeaders} from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
@@ -19,16 +20,18 @@ export type ProjectByMaintainer={
   id: string
   slug: string,
   title: string,
-  subtitle: string | null
-  current_state: string
+  subtitle: string,
   date_start: string
   date_end: string
   updated_at: string
   is_published: boolean
   image_contain: boolean,
-  image_id: string | null
-  impact_cnt: number
-  output_cnt: number
+  image_id: string | null,
+  keywords: string[] | null,
+  research_domain: string[] | null,
+  impact_cnt: number | null,
+  output_cnt: number | null,
+  project_status: ProjectStatusKey
 }
 
 type UserProjectsProp = {
@@ -44,12 +47,15 @@ export async function getProjectsForMaintainer(
 ) {
   try {
     // baseUrl
-    let url = `/api/v1/rpc/projects_by_maintainer?maintainer_id=${account}&order=is_published.desc,title`
+    let url = `/api/v1/rpc/projects_by_maintainer?maintainer_id=${account}`
 
     // search
     if (searchFor) {
       const encodedSearch = encodeURIComponent(searchFor)
       url += `&or=(title.ilike."*${encodedSearch}*", subtitle.ilike."*${encodedSearch}*")`
+    }else{
+      // default order by is_published
+      url += '&order=is_published,title'
     }
 
     // pagination

--- a/frontend/components/user/software/UserSoftwareGridCard.tsx
+++ b/frontend/components/user/software/UserSoftwareGridCard.tsx
@@ -1,0 +1,66 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+
+import StatusBanner from '~/components/cards/StatusBanner'
+import IconBtnMenuOnAction from '~/components/menu/IconBtnMenuOnAction'
+import SoftwareCardContent from '~/components/software/overview/cards/SoftwareCardContent'
+import {SoftwareByMaintainer} from './useUserSoftware'
+import useUserSoftwareActions from './useUserSoftwareActions'
+
+export type UserSoftwareGridCard = Readonly<{
+  item: SoftwareByMaintainer
+}>
+
+
+export default function UserSoftwareGridCard({item}:UserSoftwareGridCard) {
+  const {software,menuOptions,onAction} = useUserSoftwareActions({item})
+
+  // console.group('UserSoftwareGridCard')
+  // console.log('software...', software)
+  // console.log('is_published...', software.is_published)
+  // console.log('menuOptions...', menuOptions)
+  // console.groupEnd()
+
+  return (
+    <div
+      data-testid="user-software-grid-card"
+      className="relative h-full"
+    >
+      {/* standard software card with link */}
+      <Link
+        data-testid="software-grid-card"
+        href={`/software/${software.slug}`}
+        className="h-full hover:text-inherit"
+      >
+        <SoftwareCardContent
+          visibleKeywords={3}
+          visibleProgLang={3}
+          {...software}
+        />
+      </Link>
+
+      {/* menu and status icons - at the top of the card */}
+      <div className="w-full flex items-center absolute top-0 pt-2 pr-2 opacity-50 hover:opacity-100 z-10">
+        <div className="flex-1 flex flex-col">
+          <div className="flex flex-col items-start gap-1 pt-2 text-xs">
+            {/* use organisation status banner with defaults */}
+            <StatusBanner
+              status="approved"
+              is_featured={false}
+              is_published={software.is_published}
+              borderRadius='0 0.75rem 0.75rem 0'
+            />
+          </div>
+        </div>
+        <IconBtnMenuOnAction
+          options={menuOptions}
+          onAction={onAction}
+        />
+      </div>
+    </div>
+  )
+}

--- a/frontend/components/user/software/UserSoftwareListItem.tsx
+++ b/frontend/components/user/software/UserSoftwareListItem.tsx
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Link from 'next/link'
+
+import IconBtnMenuOnAction from '~/components/menu/IconBtnMenuOnAction'
+import OverviewListItem from '~/components/software/overview/list/OverviewListItem'
+import SoftwareListItemContent from '~/components/software/overview/list/SoftwareListItemContent'
+import StatusBanner from '~/components/communities/software/card/StatusBanner'
+import useUserSoftwareActions from './useUserSoftwareActions'
+import {UserSoftwareGridCard} from './UserSoftwareGridCard'
+
+
+export default function UserSoftwareListItem({item}:UserSoftwareGridCard) {
+  const {software,menuOptions,onAction} = useUserSoftwareActions({item})
+
+  // console.group('UserSoftwareListItem')
+  // console.log('software...', software)
+  // console.log('is_published...', software.is_published)
+  // console.log('menuOptions...', menuOptions)
+  // console.groupEnd()
+
+  return (
+    <OverviewListItem>
+      {/* standard software list item with link */}
+      <Link
+        data-testid="software-grid-card"
+        href={`/software/${software.slug}`}
+        className="flex-1 flex hover:text-inherit"
+      >
+        <SoftwareListItemContent
+          statusBanner={
+            <StatusBanner
+              status="approved"
+              is_published={software.is_published}
+              width='auto'
+              borderRadius='0.125rem'
+            />
+          }
+          {...software}
+        />
+      </Link>
+      {/* admin menu */}
+      <div className="flex mx-2">
+        <div className="flex items-center gap-2 mx-1">
+
+        </div>
+        <IconBtnMenuOnAction
+          options={menuOptions}
+          onAction={onAction}
+        />
+      </div>
+    </OverviewListItem>
+  )
+}

--- a/frontend/components/user/software/UserSoftwareOverview.tsx
+++ b/frontend/components/user/software/UserSoftwareOverview.tsx
@@ -1,19 +1,16 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
-
-import Link from 'next/link'
 
 import NoContent from '~/components/layout/NoContent'
 import GridOverview from '~/components/layout/GridOverview'
 import CardSkeleton from '~/components/cards/CardSkeleton'
 import {ProjectLayoutType} from '~/components/search/ToggleViewGroup'
 import SoftwareOverviewList from '~/components/software/overview/list/SoftwareOverviewList'
-import OverviewListItem from '~/components/software/overview/list/OverviewListItem'
-import SoftwareListItemContent from '~/components/software/overview/list/SoftwareListItemContent'
-import SoftwareGridCard from '~/components/software/overview/cards/SoftwareGridCard'
+import UserSoftwareGridCard from './UserSoftwareGridCard'
 import {SoftwareByMaintainer} from './useUserSoftware'
+import UserSoftwareListItem from './UserSoftwareListItem'
 
 type UserSoftwareOverviewProps=Readonly<{
   layout: ProjectLayoutType
@@ -45,19 +42,7 @@ export default function UserSoftwareOverview({loading,skeleton_items,layout,soft
     return (
       <SoftwareOverviewList>
         {software.map(item => {
-          return (
-            <Link
-              data-testid="software-list-item"
-              key={item.id}
-              href={`/software/${item.slug}`}
-              className='hover:text-inherit'
-              title={item.brand_name}
-            >
-              <OverviewListItem className='pr-4'>
-                <SoftwareListItemContent key={item.id} {...item} />
-              </OverviewListItem>
-            </Link>
-          )
+          return <UserSoftwareListItem key={item.id} item={item}/>
         })}
       </SoftwareOverviewList>
     )
@@ -67,7 +52,7 @@ export default function UserSoftwareOverview({loading,skeleton_items,layout,soft
   return (
     <GridOverview fullWidth={true}>
       {software.map((item) => {
-        return <SoftwareGridCard key={item.id} {...item as any}/>
+        return <UserSoftwareGridCard key={item.id} item={item} />
       })}
     </GridOverview>
   )

--- a/frontend/components/user/software/useUserSoftware.tsx
+++ b/frontend/components/user/software/useUserSoftware.tsx
@@ -20,11 +20,14 @@ export type SoftwareByMaintainer={
   slug:string,
   brand_name:string,
   short_statement:string,
-  is_published:boolean,
   image_id:string|null
+  is_published:boolean,
   updated_at:string,
   contributor_cnt:number,
-  mention_cnt:number
+  mention_cnt:number,
+  keywords: string[] | null,
+  prog_lang: string[] | null,
+  licenses: string[] | null
 }
 
 export type UserSoftwareProp = {
@@ -40,11 +43,15 @@ export async function getSoftwareForMaintainer({
 ) {
   try {
     // baseUrl
-    let url =`/api/v1/rpc/software_by_maintainer?maintainer_id=${account}&order=brand_name`
+    let url =`/api/v1/rpc/software_by_maintainer?maintainer_id=${account}`
+
     // search
     if (searchFor) {
       const encodedSearch = encodeURIComponent(searchFor)
       url+=`&or=(brand_name.ilike."*${encodedSearch}*", short_statement.ilike."*${encodedSearch}*")`
+    }else{
+      // default order by is_published
+      url+='&order=is_published,brand_name'
     }
     // pagination
     url += paginationUrlParams({rows, page})

--- a/frontend/components/user/software/useUserSoftwareActions.tsx
+++ b/frontend/components/user/software/useUserSoftwareActions.tsx
@@ -1,0 +1,78 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+'use client'
+
+import {useState} from 'react'
+import {useRouter} from 'next/navigation'
+
+import logger from '~/utils/logger'
+import {useSession} from '~/auth/AuthProvider'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {patchSoftwareTable} from '~/components/software/edit/information/patchSoftwareTable'
+import useUserMenuOptions, {UserMenuAction} from '~/components/user/project/useUserMenuOptions'
+import {SoftwareByMaintainer} from './useUserSoftware'
+
+export default function useUserSoftwareActions({item}:{item:SoftwareByMaintainer}) {
+  const router = useRouter()
+  const {token} = useSession()
+  const {showErrorMessage} = useSnackbar()
+  const [software, setSoftware] = useState(item)
+  // dynamic menu options
+  const menuOptions = useUserMenuOptions({
+    is_published: software.is_published
+  })
+
+  async function publishSoftware({is_published}:{is_published:boolean}){
+    const resp = await patchSoftwareTable({
+      id: software.id,
+      data:{
+        is_published
+      },
+      token
+    })
+
+    if (resp.status===200){
+      // update local software object
+      setSoftware({
+        ...software,
+        is_published
+      })
+    }else{
+      showErrorMessage(`Failed to update ${software.brand_name}. ${resp.message}`)
+    }
+  }
+
+  function onAction(action: UserMenuAction){
+    switch(action.type){
+      case 'VIEW':
+        // open software page for view
+        router.push(`/software/${software.slug}`)
+        break
+      case 'EDIT':
+        // open software page for editing
+        router.push(`/software/${software.slug}/edit`)
+        break
+      case 'PUBLISH':
+        publishSoftware({
+          is_published: true
+        })
+        break
+      case 'UNPUBLISH':
+        publishSoftware({
+          is_published: false
+        })
+        break
+      default:
+        logger(`Action type ${action.type} NOT SUPPORTED. Check your spelling.`, 'warn')
+    }
+  }
+
+  return {
+    software,
+    menuOptions,
+    onAction,
+  }
+}


### PR DESCRIPTION
# Additional functionality for user overview of software and projects

Closes #1633

Changes proposed in this pull request:
* Add not-published tag to user card and list item on software and project overview page.
* Add user menu on the card/list item to edit/view and publish/unpublish item.
* Default order of the cards is changed to: not-published, title. Previously the order was only on title, now first items are not-published items. In combination with not-published tag it makes easy for user to find not published items. In addition, new card menu makes it possible to publish/unpublish item directly from the overview (see example images).

How to test:
* `make start` to build new solution and generate test data.
* login as rsd-admin. Then you can invite yourself to become maintainer of any software/project.
* Become maintainer of some software and project items. You can also create new software and project items.
* Navigate to user overview and confirm that menu items are present and that you can: edit, view, publish and unpublish software entries. Confirm that this is possible from card and list item.

## User software overview example
<img width="1586" height="1316" alt="image" src="https://github.com/user-attachments/assets/51c611a6-b96f-448f-86cb-dcc2fe711bf9" />

## User projects overview example
<img width="1565" height="1317" alt="image" src="https://github.com/user-attachments/assets/1d54fae7-ae10-475a-b2fc-93e0bfebf63f" />

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
