### PR TITLE
Fix CodeMeta service

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
 #
@@ -14,11 +14,13 @@ on:
       - main
     paths:
       - "backend-postgrest/**"
+      - "codemeta/**"
       - "database/**"
       - "backend-tests/**"
   pull_request:
     paths:
       - "backend-postgrest/**"
+      - "codemeta/**"
       - "database/**"
       - "backend-tests/**"
 

--- a/backend-tests/README.md
+++ b/backend-tests/README.md
@@ -38,21 +38,22 @@ Each class containing tests should be annotated with `@ExtendWith({SetupAllTests
 
 This section assumes that you are in the root directory of the project.
 
-The easiest way to run the tests is with `make`. Make sure no other RSD containers are running.
+The easiest way to run the tests is with `make` from the _parent directory_. Make sure no other RSD containers are running.
 
 ```shell
 make run-backend-tests
 ```
 
-You can also run the tests directly with `docker compose`.
+You can also run the tests directly with `docker compose` from _this directory_.
 ```shell
-docker compose --file backend-tests/docker-compose.yml down --volumes && \
-docker compose --file backend-tests/docker-compose.yml build --parallel && \
-docker compose --file backend-tests/docker-compose.yml up
+docker compose down --volumes && \
+docker compose build --parallel && \
+docker compose up
 ```
-This leaves the containers running, so you can inspect the database if necessary. To clean up run
+
+_This leaves the containers running_, so you can inspect the database if necessary. To clean up run
 ```shell
-docker compose --file backend-tests/docker-compose.yml down --volumes
+docker compose down --volumes
 ```
 
 ### From an IDE
@@ -60,5 +61,6 @@ If you use an IDE that supports [JUnit](https://junit.org/), you can run each te
 Make sure to have set the following environment variables:
 - `POSTGREST_URL`
 - `PGRST_JWT_SECRET`
+- `CODEMETA_URL=http://localhost:80/metadata/codemeta`
 
 Check your `.env` file for the values, but you should **EXPLICITELY** add the port number to `POSTGREST_URL` (which is most likely `80`).

--- a/backend-tests/docker-compose.yml
+++ b/backend-tests/docker-compose.yml
@@ -1,5 +1,5 @@
-# SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -47,6 +47,20 @@ services:
     networks:
       - net-test
 
+  codemeta:
+    container_name: codemeta-test
+    build: ../codemeta
+    image: rsd/codemeta-test:1.0.0
+    ports:
+      # enable connection from outside
+      - "8000:8000"
+    environment:
+      - POSTGREST_URL
+    depends_on:
+      - "database"
+    networks:
+      - net-test
+
   postgrest-tests:
     container_name: postgrest-tests
     build:
@@ -57,6 +71,7 @@ services:
     environment:
       - PGRST_JWT_SECRET=normally_this_is_a_secret_string_that_none_knows_BUT_this_is_just_a_test
       - POSTGREST_URL=http://backend:3500
+      - CODEMETA_URL=http://codemeta:8000
     depends_on:
       - "database"
       - "backend"

--- a/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -214,7 +214,7 @@ public class AuthenticationIntegrationTest {
 		String categoryId = createUniqueCategory("long name", "short name", null);
 
 		User user = User.create();
-		String softwareId = user.createSoftware("Software 1");
+		String softwareId = user.createSoftware("Software 1").id();
 		requestAddCategoryForSoftware(user, softwareId, categoryId).then().statusCode(201);
 	}
 
@@ -223,7 +223,7 @@ public class AuthenticationIntegrationTest {
 		String categoryId = createUniqueCategory("long name", "short name", null);
 
 		User user1 = User.create();
-		String softwareId = user1.createSoftware("Software 1");
+		String softwareId = user1.createSoftware("Software 1").id();
 
 		User user2 = User.create();
 		requestAddCategoryForSoftware(user2, softwareId, categoryId).then().statusCode(403);
@@ -234,7 +234,7 @@ public class AuthenticationIntegrationTest {
 		String[] catIds = createCategoryTreeExample1();
 
 		User user = User.create();
-		String softwareId = user.createSoftware("Software 1");
+		String softwareId = user.createSoftware("Software 1").id();
 
 		addCategoryForSoftware(user, softwareId, catIds[0]);
 		addCategoryForSoftware(user, softwareId, catIds[1]);

--- a/backend-tests/src/test/java/nl/esciencecenter/CodemetaIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/CodemetaIntegrationTest.java
@@ -1,0 +1,41 @@
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+import io.restassured.RestAssured;
+import java.net.URI;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({ SetupAllTests.class })
+public class CodemetaIntegrationTest {
+
+	private static final String codemetaUrl = System.getenv("CODEMETA_URL");
+	private static final String codemetaEntryUrlUnformatted = codemetaUrl + "/v3/%s";
+
+	@Test
+	void whenSendingHeadRequestToCodemetaOverviewPage_thenSuccessResponseReturned() {
+		RestAssured.head(URI.create(codemetaUrl)).then().statusCode(200);
+	}
+
+	@Test
+	void givenPublishedSoftwarePage_whenCodemetaApiCalled_thenCorrectResponseReturned() {
+		User user = User.create();
+		SoftwareMetadata softwareMetadata = user.createSoftware("CodeMeta software");
+		String slug = softwareMetadata.slug();
+
+		RestAssured.get(createCodemetaEntryUrl(slug))
+			.then()
+			.statusCode(200)
+			.body("name", Matchers.equalTo(softwareMetadata.brandName()))
+			.body("description[0]", Matchers.equalTo(softwareMetadata.shortStatement()));
+	}
+
+	private static URI createCodemetaEntryUrl(String slug) {
+		return URI.create(codemetaEntryUrlUnformatted.formatted(slug));
+	}
+}

--- a/backend-tests/src/test/java/nl/esciencecenter/SetupAllTests.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/SetupAllTests.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -70,8 +70,7 @@ public class SetupAllTests implements BeforeAllCallback {
 	}
 
 	public static void setupRestAssured() {
-		String backendUri = System.getenv("POSTGREST_URL");
-		RestAssured.baseURI = backendUri;
+		RestAssured.baseURI = System.getenv("POSTGREST_URL");
 		RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
 
 		String secret = System.getenv("PGRST_JWT_SECRET");

--- a/backend-tests/src/test/java/nl/esciencecenter/SoftwareMetadata.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/SoftwareMetadata.java
@@ -1,0 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+public record SoftwareMetadata(String id, String slug, String brandName, String shortStatement) {}

--- a/backend-tests/src/test/java/nl/esciencecenter/User.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/User.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -39,6 +39,10 @@ public class User {
 		return new User(accountId, hasAgreedTerms);
 	}
 
+	/**
+	 *
+	 * @return a user that has accepted the terms and conditions
+	 */
 	static User create() {
 		return create(true);
 	}
@@ -59,14 +63,16 @@ public class User {
 		return this;
 	}
 
-	String createSoftware(String brand_name) {
+	SoftwareMetadata createSoftware(String brand_name) {
 		JsonObject obj = new JsonObject();
-		obj.addProperty("slug", "slug-" + Commons.createUUID());
+		String slug = "slug-" + Commons.createUUID();
+		obj.addProperty("slug", slug);
 		obj.addProperty("brand_name", brand_name);
 		obj.addProperty("is_published", true);
-		obj.addProperty("short_statement", "Test software for testing");
+		String shortStatement = "Test software for testing";
+		obj.addProperty("short_statement", shortStatement);
 
-		return RestAssured.given()
+		String softwareId = RestAssured.given()
 			.header(authHeader)
 			.header(Commons.requestEntry)
 			.contentType(ContentType.JSON)
@@ -77,10 +83,12 @@ public class User {
 			.statusCode(201)
 			.extract()
 			.path("[0].id");
+
+		return new SoftwareMetadata(softwareId, slug, brand_name, shortStatement);
 	}
 
 	// To create User objects use create() instead.
-	User(String accountId, boolean hasAgreedTerms) {
+	private User(String accountId, boolean hasAgreedTerms) {
 		this.accountId = accountId;
 		token = createJwtToken(accountId);
 		authHeader = new Header("Authorization", "bearer " + token);

--- a/codemeta/src/main.go
+++ b/codemeta/src/main.go
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +16,7 @@ import (
 	"os"
 	"regexp"
 	"slices"
+	"sort"
 )
 
 type RsdSoftware struct {
@@ -39,7 +40,7 @@ type RsdSoftware struct {
 	License []struct {
 		License string `json:"license"`
 	} `json:"license_for_software"`
-	RepositoryURL *struct {
+	RepositoryURL []struct {
 		URL       string             `json:"url"`
 		Languages map[string]float64 `json:"languages"`
 	} `json:"repository_url"`
@@ -195,16 +196,13 @@ func convertRsdToCodeMeta(bytes []byte) ([]byte, error) {
 		Type:                 "SoftwareApplication",
 		Name:                 rsdResponse.BrandName,
 		Description:          extractDescription(rsdResponse),
+		CodeRepository:       extractRepositoryUrls(rsdResponse),
 		Author:               extractContributors(rsdResponse),
 		Keywords:             extractKeywords(rsdResponse),
 		ProgrammingLanguage:  extractProgrammingLanguages(rsdResponse),
 		License:              extractLicenses(rsdResponse),
 		ReferencePublication: extractReferencePublications(rsdResponse),
 		DownloadUrl:          []string{},
-	}
-
-	if rsdResponse.RepositoryURL != nil {
-		codemetaData.CodeRepository = &rsdResponse.RepositoryURL.URL
 	}
 
 	jsonBytes, err := json.Marshal(codemetaData)
@@ -249,30 +247,20 @@ func extractKeywords(rsdSoftware RsdSoftware) []string {
 }
 
 func extractProgrammingLanguages(rsdSoftware RsdSoftware) []string {
-	result := []string{}
+	languagesSorted := []string{}
 
 	if rsdSoftware.RepositoryURL == nil {
-		return result
+		return languagesSorted
 	}
 
-	for k := range rsdSoftware.RepositoryURL.Languages {
-		result = append(result, k)
-	}
-
-	slices.SortFunc(result, func(a, b string) int {
-		valA := rsdSoftware.RepositoryURL.Languages[a]
-		valB := rsdSoftware.RepositoryURL.Languages[b]
-
-		if valA > valB {
-			return -1
-		} else if valA < valB {
-			return 1
-		} else {
-			return 0
+	for _, repoUrlEntry := range rsdSoftware.RepositoryURL {
+		for lang := range repoUrlEntry.Languages {
+			languagesSorted = append(languagesSorted, lang)
 		}
-	})
+	}
 
-	return result
+	sort.Strings(languagesSorted)
+	return slices.Compact(languagesSorted)
 }
 
 func extractLicenses(rsdSoftware RsdSoftware) terms.SingleOrArray[terms.CreativeWorkOrUrl] {
@@ -313,6 +301,16 @@ func extractReferencePublications(rsdSoftware RsdSoftware) []terms.ScholarlyArti
 	}
 
 	return result
+}
+
+func extractRepositoryUrls(rsdSoftware RsdSoftware) terms.SingleOrArray[string] {
+	result := []string{}
+
+	for _, repoUrlEntry := range rsdSoftware.RepositoryURL {
+		result = append(result, repoUrlEntry.URL)
+	}
+
+	return terms.SingleOrArray[string]{nil, result}
 }
 
 func extractContributors(rsdSoftware RsdSoftware) []terms.Person {

--- a/codemeta/src/scrapers/4tu.go
+++ b/codemeta/src/scrapers/4tu.go
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -689,7 +689,7 @@ func saveLicensesForSoftware(id string, software terms.SoftwareApplication, admi
 }
 
 func saveRepositoryUrlForSoftware(id string, software terms.SoftwareApplication, adminJwt string, backendUrl string) error {
-	if software.CodeRepository == nil {
+	if software.CodeRepository.Single == nil && (software.CodeRepository.Array == nil || len(software.CodeRepository.Array) == 0) {
 		request, err := http.NewRequest("DELETE", backendUrl+"/repository_url_for_software?software=eq."+id, nil)
 		if err != nil {
 			return err
@@ -705,64 +705,77 @@ func saveRepositoryUrlForSoftware(id string, software terms.SoftwareApplication,
 		CodePlatform string `json:"code_platform"`
 	}
 
-	repositoryUrl := rsdRepositoryUrl{
-		Url:          *software.CodeRepository,
-		CodePlatform: "4tu",
+	var repos = []rsdRepositoryUrl{}
+
+	if software.CodeRepository.Single != nil {
+		repos = append(repos, rsdRepositoryUrl{
+			Url:          *software.CodeRepository.Single,
+			CodePlatform: "4tu",
+		})
+	} else {
+		for _, repoUrl := range software.CodeRepository.Array {
+			repos = append(repos, rsdRepositoryUrl{
+				Url:          repoUrl,
+				CodePlatform: "4tu",
+			})
+		}
 	}
 
-	body, err := json.Marshal(&repositoryUrl)
-	if err != nil {
-		return err
-	}
+	for _, repoUrlEntry := range repos {
+		body, err := json.Marshal(&repoUrlEntry)
+		if err != nil {
+			return err
+		}
 
-	request, err := http.NewRequest("POST", backendUrl+"/repository_url?select=id&on_conflict=url", bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
+		request, err := http.NewRequest("POST", backendUrl+"/repository_url?select=id&on_conflict=url", bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
 
-	request.Header.Add("Authorization", "Bearer "+adminJwt)
-	request.Header.Add("Prefer", "resolution=merge-duplicates")
-	request.Header.Add("Prefer", "return=representation")
-	resp, err := defaultClient.Do(request)
-	if err != nil {
-		return err
-	}
+		request.Header.Add("Authorization", "Bearer "+adminJwt)
+		request.Header.Add("Prefer", "resolution=merge-duplicates")
+		request.Header.Add("Prefer", "return=representation")
+		resp, err := defaultClient.Do(request)
+		if err != nil {
+			return err
+		}
 
-	bodyBytes, err := utils.ReadBody(resp)
-	type repoUrlIdResponse struct {
-		Id string `json:"id"`
-	}
-	var responseContainer []repoUrlIdResponse
-	err = json.Unmarshal(bodyBytes, &responseContainer)
-	if err != nil {
-		return err
-	}
+		bodyBytes, err := utils.ReadBody(resp)
+		type repoUrlIdResponse struct {
+			Id string `json:"id"`
+		}
+		var responseContainer []repoUrlIdResponse
+		err = json.Unmarshal(bodyBytes, &responseContainer)
+		if err != nil {
+			return err
+		}
 
-	type rsdRepositoryForSoftware struct {
-		RepoId     string `json:"repository_url"`
-		SoftwareId string `json:"software"`
-	}
+		type rsdRepositoryForSoftware struct {
+			RepoId     string `json:"repository_url"`
+			SoftwareId string `json:"software"`
+		}
 
-	repositoryUrlForSoftware := rsdRepositoryForSoftware{
-		RepoId:     responseContainer[0].Id,
-		SoftwareId: id,
-	}
+		repositoryUrlForSoftware := rsdRepositoryForSoftware{
+			RepoId:     responseContainer[0].Id,
+			SoftwareId: id,
+		}
 
-	body, err = json.Marshal(&repositoryUrlForSoftware)
-	if err != nil {
-		return err
-	}
+		body, err = json.Marshal(&repositoryUrlForSoftware)
+		if err != nil {
+			return err
+		}
 
-	request, err = http.NewRequest("POST", backendUrl+"/repository_url_for_software", bytes.NewReader(body))
-	if err != nil {
-		return err
-	}
+		request, err = http.NewRequest("POST", backendUrl+"/repository_url_for_software", bytes.NewReader(body))
+		if err != nil {
+			return err
+		}
 
-	request.Header.Add("Authorization", "Bearer "+adminJwt)
-	request.Header.Add("Prefer", "resolution=ignore-duplicates")
-	_, err = defaultClient.Do(request)
-	if err != nil {
-		return err
+		request.Header.Add("Authorization", "Bearer "+adminJwt)
+		request.Header.Add("Prefer", "resolution=ignore-duplicates")
+		_, err = defaultClient.Do(request)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/codemeta/src/terms/terms.go
+++ b/codemeta/src/terms/terms.go
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -107,7 +107,7 @@ type SoftwareApplication struct {
 	Id                   *string                          `json:"identifier"`
 	Name                 string                           `json:"name"`
 	Description          SingleOrArray[string]            `json:"description"`
-	CodeRepository       *string                          `json:"codeRepository"`
+	CodeRepository       SingleOrArray[string]            `json:"codeRepository"`
 	Author               []Person                         `json:"author"`
 	Keywords             []string                         `json:"keywords"`
 	ProgrammingLanguage  []string                         `json:"programmingLanguage"`


### PR DESCRIPTION
## Fix CodeMeta service

### Changes proposed in this pull request

* Fix CodeMeta API to make use of having multiple repos for one software page
* Adapt the 4TU harvester as well

### How to test

* In your `.env` set `ENABLE_4TU_SCRAPER=true`
* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Check http://localhost/metadata/codemeta/ and some of the entries
* `docker compose down --volumes && docker compose up --scale data-generation=0`
* Sign in as admin, create a software page with repo URLs `https://github.com/research-software-directory/RSD-as-a-service` and `https://github.com/research-software-directory/KIN-RPD` and publish it
* Check this entry on http://localhost/metadata/codemeta/
* `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages`
* Check the entry again, no duplicate languages should appear (especially "TypeScript" and "JavaScript")
* Create a community with slug `4tu`
* `docker compose exec codemeta /usr/local/bin/scraper-4tu`
* Check if the software appears on the community page
* Check the CodeMeta entries, most of them should have a CodeRepository (in an array)
* `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages` (run a few times)
* Check if the languages appear (check http://localhost/api/v1/software?select=slug,brand_name,repository_url!inner(languages_scraped_at,languages)&repository_url.languages_scraped_at=not.is.null to find harvested entries more easily)

closes #1700
closes #1702

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests