### PR TITLE
1746 headers info card

### DIFF
--- a/frontend/components/admin/AdminNav.tsx
+++ b/frontend/components/admin/AdminNav.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -13,6 +13,7 @@ import {useParams} from 'next/navigation'
 import Link from 'next/link'
 
 import List from '@mui/material/List'
+import ListItem from '@mui/material/ListItem'
 import ListItemButton from '@mui/material/ListItemButton'
 import ListItemIcon from '@mui/material/ListItemIcon'
 import ListItemText from '@mui/material/ListItemText'
@@ -42,27 +43,31 @@ export default function AdminNav() {
           paddingBottom: 0
         }
       }}>
-        {items.map((key, pos) => {
+        {items.map((key) => {
           const item:AdminMenuItemProps = adminPages[key as AdminPageTypes]
           if (item.active({modules:activeModules})===true){
             return (
-              <ListItemButton
-                data-testid="admin-nav-item"
-                key={`step-${pos}`}
-                selected={key===page}
-                href = {item.path}
-                component = {Link}
-                sx={{...editMenuItemButtonSx,
-                  ':hover': {
-                    color: 'text.primary'
-                  }
-                }}
+              <ListItem
+                key={key}
+                disablePadding
               >
-                <ListItemIcon>
-                  {item.icon}
-                </ListItemIcon>
-                <ListItemText primary={item.title} secondary={item.subtitle} />
-              </ListItemButton>
+                <ListItemButton
+                  data-testid="admin-nav-item"
+                  selected={key===page}
+                  href = {item.path}
+                  component = {Link}
+                  sx={{...editMenuItemButtonSx,
+                    ':hover': {
+                      color: 'text.primary'
+                    }
+                  }}
+                >
+                  <ListItemIcon>
+                    {item.icon}
+                  </ListItemIcon>
+                  <ListItemText primary={item.title} secondary={item.subtitle} />
+                </ListItemButton>
+              </ListItem>
             )
           }
         })}

--- a/frontend/components/layout/ImageAsBackground.tsx
+++ b/frontend/components/layout/ImageAsBackground.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -26,7 +26,7 @@ export default function ImageAsBackground(
     return (
       <div
         data-testid="image-as-background"
-        className={`${className} flex flex-col justify-center items-center text-base-300 rounded-xs`}
+        className={`${className} flex flex-col justify-center items-center text-base-600 rounded-xs`}
       >
         <PhotoSizeSelectActualOutlinedIcon
           sx={{

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -1,6 +1,6 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
@@ -39,7 +39,7 @@ export default function ImageWithPlaceholder({
     }
     return (
       <div
-        className={`flex flex-col justify-center items-center text-base-500 rounded-xs ${className ?? ''}`}
+        className={`flex flex-col justify-center items-center text-base-600 rounded-xs ${className ?? ''}`}
       >
         <PhotoSizeSelectActualOutlinedIcon
           sx={{

--- a/frontend/components/projects/edit/information/AutosaveResearchDomains.tsx
+++ b/frontend/components/projects/edit/information/AutosaveResearchDomains.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -182,19 +182,18 @@ export default function AutosaveResearchDomains({project_id, research_domains}: 
         <FormControl
           variant="standard"
           fullWidth
-          // sx={{
-          //   width: '100%',
-          //   // maxWidth: '30rem'
-          // }}
         >
           <InputLabel
             shrink={true}
+            // a11y input label connection for select
+            id="l1-domain-select-label"
           >
             Level 1
           </InputLabel>
           <Select
             data-testid="l1-domain-select"
-            // variant='filled'
+            // a11y input label connection for select
+            labelId="l1-domain-select-label"
             value={l1Selected?.key ?? ''}
             onChange={({target}:{target:any}) => {
               selectDomain({
@@ -222,13 +221,11 @@ export default function AutosaveResearchDomains({project_id, research_domains}: 
         <FormControl
           variant="standard"
           fullWidth
-          // sx={{
-          //   width: '100%',
-          //   // maxWidth: '30rem'
-          // }}
         >
           <InputLabel
             shrink={true}
+            // a11y input label connection for select
+            id="l2-domain-select-label"
           >
             Level 2
           </InputLabel>
@@ -236,6 +233,8 @@ export default function AutosaveResearchDomains({project_id, research_domains}: 
           <Select
             data-testid="l2-domain-select"
             value={l2Selected?.key ?? ''}
+            // a11y input label connection for select
+            labelId="l2-domain-select-label"
             onChange={({target}:{target:any}) => {
               selectDomain({
                 key: target.value,
@@ -270,12 +269,17 @@ export default function AutosaveResearchDomains({project_id, research_domains}: 
           fullWidth
         >
           <InputLabel
-            shrink={true}>
+            shrink={true}
+            // a11y input label connection for select
+            id="l3-domain-select-label"
+          >
             Level 3
           </InputLabel>
 
           <Select
             data-testid="l3-domain-select"
+            // a11y input label connection for select
+            labelId="l3-domain-select-label"
             value={l3Selected?.key ?? ''}
             onChange={({target}:{target:any}) => {
               selectDomain({

--- a/frontend/styles/rsdMuiTheme.ts
+++ b/frontend/styles/rsdMuiTheme.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2021 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -281,6 +281,12 @@ function applyThemeConfig({colors, action, typography}: ThemeConfig) {
             maxWidth: '40rem'
           },
         }
+      },
+      MuiAlertTitle: {
+        defaultProps: {
+          // Overrides the default with 'h3' header for a11y
+          component: 'h3',
+        },
       },
     },
   })


### PR DESCRIPTION
# Use header element in alert/info card

Closes #1746

Changes proposed in this pull request:
* Use h3 for alert title. This is changed globaly in material-ui theme. It can be overwriten if different header should be used. For now it seems to work on all places.
* Improve input label on select component on edit project page. This is related fix on edit project page similar to what we did on software page (citation select).
* Improve contrast of image upload message.
* Improve nav list of admin section. This is fix related to fixes we applied on software and project pages.

How to test:
* `make start` to build and create test data
* login as admin in order to be able to edit all items
* create new software
* navigate and test all edit software pages. There should be no a11y messages related to alert/info boxes. Validate alert titles use h3. There should be no contrast warning on upload logo message.
* create new project
* navigate and test all edit project pages. There should be no a11y messages related to alert/info boxes. Confirm alert/info  title uses h3. There should be no contrast warning message on upload image.
* navigate to admin section. Confirm no a11y issues related to menu options on the left side

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
