### PR TITLE
Fix double tab presses

### DIFF
--- a/frontend/components/home/rsd/GradientBorderButton.tsx
+++ b/frontend/components/home/rsd/GradientBorderButton.tsx
@@ -1,13 +1,15 @@
 // SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import Link from 'next/link'
+
 export default function GradientBorderButton({text, url, target = '_self', minWidth = '9rem'}: {text: string, url: string, target?: string, minWidth?: string}) {
-  return <a href={url} className="cursor-pointer" target={target}>
-    <button style={{minWidth}} className="group m-2 p-[0.125rem] rounded-sm transition duration-500 bg-linear-to-tl to-base-400 via-base-500 from-primary bg-size-200 bg-pos-0 hover:bg-pos-100">
-      <span className="flex w-full bg-base-800  p-4 rounded-sm justify-center pointer-events-non group-hover:bg-base-700 transition duration-300  text-base-400 group-hover:text-base-100">
-        {text}
-      </span></button>
-  </a>
+  return <Link href={url} style={{minWidth}} target={target} className="cursor-pointer group m-2 p-[0.125rem] rounded-sm transition duration-500 bg-linear-to-tl to-base-400 via-base-500 from-primary bg-size-200 bg-pos-0 hover:bg-pos-100">
+    <span className="flex w-full bg-base-800  p-4 rounded-sm justify-center pointer-events-non group-hover:bg-base-700 transition duration-300  text-base-400 group-hover:text-base-100">
+      {text}
+    </span>
+  </Link>
 }

--- a/frontend/components/layout/PaginationLinkApp.tsx
+++ b/frontend/components/layout/PaginationLinkApp.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -36,9 +37,7 @@ export default function PaginationLinkApp({count,page,className}:PaginationLinkP
             urlParams.set('page',item.page.toString())
             const url = `${pathname}?${urlParams.toString()}`
             return (
-              <Link href={url}>
-                <PaginationItem {...item}/>
-              </Link>
+              <PaginationItem {...item} component={Link} href={url} />
             )
           } else {
             return (

--- a/frontend/components/layout/TagChipFilter.tsx
+++ b/frontend/components/layout/TagChipFilter.tsx
@@ -1,11 +1,15 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import Link from 'next/link'
+'use client'
+
+import NextLink from 'next/link'
+import MuiLink from '@mui/material/Link'
 import Chip from '@mui/material/Chip'
 import SearchIcon from '@mui/icons-material/Search'
 import CircularProgress from '@mui/material/CircularProgress'
@@ -63,15 +67,11 @@ export default function TagChipFilter({
   )
 
   return (
-    <Link
-      href={url}
-      passHref
-    >
+    <MuiLink component={NextLink} href={url}>
       <Chip
         title={`Click to filter for ${title ? title : label}`}
         label={label}
         icon={<SearchIcon />}
-        clickable
         sx={{
           maxWidth: '19rem',
           borderRadius: '0.125rem',
@@ -84,6 +84,6 @@ export default function TagChipFilter({
           }
         }}
       />
-    </Link>
+    </MuiLink>
   )
 }


### PR DESCRIPTION
## Fix double tab presses

### Changes proposed in this pull request

* Keywords and other chips now have only one tab press instead of two
* Same for pagination items, like on the bottom of the software or project overview pages

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Go to the software or project overview page
* The pagination buttons should only contain one tab press per button
* Clicking them should trigger client side navigation, not a full page reload
* Disable JavaScript, links should still work, but with a full page reload, and they don't have focus styling. We might improve on the styling when we upgrade to MUI v9, as the PaginationItem component [has a new `nativeButton` prop](https://mui.com/material-ui/api/pagination-item/#props).
* Visit a software or project page
* Keywords and categories (and research domains for projects) should only contain one tab press per button
* They should trigger client side navigation when JS is enabled
* They should still be clickable (except for categories) and have styling when JS is disabled
* Check if there are any other elements that still have double tab navigation

closes #1729

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests