### PR TITLE
Replace div by nav in keyword list

### DIFF
--- a/frontend/components/home/imperial/Keywords.tsx
+++ b/frontend/components/home/imperial/Keywords.tsx
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (ICL) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
 // SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -24,9 +25,9 @@ export default function Keywords({keywords}: KeywordsProps) {
       <div className="text-2xl ml-10 mt-14">
         <h2 className="flex justify-start text-3xl lg:text-4xl font-rsd-titles font-bold mt-6">Popular Keywords</h2>
       </div>
-      <div className="flex flex-wrap gap-10 md:gap-3 p-5 md:p-10 ">
+      <nav className="flex flex-wrap gap-10 md:gap-3 p-5 md:p-10 ">
         {keywordButtons}
-      </div>
+      </nav>
     </div>
   )
 }


### PR DESCRIPTION
# Replace div by nav in keyword list

Fixes #1745

Changes proposed in this pull request:

* Replaces the `div` surrounding the keyword list with a `nav`.

How to test:

* Edit the docker-compose file to use the Imperial data in the deployment

  ```
      volumes:
      - ./frontend/public:/app/public
    #   - ./deployment/hmz/styles:/app/public/styles
      - ./deployment/imperial/data:/app/public/data  <---- This line here
    #   - ./deployment/hmz/images:/app/public/images
  ```
* Run `make start` and make sure there are some software with keywords.
* Inspect the html - the keyword elements should now be enclosed in a `nav`.
* Using accessibility tools will show no complains about `nav` missing.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
