### PR TITLE
48 no title

### DIFF
--- a/frontend/app/(base)/software/[slug]/edit/[page]/page.tsx
+++ b/frontend/app/(base)/software/[slug]/edit/[page]/page.tsx
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {Metadata} from 'next'
 import {notFound} from 'next/navigation'
 import EditSoftwareCommunities from '~/components/software/edit/communities'
@@ -17,9 +22,34 @@ import SoftwareRepositories from '~/components/software/edit/repositories'
 
 import {app} from '~/config/app'
 
-export const metadata: Metadata = {
-  title: `Edit software | ${app.title}`,
-  description: 'Edit software page',
+const editSoftwarePageTitle: Record<EditSoftwarePageId, string> = {
+  information: 'Information',
+  links: 'Links',
+  repositories: 'Repositories',
+  contributors: 'Contributors',
+  organisations: 'Organisations',
+  mentions: 'Mentions',
+  testimonials: 'Testimonials',
+  'package-managers': 'Package managers',
+  'software-heritage': 'Software Heritage',
+  communities: 'Communities',
+  'related-software': 'Related software',
+  'related-projects': 'Related projects',
+  maintainers: 'Maintainers',
+  services: ''
+}
+
+export async function generateMetadata({
+  params
+}:Readonly<{
+  params: Promise<{slug: string, page: EditSoftwarePageId}>
+}>): Promise<Metadata> {
+  const {page} = await params
+  const pageTitle = editSoftwarePageTitle[page]
+  return {
+    title: pageTitle ? `${pageTitle} | Edit software | ${app.title}` : `Edit software | ${app.title}`,
+    description: 'Edit software page',
+  }
 }
 
 export default async function EditSoftwarePageRouter({

--- a/frontend/app/(base)/software/[slug]/edit/[page]/page.tsx
+++ b/frontend/app/(base)/software/[slug]/edit/[page]/page.tsx
@@ -7,7 +7,7 @@ import {Metadata} from 'next'
 import {notFound} from 'next/navigation'
 import EditSoftwareCommunities from '~/components/software/edit/communities'
 import EditSoftwareContributors from '~/components/software/edit/contributors'
-import {EditSoftwarePageId} from '~/components/software/edit/editSoftwareMenuItems'
+import {editSoftwareMenuItems, EditSoftwarePageId} from '~/components/software/edit/editSoftwareMenuItems'
 import EditSoftwareDescriptionPage from '~/components/software/edit/information'
 import EditSoftwareLinksPage from '~/components/software/edit/links'
 import EditSoftwareMaintainers from '~/components/software/edit/maintainers'
@@ -22,32 +22,16 @@ import SoftwareRepositories from '~/components/software/edit/repositories'
 
 import {app} from '~/config/app'
 
-const editSoftwarePageTitle: Record<EditSoftwarePageId, string> = {
-  information: 'Information',
-  links: 'Links',
-  repositories: 'Repositories',
-  contributors: 'Contributors',
-  organisations: 'Organisations',
-  mentions: 'Mentions',
-  testimonials: 'Testimonials',
-  'package-managers': 'Package managers',
-  'software-heritage': 'Software Heritage',
-  communities: 'Communities',
-  'related-software': 'Related software',
-  'related-projects': 'Related projects',
-  maintainers: 'Maintainers',
-  services: ''
-}
-
 export async function generateMetadata({
   params
 }:Readonly<{
   params: Promise<{slug: string, page: EditSoftwarePageId}>
 }>): Promise<Metadata> {
   const {page} = await params
-  const pageTitle = editSoftwarePageTitle[page]
+  const menuItem = editSoftwareMenuItems.find(item => item.id === page)
   return {
-    title: pageTitle ? `${pageTitle} | Edit software | ${app.title}` : `Edit software | ${app.title}`,
+    // use label of the menu item to added to page title
+    title: menuItem ? `${menuItem.label} | Edit software | ${app.title}` : `Edit software | ${app.title}`,
     description: 'Edit software page',
   }
 }

--- a/frontend/app/(base)/software/[slug]/page.tsx
+++ b/frontend/app/(base)/software/[slug]/page.tsx
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {Metadata} from 'next'
 import {notFound} from 'next/navigation'
 import {headers} from 'next/headers'
@@ -77,15 +82,15 @@ export async function generateMetadata(
   // console.log('resp...', resp)
   // console.groupEnd()
 
-  // if organisation exists we create metadata
-  if (software?.brand_name && software?.description){
+  // if brand_name and short_statement are present
+  if (software?.brand_name && software?.short_statement){
     // extract domain to use in url
     const domain = headersList.get('host') || ''
     // build metadata
     const metadata = createMetadata({
       domain,
       page_title: software?.brand_name,
-      description: software.description,
+      description: software?.short_statement,
       url: `https://${domain}/software/${slug}`,
       // if image present return array with image else []
       image_url: software.image_id ? [

--- a/frontend/app/(container)/user/[tab]/page.tsx
+++ b/frontend/app/(container)/user/[tab]/page.tsx
@@ -18,15 +18,38 @@ import ProjectQuality from '~/components/user/project-quality'
 import UserSettings from '~/components/user/settings'
 import UserSoftware from '~/components/user/software'
 import {UserPageId, userPageTitles} from '~/components/user/tabs/UserTabItems'
+import {UserSettingsTab, settingsMenu} from '~/components/user/settings/nav/UserSettingsNavItems'
 
-export async function generateMetadata({params }: {params: Promise<{tab: UserPageId}>}): Promise<Metadata> {
+export async function generateMetadata({params,searchParams}: {
+  params: Promise<{tab: UserPageId}>
+  searchParams: Promise<{settings?: UserSettingsTab}>
+}): Promise<Metadata> {
   // read route params
   const {token} = await getUserSettings()
   const user = await getUserFromToken(token)
-  const {tab} = await params
+  const [{tab},{settings}] = await Promise.all([
+    params,
+    searchParams
+  ])
   const tabLabel = userPageTitles[tab] ?? 'User'
 
-  // if user exists we create metadata
+  // console.group('UserPageRouter.generateMetadata')
+  // console.log('tab...', tab)
+  // console.log('settings...', settings)
+  // console.groupEnd()
+
+  // when settings page we also need to extract settings tab
+  if (tab==='settings'){
+    // find settings tab
+    const settingsTab = settingsMenu.find(item=>item.id===settings)
+    const settingTitle = settingsTab?.label() ?? 'Profile'
+    return {
+      title: `${settingTitle} | ${user?.name ?? 'User'} | ${app.title}`,
+      description: `${tabLabel} pages for ${user?.name ?? 'User'}`
+    }
+  }
+
+  // other user pages without additional settings tab
   return {
     title: `${tabLabel} | ${user?.name ?? 'User'} | ${app.title}`,
     description: `${tabLabel} pages for ${user?.name ?? 'User'}`

--- a/frontend/app/(container)/user/[tab]/page.tsx
+++ b/frontend/app/(container)/user/[tab]/page.tsx
@@ -1,6 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {Suspense} from 'react'
 import {notFound} from 'next/navigation'
+import {Metadata} from 'next'
 
+import {app} from '~/config/app'
+import {getUserFromToken} from '~/auth/getSessionServerSide'
+import {getUserSettings} from '~/components/user/ssrUserSettings'
 import ListContentSkeleton from '~/components/layout/ListContentSkeleton'
 import UserCommunities from '~/components/user/communities'
 import UserOrganisations from '~/components/user/organisations'
@@ -8,7 +17,21 @@ import UserProjects from '~/components/user/project'
 import ProjectQuality from '~/components/user/project-quality'
 import UserSettings from '~/components/user/settings'
 import UserSoftware from '~/components/user/software'
-import {UserPageId} from '~/components/user/tabs/UserTabItems'
+import {UserPageId, userPageTitles} from '~/components/user/tabs/UserTabItems'
+
+export async function generateMetadata({params }: {params: Promise<{tab: UserPageId}>}): Promise<Metadata> {
+  // read route params
+  const {token} = await getUserSettings()
+  const user = await getUserFromToken(token)
+  const {tab} = await params
+  const tabLabel = userPageTitles[tab] ?? ''
+
+  // if user exists we create metadata
+  return {
+    title: `${tabLabel} | ${user?.name ?? 'User'} | ${app.title}`,
+    description: `${tabLabel} pages for ${user?.name ?? 'User'}`
+  }
+}
 
 export default async function UserPageRouter({
   params

--- a/frontend/app/(container)/user/[tab]/page.tsx
+++ b/frontend/app/(container)/user/[tab]/page.tsx
@@ -17,7 +17,7 @@ import UserProjects from '~/components/user/project'
 import ProjectQuality from '~/components/user/project-quality'
 import UserSettings from '~/components/user/settings'
 import UserSoftware from '~/components/user/software'
-import {UserPageId, userPageTitles} from '~/components/user/tabs/UserTabItems'
+import {UserPageId, userTabItems} from '~/components/user/tabs/UserTabItems'
 import {UserSettingsTab, settingsMenu} from '~/components/user/settings/nav/UserSettingsNavItems'
 
 export async function generateMetadata({params,searchParams}: {
@@ -31,7 +31,7 @@ export async function generateMetadata({params,searchParams}: {
     params,
     searchParams
   ])
-  const tabLabel = userPageTitles[tab] ?? 'User'
+  const tabInfo = userTabItems[tab] ?? 'User'
 
   // console.group('UserPageRouter.generateMetadata')
   // console.log('tab...', tab)
@@ -45,14 +45,14 @@ export async function generateMetadata({params,searchParams}: {
     const settingTitle = settingsTab?.label() ?? 'Profile'
     return {
       title: `${settingTitle} | ${user?.name ?? 'User'} | ${app.title}`,
-      description: `${tabLabel} pages for ${user?.name ?? 'User'}`
+      description: `${tabInfo?.pageTitle} pages for ${user?.name ?? 'User'}`
     }
   }
 
   // other user pages without additional settings tab
   return {
-    title: `${tabLabel} | ${user?.name ?? 'User'} | ${app.title}`,
-    description: `${tabLabel} pages for ${user?.name ?? 'User'}`
+    title: `${tabInfo?.pageTitle} | ${user?.name ?? 'User'} | ${app.title}`,
+    description: `${tabInfo?.pageTitle} pages for ${user?.name ?? 'User'}`
   }
 }
 

--- a/frontend/app/(container)/user/[tab]/page.tsx
+++ b/frontend/app/(container)/user/[tab]/page.tsx
@@ -24,7 +24,7 @@ export async function generateMetadata({params }: {params: Promise<{tab: UserPag
   const {token} = await getUserSettings()
   const user = await getUserFromToken(token)
   const {tab} = await params
-  const tabLabel = userPageTitles[tab] ?? ''
+  const tabLabel = userPageTitles[tab] ?? 'User'
 
   // if user exists we create metadata
   return {

--- a/frontend/app/(container)/user/layout.tsx
+++ b/frontend/app/(container)/user/layout.tsx
@@ -1,7 +1,10 @@
-import {Metadata} from 'next'
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {notFound} from 'next/navigation'
 
-import {app} from '~/config/app'
 import {getUserFromToken} from '~/auth/getSessionServerSide'
 import ProtectedContent from '~/auth/ProtectedContent'
 import PageErrorMessage from '~/components/layout/PageErrorMessage'
@@ -12,29 +15,6 @@ import UserMetadata from '~/components/user/metadata'
 import UserAgreementModal from '~/components/user/settings/agreements/UserAgreementModal'
 import {loadUserProfile} from '~/components/user/settings/profile/apiUserProfile'
 import UserTabs from '~/components/user/tabs/UserTabs'
-
-/**
- * Next.js app builtin function to dynamically create page metadata
- * @param param0
- * @returns
- */
-export async function generateMetadata(): Promise<Metadata> {
-  // read route params
-  const {token} = await getUserSettings()
-  const user = await getUserFromToken(token)
-
-  // console.group('UserPageLayout.generateMetadata')
-  // console.log('token...', token)
-  // console.log('user...', user)
-  // console.groupEnd()
-
-  // if user exists we create metadata
-  return {
-    title: `${user?.name ?? 'User'} | ${app.title}`,
-    description: `${user?.name ?? 'User'} pages`
-  }
-
-}
 
 /**
  * (Partial) Layout of organisation page content.

--- a/frontend/components/user/settings/UserSettingsContent.tsx
+++ b/frontend/components/user/settings/UserSettingsContent.tsx
@@ -2,10 +2,13 @@
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
 'use client'
+import {useEffect} from 'react'
 import {useSearchParams} from 'next/navigation'
 
 import {UserSettingsTab} from './nav/UserSettingsNavItems'
@@ -14,9 +17,21 @@ import UserProfilePage from './profile'
 import UserAgreementsPage from './agreements'
 import UserAccessTokensPage from './accesstokens'
 
+export const settingsSubpageTitles: Record<UserSettingsTab, string> = {
+  profile: 'Profile',
+  about: 'About Me',
+  agreements: 'User Agreements',
+  accesstokens: 'API Access Tokens',
+}
+
 export default function UserSettingsContent() {
   const searchParams = useSearchParams()
   const settings = searchParams?.get('settings') as UserSettingsTab ?? 'profile' as UserSettingsTab
+
+  useEffect(() => {
+    const subpageLabel = settingsSubpageTitles[settings] ?? 'Profile'
+    document.title = `${subpageLabel} | ${document.title}`
+  }, [settings])
 
   switch (settings) {
     case 'about':

--- a/frontend/components/user/settings/UserSettingsContent.tsx
+++ b/frontend/components/user/settings/UserSettingsContent.tsx
@@ -8,7 +8,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 'use client'
-import {useEffect} from 'react'
 import {useSearchParams} from 'next/navigation'
 
 import {UserSettingsTab} from './nav/UserSettingsNavItems'
@@ -17,21 +16,10 @@ import UserProfilePage from './profile'
 import UserAgreementsPage from './agreements'
 import UserAccessTokensPage from './accesstokens'
 
-export const settingsSubpageTitles: Record<UserSettingsTab, string> = {
-  profile: 'Profile',
-  about: 'About Me',
-  agreements: 'User Agreements',
-  accesstokens: 'API Access Tokens',
-}
 
 export default function UserSettingsContent() {
   const searchParams = useSearchParams()
   const settings = searchParams?.get('settings') as UserSettingsTab ?? 'profile' as UserSettingsTab
-
-  useEffect(() => {
-    const subpageLabel = settingsSubpageTitles[settings] ?? 'Profile'
-    document.title = `${subpageLabel} | ${document.title}`
-  }, [settings])
 
   switch (settings) {
     case 'about':

--- a/frontend/components/user/settings/UserSettingsContent.tsx
+++ b/frontend/components/user/settings/UserSettingsContent.tsx
@@ -2,8 +2,6 @@
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
-// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
-// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,7 +13,6 @@ import UserAboutPage from './about'
 import UserProfilePage from './profile'
 import UserAgreementsPage from './agreements'
 import UserAccessTokensPage from './accesstokens'
-
 
 export default function UserSettingsContent() {
   const searchParams = useSearchParams()

--- a/frontend/components/user/tabs/UserTabItems.tsx
+++ b/frontend/components/user/tabs/UserTabItems.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,6 +26,16 @@ export type UserPageTabItemProps = {
 
 export type UserTabProps = {
   [key in UserPageId]: UserPageTabItemProps
+}
+
+export const userPageTitles: Record<string, string> = {
+  software: 'My Software',
+  projects: 'My Projects',
+  organisations: 'My Organisations',
+  communities: 'My Communities',
+  'project-quality': 'Project metadata',
+  settings: 'Settings',
+  about: 'About',
 }
 
 /**

--- a/frontend/components/user/tabs/UserTabItems.tsx
+++ b/frontend/components/user/tabs/UserTabItems.tsx
@@ -22,20 +22,11 @@ export type UserPageTabItemProps = {
   label: (props:any)=>string,
   icon: JSX.Element,
   isVisible: (props: any) => boolean
+  pageTitle: string
 }
 
 export type UserTabProps = {
   [key in UserPageId]: UserPageTabItemProps
-}
-
-export const userPageTitles: Record<string, string> = {
-  software: 'My Software',
-  projects: 'My Projects',
-  organisations: 'My Organisations',
-  communities: 'My Communities',
-  'project-quality': 'Project metadata',
-  settings: 'Settings',
-  about: 'About',
 }
 
 /**
@@ -51,6 +42,7 @@ export const userTabItems:UserTabProps = {
     isVisible: ({modules}) => {
       return modules?.includes('software')
     },
+    pageTitle: 'My software'
   },
   projects:{
     id:'projects',
@@ -59,6 +51,7 @@ export const userTabItems:UserTabProps = {
     isVisible: ({modules}) => {
       return modules?.includes('projects')
     },
+    pageTitle: 'My projects'
   },
   organisations: {
     id:'organisations',
@@ -67,6 +60,7 @@ export const userTabItems:UserTabProps = {
     isVisible: ({modules}) => {
       return modules?.includes('organisations')
     },
+    pageTitle: 'My organisations'
   },
   communities:{
     id:'communities',
@@ -75,20 +69,23 @@ export const userTabItems:UserTabProps = {
     isVisible: ({modules}) => {
       return modules?.includes('communities') && modules?.includes('software')
     },
+    pageTitle: 'My communities'
   },
   'project-quality':{
     id:'project-quality',
     label: () => 'Project metadata',
     icon: <TableViewIcon />,
     // we do not show this option if not a maintainer and project
-    isVisible: ({isMaintainer,modules}) => isMaintainer && modules?.includes('projects')
+    isVisible: ({isMaintainer,modules}) => isMaintainer && modules?.includes('projects'),
+    pageTitle: 'Project metadata'
   },
   settings:{
     id:'settings',
     label:()=>'Settings',
     icon: <SettingsIcon />,
     // we do not show this option if not a maintainer
-    isVisible: ({isMaintainer}) => isMaintainer
+    isVisible: ({isMaintainer}) => isMaintainer,
+    pageTitle: 'Settings'
   },
   about: {
     id:'about',
@@ -104,5 +101,6 @@ export const userTabItems:UserTabProps = {
       // else the description is present and we show about section
       else return true
     },
+    pageTitle: 'About'
   }
 }


### PR DESCRIPTION
# Pull request Title

Fixes https://github.com/research-software-directory/RSD-as-a-service/issues/1731

Changes proposed in this pull request:

* Modifies the generation of metadata in the Edit Software and User pages such that the page title is informative about the contents of the page.
* Does the same for the software page, where a missing description was preventing the software title to correctly display.

How to test:

* Go to one of the above pages and check in the page source that the page title correctly represents what is being shown. For example, for the User `admin`, Settings > Profile shows shows `Profile | Settings | admin | Research Software Directory`

<img width="1788" height="753" alt="image" src="https://github.com/user-attachments/assets/e157b8d5-739a-43d6-bfd2-11a665c181c7" />


PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
