### PR TITLE
fix: minor theme fixes and remove project start, end date

### DIFF
--- a/frontend/components/AppFooter/CustomLinks.tsx
+++ b/frontend/components/AppFooter/CustomLinks.tsx
@@ -17,7 +17,6 @@ export default function CustomLinks({links=[]}:{links:CustomLink[]}) {
           <a
             key={link.url}
             href={link.url}
-            className="hover:text-primary"
             target={link.target}
             rel="noreferrer">
             {link.label}

--- a/frontend/components/AppFooter/MarkdownPages.tsx
+++ b/frontend/components/AppFooter/MarkdownPages.tsx
@@ -21,7 +21,6 @@ export default function MarkdownPages({pages=[]}: {pages: RsdLink[]}) {
           <Link
             key={page.slug}
             href={`/page/${page.slug}`}
-            className="hover:text-primary"
             passHref>
             {page.title}
           </Link>

--- a/frontend/components/AppHeader/AddMenu.tsx
+++ b/frontend/components/AppHeader/AddMenu.tsx
@@ -65,9 +65,9 @@ export default function AddMenu() {
         onClick={handleClick}
         sx={{
           color: 'primary.contrastText',
-          '&:hover': {
-            color: 'primary.main'
-          },
+          // '&:hover': {
+          //   color: 'primary.main'
+          // },
           alignSelf: 'center',
           '&:focus-visible': {
             outline: 'auto'

--- a/frontend/components/layout/EditPageButton.tsx
+++ b/frontend/components/layout/EditPageButton.tsx
@@ -6,7 +6,8 @@
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
-
+'use client'
+import Link from 'next/link'
 import EditIcon from '@mui/icons-material/Edit'
 import Button from '@mui/material/Button'
 import EditFab from './EditFab'
@@ -66,8 +67,7 @@ export default function EditPageButton({title, url, isMaintainer, variant}: Edit
             // minWidth: '6rem'
           }}
           href={url}
-          // this causes unexpected error after upgrade to v16
-          // LinkComponent={Link}
+          LinkComponent={Link}
         >
           {/* Edit page */}
           {title}

--- a/frontend/components/layout/ViewPageButton.tsx
+++ b/frontend/components/layout/ViewPageButton.tsx
@@ -6,10 +6,10 @@
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
-
+'use client'
+import Link from 'next/link'
 import ArticleOutlinedIcon from '@mui/icons-material/ArticleOutlined'
 import Button from '@mui/material/Button'
-import Link from 'next/link'
 
 type ViewButtonProps = {
   title: string,

--- a/frontend/components/projects/edit/information/AutosaveProjectPeriod.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectPeriod.tsx
@@ -91,7 +91,6 @@ export default function AutosaveProjectPeriod({date_start, date_end}:
         options={{
           name: 'date_start',
           label: '',
-          helperTextMessage: 'Month / Day / Year',
           defaultValue: date_start,
           useNull: true,
           muiProps:{
@@ -114,7 +113,6 @@ export default function AutosaveProjectPeriod({date_start, date_end}:
         options={{
           name: 'date_end',
           label: '',
-          helperTextMessage: 'Month / Day / Year',
           defaultValue: date_end,
           useNull: true,
           muiProps:{

--- a/frontend/components/software/edit/organisations/FindOrganisation.tsx
+++ b/frontend/components/software/edit/organisations/FindOrganisation.tsx
@@ -100,8 +100,8 @@ export default function FindOrganisation({onAdd, onCreate}:
     return (
       <li
         data-testid="find-organisation-option"
-        key={option.key}
         {...props}
+        key={option.key}
       >
         <FindOrganisationItem {...option.data} />
       </li>

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
# Minor theme fix and start/end date

Closes #1660

Changes proposed in this pull request:
* Removed custom theme interventions we had in base RSD that do not play well with other themes
* Removed default help message of start and end date on the edit project page
* Fix EditPageButton use of Link component after upgrade to v16

How to test:
* `make start` to build and generate test data
* Check add button styles in the page header
* Check page links at the bottom right of the page footer
* Check project start end date labels (removed fixed date format that does not follow regional settings).

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
