### PR TITLE
Fix release harvesting

### DIFF
--- a/frontend/components/software/edit/links/ValidateConceptDoi.tsx
+++ b/frontend/components/software/edit/links/ValidateConceptDoi.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -39,7 +39,7 @@ export default function ValidateConceptDoi({doi, onUpdate, disabled}: ValidateCo
     if (info?.status === 200) {
       const {software} = info.data
       const conceptDoi = extractConceptDoi(software)
-      if (conceptDoi === null) {
+      if (conceptDoi === null || conceptDoi === doi) {
         showSuccessMessage(`The DOI ${doi} is a valid Concept DOI`)
       } else {
         // update version DOI with concept DOI

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataCiteReleaseRepository.java
+++ b/scrapers/src/main/java/nl/esciencecenter/rsd/scraper/doi/DataCiteReleaseRepository.java
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,16 +28,15 @@ public class DataCiteReleaseRepository {
 		  works(ids: [%s], first: 10000) {
 		    nodes {
 		      doi
-		      versionOfCount
-		      relatedIdentifiers {
-		        relationType
-		        relatedIdentifierType
-		        relatedIdentifier
+		      versions(first: 10000) {
+		        totalCount
+		        nodes {
+		          doi
+		        }
 		      }
 		    }
 		  }
-		}
-		""";
+		}""";
 
 	// editorconfig-checker-enable
 
@@ -69,28 +68,29 @@ public class DataCiteReleaseRepository {
 				JsonObject workObject = work.getAsJsonObject();
 				String conceptDoiString = workObject.getAsJsonPrimitive("doi").getAsString();
 				Doi conceptDoi = Doi.fromString(conceptDoiString);
-				Integer versionOfCount = Utils.integerOrNull(workObject.get("versionOfCount"));
-				if (versionOfCount == null || versionOfCount.intValue() != 0) {
-					LOGGER.debug("{} is not a concept DOI", conceptDoiString);
-					continue;
-				}
 
 				Collection<Doi> versionDois = new ArrayList<>();
-				JsonArray relatedIdentifiers = workObject.getAsJsonArray("relatedIdentifiers");
-				for (JsonElement relatedIdentifier : relatedIdentifiers) {
-					JsonObject relatedIdentifierObject = relatedIdentifier.getAsJsonObject();
-					String relationType = relatedIdentifierObject.getAsJsonPrimitive("relationType").getAsString();
-					if (relationType == null || !relationType.equals("HasVersion")) continue;
+				JsonObject versionsObject = workObject.getAsJsonObject("versions");
+				int versionCount = versionsObject.getAsJsonPrimitive("totalCount").getAsInt();
+				if (versionCount > 10000) {
+					LOGGER.warn(
+						"There are {} versions for {}, while we can only harvest 10000",
+						versionCount,
+						conceptDoi
+					);
+				}
 
-					String relatedIdentifierType = relatedIdentifierObject
-						.getAsJsonPrimitive("relatedIdentifierType")
-						.getAsString();
-					if (relatedIdentifierType == null || !relatedIdentifierType.equals("DOI")) continue;
-
-					String relatedIdentifierDoi = relatedIdentifierObject
-						.getAsJsonPrimitive("relatedIdentifier")
-						.getAsString();
-					versionDois.add(Doi.fromString(relatedIdentifierDoi));
+				JsonArray versionsDoiArray = versionsObject.getAsJsonArray("nodes");
+				for (JsonElement versionElement : versionsDoiArray) {
+					JsonObject relatedIdentifierObject = versionElement.getAsJsonObject();
+					Doi versionDoi;
+					try {
+						versionDoi = Doi.fromString(relatedIdentifierObject.getAsJsonPrimitive("doi").getAsString());
+					} catch (RuntimeException e) {
+						LOGGER.warn("Could not read a version DOI for {}", conceptDoi, e);
+						continue;
+					}
+					versionDois.add(versionDoi);
 				}
 				Collection<ExternalMentionRecord> versionedMentions = dataciteMentionRepository.mentionData(
 					versionDois


### PR DESCRIPTION
## Fix release harvesting

### Changes proposed in this pull request

* Use a different GraphQL query to harvest releases
* In the frontend, if the concept DOI is a version of itself, show it as a success

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Create some software pages with the following concept DOIs
	- `10.5281/zenodo.6379973`
	- `10.5281/zenodo.15607642`
	- `10.5281/zenodo.16941288`
	- `10.5281/zenodo.15607642`
* When clicking the `Validate` button, none of them should say they updated the concept DOI to themselves
* `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.doi.MainReleases`
* Most releases should have been harvested, although we still suffer from https://github.com/datacite/datacite/issues/2498
* Some version DOIs don't have a registration date in the GraphQL API (same issue as above?), so they might be ordered incorrectly

closes #1734

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests