### PR TITLE
More lenient `Bearer` keyword

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/accesstoken/ProxyWithAccessTokenBeforeHandler.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/accesstoken/ProxyWithAccessTokenBeforeHandler.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,25 +23,35 @@ public class ProxyWithAccessTokenBeforeHandler implements Handler {
 
 	@Override
 	public void handle(@NotNull Context ctx) throws IOException, InterruptedException {
-		String authHeader = ctx.header("Authorization");
+		String authHeaderValue = ctx.header("Authorization");
 
-		if (authHeader == null) {
+		if (authHeaderValue == null) {
 			// the request is from the frontend, skip access token validation
 			return;
 		}
 
-		if (!authHeader.startsWith("Bearer ")) {
+		String[] authHeaderValueSplit = authHeaderValue.split(" ");
+		if (authHeaderValueSplit.length != 2) {
 			String jsonError = JsonErrorMessageCreator.createErrorJson(
 				INVALID_ACCESS_TOKEN_MESSAGE,
-				List.of("The Authorization header must start with \"Bearer \"")
+				List.of("The Authorization header value has to contain exactly one space")
 			);
 
 			ctx.status(HttpStatus.UNAUTHORIZED).json(jsonError).skipRemainingHandlers();
 			return;
 		}
 
-		// length of "Bearer "
-		String authToken = authHeader.substring(7);
+		if (!"bearer".equalsIgnoreCase(authHeaderValueSplit[0])) {
+			String jsonError = JsonErrorMessageCreator.createErrorJson(
+				INVALID_ACCESS_TOKEN_MESSAGE,
+				List.of("The Authorization header value must start with \"Bearer \" (case insensitive)")
+			);
+
+			ctx.status(HttpStatus.UNAUTHORIZED).json(jsonError).skipRemainingHandlers();
+			return;
+		}
+
+		String authToken = authHeaderValueSplit[1];
 
 		String[] tokenParts = authToken.split("\\.", 2);
 		if (tokenParts.length < 2) {

--- a/documentation/docs/02-API/01-rest-api.md
+++ b/documentation/docs/02-API/01-rest-api.md
@@ -23,7 +23,7 @@ You can visit the [Swagger UI here](https://research-software-directory.org/swag
 
 When wanting to use the REST API via an API access token (as described in [User settings](/users/user-settings#api-access-tokens)), requests need to be made to the endpoint `/api/v2`, which mirrors `/api/v1`. You can find all available endpoints and corresponding data fields in [Swagger](https://research-software-directory.org/swagger/).
 
-The token that you copied after generating it, needs to be provided in the `Authorization` header of the request.
+The token that you copied after generating it, needs to be provided in the `Authorization` header of the request. The value of this header needs to have the form `Bearer <token>`, where the `Bearer` keyword is case insensitive and where you replace `<token>` with your token.
 
 #### Example 1: Get your software entries
 
@@ -37,10 +37,10 @@ The token that you copied after generating it, needs to be provided in the `Auth
         PROFILE_ID="YOUR_PROFILE_ID"
 
         curl \
-                -X POST \
-                -H "Authorization: Bearer $TOKEN" \
-                -H "Content-Type: application/json" \
-                -d "{"maintainer_id": $PROFILE_ID}"\
+                --request POST \
+                --header "Authorization: Bearer $TOKEN" \
+                --header "Content-Type: application/json" \
+                --data '{"maintainer_id": "'$PROFILE_ID'"}' \
                 ${API_URL}/rpc/software_by_maintainer
         ```
     </TabItem>
@@ -50,11 +50,11 @@ The token that you copied after generating it, needs to be provided in the `Auth
 import requests
 
 accessToken = "MY_TOKEN" # replace with your Access Token String
-profileID = "MY_PROFILE_ID" # replace with your profile id, you can find it under Profile Settings
+profileID = "MY_PROFILE_ID" # replace with your profile ID, you can find it under Profile Settings
 
 params = {"maintainer_id": profileID}
 
-url = f"http://research-software-directory.org/api/v2/rpc/software_by_maintainer"
+url = f"https://research-software-directory.org/api/v2/rpc/software_by_maintainer"
 headers = {
     'Authorization': f'Bearer {accessToken}',
     'Content-Type': "application/json"
@@ -78,10 +78,10 @@ print(response.json())
         TOKEN="YOUR-ACCESS-TOKEN"
 
         curl \
-                -X POST \
-                -H "Authorization: Bearer $TOKEN" \
-                -H "Content-Type: application/json" \
-                -d '{"slug":"'$1'","brand_name":"'$1'"}'\
+                --request POST \
+                --header "Authorization: Bearer $TOKEN" \
+                --header "Content-Type: application/json" \
+                --data '{"slug":"my-software","brand_name":"My Software"}' \
                 ${API_URL}/software
         ```
     </TabItem>
@@ -92,7 +92,7 @@ print(response.json())
 
         accessToken = "MY_TOKEN" # replace with your Access Token String
 
-        url = "http://research-software-directory.org/api/v2/software"
+        url = "https://research-software-directory.org/api/v2/software"
         data = {"slug": "test-software", "brand_name": "TEST-Software", "description": "My new software entry"}
         headers = {
             'Authorization': f'Bearer {accessToken}',

--- a/documentation/docs/02-API/01-rest-api.md.license
+++ b/documentation/docs/02-API/01-rest-api.md.license
@@ -1,5 +1,5 @@
+SPDX-FileCopyrightText: 2023 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 
 SPDX-License-Identifier: CC-BY-4.0


### PR DESCRIPTION
## More lenient `Bearer` keyword

### Changes proposed in this pull request

* Make the `Bearer` keyword case insensitive for the access token API
* Expand the respective the docs

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, create an access token, try out the examples in the docs (make sure to use localhost), accept the terms and contitions and try again
* Try the examples with a different casing of `Bearer`
* When sending a malformed `Authorization` header, an error response should be returned

closes #1699

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [ ] Tests