### PR TITLE
fix: markdown input label and select input label

### DIFF
--- a/frontend/components/form/MarkdownInputWithPreview.tsx
+++ b/frontend/components/form/MarkdownInputWithPreview.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -98,6 +99,7 @@ export default function MarkdownInputWithPreview({markdown, register, disabled =
           disabled={disabled}
           name="markdown-input"
           id="markdown-textarea"
+          aria-label="Markdown input"
           rows={30}
           className="text-base-content w-full h-full px-8 font-mono text-sm min-h-[10rem]"
           {...register}

--- a/frontend/components/layout/EditSectionTitle.tsx
+++ b/frontend/components/layout/EditSectionTitle.tsx
@@ -1,11 +1,12 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -39,7 +40,15 @@ export default function EditSectionTitle({title, subtitle = '', children, hlevel
     return (
       <>
         <div className="flex">
-          <HeadingTag className={`flex-1 ${className ?? ''}`}>{title} {infoLink && <Link href={infoLink} target="_blank" rel="noreferrer"><InfoOutlinedIcon fontSize="small"/></Link>}</HeadingTag>
+          <HeadingTag className={`flex-1 ${className ?? ''}`}>{title} {
+            infoLink &&
+            <Link
+              aria-label="Link to info page"
+              href={infoLink} target="_blank" rel="noreferrer">
+              <InfoOutlinedIcon fontSize="small"/>
+            </Link>
+          }
+          </HeadingTag>
           {children}
         </div>
         {getSubtitle()}
@@ -49,7 +58,15 @@ export default function EditSectionTitle({title, subtitle = '', children, hlevel
 
   return (
     <>
-      <HeadingTag className={`${className ?? ''}`}>{title} {infoLink && <Link href={infoLink} target="_blank" rel="noreferrer"><InfoOutlinedIcon fontSize="small"/></Link>}</HeadingTag>
+      <HeadingTag className={`${className ?? ''}`}>{title} {
+        infoLink &&
+          <Link
+            aria-label="Link to info page"
+            href={infoLink} target="_blank" rel="noreferrer">
+            <InfoOutlinedIcon fontSize="small"/>
+          </Link>
+      }
+      </HeadingTag>
       {getSubtitle()}
     </>
   )

--- a/frontend/components/layout/ReactMarkdownWithSettings.tsx
+++ b/frontend/components/layout/ReactMarkdownWithSettings.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,7 +21,10 @@ export default function ReactMarkdownWithSettings({markdown, className, breaks=t
   if (breaks===true) remarkPlugins.push(remarkBreaks)
 
   return (
-    <div className={`prose max-w-none prose-h1:text-3xl prose-headings:font-normal prose-code:before:hidden prose-code:after:hidden ${className ?? ''}`}>
+    <div
+      className={`prose max-w-none prose-h1:text-3xl prose-headings:font-normal prose-code:before:hidden prose-code:after:hidden ${className ?? ''}`}
+      aria-label="Markdown preview"
+    >
       <ReactMarkdown
         data-testid="react-markdown-with-settings"
         skipHtml={true}

--- a/frontend/components/software/CiteDropdown.tsx
+++ b/frontend/components/software/CiteDropdown.tsx
@@ -1,10 +1,12 @@
 // SPDX-FileCopyrightText: 2021 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 dv4all
 // SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {useId} from 'react'
 import Select from '@mui/material/Select'
 import FormControl from '@mui/material/FormControl'
 import InputLabel from '@mui/material/InputLabel'
@@ -18,16 +20,26 @@ export type SelectOption={
 
 export default function CiteDropdown({label,options=[],value,onChange}:
 {label:string,options:SelectOption[],value:string,onChange:any}) {
+  // Generates a unique, valid HTML ID safe from spaces or special characters
+  const uniqueId = useId()
+  // ensure valid unique id's created to link label for a11y
+  const labelId = `cite-label-${uniqueId}`
+  const selectId = `cite-select-${uniqueId}`
 
   return (
     <FormControl fullWidth>
-      <InputLabel id={`cite-dropdown-${label}`}>{label}</InputLabel>
+      <InputLabel id={labelId}>{label}</InputLabel>
       <Select
         data-testid="cite-dropdown"
-        labelId={`cite-dropdown-${label}`}
-        // id="cite-dropdown-select"
+        id={selectId}
+        // pass label id to use for a11y
+        labelId={labelId}
         value={value}
         label={label}
+        inputProps={{
+          // Fallback visual anchor for testing tools
+          'aria-label': label,
+        }}
         onChange={onChange}
         sx={{
           minWidth:'14rem',

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/next-env.d.ts.license
+++ b/frontend/next-env.d.ts.license
@@ -4,6 +4,7 @@ SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Cen
 SPDX-FileCopyrightText: 2022 dv4all
 SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
+SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center) <d.mijatovic@esciencecenter.nl>
 SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 
 SPDX-License-Identifier: Apache-2.0


### PR DESCRIPTION
# Markdown and select input label

Closes #1747

Changes proposed in this pull request:
* Added arial labels to makrdown input and preview
* Fixed broken link to input label on material-ui select component    

How to test:
* `make start` to build and generate test data.
* Find a software that has versions module active and check the a11y using plugin `Accessibility Insights for Web` or some other a11y tool. The citation dropdowns should function correctly
* Open edit software and confirm that markdown input is also according to a11y requirements

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
