### PR TITLE
Use OpenAlex mention types

### DIFF
--- a/frontend/utils/getCrossref.ts
+++ b/frontend/utils/getCrossref.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
@@ -162,35 +162,24 @@ function crossrefToRsdType(type: string): MentionTypeKeys {
       return 'conferencePaper'
     case 'dissertation':
       return 'thesis'
+    case 'database':
     case 'dataset':
       return 'dataset'
-    // n/a
-    // case 'interview':
-    //   return 'interview'
     case 'journal':
     case 'journal-article':
     case 'journal-volume':
     case 'journal-issue':
     case 'journal article':
       return 'journalArticle'
-    // n/a
-    // case 'magazine-article':
-    //   return 'magazineArticle'
-    // case 'newspaper-article':
-    //   return 'newspaperArticle'
     case 'presentation':
       return 'presentation'
     case 'report-series':
     case 'report':
+    case 'report-component':
       return 'report'
     case 'software':
     case 'computer-program':
       return 'computerProgram'
-    // n/a
-    // case 'video-recording':
-    //   return 'videoRecording'
-    // case 'webpage':
-    //   return 'webpage'
     default:
       return 'other'
   }

--- a/frontend/utils/getCrossref.ts
+++ b/frontend/utils/getCrossref.ts
@@ -141,7 +141,7 @@ export async function getCrossrefItemsByTitle(title: string) {
   }
 }
 
-export function crossrefToRsdType(type: string): MentionTypeKeys {
+function crossrefToRsdType(type: string): MentionTypeKeys {
   if (!type) return 'other'
   switch (type.trim().toLowerCase()) {
     case 'book':

--- a/frontend/utils/getDataCite.ts
+++ b/frontend/utils/getDataCite.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
@@ -343,6 +343,7 @@ function rsdTypeFromResourceType(resourceType: string) {
     case 'conferenceproceeding':
       return 'conferencePaper'
     case 'dissertation':
+    case 'studyregistration':
     case 'thesis':
       return 'thesis'
     case 'dataset':

--- a/frontend/utils/getOpenalex.ts
+++ b/frontend/utils/getOpenalex.ts
@@ -1,11 +1,10 @@
-// SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import logger from '~/utils/logger'
-import {MentionItemProps} from '~/types/Mention'
-import {crossrefToRsdType} from '~/utils/getCrossref'
+import {MentionItemProps, MentionTypeKeys} from '~/types/Mention'
 
 export async function getMentionByOpenalexId(id: string) {
   try {
@@ -161,7 +160,7 @@ export function openalexItemToMentionItem(json: any): MentionItemProps {
     // url to external image
     image_url: null,
     // is_featured?: boolean
-    mention_type: crossrefToRsdType(json.type_crossref),
+    mention_type: openalexToRsdType(json.type),
     source: 'OpenAlex',
     note: null
   })
@@ -169,4 +168,29 @@ export function openalexItemToMentionItem(json: any): MentionItemProps {
 
 function extractAuthors(json: any): string {
   return json.authorships.map((authorship: any) => authorship.raw_author_name as string).join(', ')
+}
+
+function openalexToRsdType(type: string): MentionTypeKeys {
+  switch (type) {
+    case 'article': return 'journalArticle'
+    case 'book': return 'book'
+    case 'book-chapter': return 'bookSection'
+    case 'dataset': return 'dataset'
+    case 'dissertation': return 'thesis'
+    case 'editorial': return 'journalArticle'
+    case 'erratum': return 'other'
+    case 'letter': return 'other'
+    case 'libguides': return 'other'
+    case 'other': return 'other'
+    case 'paratext': return 'other'
+    case 'peer-review': return 'other'
+    case 'preprint': return 'other'
+    case 'reference-entry': return 'other'
+    case 'report': return 'report'
+    case 'retraction': return 'other'
+    case 'review': return 'other'
+    case 'standard': return 'other'
+    case 'supplementary-materials': return 'other'
+    default: return 'other'
+  }
 }

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 //
@@ -23,10 +23,10 @@ import nl.esciencecenter.rsd.scraper.Utils;
 
 public class CrossrefMention {
 
-	static final Map<String, MentionType> crossrefTypeMap;
+	private static final Map<String, MentionType> crossrefTypeMap;
 
 	static {
-		//		https://api.crossref.org/types
+		// https://api.crossref.org/types
 		crossrefTypeMap = new HashMap<>();
 
 		crossrefTypeMap.put("book-section", MentionType.bookSection);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/CrossrefMention.java
@@ -31,6 +31,7 @@ public class CrossrefMention {
 
 		crossrefTypeMap.put("book-section", MentionType.bookSection);
 		crossrefTypeMap.put("monograph", MentionType.other);
+		crossrefTypeMap.put("report-component", MentionType.report);
 		crossrefTypeMap.put("report", MentionType.report);
 		crossrefTypeMap.put("peer-review", MentionType.other);
 		crossrefTypeMap.put("book-track", MentionType.book);
@@ -48,6 +49,7 @@ public class CrossrefMention {
 		crossrefTypeMap.put("proceedings-series", MentionType.conferencePaper);
 		crossrefTypeMap.put("report-series", MentionType.report);
 		crossrefTypeMap.put("proceedings", MentionType.conferencePaper);
+		crossrefTypeMap.put("database", MentionType.dataset);
 		crossrefTypeMap.put("standard", MentionType.other);
 		crossrefTypeMap.put("reference-book", MentionType.book);
 		crossrefTypeMap.put("posted-content", MentionType.other);
@@ -57,7 +59,6 @@ public class CrossrefMention {
 		crossrefTypeMap.put("dataset", MentionType.dataset);
 		crossrefTypeMap.put("book-series", MentionType.book);
 		crossrefTypeMap.put("edited-book", MentionType.book);
-		crossrefTypeMap.put("standard-series", MentionType.other);
 	}
 
 	private final Doi doi;

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataciteMentionRepository.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -70,9 +70,10 @@ public class DataciteMentionRepository {
 	private static final Pattern URL_TREE_TAG_PATTERN = Pattern.compile("/tree/([^/]+)$");
 
 	static {
-		// https://schema.datacite.org/meta/kernel-4.4/
+		// https://schema.datacite.org/meta/kernel-4.7/
 		dataciteTypeMap = new HashMap<>();
 		dataciteTypeMap.put("Audiovisual", MentionType.presentation);
+		dataciteTypeMap.put("Award", MentionType.other);
 		dataciteTypeMap.put("Book", MentionType.book);
 		dataciteTypeMap.put("BookChapter", MentionType.bookSection);
 		dataciteTypeMap.put("Collection", MentionType.other);
@@ -84,19 +85,24 @@ public class DataciteMentionRepository {
 		dataciteTypeMap.put("Dissertation", MentionType.thesis);
 		dataciteTypeMap.put("Event", MentionType.workshop);
 		dataciteTypeMap.put("Image", MentionType.other);
+		dataciteTypeMap.put("Instrument", MentionType.other);
 		dataciteTypeMap.put("InteractiveResource", MentionType.other);
 		dataciteTypeMap.put("Journal", MentionType.journalArticle);
 		dataciteTypeMap.put("JournalArticle", MentionType.journalArticle);
 		dataciteTypeMap.put("Model", MentionType.other);
 		dataciteTypeMap.put("OutputManagementPlan", MentionType.other);
 		dataciteTypeMap.put("PeerReview", MentionType.other);
+		dataciteTypeMap.put("Poster", MentionType.poster);
 		dataciteTypeMap.put("Preprint", MentionType.other);
+		dataciteTypeMap.put("Presentation", MentionType.presentation);
+		dataciteTypeMap.put("Project", MentionType.other);
 		dataciteTypeMap.put("PhysicalObject", MentionType.other);
 		dataciteTypeMap.put("Report", MentionType.report);
 		dataciteTypeMap.put("Service", MentionType.other);
 		dataciteTypeMap.put("Software", MentionType.computerProgram);
 		dataciteTypeMap.put("Sound", MentionType.other);
 		dataciteTypeMap.put("Standard", MentionType.other);
+		dataciteTypeMap.put("StudyRegistration", MentionType.thesis);
 		// dataciteTypeMap.put("Text", MentionType.other);
 		dataciteTypeMap.put("Workflow", MentionType.other);
 		dataciteTypeMap.put("Other", MentionType.other);

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnector.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/OpenAlexConnector.java
@@ -15,7 +15,9 @@ import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -37,6 +39,31 @@ class OpenAlexConnector {
 	// The docs and empirical experiments indicate 10 requests per second.
 	// We make it slightly lower to be safe.
 	private static final Throttler apiThrottler = new Throttler(9, 1050, TimeUnit.MILLISECONDS);
+
+	private static final Map<String, MentionType> openalexTypeMap = new HashMap<>();
+
+	static {
+		// https://developers.openalex.org/api-reference/work-types
+		openalexTypeMap.put("article", MentionType.journalArticle);
+		openalexTypeMap.put("book", MentionType.book);
+		openalexTypeMap.put("book-chapter", MentionType.bookSection);
+		openalexTypeMap.put("dataset", MentionType.dataset);
+		openalexTypeMap.put("dissertation", MentionType.thesis);
+		openalexTypeMap.put("editorial", MentionType.journalArticle);
+		openalexTypeMap.put("erratum", MentionType.other);
+		openalexTypeMap.put("letter", MentionType.other);
+		openalexTypeMap.put("libguides", MentionType.other);
+		openalexTypeMap.put("other", MentionType.other);
+		openalexTypeMap.put("paratext", MentionType.other);
+		openalexTypeMap.put("peer-review", MentionType.other);
+		openalexTypeMap.put("preprint", MentionType.other);
+		openalexTypeMap.put("reference-entry", MentionType.other);
+		openalexTypeMap.put("report", MentionType.report);
+		openalexTypeMap.put("retraction", MentionType.other);
+		openalexTypeMap.put("review", MentionType.other);
+		openalexTypeMap.put("standard", MentionType.other);
+		openalexTypeMap.put("supplementary-materials", MentionType.other);
+	}
 
 	private static String doOpenAlexGetRequest(String url)
 		throws IOException, InterruptedException, RsdResponseException {
@@ -231,8 +258,8 @@ class OpenAlexConnector {
 
 		Integer publicationYear = Utils.integerOrNull(citationObject.get("publication_year"));
 
-		String crossrefType = Utils.stringOrNull(citationObject.get("type_crossref"));
-		MentionType mentionType = CrossrefMention.crossrefTypeMap.getOrDefault(crossrefType, MentionType.other);
+		String type = Utils.stringOrNull(citationObject.get("type"));
+		MentionType mentionType = openalexTypeMap.getOrDefault(type, MentionType.other);
 
 		String openalexIdString = citationObject.getAsJsonObject("ids").getAsJsonPrimitive("openalex").getAsString();
 		OpenalexId openalexId = OpenalexId.fromString(openalexIdString);


### PR DESCRIPTION
## Use OpenAlex mention types

### Changes proposed in this pull request

* Use the OpenAlex field `type` instead of the removed field `type_crossref`. The types can be found [here](https://developers.openalex.org/api-reference/work-types).
* Update the types from Crossref in accordance with [its types](https://api.crossref.org/types)
* Update the types from DataCite in accordance with [its types](https://schema.datacite.org/meta/kernel-4.7/)

### How to test

* Check the source code to see if you agree with the new mappings
* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in, add software
* Add reference papers, like `10.3389/fhpcp.2025.1709051`,  `10.1016/j.future.2024.07.050` or `10.1016/j.future.2018.08.004`
* `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainCitations`
* Most of the citations should not have mention type `Other`

closes #1723

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests