### PR TITLE
1750 skip to main

### DIFF
--- a/e2e/helpers/project.ts
+++ b/e2e/helpers/project.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -99,7 +99,7 @@ export async function createProjectLink(page: Page, {label, url}: { label: strin
   // add link label in the modal
   await page.getByRole('dialog', {
     name: 'Project link'
-  }).locator('#title').fill(label)
+  }).getByLabel('Title').fill(label)
 
   // add url
   await page.getByLabel('Url').fill(url)

--- a/e2e/helpers/utils.ts
+++ b/e2e/helpers/utils.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -67,7 +67,7 @@ export async function openEditPage(page: Page, url: string, title: string) {
  * @returns
  */
 export async function uploadFile(page: Page, inputSelector: string,
-                                 file: string, imageSelector = '[role="img"]') {
+  file: string, imageSelector = '[role="img"]') {
   // breakpoint
   // await page.pause()
 

--- a/e2e/tests/software.spec.ts
+++ b/e2e/tests/software.spec.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -79,7 +79,11 @@ test.describe.serial('Software', async()=> {
     await editSoftwareDescription(page, software)
 
     // upload file
-    await uploadFile(page, '#upload-software-logo', software.logo)
+    await uploadFile(
+      page, '#upload-software-logo',
+      software.logo,
+      '[data-testid="image-with-placeholder"]'
+    )
 
     // publish the software
     await page.getByLabel('Published').check()

--- a/frontend/app/(base)/software/[slug]/page.tsx
+++ b/frontend/app/(base)/software/[slug]/page.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2026 Imperial College London
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -63,7 +65,7 @@ export async function generateMetadata(
     getUserSettings(),
     headers()
   ])
-  // find project by slug
+  // find software by slug
   const software = await getSoftwareItem({
     slug: slug,
     token: token

--- a/frontend/app/(container)/organisations/page.tsx
+++ b/frontend/app/(container)/organisations/page.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,7 @@ import {ssrBasicParams} from '~/utils/extractQueryParam'
 import {getUserSettings} from '~/components/user/ssrUserSettings'
 import {getActiveModuleNames} from '~/config/getSettingsServerSide'
 import {getOrganisationsList} from '~/components/organisation/apiOrganisations'
-import OrganisationOverviewClient from '~/components/organisation/overview/OrganisationOverviewClient'
+import OrganisationOverviewClient from '~/components/organisation/overview'
 
 export const metadata: Metadata = {
   title: `Organisations | ${app.title}`,

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -30,6 +30,7 @@ import {appUserSettings} from '~/components/cookies/appUserSettings'
 import CookieConsentMatomo from '~/components/cookies/CookieConsentMatomo'
 import Announcement from '~/components/Announcement/Announcement'
 import ProgressProviderApp from '~/components/bprogress/ProgressProviderApp'
+import SkipToMainContent from '~/components/a11y/SkipToMainContent'
 
 import '~/styles/global.css'
 
@@ -118,6 +119,7 @@ export default async function RootLayout({
                       <UserSettingsProvider user={userSettings}>
                         {/* Login providers list */}
                         <LoginProvidersProvider providers = {providers}>
+                          <SkipToMainContent />
                           <AppHeader />
                           {children}
                           <AppFooter/>

--- a/frontend/components/GlobalSearchAutocomplete/index.tsx
+++ b/frontend/components/GlobalSearchAutocomplete/index.tsx
@@ -296,6 +296,7 @@ export default function GlobalSearchAutocomplete(props: Props) {
         <section
           role="search"
           aria-label="Search RSD website"
+          className='flex-1'
         >
           <input className="px-2 pl-8 py-2 bg-transparent rounded-xs border border-base-600 focus:outline-0 w-full focus:bg-base-100 focus:text-base-900 duration-200"
             ref={inputRef}

--- a/frontend/components/a11y/SkipToMainContent.tsx
+++ b/frontend/components/a11y/SkipToMainContent.tsx
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+export default function SkipToMainContent(){
+  return (
+    <a
+      href="#main-content"
+      className="sr-only focus:not-sr-only focus:absolute focus:top-4 focus:left-4 focus:z-50 focus:p-4 focus:bg-primary focus:text-primary-content focus:rounded-sm focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-primary"
+    >
+      Skip to main content
+    </a>
+  )
+}

--- a/frontend/components/cards/StatusBanner.tsx
+++ b/frontend/components/cards/StatusBanner.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -42,7 +42,7 @@ export default function StatusBanner({
       }
       {is_published === false &&
         <div
-          className="bg-base-700 text-base-100 px-2 py-1 uppercase font-medium"
+          className="bg-base-300 text-base-900 px-2 py-1 uppercase font-medium"
           style={{width, borderRadius, letterSpacing}}
         >
           Not published

--- a/frontend/components/communities/metadata/CommunityLogo.tsx
+++ b/frontend/components/communities/metadata/CommunityLogo.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -116,7 +116,6 @@ export default function CommunityLogo({id,name,logo_id,isMaintainer}:CommunityLo
       canEdit={isMaintainer}
       src={getImageUrl(logo) ?? undefined}
       sx={{
-        backgroundColor: logo ? 'inherit' : 'text.disabled',
         height: '10rem',
         'img': {
           objectFit: 'contain',

--- a/frontend/components/communities/overview/index.tsx
+++ b/frontend/components/communities/overview/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -40,7 +40,10 @@ export default function CommunitiesOverview({
         <h1 className="mr-4 lg:flex-1">
           Communities
         </h1>
-        <div className="flex-2 flex min-w-[20rem]">
+        <section
+          // define a11y region
+          aria-label="Search community by name or short description"
+          className="flex-2 flex min-w-[20rem]">
           <SearchInput
             placeholder="Search community by name or short description"
             onSearch={(search: string) => handleQueryChange('search', search)}
@@ -60,7 +63,7 @@ export default function CommunitiesOverview({
               handleQueryChange('rows', items.toString())
             }}
           />
-        </div>
+        </section>
       </div>
 
       {/* community cards, grid is default */}

--- a/frontend/components/filter/FiltersPanel.tsx
+++ b/frontend/components/filter/FiltersPanel.tsx
@@ -23,10 +23,11 @@ export default function FiltersPanel({children}: {children: any}) {
   if (smallScreen) return null
 
   return (
-    <div
+    <section
       data-testid="filters-panel"
+      aria-label="Filters"
       className="flex bg-base-100 p-4 shadow-sm rounded-md flex-col gap-8 min-w-[18rem]">
       {children}
-    </div>
+    </section>
   )
 }

--- a/frontend/components/form/ControlledTextField.tsx
+++ b/frontend/components/form/ControlledTextField.tsx
@@ -9,7 +9,7 @@
 
 'use client'
 
-import {useEffect, useRef, JSX} from 'react'
+import {useEffect, useRef, JSX, useId} from 'react'
 import {Controller} from 'react-hook-form'
 import TextField, {TextFieldProps} from '@mui/material/TextField'
 import InputAdornment from '@mui/material/InputAdornment'
@@ -55,6 +55,11 @@ export default function ControlledTextField<T>({options, control, rules}:Control
 
   if (options?.useNull && options?.defaultValue==='') options.defaultValue=null
 
+  // Stable ID generation for accessibility mapping
+  const reactId = useId()
+  const inputId = `${reactId}-${options.name.toString()}`
+  const helperId = `${reactId}-helper-text`
+
   return (
     <Controller
       name={options.name.toString()}
@@ -67,8 +72,7 @@ export default function ControlledTextField<T>({options, control, rules}:Control
 
         return (
           <TextField
-            // eslint-disable-next-line react-hooks/purity
-            id={options.name.toString() ?? `input-${Math.floor(Math.random()*10000)}`}
+            id={inputId}
             inputRef={inputRef}
             disabled={options?.disabled ?? false}
             autoComplete={options?.autoComplete ?? 'off'}
@@ -90,15 +94,20 @@ export default function ControlledTextField<T>({options, control, rules}:Control
                 endAdornment: options?.endAdornment ? <InputAdornment position="end">{options?.endAdornment}</InputAdornment> : undefined
               },
               formHelperText:{
+                // Force a matched programmatic ID string
+                id: helperId,
                 sx:{
                   display: 'flex',
                   justifyContent:'space-between'
                 }
               },
+              // a11y link the input to the text helper block
+              htmlInput: {
+                'aria-describedby': helperId
+              },
             }}
             helperText={
               <HelperTextWithCounter
-                // message={options?.helperTextMessage ?? ''}
                 message={error?.message ?? options?.helperTextMessage ?? ''}
                 count={options?.helperTextCnt ?? ''}
               />

--- a/frontend/components/home/helmholtz/index.tsx
+++ b/frontend/components/home/helmholtz/index.tsx
@@ -6,13 +6,16 @@
 'use client'
 
 import {HomeProps} from '~/app/page'
+import MainContent from '~/components/layout/MainContent'
 
 export default function HelmholtzHome({counts,news}: HomeProps) {
   return (
-    <main className="flex-1 flex flex-col bg-base-100" data-testid="rsd-helmholtz-home">
+    <MainContent
+      className="flex-1 flex flex-col bg-base-100" data-testid="rsd-helmholtz-home"
+    >
       <h1 className='mx-auto mt-12'>Helmholtz homepage placeholder</h1>
       <pre className="container mx-auto p-8 overflow-hidden text-wrap">{JSON.stringify(counts,null,2)}</pre>
       <pre className="container mx-auto p-8 overflow-hidden text-wrap">{JSON.stringify(news,null,2)}</pre>
-    </main>
+    </MainContent>
   )
 }

--- a/frontend/components/home/rsd/index.tsx
+++ b/frontend/components/home/rsd/index.tsx
@@ -32,7 +32,13 @@ export default function RsdHome({counts,news}: HomeProps) {
   }, [])
 
   return (
-    <main className="bg-base-100 dark:bg-base-900 dark:text-base-100" data-testid="rsd-home-page">
+    <main
+      // a11y id to be used to skip to main content link
+      id="main-content"
+      tabIndex={-1}
+      className="bg-base-100 dark:bg-base-900 dark:text-base-100 outline-none"
+      data-testid="rsd-home-page"
+    >
       {/* Jumbo Banner  */}
       <JumboBanner />
 

--- a/frontend/components/layout/GridOverview.tsx
+++ b/frontend/components/layout/GridOverview.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,6 +24,7 @@ export default function GridOverview({children,fullWidth=false,className='mt-2 a
   if (fullWidth){
     return (
       <section
+        aria-label="Grid overview"
         data-testid="grid-overview-4"
         className={`flex-1 grid gap-8 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 ${className}`}
       >
@@ -34,6 +35,7 @@ export default function GridOverview({children,fullWidth=false,className='mt-2 a
   // default is for grid with 3 cols next to filter panel
   return (
     <section
+      aria-label="Grid overview"
       data-testid="grid-overview-3"
       className={`flex-1 grid gap-8 md:grid-cols-2 lg:grid-cols-3 ${className}`}
     >

--- a/frontend/components/layout/ImageWithPlaceholder.test.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.test.tsx
@@ -1,7 +1,9 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2026 Imperial College London
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -39,13 +41,13 @@ it('renders image with default positioning', async() => {
   const icon = screen.queryByTestId('PhotoSizeSelectActualOutlinedIcon')
   expect(icon).not.toBeInTheDocument()
 
-  const img = screen.getByRole('img')
+  const img = screen.getByTestId('image-with-placeholder')
   expect(img).toBeInTheDocument()
 
   //expect image src attribute
   expect(img).toHaveAttribute('src', mockProps.src)
   // expect aria-label attribute
-  expect(img).toHaveAttribute('aria-label', mockProps.alt)
+  // expect(img).toHaveAttribute('aria-label', mockProps.alt)
   // but not alt attribute
   expect(img).toHaveAttribute('alt', '')
   // expect title attribute

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -57,13 +57,11 @@ export default function ImageWithPlaceholder({
   return (
     <img
       title={placeholder ?? alt}
-      role="img"
       src={src}
       style={{
         objectFit: bgSize,
         objectPosition: bgPosition
       }}
-      aria-label={alt}
       alt=""
       className={`rounded-xs ${className ?? ''}`}
     ></img>

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -56,6 +56,7 @@ export default function ImageWithPlaceholder({
 
   return (
     <img
+      data-testid="image-with-placeholder"
       title={placeholder ?? alt}
       src={src}
       style={{

--- a/frontend/components/layout/ListOverviewSection.tsx
+++ b/frontend/components/layout/ListOverviewSection.tsx
@@ -13,6 +13,7 @@ type ListOverviewSectionProps=Readonly<{
 export default function ListOverviewSection({children, className='mt-2'}:ListOverviewSectionProps) {
   return (
     <section
+      aria-label="List overview"
       data-testid="list-overview"
       className={`flex-1 flex flex-col gap-2 ${className}`}
     >

--- a/frontend/components/layout/MainContent.tsx
+++ b/frontend/components/layout/MainContent.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +17,10 @@ export default function MainContent({className, children, ...props}: MainContain
   // keep these styles in sync with AppHeader and AppFooter
   return (
     <main
-      className={`flex-1 flex flex-col py-4 lg:pb-12 ${className ?? ''}`}
+      // a11y id to be used to skip to main content link
+      id="main-content"
+      tabIndex={-1}
+      className={`flex-1 flex flex-col py-4 lg:pb-12 outline-none ${className ?? ''}`}
       {...props}
     >
       {children}

--- a/frontend/components/news/overview/card/NewsAuthors.tsx
+++ b/frontend/components/news/overview/card/NewsAuthors.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,7 +12,7 @@ export default function NewsAuthors({author, className}:PublicationDateProps) {
   if (author){
     return (
       <span
-        className={`line-clamp-1 text-sm text-base-content-disabled ${className ?? ''}`}
+        className={`line-clamp-1 text-sm text-base-content-secondary ${className ?? ''}`}
       >
         {author}
       </span>

--- a/frontend/components/news/overview/card/PublicationDate.tsx
+++ b/frontend/components/news/overview/card/PublicationDate.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -14,7 +14,7 @@ export default function PublicationDate({publication_date, className}:Publicatio
   if (publication_date){
     return (
       <span
-        className={`line-clamp-1 text-sm text-base-content-disabled tracking-widest uppercase ${className ?? ''}`}
+        className={`line-clamp-1 text-sm text-base-content-secondary tracking-widest uppercase ${className ?? ''}`}
       >
         {isoStrToLocalDateStr(publication_date)}
       </span>

--- a/frontend/components/news/overview/index.tsx
+++ b/frontend/components/news/overview/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -36,7 +36,10 @@ export default function NewsOverview({pages,page,rows,search,news}:NewsOverviewP
         <h1 className="mr-4 lg:flex-1">
           News
         </h1>
-        <div className="flex-2 flex min-w-[20rem]">
+        <section
+          // define a11y region
+          aria-label="Search news items by title, summary or author"
+          className="flex-2 flex min-w-[20rem]">
           <SearchInput
             placeholder="Search news items by title, summary or author"
             onSearch={(search: string) => handleQueryChange('search', search)}
@@ -56,7 +59,7 @@ export default function NewsOverview({pages,page,rows,search,news}:NewsOverviewP
               handleQueryChange('rows', items.toString())
             }}
           />
-        </div>
+        </section>
       </div>
 
       {/* news cards, grid is default */}

--- a/frontend/components/organisation/metadata/OrganisationLogo.tsx
+++ b/frontend/components/organisation/metadata/OrganisationLogo.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -113,7 +113,6 @@ export default function OrganisationLogo({isMaintainer}:OrganisationLogoProps) {
       canEdit={isMaintainer}
       src={getImageUrl(logo) ?? undefined}
       sx={{
-        backgroundColor: logo ? 'inherit' : 'text.disabled',
         height: '10rem',
         'img': {
           objectFit: 'contain',

--- a/frontend/components/organisation/overview/index.tsx
+++ b/frontend/components/organisation/overview/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -40,7 +40,10 @@ export default function OrganisationsOverviewClient({
         <h1 className="mr-4 lg:flex-1">
           Organisations
         </h1>
-        <div className="flex-2 flex min-w-[20rem]">
+        <section
+          // define a11y region
+          aria-label="Search organisation by name, ROR name or website"
+          className="flex-2 flex min-w-[20rem]">
           <SearchInput
             placeholder="Search organisation by name, ROR name or website"
             onSearch={(search: string) => handleQueryChange('search', search)}
@@ -60,7 +63,7 @@ export default function OrganisationsOverviewClient({
               handleQueryChange('rows', items.toString())
             }}
           />
-        </div>
+        </section>
       </div>
       {/* Organizations cards */}
       {view === 'list' ?

--- a/frontend/components/projects/overview/search/ProjectSearchSection.tsx
+++ b/frontend/components/projects/overview/search/ProjectSearchSection.tsx
@@ -44,7 +44,7 @@ export default function ProjectSearchSection({
   // console.groupEnd()
 
   return (
-    <section 
+    <section
       aria-label="Find project"
       data-testid="search-section">
       <div className="flex border rounded-md shadow-xs bg-base-100 p-2">

--- a/frontend/components/projects/overview/search/ProjectSearchSection.tsx
+++ b/frontend/components/projects/overview/search/ProjectSearchSection.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -44,7 +44,9 @@ export default function ProjectSearchSection({
   // console.groupEnd()
 
   return (
-    <section data-testid="search-section">
+    <section 
+      aria-label="Find project"
+      data-testid="search-section">
       <div className="flex border rounded-md shadow-xs bg-base-100 p-2">
         <SearchInput
           placeholder={placeholder}

--- a/frontend/components/software/edit/information/AutosaveSoftwareLogo.test.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareLogo.test.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -64,7 +64,7 @@ it('renders image with proper src value', () => {
     </WithAppContext>
   )
 
-  const img = screen.getByRole('img')
+  const img = screen.getByTestId('image-with-placeholder')
   expect(img).toHaveAttribute('src',`/image/rpc/get_image?uid=${formValues.image_id}`)
 })
 

--- a/frontend/components/software/edit/information/AutosaveSoftwareMarkdown.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareMarkdown.tsx
@@ -1,17 +1,17 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import {FocusEventHandler} from 'react'
+import {useController, useFormContext} from 'react-hook-form'
 import Radio from '@mui/material/Radio'
 import RadioGroup from '@mui/material/RadioGroup'
 import FormControlLabel from '@mui/material/FormControlLabel'
-import {useController, useFormContext} from 'react-hook-form'
 
 import {useSession} from '~/auth/AuthProvider'
 import MarkdownInputWithPreview from '~/components/form/MarkdownInputWithPreview'
@@ -20,6 +20,7 @@ import useSnackbar from '~/components/snackbar/useSnackbar'
 import {softwareInformation as config} from '../editSoftwareConfig'
 import {patchSoftwareTable} from './patchSoftwareTable'
 import AutosaveRemoteMarkdown from './AutosaveRemoteMarkdown'
+
 
 type SaveInfo = {
   name: string,
@@ -125,7 +126,7 @@ export default function AutosaveSoftwareMarkdown() {
       return (
         <AutosaveRemoteMarkdown
           options={{
-            autofocus: true,
+            // autofocus: true,
             type: 'url',
             name: 'description_url',
             label: config.description_url.label,
@@ -156,15 +157,22 @@ export default function AutosaveSoftwareMarkdown() {
     )
   }
 
+  // Generate unique ID for screen reader bindings
+  const radioGroupId = 'software-description-type-group'
+
   return (
     <>
       <EditSectionTitle
         title={config.description.label}
         infoLink={config.description.help}
       />
+      {/* Visual title for screen readers to bind with the choices */}
+      <label id={radioGroupId} className="sr-only">
+        {config.description.label} Type
+      </label>
       <RadioGroup
         row
-        aria-labelledby="radio-group"
+        aria-labelledby={radioGroupId}
         value={description_type ?? 'markdown'}
         defaultValue={description_type ?? 'markdown'}
         onChange={(e, value) => {
@@ -177,20 +185,18 @@ export default function AutosaveSoftwareMarkdown() {
           })
         }}
         sx={{
-          margin:'0.75rem 0rem'
+          margin:'0.75rem 0rem',
+          gap: '1rem'
         }}
       >
         <FormControlLabel
           label="Custom markdown"
           value="markdown"
-          defaultValue={'markdown'}
           control={<Radio />}
         />
-        <div className="py-2"></div>
         <FormControlLabel
           label="Markdown URL"
           value="link"
-          defaultValue={'link'}
           control={<Radio />}
         />
       </RadioGroup>

--- a/frontend/components/software/overview/SoftwareHighlights.tsx
+++ b/frontend/components/software/overview/SoftwareHighlights.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 - 2024 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
@@ -35,9 +35,11 @@ export default function SoftwareHighlights({title,page,highlights}:SoftwareHighl
   if (page > 1) return null
 
   return (
-    <section className="mt-8 hide-on-no-script">
+    <section
+      aria-label={title}
+      className="mt-8 hide-on-no-script">
       {/* title should be in the container */}
-      <div className="text-3xl px-4 lg:container lg:mx-auto">
+      <div className="text-3xl text-secondary px-4 lg:container lg:mx-auto">
         {title}
       </div>
 

--- a/frontend/components/software/overview/cards/SoftwareOverviewMasonry.tsx
+++ b/frontend/components/software/overview/cards/SoftwareOverviewMasonry.tsx
@@ -10,6 +10,7 @@ import {JSX} from 'react'
 export default function SoftwareOverviewMasonry({children}: {children: JSX.Element | JSX.Element[]}) {
   return (
     <section
+      aria-label="Masonry overview"
       data-testid="software-overview-masonry"
       className="w-full lg:columns-2 xl:columns-3 gap-8 mt-2 mb-12">
       {children}

--- a/frontend/components/software/overview/search/SoftwareSearchSection.tsx
+++ b/frontend/components/software/overview/search/SoftwareSearchSection.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -37,7 +37,9 @@ export default function SoftwareSearchSection({
   const placeholder = filterCnt > 0 ? 'Find within selection' : 'Find software'
 
   return (
-    <section data-testid="search-section">
+    <section
+      aria-label="Find software"
+      data-testid="search-section">
       <div className="flex border rounded-md shadow-xs bg-base-100 p-2">
         <SearchInput
           placeholder={placeholder}

--- a/frontend/components/user/metadata/UserAvatar.tsx
+++ b/frontend/components/user/metadata/UserAvatar.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -113,7 +113,6 @@ export default function UserAvatar() {
       initials={initials}
       src={getImageUrl(avatar) ?? undefined}
       sx={{
-        backgroundColor: avatar ? 'inherit' : 'text.disabled',
         width: '10rem',
         height: '10rem',
         'img': {


### PR DESCRIPTION
# Add skip to main option for screen readers

Closes #1750
Closes #1754 

Changes proposed in this pull request:
* Add "skip to main" link to support quick navigation #1750 
* Improve software markdown options a11y based on #1754 remarks
* Create additional landmarks to ease navigation for screen readers. This is additional improvement based on `Skip to main` a11y suggestion.
* Improve contrast of avatar background elements
* Remove role and aria label from image elements, based on a11y advice of Chrome plugin 
* Let search expand to use free space as it was before search a11y fix.

How to test:
* `make start` to build and generate test data
* To test "Skip to main" use tab key on your keyboard immediately after refreshing the page. The button should appear and you should be able to use Enter to navigate to main section.
* To test markdown options improvement (#1754), login and created new software. On the description page navigate using tabs to Description section and toggle the options. Confirm that you can toggle markdown options and there is no lost of focus (change of focus to inputs).
* To test improvement of image, navigate to project overview page and run `Accessibility Insights For Web` plugin to test for errors. Test also organisation, communities and news overview pages.
* Use `Headings Map` plugin to view landmarks on the software, project, organisation overview pages.

## Skip to main option (use Tab directly after page reload)

<img width="1627" height="1297" alt="image" src="https://github.com/user-attachments/assets/15cabc30-9e20-466c-a075-7026eff7e036" />

## Landmarks software overview page

<img width="1657" height="1032" alt="image" src="https://github.com/user-attachments/assets/c7e56fd2-a8f4-4136-81cb-f25a85bfc3ee" />



PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
