### PR TITLE
Add accessible name to feedback dialog

### DIFF
--- a/frontend/components/feedback/FeedbackPanelButton.tsx
+++ b/frontend/components/feedback/FeedbackPanelButton.tsx
@@ -95,9 +95,9 @@ User Agent: ${navigator.userAgent}`
       >
         <div className="h-full w-full bg-base-700 p-5 ">
           <div className="mx-auto max-w-[500px]">
-            <h1 className="text-base-100 mb-4" id="feedback-dialog-title">
+            <h2 className="text-base-100 mb-4" id="feedback-dialog-title">
               Send Feedback
-            </h1>
+            </h2>
             <textarea
               autoFocus
               className="placeholder:text-base-500 outline-0 p-2 w-full h-28 text-sm bg-base-700 text-base-100 border border-base-600 rounded-sm"

--- a/frontend/components/feedback/FeedbackPanelButton.tsx
+++ b/frontend/components/feedback/FeedbackPanelButton.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -88,14 +90,14 @@ User Agent: ${navigator.userAgent}`
         fullScreen={fullScreen}
         open={open}
         onClose={handleClose}
-        aria-labelledby="responsive-dialog-title"
+        aria-labelledby="feedback-dialog-title"
         disableScrollLock={disable}
       >
         <div className="h-full w-full bg-base-700 p-5 ">
           <div className="mx-auto max-w-[500px]">
-            <div className="text-base-100 text-xl mb-4">
+            <h1 className="text-base-100 mb-4" id="feedback-dialog-title">
               Send Feedback
-            </div>
+            </h1>
             <textarea
               autoFocus
               className="placeholder:text-base-500 outline-0 p-2 w-full h-28 text-sm bg-base-700 text-base-100 border border-base-600 rounded-sm"


### PR DESCRIPTION
# Add accessible name to feedback dialog

Fixes #1752 

Changes proposed in this pull request:

Adds an accessible name to the feedback dialog. I believe this is what this issue required, although the accesiblity page pointed out does not contain the relevant information. The following one does, and that has been the approach taken.

https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/

How to test:

* If you inspect the dialog now, it should have an accessible name. 

<img width="1575" height="747" alt="Screenshot From 2026-05-14 14-22-17" src="https://github.com/user-attachments/assets/a7e8cf43-008f-416c-8e1d-67b79f57b95b" />

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
