### PR TITLE
fix: mobile phone page size

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@
 # SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 # SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -130,9 +131,9 @@ services:
       # rsd version passed into image
       # for release the tag is passed in GH action _ghcr.yml
       args:
-        APP_VERSION: "5.3.1"
+        APP_VERSION: "6.0.1"
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:5.3.1
+    image: rsd/frontend:6.0.1
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/app/(base)/add/layout.tsx
+++ b/frontend/app/(base)/add/layout.tsx
@@ -1,3 +1,7 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
 
 // force to be dynamic route
 export const dynamic = 'force-dynamic'
@@ -16,7 +20,7 @@ export default function AddLayout({
 }>) {
 
   return (
-    <article className="flex-1 pt-12">
+    <article className="flex-1 p-4 lg:pt-12">
       {children}
     </article>
   )

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -31,6 +32,13 @@ import Announcement from '~/components/Announcement/Announcement'
 import ProgressProviderApp from '~/components/bprogress/ProgressProviderApp'
 
 import '~/styles/global.css'
+
+export const viewport = {
+  // Matches 30rem defined in global.css
+  width: 480,
+  // Do not use initialScale to allow smartphone to scale it properly
+  initialScale: -1,
+}
 
 export const metadata: Metadata = {
   title: 'Home',

--- a/frontend/components/admin/package-manager/AdminPacManListItem.tsx
+++ b/frontend/components/admin/package-manager/AdminPacManListItem.tsx
@@ -1,13 +1,14 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import IconButton from '@mui/material/IconButton'
-import ListItem from '@mui/material/ListItem'
 import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
 
+import ListItemWithAction from '~/components/layout/ListItemWithAction'
 import {PackageManager} from '~/components/software/edit/package-managers/apiPackageManager'
 import PackageManagerItemBody from '~/components/software/edit/package-managers/PackageManagerItemBody'
 
@@ -19,7 +20,7 @@ type AdminPacManListItemProps=Readonly<{
 
 export default function AdminPacManListItem({item,onEdit,onDelete}:AdminPacManListItemProps) {
   return (
-    <ListItem
+    <ListItemWithAction
       secondaryAction={
         <>
           <IconButton
@@ -46,6 +47,6 @@ export default function AdminPacManListItem({item,onEdit,onDelete}:AdminPacManLi
       }
     >
       <PackageManagerItemBody item={item} />
-    </ListItem>
+    </ListItemWithAction>
   )
 }

--- a/frontend/components/admin/package-manager/index.tsx
+++ b/frontend/components/admin/package-manager/index.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +24,7 @@ export default function AdminRepositories() {
   return (
     <SearchProvider>
       <PaginationProvider pagination={pagination}>
-        <section className="flex-1">
+        <section className="flex-1 overflow-hidden">
           <div className="flex flex-wrap items-center justify-end">
             <Searchbox />
             <Pagination />

--- a/frontend/components/admin/repositories/AdminRepoListItem.tsx
+++ b/frontend/components/admin/repositories/AdminRepoListItem.tsx
@@ -1,13 +1,14 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import IconButton from '@mui/material/IconButton'
-import ListItem from '@mui/material/ListItem'
 import DeleteIcon from '@mui/icons-material/Delete'
 import EditIcon from '@mui/icons-material/Edit'
 
+import ListItemWithAction from '~/components/layout/ListItemWithAction'
 import {RepositoryUrl} from '~/components/software/edit/repositories/apiRepositories'
 import RepositoryItemContent from '~/components/software/edit/repositories/RepositoryItemContent'
 
@@ -19,7 +20,7 @@ type AdminRepoListItemProps=Readonly<{
 
 export default function AdminRepoListItem({item,onEdit,onDelete}:AdminRepoListItemProps) {
   return (
-    <ListItem
+    <ListItemWithAction
       secondaryAction={
         <>
           <IconButton
@@ -46,6 +47,6 @@ export default function AdminRepoListItem({item,onEdit,onDelete}:AdminRepoListIt
       }
     >
       <RepositoryItemContent item={item}/>
-    </ListItem>
+    </ListItemWithAction>
   )
 }

--- a/frontend/components/admin/repositories/index.tsx
+++ b/frontend/components/admin/repositories/index.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +24,7 @@ export default function AdminRepositories() {
   return (
     <SearchProvider>
       <PaginationProvider pagination={pagination}>
-        <section className="flex-1">
+        <section className="flex-1 overflow-hidden">
           <div className="flex flex-wrap items-center justify-end">
             <Searchbox />
             <Pagination />

--- a/frontend/components/layout/ListItemWithAction.tsx
+++ b/frontend/components/layout/ListItemWithAction.tsx
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import ListItem, {ListItemProps} from '@mui/material/ListItem'
+/**
+ * ListItemWithAction changes the layout of list component. Instead of having secondaryAction
+ * component at absolute position we use it relative element in the flex. This ensures that
+ * button area is automatically resized to fix action buttons. Default layout is optimized for only 1 button
+ */
+export default function ListItemWithAction({children,secondaryAction,...otherProps}:ListItemProps) {
+  return (
+    <ListItem
+      sx={{
+        paddingLeft:'8px',
+        paddingRight: '8px',
+        '.MuiListItemSecondaryAction-root':{
+          display: 'flex',
+          position: 'relative',
+          right: 'auto',
+          transform: 'none',
+          top: 'inherit'
+        }
+      }}
+      secondaryAction={secondaryAction}
+      {...otherProps}
+    >
+      {children}
+    </ListItem>
+  )
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "5.3.0",
+  "version": "6.0.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/frontend/package.json.license
+++ b/frontend/package.json.license
@@ -6,6 +6,7 @@ SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.
 SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: CC-BY-4.0

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -108,6 +108,11 @@ html {
 
 body {
   font-size: 1rem;
+  /* minimal with to have logo,
+  add button, mobile menu and profile.
+  NOTE ! when changing this value we need to update
+  useDisableScrollLock hook in utils folder too.
+  */
   min-width: 30rem;
   /* fix jumping scrollbar */
   overflow: overlay;

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -4,8 +4,9 @@
  * SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
  * SPDX-FileCopyrightText: 2022 Marc Hanisch (GFZ) <marc.hanisch@gfz-potsdam.de>
  * SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
- * SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+ * SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
  * SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
+ * SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -107,11 +108,6 @@ html {
 
 body {
   font-size: 1rem;
-  /* minimal with to have logo,
-  add button, mobile menu and profile.
-  NOTE ! when changing this value we need to update
-  useDisableScrollLock hook in utils folder too.
-  */
   min-width: 30rem;
   /* fix jumping scrollbar */
   overflow: overlay;


### PR DESCRIPTION
# Mobile phone initial page width

Closes #1706

Changes proposed in this pull request:
* Fixed mobile page sizing of homepage
* Improved list component for mobile on admin pages

How to test:
* `make start` to build and generate test data. Confirm the mobile views open with full size page: F12 and then select various mobile phone views.
* I have put this fix on dev so [it can be verified with smartphone](https://research-software.dev/)

PR Checklist:

*   [x] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
