### PR TITLE
Add description to commit chart

### DIFF
--- a/frontend/components/charts/d3LineChart/SingleLineChart.tsx
+++ b/frontend/components/charts/d3LineChart/SingleLineChart.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,7 +20,7 @@ export type Point = {
   y: number
 }
 
-export default function SingleLineChart({data = []}: {data: Point[]}) {
+export default function SingleLineChart({data = [], description=''}: {data: Point[], description: string}) {
   const theme = useTheme()
   const svgRef: any = useRef(undefined)
   const divRef: any = useRef(undefined)
@@ -59,6 +61,8 @@ export default function SingleLineChart({data = []}: {data: Point[]}) {
         style={{
           display: 'block'
         }}
+        role="img"
+        aria-label={description}
       ></svg>
     </div>
   )

--- a/frontend/components/software/CommitsChart.tsx
+++ b/frontend/components/software/CommitsChart.tsx
@@ -75,9 +75,8 @@ export default function CommitsChart({
 
     // Get the date range of the commits to build a meaningful description
     // define date formatting using locale: default = user specific, en_GB = if user local fails etc.
-    const locale = ['default','en-GB','en-US']
-    const fist_date = new Date(lineData[0].x).toLocaleDateString(locale)
-    const last_date = new Date(lineData[lineData.length - 1].x).toLocaleDateString(locale)
+    const fist_date = new Date(lineData[0].x).toLocaleDateString()
+    const last_date = new Date(lineData[lineData.length - 1].x).toLocaleDateString()
     const description = `Curve showing the daily commits during the history of the software, from ${fist_date} to ${last_date}.`
 
     // render

--- a/frontend/components/software/CommitsChart.tsx
+++ b/frontend/components/software/CommitsChart.tsx
@@ -5,6 +5,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -70,10 +72,20 @@ export default function CommitsChart({
   if (commit_history && Object.keys(commit_history).length > 0) {
     // format commits data for chart and calculate other stats
     const {lineData, lastCommitDate, totalCountY} = prepareDataForSoftwarePage(commit_history)
+
+    // Get the date range of the commits to build a meaningful description
+    let date = new Date(lineData[0].x)
+    const fist_date = date.getDate() + '/' + (date.getMonth() + 1) + '/' +
+    date.getFullYear()
+    date = new Date(lineData[lineData.length - 1].x)
+    const last_date = date.getDate() + '/' + (date.getMonth() + 1) + '/' +
+    date.getFullYear()
+    const description = `Curve showing the daily commits during the history of the software, from ${fist_date} to ${last_date}.`
+
     // render
     return (
       <div className={`flex-1 w-full ${className ?? ''}`}>
-        <SingleLineChart data={lineData} />
+        <SingleLineChart data={lineData} description={description} />
         <div className="flex pt-4 px-2 *:border-l *:border-base-700 *:px-2 *:text-center" id="commitsStat">
           <ArchivedRepo archived={archived} />
           <Commits commits={totalCountY} lastCommitDate={lastCommitDate}/>

--- a/frontend/components/software/CommitsChart.tsx
+++ b/frontend/components/software/CommitsChart.tsx
@@ -74,7 +74,6 @@ export default function CommitsChart({
     const {lineData, lastCommitDate, totalCountY} = prepareDataForSoftwarePage(commit_history)
 
     // Get the date range of the commits to build a meaningful description
-    // define date formatting using locale: default = user specific, en_GB = if user local fails etc.
     const fist_date = new Date(lineData[0].x).toLocaleDateString()
     const last_date = new Date(lineData[lineData.length - 1].x).toLocaleDateString()
     const description = `Curve showing the daily commits during the history of the software, from ${fist_date} to ${last_date}.`

--- a/frontend/components/software/CommitsChart.tsx
+++ b/frontend/components/software/CommitsChart.tsx
@@ -74,12 +74,10 @@ export default function CommitsChart({
     const {lineData, lastCommitDate, totalCountY} = prepareDataForSoftwarePage(commit_history)
 
     // Get the date range of the commits to build a meaningful description
-    let date = new Date(lineData[0].x)
-    const fist_date = date.getDate() + '/' + (date.getMonth() + 1) + '/' +
-    date.getFullYear()
-    date = new Date(lineData[lineData.length - 1].x)
-    const last_date = date.getDate() + '/' + (date.getMonth() + 1) + '/' +
-    date.getFullYear()
+    // define date formatting using locale: default = user specific, en_GB = if user local fails etc.
+    const locale = ['default','en-GB','en-US']
+    const fist_date = new Date(lineData[0].x).toLocaleDateString(locale)
+    const last_date = new Date(lineData[lineData.length - 1].x).toLocaleDateString(locale)
     const description = `Curve showing the daily commits during the history of the software, from ${fist_date} to ${last_date}.`
 
     // render


### PR DESCRIPTION
# Add description to commit chart

Fixes #1748 

Changes proposed in this pull request:

* Add a description to the commit history chart, to inform the screen readers users of its content, indicating the start and end date of the history. Describing the individual data points is probably not practical.
* Also add `role=img`, so the object can correctly be identified as an image.
* This follows the recommendations indicated by [Mozilla](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/img_role#svg_and_roleimg).  

How to test:

* Run the tool with some test data with `make start`
* In a software with a commit history, the graph should show an aria-label and its role as an image. Something like the following:
* 
<img width="1798" height="527" alt="Screenshot From 2026-05-21 06-42-02" src="https://github.com/user-attachments/assets/93853c21-5cc3-49a5-a5dd-3a0e115ba67d" />

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
