### PR TITLE
Integration tests for access tokens

### DIFF
--- a/.github/workflows/backend_tests.yml
+++ b/.github/workflows/backend_tests.yml
@@ -13,12 +13,14 @@ on:
     branches:
       - main
     paths:
+      - "authentication/**"
       - "backend-postgrest/**"
       - "codemeta/**"
       - "database/**"
       - "backend-tests/**"
   pull_request:
     paths:
+      - "authentication/**"
       - "backend-postgrest/**"
       - "codemeta/**"
       - "database/**"

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/accesstoken/CreateAccessTokenHandler.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/accesstoken/CreateAccessTokenHandler.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -47,6 +47,15 @@ public class CreateAccessTokenHandler implements Handler {
 			String jsonError = JsonErrorMessageCreator.createErrorJson(
 				INVALID_ACCESS_TOKEN_REQUEST_MESSAGE,
 				List.of("The expiry date should be in the future")
+			);
+
+			ctx.status(HttpStatus.BAD_REQUEST).json(jsonError);
+			return;
+		}
+		if (LocalDate.now().plusDays(365).isBefore(expiresAt)) {
+			String jsonError = JsonErrorMessageCreator.createErrorJson(
+				INVALID_ACCESS_TOKEN_REQUEST_MESSAGE,
+				List.of("The expiry date should not be more than one year in the future")
 			);
 
 			ctx.status(HttpStatus.BAD_REQUEST).json(jsonError);

--- a/backend-tests/docker-compose.yml
+++ b/backend-tests/docker-compose.yml
@@ -61,6 +61,23 @@ services:
     networks:
       - net-test
 
+  auth:
+    build: ../authentication
+    image: rsd/auth-tests:1.0.0
+    ports:
+      - "7000:7000"
+    environment:
+      # it uses values from .env file
+      - RSD_ENVIRONMENT=test
+      - POSTGREST_URL=http://backend:3500
+      - PGRST_JWT_SECRET=normally_this_is_a_secret_string_that_none_knows_BUT_this_is_just_a_test
+      - RSD_API_ACCESS_TOKEN_ENABLED=true
+    depends_on:
+      - "database"
+      - "backend"
+    networks:
+      - net-test
+
   postgrest-tests:
     container_name: postgrest-tests
     build:
@@ -72,6 +89,8 @@ services:
       - PGRST_JWT_SECRET=normally_this_is_a_secret_string_that_none_knows_BUT_this_is_just_a_test
       - POSTGREST_URL=http://backend:3500
       - CODEMETA_URL=http://codemeta:8000
+      - AUTH_URL=http://auth:7000/auth
+      - API_V2_URL=http://auth:7000/api/v2
     depends_on:
       - "database"
       - "backend"

--- a/backend-tests/src/test/java/nl/esciencecenter/AccessTokenIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AccessTokenIntegrationTest.java
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import io.restassured.http.Header;
+import java.time.LocalDate;
+import java.util.UUID;
+import java.util.random.RandomGenerator;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@ExtendWith({ SetupAllTests.class })
+public class AccessTokenIntegrationTest {
+
+	@Test
+	void givenUser_whenCreatingAccessTokenWithinYear_thenAccessTokenReturned() {
+		User user = User.create();
+
+		String accessTokenToday = user.createAndUseAccessToken("My access token", LocalDate.now());
+		Assertions.assertDoesNotThrow(() -> UUID.fromString(accessTokenToday.split("\\.")[0]));
+
+		String accessTokenYear = user.createAndUseAccessToken("My access token", LocalDate.now().plusDays(365));
+		Assertions.assertDoesNotThrow(() -> UUID.fromString(accessTokenYear.split("\\.")[0]));
+
+		String accessTokenWithinYear = user.createAndUseAccessToken(
+			"My access token",
+			LocalDate.now().plusDays(RandomGenerator.getDefault().nextInt(1, 365))
+		);
+		Assertions.assertDoesNotThrow(() -> UUID.fromString(accessTokenWithinYear.split("\\.")[0]));
+	}
+
+	@Test
+	void givenUser_whenCreatingAccessTokenInPast_thenErrorReturned() {
+		User user = User.create();
+
+		user.createAccessToken("My access token", LocalDate.now().minusDays(1)).then().statusCode(400);
+
+		user
+			.createAccessToken(
+				"My access token",
+				LocalDate.now().minusDays(RandomGenerator.getDefault().nextInt(2, Integer.MAX_VALUE))
+			)
+			.then()
+			.statusCode(400);
+	}
+
+	@Test
+	void givenUser_whenCreatingAccessTokenBeyondOneYear_thenErrorReturned() {
+		User user = User.create();
+
+		user.createAccessToken("My access token", LocalDate.now().plusDays(366)).then().statusCode(400);
+
+		user
+			.createAccessToken(
+				"My access token",
+				LocalDate.now().plusDays(RandomGenerator.getDefault().nextInt(367, Integer.MAX_VALUE))
+			)
+			.then()
+			.statusCode(400);
+	}
+
+	@Test
+	void givenUserWithAccessToken_whenCreatingSoftwareThroughV2_thenSuccess() {
+		User user = User.create();
+		user.createAndUseAccessToken("My access token", LocalDate.now().plusDays(3));
+
+		String brandName = "Some software created through v2";
+		SoftwareMetadata softwareMetadata = user.createSoftwareV2(brandName);
+
+		Assertions.assertEquals(brandName, softwareMetadata.brandName());
+	}
+
+	@Test
+	void givenFakeAccessToken_whenCreatingSoftwareThroughV2_thenErrorReturned() {
+		User user = User.create();
+		user.createAndUseAccessToken("My access token", LocalDate.now().plusDays(3));
+		String fakeAccessToken = user.accessToken.split("\\.")[0] + ".abc";
+
+		String brandName = "Some software created through v2";
+
+		RestAssured.given()
+			.header(new Header("Authorization", "bearer " + fakeAccessToken))
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body(User.createSoftwareJson(brandName).toString())
+			.when()
+			.post(Commons.apiV2Url + "/software")
+			.then()
+			.statusCode(401);
+	}
+}

--- a/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
@@ -214,7 +214,7 @@ public class AuthenticationIntegrationTest {
 		String categoryId = createUniqueCategory("long name", "short name", null);
 
 		User user = User.create();
-		String softwareId = user.createSoftware("Software 1").id();
+		String softwareId = user.createSoftwareV1("Software 1").id();
 		requestAddCategoryForSoftware(user, softwareId, categoryId).then().statusCode(201);
 	}
 
@@ -223,7 +223,7 @@ public class AuthenticationIntegrationTest {
 		String categoryId = createUniqueCategory("long name", "short name", null);
 
 		User user1 = User.create();
-		String softwareId = user1.createSoftware("Software 1").id();
+		String softwareId = user1.createSoftwareV1("Software 1").id();
 
 		User user2 = User.create();
 		requestAddCategoryForSoftware(user2, softwareId, categoryId).then().statusCode(403);
@@ -234,7 +234,7 @@ public class AuthenticationIntegrationTest {
 		String[] catIds = createCategoryTreeExample1();
 
 		User user = User.create();
-		String softwareId = user.createSoftware("Software 1").id();
+		String softwareId = user.createSoftwareV1("Software 1").id();
 
 		addCategoryForSoftware(user, softwareId, catIds[0]);
 		addCategoryForSoftware(user, softwareId, catIds[1]);

--- a/backend-tests/src/test/java/nl/esciencecenter/CodemetaIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/CodemetaIntegrationTest.java
@@ -25,7 +25,7 @@ public class CodemetaIntegrationTest {
 	@Test
 	void givenPublishedSoftwarePage_whenCodemetaApiCalled_thenCorrectResponseReturned() {
 		User user = User.create();
-		SoftwareMetadata softwareMetadata = user.createSoftware("CodeMeta software");
+		SoftwareMetadata softwareMetadata = user.createSoftwareV1("CodeMeta software");
 		String slug = softwareMetadata.slug();
 
 		RestAssured.get(createCodemetaEntryUrl(slug))

--- a/backend-tests/src/test/java/nl/esciencecenter/Commons.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/Commons.java
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
 package nl.esciencecenter;
 
 import io.restassured.http.Header;
@@ -6,6 +11,10 @@ import java.util.UUID;
 public class Commons {
 
 	static final Header requestEntry = new Header("Prefer", "return=representation");
+	static final String authUrl =
+		System.getenv("AUTH_URL") == null ? "http://localhost:80/auth" : System.getenv("AUTH_URL");
+	static final String apiV2Url =
+		System.getenv("AUTH_URL") == null ? "http://localhost:80/api/v2" : System.getenv("API_V2_URL");
 
 	static String createUUID() {
 		return UUID.randomUUID().toString();

--- a/backend-tests/src/test/java/nl/esciencecenter/User.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/User.java
@@ -10,14 +10,22 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.google.gson.JsonObject;
 import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
+import io.restassured.http.Cookie;
 import io.restassured.http.Header;
+import io.restassured.response.Response;
+import java.time.LocalDate;
 import java.util.Date;
 
 public class User {
 
 	String accountId;
-	String token;
+	String jwtToken;
+
 	Header authHeader;
+	Cookie authCookie;
+
+	String accessToken;
+	Header accessTokenHeader;
 
 	static Header adminAuthHeader;
 
@@ -63,20 +71,16 @@ public class User {
 		return this;
 	}
 
-	SoftwareMetadata createSoftware(String brand_name) {
-		JsonObject obj = new JsonObject();
-		String slug = "slug-" + Commons.createUUID();
-		obj.addProperty("slug", slug);
-		obj.addProperty("brand_name", brand_name);
-		obj.addProperty("is_published", true);
-		String shortStatement = "Test software for testing";
-		obj.addProperty("short_statement", shortStatement);
+	SoftwareMetadata createSoftwareV1(String brandName) {
+		JsonObject softwareJson = createSoftwareJson(brandName);
+		String slug = softwareJson.getAsJsonPrimitive("slug").getAsString();
+		String shortStatement = softwareJson.getAsJsonPrimitive("short_statement").getAsString();
 
 		String softwareId = RestAssured.given()
 			.header(authHeader)
 			.header(Commons.requestEntry)
 			.contentType(ContentType.JSON)
-			.body(obj.toString())
+			.body(softwareJson.toString())
 			.when()
 			.post("software")
 			.then()
@@ -84,14 +88,82 @@ public class User {
 			.extract()
 			.path("[0].id");
 
-		return new SoftwareMetadata(softwareId, slug, brand_name, shortStatement);
+		return new SoftwareMetadata(softwareId, slug, brandName, shortStatement);
+	}
+
+	SoftwareMetadata createSoftwareV2(String brandName) {
+		JsonObject softwareJson = createSoftwareJson(brandName);
+		String slug = softwareJson.getAsJsonPrimitive("slug").getAsString();
+		String shortStatement = softwareJson.getAsJsonPrimitive("short_statement").getAsString();
+
+		String softwareId = RestAssured.given()
+			.header(accessTokenHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body(softwareJson.toString())
+			.when()
+			.post(Commons.apiV2Url + "/software")
+			.then()
+			.statusCode(201)
+			.extract()
+			.path("[0].id");
+
+		return new SoftwareMetadata(softwareId, slug, brandName, shortStatement);
+	}
+
+	static JsonObject createSoftwareJson(String brandName) {
+		JsonObject obj = new JsonObject();
+		String slug = "slug-" + Commons.createUUID();
+		obj.addProperty("slug", slug);
+		obj.addProperty("brand_name", brandName);
+		obj.addProperty("is_published", true);
+		String shortStatement = "Test software for testing";
+		obj.addProperty("short_statement", shortStatement);
+
+		return obj;
+	}
+
+	/**
+	 * Request an access token for version 2 of the API to be generated. When successful, the token is returned and
+	 * will be automatically used for any subsequent requests to that API.
+	 *
+	 * @param displayName the display name of the token which is in the frontend presented to the user
+	 * @param expiresAt the date at which the token will expire
+	 * @return the newly generated access token, which is also stored in this User instance
+	 */
+	public String createAndUseAccessToken(String displayName, LocalDate expiresAt) {
+		accessToken = createAccessToken(displayName, expiresAt).then().statusCode(201).extract().path("access_token");
+		accessTokenHeader = new Header("Authorization", "bearer " + accessToken);
+
+		return accessToken;
+	}
+
+	/**
+	 * Request an access token for version 2 of the API to be generated. The response is returned for further testing
+	 * purposes. This User is not mutated.
+	 *
+	 * @param displayName the display name of the token which is in the frontend presented to the user
+	 * @param expiresAt the date at which the token will expire
+	 * @return the HTTP response corresponding to the request of creating the access token
+	 */
+	public Response createAccessToken(String displayName, LocalDate expiresAt) {
+		String body = "{\"display_name\": \"%s\", \"expires_at\": \"%s\"}".formatted(displayName, expiresAt);
+
+		return RestAssured.given()
+			.cookie(authCookie)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body(body)
+			.when()
+			.post(Commons.authUrl + "/accesstoken");
 	}
 
 	// To create User objects use create() instead.
 	private User(String accountId, boolean hasAgreedTerms) {
 		this.accountId = accountId;
-		token = createJwtToken(accountId);
-		authHeader = new Header("Authorization", "bearer " + token);
+		jwtToken = createJwtToken(accountId);
+		authHeader = new Header("Authorization", "bearer " + jwtToken);
+		authCookie = new Cookie.Builder("rsd_token", jwtToken).build();
 
 		if (hasAgreedTerms) {
 			agreeTerms();


### PR DESCRIPTION
## Integration tests for access tokens

### Changes proposed in this pull request

* Add check in the V2 API that access tokens don't expire in more than a year
* Create tests for the access token API

### How to test

* Follow the instructions in `backend-tests/README.md`

closes #1708

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [x] Tests