### PR TITLE
Fix releases layout and news images

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -131,9 +131,9 @@ services:
       # rsd version passed into image
       # for release the tag is passed in GH action _ghcr.yml
       args:
-        APP_VERSION: "6.0.2"
+        APP_VERSION: "6.0.3"
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:6.0.2
+    image: rsd/frontend:6.0.3
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -56,9 +57,6 @@ export default function ImageWithPlaceholder({
       title={placeholder ?? alt}
       role="img"
       src={src}
-      // lighthouse audit requires explicit width and height
-      height="100%"
-      width="100%"
       style={{
         objectFit: bgSize,
         objectPosition: bgPosition

--- a/frontend/components/news/edit/AutosaveNewsImage.tsx
+++ b/frontend/components/news/edit/AutosaveNewsImage.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -52,7 +52,6 @@ function UploadedImage({imgUrl,onDelete}:UploadedImageProps){
         alt={'image'}
         bgSize={'scale-down'}
         bgPosition={'left top'}
-        className="w-full"
       />
       <div className="absolute top-[0.5rem] flex gap-4 justify-between bg-base-100 opacity-70 hover:opacity-100">
         <Button

--- a/frontend/components/organisation/releases/ReleaseItem.tsx
+++ b/frontend/components/organisation/releases/ReleaseItem.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -86,7 +86,7 @@ export default function ReleaseItem({release}: {release: SoftwareReleaseInfo}) {
 
         <div className='flex-1 flex flex-col'>
           {/* name and version */}
-          <div className="flex-1 grid grid-cols-[1fr_5rem] gap-4">
+          <div className="flex-1 grid grid-cols-2 justify-between gap-4">
 
             <Link
               title="Link to RSD page"
@@ -102,10 +102,12 @@ export default function ReleaseItem({release}: {release: SoftwareReleaseInfo}) {
               }} />
             </Link>
 
-            <LinkToVersionDoi
-              tag={release.release_tag}
-              doi={release.release_doi}
-            />
+            <div className="justify-self-end">
+              <LinkToVersionDoi
+                tag={release.release_tag}
+                doi={release.release_doi}
+              />
+            </div>
           </div>
           {/* authors, contributors */}
           {release.release_authors?.length > 0 ?

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next-env.d.ts.license
+++ b/frontend/next-env.d.ts.license
@@ -4,6 +4,7 @@ SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Cen
 SPDX-FileCopyrightText: 2022 dv4all
 SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 
 SPDX-License-Identifier: Apache-2.0
 SPDX-License-Identifier: CC-BY-4.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsd-frontend",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "private": true,
   "scripts": {
     "dev": "next dev --turbo",

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -7,6 +7,7 @@
  * SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
  * SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
  * SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+ * SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
  *
  * SPDX-License-Identifier: Apache-2.0
  */
@@ -115,7 +116,7 @@ body {
   */
   min-width: 30rem;
   /* fix jumping scrollbar */
-  overflow: overlay;
+  overflow: auto;
   --scrollbar-thumb: #e4e4e7;
 }
 


### PR DESCRIPTION
## Fix releases layout and news images

### Changes proposed in this pull request

* Right align release version tags so they don't extend too far to the right
* Fix spacing between small and tall news images

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, add software, publish, add an organisation, add Vantage6 concept DOI: `10.5281/zenodo.7221216`
* `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases`
* Check the releases page of the organisation, release tags should be right aligned (on of the releases has an unkown release date messing up the layout, but that's an independent issue that already existed)
* Create a news item, add some small and tall images, there should be no big gaps between the images
* Check if images in other places still render correctly

closes #1687
closes #1546

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests