### PR TITLE
Show mention usages to admins

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,6 +53,8 @@ services:
       - PGRST_DB_SCHEMA
       - PGRST_SERVER_PORT
       - PGRST_JWT_SECRET
+      - PGRST_DB_POOL=30
+      - PGRST_DB_POOL_ACQUISITION_TIMEOUT=30
     depends_on:
       - database
     networks:
@@ -133,7 +135,7 @@ services:
       args:
         APP_VERSION: "6.0.3"
     # update version number to correspond to frontend/package.json
-    image: rsd/frontend:6.0.3
+    image: rsd/frontend:6.1.0
     environment:
       # it uses values from .env file
       - POSTGREST_URL

--- a/documentation/docs/03-rsd-instance/03-administration.md
+++ b/documentation/docs/03-rsd-instance/03-administration.md
@@ -221,7 +221,7 @@ fill the `provenance_iri` column. Further read [Linked Data](https://en.wikipedi
 
 ## Mentions
 
-In this section, admins can search for mentions and edit them. If you enter a DOI or UUID, we search on that field only. Otherwise, we search on title, authors, journal, URL, note and OpenAlex ID.
+In this section, admins can search for mentions and edit them. You an also see where the mention is used. If you enter a DOI or UUID, we search on that field only. Otherwise, we search on title, authors, journal, URL, note and OpenAlex ID.
 
 :::warning
 Edit mentions with care: they might be referenced to in multiple places. If you want to fully change a mention attached to e.g. a software page, you should delete it there and create a new one instead of editing it.
@@ -229,7 +229,7 @@ Edit mentions with care: they might be referenced to in multiple places. If you 
 
 ## Repositories
 
-In this section admins can manage software repository entries. The background services use repository url and the platform information to "scrape" additional information about the software. When background service fails it logs the error. The error message is shown to software maintainers. However the background services will continue trying to retrieve additional information from the platform API.
+In this section admins can manage software repository entries. The background services use repository URL and the platform information to "scrape" additional information about the software. When background service fails it logs the error. The error message is shown to software maintainers. However the background services will continue trying to retrieve additional information from the platform API.
 
 :::tip
 The admins can exclude/disable background services for the specific repository by providing the reason for exclusion. The reason is shown to maintainers of the software. In short, if the 'Reason why scraping is disabled' has an value the repository will be excluded from background services.
@@ -243,14 +243,14 @@ Deleting the repository entry will remove it from all software entries including
 
 ## Package Managers
 
-Similar to repositories this section shows all package managers entries in the RSD. The background services try to extract additional information from the url the maintainers added to their software.
+Similar to repositories this section shows all package managers entries in the RSD. The background services try to extract additional information from the URL the maintainers added to their software.
 
 Admin can disable background services for specific package manager entry by providing the explanation / reason in the 'Reason to disable [service name]' input. This reason will be shown to software maintainers.
 
 :::info
-The package manager entries are currently not normalized in the RSD, so there could be multiple entries of the same package manager url in the RSD.
+The package manager entries are currently not normalised in the RSD, so there could be multiple entries of the same package manager URL in the RSD.
 
-If you need to disable background services for specific url you should first search for all entries and change them all in the same way. In the future we expect to "normalize" package manager url.
+If you need to disable background services for specific URL you should first search for all entries and change them all in the same way. In the future we expect to "normalise" package manager URL.
 :::
 
 ![image](img/admin-package-managers.webp)
@@ -298,7 +298,7 @@ This section is used to show public announcements to all users of the RSD. It is
 RSD administrators are able to create news items. The additional option "Add news" will appear in the "+" menu at the top right of the page header.
 
 :::info
-News section is separate module defined in the settings.json. When enabled the News will be shown on homepage and if defined in settings the main menu entry will appear.
+News section is a separate module defined in the settings.json. When enabled, the News will be shown on the homepage, and if defined in settings, the main menu entry will appear.
 :::
 
 ### Add news item
@@ -307,8 +307,8 @@ Using the "Add news" option in the "+" menu will open add news item page where y
 
 :::info
 
-- The news item url (slug) is generated using publication date and title.
-- In case the slug is already taken the warning will appear below the url. You can manually change the url part created from the title or change the publication date if possible.
+- The news item URL (slug) is generated using publication date and title.
+- In case the slug is already taken the warning will appear below the URL. You can manually change the URL part created from the title or change the publication date if possible.
 
 :::
 
@@ -321,7 +321,7 @@ After news item is created you will be redirected to edit news item page. Here y
 :::info
 
 - Summary is used in the latest news section of the homepage and in the news card on the news overview.
-- Publication date is shown in the header of the news title. It can be changed at any time. Note that changing the publication title also changes public url of the news item.
+- Publication date is shown in the header of the news title. It can be changed at any time. Note that changing the publication title also changes public URL of the news item.
 - First uploaded image is used in the news card.
 - Using "Copy link" button you can copy the Markdown syntax to the clipboard and the paste the link at the desired location of the body.
 - Using "Delete" button will delete the image and the Markdown link syntax from the news body.

--- a/documentation/docs/03-rsd-instance/03-administration.md.license
+++ b/documentation/docs/03-rsd-instance/03-administration.md.license
@@ -1,8 +1,8 @@
 SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (dv4all) (dv4all)
-SPDX-FileCopyrightText: 2023 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 SPDX-FileCopyrightText: 2023 - 2025 dv4all
+SPDX-FileCopyrightText: 2023 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 

--- a/frontend/components/admin/mentions/MentionLocations.tsx
+++ b/frontend/components/admin/mentions/MentionLocations.tsx
@@ -1,13 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {useEffect, useState} from 'react'
+import Paper from '@mui/material/Paper'
 import CircularProgress from '@mui/material/CircularProgress'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
 import Link from 'next/link'
-import {useEffect, useState} from 'react'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {createJsonHeaders} from '~/utils/fetchHelpers'
 import {getUserSettings} from '~/components/user/ssrUserSettings'
@@ -131,13 +133,20 @@ export default function MentionLocations({mentionId}: Readonly<{mentionId: strin
 
   return (
     <>
-      {mentionLocations.entries().map(entry => {
+      {Array.from(mentionLocations.entries()).map(entry => {
         if (entry[1].length === 0) {
           return null
         }
 
         return (
-          <>
+          <Paper
+            key={typeToHeader.get(entry[0])}
+            variant="outlined"
+            sx={{
+              padding: '1em',
+              margin: '1em',
+              backgroundColor: 'var(--rsd-base-200)'
+            }}>
             <h3>{typeToHeader.get(entry[0])}:</h3>
             <List>
               {entry[1].map((item) => {
@@ -149,7 +158,7 @@ export default function MentionLocations({mentionId}: Readonly<{mentionId: strin
                 )
               })}
             </List>
-          </>
+          </Paper>
         )
       })}
     </>

--- a/frontend/components/admin/mentions/MentionLocations.tsx
+++ b/frontend/components/admin/mentions/MentionLocations.tsx
@@ -1,0 +1,157 @@
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import CircularProgress from '@mui/material/CircularProgress'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import Link from 'next/link'
+import {useEffect, useState} from 'react'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import {createJsonHeaders} from '~/utils/fetchHelpers'
+import {getUserSettings} from '~/components/user/ssrUserSettings'
+
+type MentionUsageType =
+  'Software' |
+  'SoftwareReferencePaper'|
+  'ProjectImpact'|
+  'ProjectOutput' |
+  'Citation' |
+  'Release'
+
+type MentionBasicData = {
+  name: string,
+  slug: string | null,
+}
+
+const typeToHeader: Map<MentionUsageType, string> = new Map()
+typeToHeader.set('Software', 'Software')
+typeToHeader.set('SoftwareReferencePaper', 'Software reference papers')
+typeToHeader.set('ProjectImpact', 'Project impact')
+typeToHeader.set('ProjectOutput', 'Project output')
+typeToHeader.set('Citation', 'Citation of')
+typeToHeader.set('Release', 'Release of')
+
+async function getUsageOfMention(id: string, token: string | undefined): Promise<Map<MentionUsageType, MentionBasicData[]>> {
+  let select = 'software!mention_for_software(brand_name,slug)'
+  select += ',softwareReference:software!reference_paper_for_software(brand_name,slug)'
+  select += ',projectImpact:project!impact_for_project(title,slug)'
+  select += ',projectOutput:project!output_for_project(title,slug)'
+  select += ',citations:citation_for_mention!citation_for_mention_citation_fkey(mention!citation_for_mention_mention_fkey(id,doi,title))'
+  select += ',releases:release(software!release_software_fkey(brand_name,slug))'
+
+  const resp = await fetch(`/api/v1/mention?id=eq.${id}&select=${select}`, {
+    headers: createJsonHeaders(token)
+  })
+  if (!resp.ok) {
+    throw new Error(`Could not obtain usages of this mention with ID ${id}`)
+  }
+
+  const json = await resp.json()
+
+  const result: Map<MentionUsageType, MentionBasicData[]> = new Map()
+  result.set('Software', [])
+  result.set('SoftwareReferencePaper', [])
+  result.set('ProjectImpact', [])
+  result.set('ProjectOutput', [])
+  result.set('Citation', [])
+  result.set('Release', [])
+
+  const mentions = json[0]
+
+  mentions.software.forEach((item: {brand_name: string; slug: string}) => {
+    const name = item.brand_name
+    const slug = item.slug
+    result.get('Software')!.push({name, slug})
+  })
+  mentions.softwareReference.forEach((item: {brand_name: string; slug: string}) => {
+    const name = item.brand_name
+    const slug = item.slug
+    result.get('SoftwareReferencePaper')!.push({name, slug})
+  })
+  mentions.projectImpact.forEach((item: {title: string; slug: string}) => {
+    const name = item.title
+    const slug = item.slug
+    result.get('ProjectImpact')!.push({name, slug})
+  })
+  mentions.projectOutput.forEach((item: {title: string; slug: string}) => {
+    const name = item.title
+    const slug = item.slug
+    result.get('ProjectOutput')!.push({name, slug})
+  })
+  mentions.citations.forEach((item: {mention: {id: string; doi: string | null, title: string}}) => {
+    const name = `${item.mention.id}, ${item.mention.doi ?? 'no DOI'}, ${item.mention.title}`
+    const slug = null
+    result.get('Citation')!.push({name, slug})
+  })
+  mentions.releases.forEach((item: {software: {brand_name: string; slug: string}}) => {
+    const name = item.software.brand_name
+    const slug = item.software.slug
+    result.get('Release')!.push({name, slug})
+  })
+
+  return result
+}
+
+function createLinkFromMentionItem(mentionBasicData: MentionBasicData, mentionUsGeType: MentionUsageType): string | null {
+  switch(mentionUsGeType) {
+    case 'Software':
+    case 'SoftwareReferencePaper': return `/software/${mentionBasicData.slug}/edit/mentions`
+    case 'ProjectImpact':
+    case 'ProjectOutput': return `/projects/${mentionBasicData.slug}/edit/mentions`
+    case 'Citation': return null
+    case 'Release': return `/software/${mentionBasicData.slug}`
+  }
+}
+
+export default function MentionLocations({mentionId}: Readonly<{mentionId: string}>) {
+  const [mentionLocations, setMentionLocations] = useState<Map<MentionUsageType, MentionBasicData[]> | null>(null)
+  const {showErrorMessage} = useSnackbar()
+
+  useEffect(() => {
+    getUserSettings()
+      .then(({token}) => getUsageOfMention(mentionId, token))
+      .then(mentionLocations => setMentionLocations(mentionLocations))
+      .catch(reason => showErrorMessage(reason.toString()))
+  }, [mentionId]) // eslint-disable-line react-hooks/exhaustive-deps
+
+
+  if (mentionLocations === null) {
+    return <CircularProgress/>
+  }
+
+  if (mentionLocations.values().every(arr => arr.length === 0)) {
+    return (
+      <div>
+        No uses found
+      </div>
+    )
+  }
+
+  return (
+    <>
+      {mentionLocations.entries().map(entry => {
+        if (entry[1].length === 0) {
+          return null
+        }
+
+        return (
+          <>
+            <h3>{typeToHeader.get(entry[0])}:</h3>
+            <List>
+              {entry[1].map((item) => {
+                const link = createLinkFromMentionItem(item, entry[0])
+                return (
+                  <ListItem key={item.slug}>
+                    {link === null ? item.name : <Link href={link}>{item.name}</Link>}
+                  </ListItem>
+                )
+              })}
+            </List>
+          </>
+        )
+      })}
+    </>
+  )
+}

--- a/frontend/components/admin/mentions/MentionsOverviewList.tsx
+++ b/frontend/components/admin/mentions/MentionsOverviewList.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -19,7 +20,6 @@ import useSnackbar from '~/components/snackbar/useSnackbar'
 import MentionLocations from '~/components/admin/mentions/MentionLocations'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
-import Paper from '@mui/material/Paper'
 
 function leaveOutSomeFieldsReplacer(key: string, value: any) {
   if (key === 'id' || key === 'doi_registration_date' || key === 'created_at' || key === 'updated_at') {
@@ -59,14 +59,15 @@ function AdminMention({mention, idx, onUpdate}: Readonly<{mention: MentionItemPr
         <IconButton onClick={() => setModalOpen(true)} ><EditIcon></EditIcon></IconButton>
         <IconButton
           aria-label={isOpenMentionLocations ? `Hide usages of ${mention.title}` : `Show usages of ${mention.title}`}
-          onClick={() => setIsOpenMentionLocations(!isOpenMentionLocations)}>
+          onClick={() => setIsOpenMentionLocations(!isOpenMentionLocations)}
+        >
           <HubIcon />
         </IconButton>
       </div>
-      {isOpenMentionLocations &&
-        <Paper variant="outlined" sx={{padding: '1em', margin: '1em', backgroundColor: 'var(--rsd-base-300)'}}>
-          <MentionLocations mentionId={mention.id as string}/>
-        </Paper>}
+      {isOpenMentionLocations ?
+        <MentionLocations mentionId={mention.id as string}/>
+        : null
+      }
       {modalOpen ?
         <EditMentionModal
           title={mention.id as string ?? 'undefined'}

--- a/frontend/components/admin/mentions/MentionsOverviewList.tsx
+++ b/frontend/components/admin/mentions/MentionsOverviewList.tsx
@@ -1,14 +1,13 @@
 // SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {useState} from 'react'
-import List from '@mui/material/List'
-import ListItem from '@mui/material/ListItem'
 import EditIcon from '@mui/icons-material/Edit'
 import IconButton from '@mui/material/IconButton'
+import HubIcon from '@mui/icons-material/Hub'
 import Alert from '@mui/material/Alert'
 import {useSession} from '~/auth/AuthProvider'
 import {createJsonHeaders} from '~/utils/fetchHelpers'
@@ -17,6 +16,10 @@ import {MentionItemProps} from '~/types/Mention'
 import MentionViewItem from '~/components/mention/MentionViewItem'
 import EditMentionModal from '~/components/mention/EditMentionModal'
 import useSnackbar from '~/components/snackbar/useSnackbar'
+import MentionLocations from '~/components/admin/mentions/MentionLocations'
+import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
+import Paper from '@mui/material/Paper'
 
 function leaveOutSomeFieldsReplacer(key: string, value: any) {
   if (key === 'id' || key === 'doi_registration_date' || key === 'created_at' || key === 'updated_at') {
@@ -26,12 +29,12 @@ function leaveOutSomeFieldsReplacer(key: string, value: any) {
   }
 }
 
-export default function MentionsOverviewList({list, onUpdate}: {list: MentionItemProps[], onUpdate: ()=>void}) {
-  const [modalOpen, setModalOpen] = useState<boolean>(false)
-  const [mentionToEdit, setMentionToEdit] = useState<MentionItemProps | undefined>(undefined)
+function AdminMention({mention, idx, onUpdate}: Readonly<{mention: MentionItemProps, idx: number, onUpdate: () => void}>) {
+  const [isOpenMentionLocations, setIsOpenMentionLocations] = useState<boolean>(false)
   const {token} = useSession()
   const {showErrorMessage} = useSnackbar()
   const {page, rows} = usePaginationWithSearch('Find mentions')
+  const [modalOpen, setModalOpen] = useState<boolean>(false)
 
   async function updateMention(data: MentionItemProps) {
     const id = data.id as string
@@ -49,6 +52,37 @@ export default function MentionsOverviewList({list, onUpdate}: {list: MentionIte
     }
   }
 
+  return(
+    <ListItem sx={{display: 'list-item'}}>
+      <div className="grid grid-cols-[1fr_auto_auto] items-center hover:bg-base-200">
+        <MentionViewItem item={mention} pos={page * rows + idx + 1} />
+        <IconButton onClick={() => setModalOpen(true)} ><EditIcon></EditIcon></IconButton>
+        <IconButton
+          aria-label={isOpenMentionLocations ? `Hide usages of ${mention.title}` : `Show usages of ${mention.title}`}
+          onClick={() => setIsOpenMentionLocations(!isOpenMentionLocations)}>
+          <HubIcon />
+        </IconButton>
+      </div>
+      {isOpenMentionLocations &&
+        <Paper variant="outlined" sx={{padding: '1em', margin: '1em', backgroundColor: 'var(--rsd-base-300)'}}>
+          <MentionLocations mentionId={mention.id as string}/>
+        </Paper>}
+      {modalOpen ?
+        <EditMentionModal
+          title={mention.id as string ?? 'undefined'}
+          open={modalOpen}
+          pos={undefined} //why does this exist?
+          item={mention}
+          onCancel={() => setModalOpen(false)}
+          onSubmit={({data}) => {updateMention(data)}}
+        />
+        : null
+      }
+    </ListItem>
+  )
+}
+
+export default function MentionsOverviewList({list, onUpdate}: {list: MentionItemProps[], onUpdate: ()=>void}) {
   if (list.length === 0) {
     return (
       <Alert severity="info" sx={{margin:'1rem 0rem'}}>
@@ -58,34 +92,9 @@ export default function MentionsOverviewList({list, onUpdate}: {list: MentionIte
   }
 
   return (
-    <>
-      <List>
-        {list.map((mention, idx) => {
-          return (
-            <ListItem
-              key={mention.id}
-              secondaryAction={
-                <IconButton onClick={() => {setModalOpen(true); setMentionToEdit(mention)}} ><EditIcon></EditIcon></IconButton>
-              }
-              className="hover:bg-base-200 flex-1 pr-4"
-            >
-              <MentionViewItem item={mention} pos={page * rows + idx + 1} />
-            </ListItem>
-          )
-        })}
-      </List>
-      {modalOpen ?
-        <EditMentionModal
-          title={mentionToEdit?.id as string ?? 'undefined'}
-          open={modalOpen}
-          pos={undefined} //why does this exist?
-          item={mentionToEdit}
-          onCancel={() => setModalOpen(false)}
-          onSubmit={({data}) => {updateMention(data)}}
-        />
-        : null
-      }
-    </>
+    <List>
+      {list.map((mention, idx) => <AdminMention key={mention.id} mention={mention} idx={idx} onUpdate={onUpdate} />)}
+    </List>
   )
 };
 


### PR DESCRIPTION
## Show mention usages to admins

### Changes proposed in this pull request

* On the mentions overview for admins, the usages of a mention can now be viewed
* Increase the connection timeout and size of PostgREST for development, as the data-generation script otherwise gives errors

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, add software
* Add a concept DOI, like `10.5281/zenodo.6379973` or `10.5281/zenodo.1220113`
* Add a reference paper, like `10.1109/escience.2018.00013` or `10.1109/tevc.2022.3210654`
* `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations`
* `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases`
* Check the usages of the mentions as admin
* `docker compose down --volumes && docker compose up --scale data-generation=0`
* Sign in as admin, check the mentions overview


closes #1686

PR Checklist:

* [x] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [ ] Tests