### PR TITLE
Fix app header menu positioning

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -33,13 +33,6 @@ import ProgressProviderApp from '~/components/bprogress/ProgressProviderApp'
 
 import '~/styles/global.css'
 
-export const viewport = {
-  // Matches 30rem defined in global.css
-  width: 480,
-  // Do not use initialScale to allow smartphone to scale it properly
-  initialScale: -1,
-}
-
 export const metadata: Metadata = {
   title: 'Home',
   description: 'Welcome to RSD',

--- a/frontend/components/AppHeader/index.tsx
+++ b/frontend/components/AppHeader/index.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -67,10 +68,10 @@ export default function AppHeader() {
           <GlobalSearchAutocomplete className="hidden xl:block ml-12 mr-6"/>
 
           {/* Large menu*/}
-          <nav aria-label="Main Navigation" className="flex items-center">
+          <nav aria-label="Main Navigation" className="flex-1 flex items-center">
             <DesktopMenu activePath={pathname ?? '/'}/>
 
-            <div className="text-primary-content flex gap-2 justify-end items-center min-w-[8rem] text-right ml-4">
+            <div className="flex-1 flex gap-2 justify-end items-center min-w-[8rem] text-right ml-4 text-primary-content">
               {/* FEEDBACK panel */}
               {host.feedback?.enabled
                 ? <FeedbackPanelButton


### PR DESCRIPTION
# Fix main and mobile menu position

Changes proposed in this pull request:
* Fix main and mobile menu position after A11y nav introduction. The main menu should be left side oriented when there is enough space and the user and mobile menu should be on the right side. 
* Remove custom viewport as it is interferes with user zoom in/uit gestures and with mobile emulators in the browsers    

How to test:
* `make start to start and generate data`
* on full screen the main menu shoul be on left and user menu on the right (see  image 1)
* on tablet screen mobile and user menu should be on the right side (see image 2)
* F12 to open dev console use responsive layout and drag the page with confirm that unexpected "zoom" is not applied anymore

## Example desktop layout main menu
<img width="1720" height="1179" alt="image" src="https://github.com/user-attachments/assets/5038c54e-4a1c-46e3-b29b-c637cbc2c1d9" />

## Example responsive layout mobile menu and no zoom
<img width="1738" height="1318" alt="image" src="https://github.com/user-attachments/assets/5a21d535-2a9c-474e-be4f-c80a567683cc" />


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
