### PR TITLE
Set alt='' in decorative images

### DIFF
--- a/frontend/components/communities/overview/CommunityListItem.tsx
+++ b/frontend/components/communities/overview/CommunityListItem.tsx
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,7 +24,6 @@ export default function CommunityListItem({community}:{community:CommunityListPr
       >
         <ListImageWithGradientPlaceholder
           imgSrc={imgSrc}
-          alt = {`Cover image for ${community.name}`}
         />
         <div className="flex-1 flex flex-col md:flex-row gap-3 py-2">
           {/* basic info */}

--- a/frontend/components/layout/ImageWithPlaceholder.test.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.test.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -42,8 +44,10 @@ it('renders image with default positioning', async() => {
 
   //expect image src attribute
   expect(img).toHaveAttribute('src', mockProps.src)
-  // expect alt attribute
-  expect(img).toHaveAttribute('alt', mockProps.alt)
+  // expect aria-label attribute
+  expect(img).toHaveAttribute('aria-label', mockProps.alt)
+  // but not alt attribute
+  expect(img).toHaveAttribute('alt', '')
   // expect title attribute
   expect(img).toHaveAttribute('title', mockProps.placeholder)
   // expect default positioning

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
 // SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -62,7 +64,7 @@ export default function ImageWithPlaceholder({
         objectPosition: bgPosition
       }}
       aria-label={alt}
-      alt={alt}
+      alt=""
       className={`rounded-xs ${className ?? ''}`}
     ></img>
   )

--- a/frontend/components/news/overview/list/NewsListItem.tsx
+++ b/frontend/components/news/overview/list/NewsListItem.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -51,7 +53,6 @@ export default function NewsListItem({item}:ListItemProps) {
       >
         <ListImageWithGradientPlaceholder
           imgSrc={imgUrl}
-          alt = {`Cover image for ${item.title}`}
         />
         <div className="flex-1 flex flex-col md:flex-row gap-3 py-2">
           {/* basic info */}

--- a/frontend/components/projects/overview/list/ListImageWithGradientPlaceholder.tsx
+++ b/frontend/components/projects/overview/list/ListImageWithGradientPlaceholder.tsx
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import useValidateImageSrc from '~/utils/useValidateImageSrc'
 
-export default function ListImageWithGradientPlaceholder({imgSrc,alt}:{imgSrc:string|null, alt:string|null}) {
+export default function ListImageWithGradientPlaceholder({imgSrc}:{imgSrc:string|null}) {
   const validImg = useValidateImageSrc(imgSrc)
 
   // console.group('ListItemImageWithGradientPlaceholder')
@@ -25,7 +27,7 @@ export default function ListImageWithGradientPlaceholder({imgSrc,alt}:{imgSrc:st
   return (
     <img
       src={`${imgSrc ?? ''}`}
-      alt={alt ?? 'Image'}
+      alt=""
       className="w-[6rem] max-h-[4rem] self-center text-base-content-disabled p-2 object-contain object-center"
       // lighthouse audit requires explicit width and height
       height="2.5rem"

--- a/frontend/components/projects/overview/list/ProjectListItemContent.tsx
+++ b/frontend/components/projects/overview/list/ProjectListItemContent.tsx
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,7 +29,6 @@ export default function ProjectListItemContent(item: ProjectListItemProps) {
     <>
       <ListImageWithGradientPlaceholder
         imgSrc={imgSrc}
-        alt = {`Cover image for ${item.title}`}
       />
       <div className="flex flex-col md:flex-row gap-3 flex-1 py-2">
         <div className="flex-1">

--- a/frontend/components/search/SearchResultsContent.tsx
+++ b/frontend/components/search/SearchResultsContent.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2025 Jesse Gonzalez (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -44,7 +46,6 @@ function SearchResultCard({item, view}: {item: GlobalSearchResults, view: string
       >
         {/* Image */}
         <ListImageWithGradientPlaceholder
-          alt={`Cover image for ${item.name}`}
           imgSrc={imageUrl}
         />
         <div className="flex-1 min-w-0 p-2">

--- a/frontend/components/software/overview/cards/SoftwareMasonryCard.tsx
+++ b/frontend/components/software/overview/cards/SoftwareMasonryCard.tsx
@@ -3,6 +3,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -44,7 +46,7 @@ export default function SoftwareMasonryCard({item}:SoftwareCardProps){
           <img
             className="object-cover w-full rounded-tr-lg rounded-tl-lg"
             src={imgUrl ?? undefined}
-            alt={`Cover image for ${item.brand_name}`}
+            alt=""
             // loading = "lazy"
             // lighthouse audit requires explicit with and height
             height="100%"

--- a/frontend/components/software/overview/list/SoftwareListItemContent.tsx
+++ b/frontend/components/software/overview/list/SoftwareListItemContent.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -30,7 +32,6 @@ export default function SoftwareListItemContent(item:SoftwareOverviewListItemPro
     <>
       <ListImageWithGradientPlaceholder
         imgSrc={imgUrl}
-        alt = {`Cover image for ${item.brand_name}`}
       />
       <div className="flex flex-col md:flex-row gap-3 flex-1 py-2">
         <div className="flex-1">

--- a/frontend/components/user/organisations/OrganisationListItem.tsx
+++ b/frontend/components/user/organisations/OrganisationListItem.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -30,7 +32,6 @@ export default function OrganisationListItem({organisation}:Readonly<{organisati
       >
         <ListImageWithGradientPlaceholder
           imgSrc={imgSrc}
-          alt = {`Cover image for ${organisation.name}`}
         />
         <div className="flex-1 flex flex-col md:flex-row gap-3 py-2">
           {/* basic info */}


### PR DESCRIPTION
# Set alt='' in decorative images

Fixes #1749 

Changes proposed in this pull request:

As software (and projects and other) logos are decorative and not convey any information, they should not have an `alt` attribute. Specifically, it should be set `alt=""`. As a result, all the images in cards have been changed this way.

How to test:

* Run the tool with some test data with `make start`
* In the software page, check that the `alt` attribute is empty for all software and all visualisation types (grid, list, mosaic).
* In the individual software page, check that the logo has an empty `alt` attribute.
* The `projects` and other pages should show have been similarly modified.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
