### PR TITLE
Fix highlight search

### DIFF
--- a/frontend/components/admin/software-highlights/AddSoftwareHighlights.tsx
+++ b/frontend/components/admin/software-highlights/AddSoftwareHighlights.tsx
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +12,7 @@ import {HTMLAttributes, useState} from 'react'
 
 import {SoftwareOverviewItemProps} from '~/types/SoftwareTypes'
 import {getBaseUrl} from '~/utils/fetchHelpers'
-import {softwareListUrl} from '~/utils/postgrestUrl'
+import {localSoftwareListUrl} from '~/utils/postgrestUrl'
 import {itemsNotInReferenceList} from '~/utils/itemsNotInReferenceList'
 import {getSoftwareList} from '~/components/software/apiSoftware'
 import AsyncAutocompleteSC, {AutocompleteOption} from '~/components/form/AsyncAutocompleteSC'
@@ -37,15 +38,14 @@ export default function AddSoftwareHighlights({onAddSoftware,highlights}:AddSoft
   async function searchSoftware(searchFor: string) {
     setStatus({loading: true, foundFor: undefined})
 
-    const url = softwareListUrl({
+    const url = localSoftwareListUrl({
       baseUrl: getBaseUrl(),
       search: searchFor,
-      order: 'mention_cnt.desc.nullslast,contributor_cnt.desc.nullslast,updated_at.desc.nullslast',
       limit: 50,
       offset: 0,
     })
-    // get software list, we do not pass the token
-    // when token is passed it will return not published items too
+    // get software list, we do not pass the token;
+    // when token is passed, it will return non-published items too
     const resp= await getSoftwareList({url})
     // remove items already in highlights
     const software = itemsNotInReferenceList({

--- a/frontend/utils/postgrestUrl.ts
+++ b/frontend/utils/postgrestUrl.ts
@@ -3,7 +3,7 @@
 // SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 //
@@ -343,6 +343,35 @@ export function baseQueryString(props: BaseQueryStringProps) { // NOSONAR - avoi
   // console.log('query...', query)
   // console.groupEnd()
   return query
+}
+
+export function localSoftwareListUrl(props: PostgrestParams) {
+  const {baseUrl, search} = props
+  let query = baseQueryString(props)
+  let url = ''
+
+  if (search) {
+    // console.log('localSoftwareListUrl...keywords...', props.keywords)
+    const encodedSearch = encodeURIComponent(search)
+    // search query is performed in aggregated_software_search RPC
+    // we search in title,subtitle,slug,keywords_text and prog_lang
+    // check rpc in 104-software-views.sql.sql for exact filtering
+    query += `&search=${encodedSearch}`
+
+    url = `${baseUrl}/rpc/software_search`
+    // console.log('localSoftwareListUrl...', url)
+  } else {
+    url = `${baseUrl}/rpc/software_overview`
+  }
+
+  if (!props.categories) {
+    const selectList = 'id,slug,brand_name,short_statement,image_id,updated_at,contributor_cnt,mention_cnt,is_published,keywords,keywords_text,prog_lang,licenses'
+    query += `&select=${selectList}`
+  }
+
+  url += `?${query}`
+  // console.log('localSoftwareListUrl...', url)
+  return url
 }
 
 export function softwareListUrl(props: PostgrestParams) {


### PR DESCRIPTION
## Fix highlight search

### Changes proposed in this pull request

* When searching as admin to add highlights, only search local software (so not remote RSDs)

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in as admin
* Add software
* Add a remote RSD, like `https://research-software-directory.org/`
* When searching to add a highlight, only local software should be shown

closes #1663

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests