### PR TITLE
1730 fieldset text field

### DIFF
--- a/e2e/helpers/project.ts
+++ b/e2e/helpers/project.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -99,7 +99,7 @@ export async function createProjectLink(page: Page, {label, url}: { label: strin
   // add link label in the modal
   await page.getByRole('dialog', {
     name: 'Project link'
-  }).locator('#title').fill(label)
+  }).getByLabel('Title').fill(label)
 
   // add url
   await page.getByLabel('Url').fill(url)

--- a/e2e/helpers/utils.ts
+++ b/e2e/helpers/utils.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -67,7 +67,7 @@ export async function openEditPage(page: Page, url: string, title: string) {
  * @returns
  */
 export async function uploadFile(page: Page, inputSelector: string,
-                                 file: string, imageSelector = '[role="img"]') {
+  file: string, imageSelector = '[role="img"]') {
   // breakpoint
   // await page.pause()
 

--- a/frontend/components/form/ControlledTextField.tsx
+++ b/frontend/components/form/ControlledTextField.tsx
@@ -9,7 +9,7 @@
 
 'use client'
 
-import {useEffect, useRef, JSX} from 'react'
+import {useEffect, useRef, JSX, useId} from 'react'
 import {Controller} from 'react-hook-form'
 import TextField, {TextFieldProps} from '@mui/material/TextField'
 import InputAdornment from '@mui/material/InputAdornment'
@@ -55,6 +55,11 @@ export default function ControlledTextField<T>({options, control, rules}:Control
 
   if (options?.useNull && options?.defaultValue==='') options.defaultValue=null
 
+  // Stable ID generation for accessibility mapping
+  const reactId = useId()
+  const inputId = `${reactId}-${options.name.toString()}`
+  const helperId = `${reactId}-helper-text`
+
   return (
     <Controller
       name={options.name.toString()}
@@ -67,8 +72,7 @@ export default function ControlledTextField<T>({options, control, rules}:Control
 
         return (
           <TextField
-            // eslint-disable-next-line react-hooks/purity
-            id={options.name.toString() ?? `input-${Math.floor(Math.random()*10000)}`}
+            id={inputId}
             inputRef={inputRef}
             disabled={options?.disabled ?? false}
             autoComplete={options?.autoComplete ?? 'off'}
@@ -90,15 +94,20 @@ export default function ControlledTextField<T>({options, control, rules}:Control
                 endAdornment: options?.endAdornment ? <InputAdornment position="end">{options?.endAdornment}</InputAdornment> : undefined
               },
               formHelperText:{
+                // Force a matched programmatic ID string
+                id: helperId,
                 sx:{
                   display: 'flex',
                   justifyContent:'space-between'
                 }
               },
+              // a11y link the input to the text helper block
+              htmlInput: {
+                'aria-describedby': helperId
+              },
             }}
             helperText={
               <HelperTextWithCounter
-                // message={options?.helperTextMessage ?? ''}
                 message={error?.message ?? options?.helperTextMessage ?? ''}
                 count={options?.helperTextCnt ?? ''}
               />

--- a/frontend/components/user/metadata/UserAvatar.tsx
+++ b/frontend/components/user/metadata/UserAvatar.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -113,7 +113,6 @@ export default function UserAvatar() {
       initials={initials}
       src={getImageUrl(avatar) ?? undefined}
       sx={{
-        backgroundColor: avatar ? 'inherit' : 'text.disabled',
         width: '10rem',
         height: '10rem',
         'img': {


### PR DESCRIPTION
# Fieldset in text field

Closes #1730

@dalonsoa  I have remarks concerning this and the original issue. If I read the improvement suggestion correctly, it marks use of `<fieldset>` element in the material-ui TextField component as confusing for screen readers. The `fieldset` is used as visual element in "outlined" text type to draw outline around the text box. Our design called specifically for the outlined type as "default" type was somewhat "unclear" to our design specialist. Although `<fieldset>` element is used it is disabled for the screen readers using `aria-hidden="true"`. The screen readers should ignore this `fieldset` and the child element(s). **Can you validate this with the audit team? If this is correct assumption please approve this PR, otherwise we would need to consider alternative approaches:  using default type or developing custom component.**

Changes proposed in this pull request:
* No changes are performed on text field. The fieldset is used as style item and it is disabled for screen readers by `aria-hidden="true"`.
* The element id is made more robust. This was not flagged as problem but based on the fixes performed on select component the improvement on element id is implemented.
* The contrast of avatar background is improved. The custom background color is removed which had not sufficient contrast.

How to test:
* `make start` to build and generate test data
* login as user
* navigate to user section and run `Accessibility Insights For Web` plugin or other a11y tool. There should be no a11y warnings or errors.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
