### PR TITLE
Make list items acceptable from the accessibility perspective

### DIFF
--- a/frontend/components/software/edit/EditSoftwareNav.tsx
+++ b/frontend/components/software/edit/EditSoftwareNav.tsx
@@ -7,19 +7,19 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 PERFACCT GmbH
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
 'use client'
 import {useRouter, useParams} from 'next/navigation'
-import Link from 'next/link'
 
 import List from '@mui/material/List'
-import ListItemButton from '@mui/material/ListItemButton'
+import ListItem from '@mui/material/ListItem'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
 
-import {editMenuItemButtonSx} from '~/config/menuItems'
 import useRsdSettings from '~/config/useRsdSettings'
 import {usePluginSlots} from '~/config/RsdPluginContext'
 import SvgFromString from '~/components/icons/SvgFromString'
@@ -44,20 +44,35 @@ export default function EditSoftwareNav({slug}:Readonly<{slug:string}>) {
       }}>
         {editSoftwareMenuItems.map(item => {
           if (item.active({modules:activeModules})===true){
+            const isSelected = item.id === pageId
             return (
-              <ListItemButton
+              <ListItem
                 data-testid="edit-software-nav-item"
                 key={item.id}
-                selected={item.id === pageId}
-                href={`/software/${slug}/edit/${item.id}`}
-                LinkComponent={Link}
-                sx={editMenuItemButtonSx}
+                tabIndex={0}
+                onClick={() => {
+                  router.push(`/software/${slug}/edit/${item.id}`)
+                }}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    router.push(`/software/${slug}/edit/${item.id}`)
+                  }
+                }}
+                sx={{
+                  cursor: 'pointer',
+                  ...(isSelected && {
+                    backgroundColor: 'action.selected',
+                    '& > div > span': {
+                      fontWeight: 500
+                    }
+                  })
+                }}
               >
                 <ListItemIcon>
                   {item.icon}
                 </ListItemIcon>
                 <ListItemText primary={item.label} secondary={item.status} />
-              </ListItemButton>
+              </ListItem>
             )
           }
         })}
@@ -65,20 +80,27 @@ export default function EditSoftwareNav({slug}:Readonly<{slug:string}>) {
           pluginSlots.map((pluginSlot) => {
             const url = pluginSlot.href ? pluginSlot.href.replace('{slug}', slug) : '#'
             return (
-              <ListItemButton
+              <ListItem
                 data-testid="edit-software-plugin-item"
                 key={pluginSlot.title}
-                selected={false}
+                tabIndex={0}
                 onClick={() => {
                   router.push(url)
                 }}
-                sx={editMenuItemButtonSx}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    router.push(url)
+                  }
+                }}
+                sx={{
+                  cursor: 'pointer'
+                }}
               >
                 <ListItemIcon>
                   <SvgFromString svg={pluginSlot.icon}/>
                 </ListItemIcon>
                 <ListItemText primary={pluginSlot.title} secondary={''} />
-              </ListItemButton>
+              </ListItem>
             )
           })
         }


### PR DESCRIPTION
# Make list items acceptable from the accessibility perspective

Fixes #1753 

Changes proposed in this pull request:

It seems that the `ListItemButton` control is creating an underlying html code for the menu items that is not accessible, as it does not convey the right information - they are not `<li>` objects, but `<a>`. Also, they have as role `button`, which apparently is not accessible, either. 

To fix this, I used the less customised `ListItem` and add the right functionality and similar styling manually. The result is a bit ugly and defeats the purpose of using the nice MUI components, so we might need to reconsider the approach.

How to test:

* Launch the tool and edit a software. Check the source code of the menu and see that the items now are `<li>` and have no `button` role. 
* Use a tool like `Accessibility Insights for Web` to make sure that particular issue is not an issue. 

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
