### PR TITLE
1693 parse archived response

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2021 - 2023 dv4all
-# SPDX-FileCopyrightText: 2021 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2021 - 2025 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2021 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2021 - 2026 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre for Environmental Research (UFZ)
@@ -165,9 +165,6 @@ services:
     image: rsd/scrapers:2.0.1
     environment:
       # it uses values from .env file
-      - POSTGRES_DB
-      - POSTGRES_USER
-      - POSTGRES_PASSWORD
       - POSTGREST_URL
       - MAX_REQUESTS_GITHUB
       - MAX_REQUESTS_GITLAB

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitlabScraper.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/git/GitlabScraper.java
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -189,7 +189,7 @@ public class GitlabScraper implements GitScraper {
 		}
 	}
 
-	private Boolean checkIfArchived() throws IOException, InterruptedException, RsdResponseException {
+	private Boolean checkIfArchived() {
 		String graphqlQuery = String.format(
 			"""
 			{
@@ -204,12 +204,28 @@ public class GitlabScraper implements GitScraper {
 		JsonObject body = new JsonObject();
 		body.addProperty("query", graphqlQuery);
 		String response = Utils.post(graphqlUri, body.toString(), "Content-Type", "application/json");
+		return parseArchivedResponse(response);
+	}
+
+	static Boolean parseArchivedResponse(String response) {
 		JsonObject jsonObject = JsonParser.parseString(response).getAsJsonObject();
-		return jsonObject
-			.getAsJsonObject("data")
-			.getAsJsonObject("project")
-			.getAsJsonPrimitive("archived")
-			.getAsBoolean();
+
+		JsonElement dataElement = jsonObject.get("data");
+		if (dataElement == null || !dataElement.isJsonObject()) {
+			return null;
+		}
+
+		JsonElement projectElement = dataElement.getAsJsonObject().get("project");
+		if (projectElement == null || !projectElement.isJsonObject()) {
+			return null;
+		}
+
+		JsonElement archivedElement = projectElement.getAsJsonObject().get("archived");
+		if (archivedElement == null || !archivedElement.isJsonPrimitive()) {
+			return null;
+		}
+
+		return archivedElement.getAsJsonPrimitive().isBoolean() ? archivedElement.getAsBoolean() : null;
 	}
 
 	static BasicGitData parseBasicData(String json, Boolean archived) {

--- a/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperTest.java
+++ b/scrapers/src/test/java/nl/esciencecenter/rsd/scraper/git/GithubScraperTest.java
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class GithubScraperTest {
 
@@ -70,5 +72,23 @@ class GithubScraperTest {
 	void givenGitRepoUrl_whenCreatingScraper_thenRemoveGitSuffix() {
 		Optional<GithubScraper> scraper = GithubScraper.create(githubUrlPrefix + repoGit);
 		Assertions.assertEquals(repo, scraper.get().organisation + "/" + scraper.get().repo);
+	}
+
+	@Test
+	void givenFullIsArchivedResponse_whenParsing_thenCorrectResultReturned() {
+		String trueResponse = "{\"data\": {\"project\": {\"archived\": true}}}";
+		Assertions.assertEquals(Boolean.TRUE, GitlabScraper.parseArchivedResponse(trueResponse));
+
+		String falseResponse = "{\"data\": {\"project\": {\"archived\": false}}}";
+		Assertions.assertEquals(Boolean.FALSE, GitlabScraper.parseArchivedResponse(falseResponse));
+
+		String nullResponse = "{\"data\": {\"project\": {\"archived\": null}}}";
+		Assertions.assertNull(GitlabScraper.parseArchivedResponse(nullResponse));
+	}
+
+	@ParameterizedTest
+	@ValueSource(strings = { "{\"data\": {\"project\": null}}", "{\"data\": null}", "{}" })
+	void givenIncompleteIsArchivedResponse_whenParsing_thenCorrectResultReturned(String response) {
+		Assertions.assertNull(GitlabScraper.parseArchivedResponse(response));
 	}
 }


### PR DESCRIPTION
## Fix GitLab harvester

### Changes proposed in this pull request

* Check properly the structure of the response from the GitLab when parsing the GraphQL response to see whether a repository is archived
* remove unused env variables for the scrapers

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, add software
* Add https://gitlab.utwente.nl/bss_development/movement-science/fpa-estimation and https://git.iws.uni-stuttgart.de/dumux-repositories/dumux as repos (both GitLab) to the software
* Wait for the basic data harvester to run or run `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainBasicData`
* There should be no errors in the error logs
* The entries on http://localhost/api/v1/repository_url should have `null` and `false` respectively as value for `archived`

closes #1693
closes #1690

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests