### PR TITLE
1753 list structure

### DIFF
--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -294,7 +294,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
               fill="#707070"/>
           </svg>
         </div>
-        <label
+        <section
           role="search"
           aria-label="Search RSD website"
         >
@@ -323,14 +323,14 @@ export default function GlobalSearchAutocomplete(props: Props) {
             // Tells which item is highlighted via arrow keys
             aria-activedescendant={selected !== -1 && isOpen ? `search-item-${selected}` : undefined}
           />
-        </label>
+        </section>
         <span
           className="absolute top-[9px] right-2 text-base-600"
           hidden={isOpen}
         >{searchCombo}</span>
 
         {isOpen &&
-          <ul // NOSONAR
+          <ul
             // AI-assisted suggestion Google seach AI-Mode
             // Matches the aria-controls tag on the input element
             id="global-search-results"
@@ -359,14 +359,14 @@ export default function GlobalSearchAutocomplete(props: Props) {
               })
 
               return (
-                <li // NOSONAR
-                  key={item.slug}
+                <li
+                  key={url}
                   // Distinct ID mapped to aria-activedescendant
                   id={`search-item-${index}`}
-                  // AI-assisted suggestion Google seach AI-Mode
+                  // AI-assisted suggestion Google search AI-Mode
                   // Explicitly states this element is a selectable list option
                   role="option"
-                  // AI-assisted suggestion Google seach AI-Mode
+                  // AI-assisted suggestion Google search AI-Mode
                   // Dynamic flag tracking current keyboard focus
                   aria-selected={selected === index}
                   data-testid="global-search-list-item"

--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -6,7 +6,7 @@
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
-// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -235,7 +235,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
     }
   }
 
-  function handleChange(e: React.FormEvent<HTMLInputElement>) {
+  function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
     const search = e.currentTarget.value
     // Update state
     setInputValue(search)
@@ -309,15 +309,18 @@ export default function GlobalSearchAutocomplete(props: Props) {
             onKeyDown={handleKeyDown}
             type="text"
             onFocus={focusSearch}
-            // Tells AT this input controls a dynamic dropdown panel
+            // AI-assisted suggestion using Google search AI-Mode
             role="combobox"
+            // AI-assisted suggestion using Google search AI-Mode
             // Notifies user that typing populates a list below
             aria-autocomplete="list"
             // Dynamic state: true when dropdown opens, false when closed
             aria-expanded={isOpen}
+            // AI-assisted suggestion Google seach AI-Mode
             // Direct semantic link to the list wrapper element id
             aria-controls="global-search-results"
-            // Tells AT which item is highlighted via your arrow keys
+            // AI-assisted suggestion Google seach AI-Mode
+            // Tells which item is highlighted via arrow keys
             aria-activedescendant={selected !== -1 && isOpen ? `search-item-${selected}` : undefined}
           />
         </label>
@@ -327,11 +330,14 @@ export default function GlobalSearchAutocomplete(props: Props) {
         >{searchCombo}</span>
 
         {isOpen &&
-          <ul
+          <ul // NOSONAR
+            // AI-assisted suggestion Google seach AI-Mode
             // Matches the aria-controls tag on the input element
             id="global-search-results"
-            // Tells AT that this div wrapper contains listbox options
+            // AI-assisted suggestion Google seach AI-Mode
+            // Tells that this ul wrapper contains listbox options
             role="listbox"
+            // AI-assisted suggestion Google seach AI-Mode
             aria-label="Search results"
             data-testid="global-search-list"
             className="list-none m-0 shadow-xl absolute top-[50px] w-full left-0 bg-base-100 text-base-900 py-2 rounded-xs"
@@ -354,11 +360,13 @@ export default function GlobalSearchAutocomplete(props: Props) {
 
               return (
                 <li // NOSONAR
-                  key={index}
+                  key={item.slug}
                   // Distinct ID mapped to aria-activedescendant
                   id={`search-item-${index}`}
+                  // AI-assisted suggestion Google seach AI-Mode
                   // Explicitly states this element is a selectable list option
                   role="option"
+                  // AI-assisted suggestion Google seach AI-Mode
                   // Dynamic flag tracking current keyboard focus
                   aria-selected={selected === index}
                   data-testid="global-search-list-item"

--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -1,11 +1,12 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -48,7 +49,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
   const [searchCombo, setSearchCombo] = useState('Ctrl K')
   const {hasRemotes} = useHasRemotes()
 
-  const lastValue = useDebounce(inputValue, 150)
+  const lastValue = useDebounce(inputValue, 300)
   const inputRef = useRef<HTMLInputElement>(null)
   const defaultValues: GlobalSearchResults[] = []
 
@@ -277,35 +278,63 @@ export default function GlobalSearchAutocomplete(props: Props) {
         className={`${props.className} relative flex w-full xl:w-[14.5rem] xl:max-w-[20rem] focus-within:w-full duration-700`}>
         <div className="absolute top-[14px] left-3 pointer-events-none">
           {/* Search Icon */}
-          <svg width="16" height="16" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
+          <svg
+            // Hide icon from screen reader announcements
+            aria-hidden="true"
+            // Prevent browser focus on the vector asset
+            focusable="false"
+            width="16"
+            height="16"
+            viewBox="0 0 14 14"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
             <path
               d="M5.72217 0.34082C2.86783 0.34082 0.559204 2.64944 0.559204 5.50378C0.559204 8.35812 2.86783 10.6667 5.72217 10.6667C6.74123 10.6667 7.68438 10.3678 8.48397 9.86003L12.2138 13.5899L13.5046 12.2992L9.82216 8.62624C10.4841 7.75783 10.8851 6.68182 10.8851 5.50378C10.8851 2.64944 8.57651 0.34082 5.72217 0.34082ZM5.72217 1.55564C7.90859 1.55564 9.67031 3.31735 9.67031 5.50378C9.67031 7.69021 7.90859 9.45193 5.72217 9.45193C3.53574 9.45193 1.77402 7.69021 1.77402 5.50378C1.77402 3.31735 3.53574 1.55564 5.72217 1.55564Z"
               fill="#707070"/>
           </svg>
         </div>
-        <input className="px-2 pl-8 py-2 bg-transparent rounded-xs border border-base-600 focus:outline-0 w-full focus:bg-base-100 focus:text-base-900 duration-200"
-          ref={inputRef}
-          data-testid="global-search"
-          name="global-search"
-          placeholder="Search or jump to..."
-          autoComplete="off"
-          value={inputValue}
-          onChange={handleChange}
-          onKeyDown={handleKeyDown}
-          type="text"
-          onFocus={focusSearch}
-          aria-label="Search RSD website"
+        <label
           role="search"
-        />
+          aria-label="Search RSD website"
+        >
+          <input className="px-2 pl-8 py-2 bg-transparent rounded-xs border border-base-600 focus:outline-0 w-full focus:bg-base-100 focus:text-base-900 duration-200"
+            ref={inputRef}
+            data-testid="global-search"
+            name="global-search"
+            placeholder="Search or jump to..."
+            autoComplete="off"
+            value={inputValue}
+            onChange={handleChange}
+            onKeyDown={handleKeyDown}
+            type="text"
+            onFocus={focusSearch}
+            // Tells AT this input controls a dynamic dropdown panel
+            role="combobox"
+            // Notifies user that typing populates a list below
+            aria-autocomplete="list"
+            // Dynamic state: true when dropdown opens, false when closed
+            aria-expanded={isOpen}
+            // Direct semantic link to the list wrapper element id
+            aria-controls="global-search-results"
+            // Tells AT which item is highlighted via your arrow keys
+            aria-activedescendant={selected !== -1 && isOpen ? `search-item-${selected}` : undefined}
+          />
+        </label>
         <span
           className="absolute top-[9px] right-2 text-base-600"
           hidden={isOpen}
         >{searchCombo}</span>
 
         {isOpen &&
-          <div
+          <ul
+            // Matches the aria-controls tag on the input element
+            id="global-search-results"
+            // Tells AT that this div wrapper contains listbox options
+            role="listbox"
+            aria-label="Search results"
             data-testid="global-search-list"
-            className="shadow-xl absolute top-[50px] w-full left-0 bg-base-100 text-base-900 py-2 rounded-xs"
+            className="list-none m-0 shadow-xl absolute top-[50px] w-full left-0 bg-base-100 text-base-900 py-2 rounded-xs"
             style={{
               maxHeight: '50vh',
               overflow: 'auto',
@@ -323,9 +352,15 @@ export default function GlobalSearchAutocomplete(props: Props) {
                 slug: item?.slug ?? '/'
               })
 
-              // debugger
               return (
-                <div key={index}
+                <li // NOSONAR
+                  key={index}
+                  // Distinct ID mapped to aria-activedescendant
+                  id={`search-item-${index}`}
+                  // Explicitly states this element is a selectable list option
+                  role="option"
+                  // Dynamic flag tracking current keyboard focus
+                  aria-selected={selected === index}
                   data-testid="global-search-list-item"
                   className={`${selected === index ? 'bg-base-200' : ''} flex gap-2 p-2 cursor-pointer transition justify-between items-center`}
                   onClick={handleClick}
@@ -340,7 +375,10 @@ export default function GlobalSearchAutocomplete(props: Props) {
                 >
                   <div className="flex gap-3 w-full">
                     {/*icon*/}
-                    <div className={selected === index ? 'text-content' : 'opacity-40'}>
+                    <div
+                      // Hide icon from screen reader announcements
+                      aria-hidden="true"
+                      className={selected === index ? 'text-content' : 'opacity-40'}>
                       <SearchItemIcon source={item.source} />
                     </div>
 
@@ -359,16 +397,22 @@ export default function GlobalSearchAutocomplete(props: Props) {
                         domain={item.domain}
                         rsd_host={item.rsd_host}
                       />
-                      <UnpublishedLabel is_published={item?.is_published} />
+                      <UnpublishedLabel
+                        is_published={item?.is_published}
+                      />
                     </div>
-                    {selected === index && <div>
+                    {selected === index &&
+                    <div
+                      // Hide icon from screen reader announcements
+                      aria-hidden="true"
+                    >
                       <EnterkeyIcon/>
                     </div>}
                   </div>
-                </div>
+                </li>
               )
             })}
-          </div>
+          </ul>
         }
       </div>
     </ClickAwayListener>

--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -1,12 +1,11 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
-// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -330,7 +329,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
         >{searchCombo}</span>
 
         {isOpen &&
-          <ul
+          <ul //NOSONAR
             // AI-assisted suggestion Google seach AI-Mode
             // Matches the aria-controls tag on the input element
             id="global-search-results"
@@ -359,7 +358,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
               })
 
               return (
-                <li
+                <li //NOSONAR
                   key={url}
                   // Distinct ID mapped to aria-activedescendant
                   id={`search-item-${index}`}

--- a/frontend/components/projects/edit/EditProjectNav.tsx
+++ b/frontend/components/projects/edit/EditProjectNav.tsx
@@ -1,10 +1,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/projects/edit/EditProjectNav.tsx
+++ b/frontend/components/projects/edit/EditProjectNav.tsx
@@ -4,7 +4,7 @@
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/projects/edit/EditProjectNav.tsx
+++ b/frontend/components/projects/edit/EditProjectNav.tsx
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,6 +13,7 @@
 import {useParams} from 'next/navigation'
 import Link from 'next/link'
 import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
@@ -20,32 +22,44 @@ import {editMenuItemButtonSx} from '~/config/menuItems'
 import useRsdSettings from '~/config/useRsdSettings'
 import {editProjectMenuItems} from './editProjectMenuItems'
 
+
 export default function EditProjectNav({slug}:Readonly<{slug:string}>) {
   const {activeModules} = useRsdSettings()
   const params = useParams()
   const pageId = params?.page
   return (
-    <nav>
+    // 1. Label the nav so screen readers know its purpose
+    <nav aria-label="Edit project navigation">
       <List sx={{
         width:['100%','100%','15rem']
       }}>
         {editProjectMenuItems.map((item, pos) => {
           // show only "active" mention options
           if (item.active({modules: activeModules})===true){
+            const isSelected = item.id === pageId
             return (
-              <ListItemButton
-                data-testid="edit-project-nav-item"
-                key={`step-${pos}`}
-                selected={item.id === pageId}
-                href={`/projects/${slug}/edit/${item.id}`}
-                LinkComponent={Link}
-                sx={editMenuItemButtonSx}
+              // 2. Wrap button in a semantic ListItem (<li>)
+              <ListItem
+                key={item.id}
+                disablePadding
               >
-                <ListItemIcon>
-                  {item.icon}
-                </ListItemIcon>
-                <ListItemText primary={item.label} secondary={item.status} />
-              </ListItemButton>
+                <ListItemButton
+                  data-testid="edit-project-nav-item"
+                  key={`step-${pos}`}
+                  selected={isSelected}
+                  href={`/projects/${slug}/edit/${item.id}`}
+                  LinkComponent={Link}
+                  // 3. Inform screen readers which page is active
+                  aria-current={isSelected ? 'page' : undefined}
+                  sx={editMenuItemButtonSx}
+                >
+                  {/* 4. Hide icons from screen readers if they are purely decorative */}
+                  <ListItemIcon aria-hidden="true">
+                    {item.icon}
+                  </ListItemIcon>
+                  <ListItemText primary={item.label} secondary={item.status} />
+                </ListItemButton>
+              </ListItem>
             )
           }
         })}

--- a/frontend/components/software/edit/EditSoftwareNav.tsx
+++ b/frontend/components/software/edit/EditSoftwareNav.tsx
@@ -2,19 +2,21 @@
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 PERFACCT GmbH
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 'use client'
-import {useRouter, useParams} from 'next/navigation'
+import {useParams} from 'next/navigation'
 import Link from 'next/link'
 
 import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
@@ -26,7 +28,6 @@ import SvgFromString from '~/components/icons/SvgFromString'
 import {editSoftwareMenuItems} from './editSoftwareMenuItems'
 
 export default function EditSoftwareNav({slug}:Readonly<{slug:string}>) {
-  const router = useRouter()
   const params = useParams()
   const pageId = params?.page
   const {activeModules} = useRsdSettings()
@@ -38,26 +39,36 @@ export default function EditSoftwareNav({slug}:Readonly<{slug:string}>) {
   // console.groupEnd()
 
   return (
-    <nav>
+    // 1. Label the nav so screen readers know its purpose
+    <nav aria-label="Edit software navigation">
       <List sx={{
         width:['100%','100%','15rem']
       }}>
         {editSoftwareMenuItems.map(item => {
           if (item.active({modules:activeModules})===true){
+            const isSelected = item.id === pageId
             return (
-              <ListItemButton
-                data-testid="edit-software-nav-item"
+              // 2. Wrap button in a semantic ListItem (<li>)
+              <ListItem
                 key={item.id}
-                selected={item.id === pageId}
-                href={`/software/${slug}/edit/${item.id}`}
-                LinkComponent={Link}
-                sx={editMenuItemButtonSx}
+                disablePadding
               >
-                <ListItemIcon>
-                  {item.icon}
-                </ListItemIcon>
-                <ListItemText primary={item.label} secondary={item.status} />
-              </ListItemButton>
+                <ListItemButton
+                  data-testid="edit-software-nav-item"
+                  selected={isSelected}
+                  href={`/software/${slug}/edit/${item.id}`}
+                  LinkComponent={Link}
+                  // 3. Inform screen readers which page is active
+                  aria-current={isSelected ? 'page' : undefined}
+                  sx={editMenuItemButtonSx}
+                >
+                  {/* 4. Hide icons from screen readers if they are purely decorative */}
+                  <ListItemIcon aria-hidden="true">
+                    {item.icon}
+                  </ListItemIcon>
+                  <ListItemText primary={item.label} secondary={item.status} />
+                </ListItemButton>
+              </ListItem>
             )
           }
         })}
@@ -65,20 +76,27 @@ export default function EditSoftwareNav({slug}:Readonly<{slug:string}>) {
           pluginSlots.map((pluginSlot) => {
             const url = pluginSlot.href ? pluginSlot.href.replace('{slug}', slug) : '#'
             return (
-              <ListItemButton
-                data-testid="edit-software-plugin-item"
+              // 2. Wrap button in a semantic ListItem (<li>)
+              <ListItem
                 key={pluginSlot.title}
-                selected={false}
-                onClick={() => {
-                  router.push(url)
-                }}
-                sx={editMenuItemButtonSx}
+                disablePadding
               >
-                <ListItemIcon>
-                  <SvgFromString svg={pluginSlot.icon}/>
-                </ListItemIcon>
-                <ListItemText primary={pluginSlot.title} secondary={''} />
-              </ListItemButton>
+                <ListItemButton
+                  data-testid="edit-software-plugin-item"
+                  selected={false}
+                  href={url}
+                  LinkComponent={Link}
+                  // 3. Inform screen readers which page is active
+                  aria-current={undefined}
+                  sx={editMenuItemButtonSx}
+                >
+                  {/* 4. Hide icons from screen readers if they are purely decorative */}
+                  <ListItemIcon aria-hidden="true">
+                    <SvgFromString svg={pluginSlot.icon}/>
+                  </ListItemIcon>
+                  <ListItemText primary={pluginSlot.title} secondary={''} />
+                </ListItemButton>
+              </ListItem>
             )
           })
         }
@@ -86,4 +104,3 @@ export default function EditSoftwareNav({slug}:Readonly<{slug:string}>) {
     </nav>
   )
 }
-

--- a/frontend/components/software/edit/EditSoftwareNav.tsx
+++ b/frontend/components/software/edit/EditSoftwareNav.tsx
@@ -7,7 +7,7 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 PERFACCT GmbH
-// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/frontend/components/software/edit/EditSoftwareNav.tsx
+++ b/frontend/components/software/edit/EditSoftwareNav.tsx
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 - 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 PERFACCT GmbH
-// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
# Improve edit software and edit project navigation for a11y

Closes #1753 
Closes #1773 

Changes proposed in this pull request:
* Wrap edit software menu items with ListItem in order to achieve semantically correct structure nav>ul>li>a
* Add a11y aria markup to communicate menu items, current menu item and hide icons
* Improve global search markup for a11 based on  `Accessibility Insights for Web` chrome plugin feedback

How to test:
* `make start` to build and generate test data 
* login as rsd admin to be able edit software and project
* navigate to edit software pages
* confirm menu structure is: nav > ul > li > a 
* use browser plugin `Accessibility Insights for Web` to confirm A11y of the menu items
* perform same check for edit project menu items
* perform a11y check on global search (it's same on all pages)

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests