### PR TITLE
Fix parsing name

### DIFF
--- a/frontend/sonar-project.properties
+++ b/frontend/sonar-project.properties
@@ -1,6 +1,6 @@
+# SPDX-FileCopyrightText: 2023 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-# SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-# SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -19,10 +19,11 @@ sonar.organization=research-software-directory
 #sonar.sourceEncoding=UTF-8
 
 # Exclude specific folders without "real" code and the test files from code analyses
-# NOTE! test inclusion pattern is automatically added by Sonar (see github acion logs)
+# NOTE! test inclusion pattern is automatically added by Sonar (see GitHub action logs)
 sonar.exclusions=./utils/jest/**, **/__tests__/**, **/__mocks__/**
 
 # Include all test files in the test analyses
+sonar.coverage.exclusions=**/*.test.{js,jsx,ts,tsx}
 sonar.test.inclusions=**/*.test.{js,jsx,ts,tsx}
 
 # Test coverage report, see https://docs.sonarcloud.io/enriching/test-coverage/javascript-typescript-test-coverage/

--- a/frontend/utils/getDisplayName.test.ts
+++ b/frontend/utils/getDisplayName.test.ts
@@ -1,0 +1,31 @@
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {splitName} from '~/utils/getDisplayName'
+
+it('returns empty names when name is null or undefined', () => {
+  expect(splitName(null!)).toEqual({given_names: '', family_names: ''})
+  expect(splitName(undefined!)).toEqual({given_names: '', family_names: ''})
+})
+
+it('returns empty names when name is empty or blank', () => {
+  expect(splitName(' ')).toEqual({given_names: '', family_names: ''})
+  expect(splitName(' ')).toEqual({given_names: '', family_names: ''})
+  expect(splitName('   ')).toEqual({given_names: '', family_names: ''})
+})
+
+it('returns names correctly when name contains ", "', () => {
+  expect(splitName('FamilyName, FirstName')).toEqual({given_names: 'FirstName', family_names: 'FamilyName'})
+  expect(splitName(' FamilyName, FirstName ')).toEqual({given_names: 'FirstName', family_names: 'FamilyName'})
+  expect(splitName('FamilyName, FirstName0, FirstName1')).toEqual({given_names: 'FirstName0 FirstName1', family_names: 'FamilyName'})
+  expect(splitName('FamilyName, FirstName0 FirstName1')).toEqual({given_names: 'FirstName0 FirstName1', family_names: 'FamilyName'})
+  expect(splitName('FamilyName0 FamilyName1, FirstName0 FirstName1')).toEqual({given_names: 'FirstName0 FirstName1', family_names: 'FamilyName0 FamilyName1'})
+})
+
+it('returns names correctly when name does not contain ", "', () => {
+  expect(splitName('FirstName FamilyName')).toEqual({given_names: 'FirstName', family_names: 'FamilyName'})
+  expect(splitName(' FirstName FamilyName ')).toEqual({given_names: 'FirstName', family_names: 'FamilyName'})
+  expect(splitName('FirstName FamilyName0 FamilyName1')).toEqual({given_names: 'FirstName', family_names: 'FamilyName0 FamilyName1'})
+})

--- a/frontend/utils/getDisplayName.ts
+++ b/frontend/utils/getDisplayName.ts
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -42,13 +43,25 @@ export function getDisplayInitials({given_names, family_names}:
  * @param name
  * @returns
  */
-export function splitName(name: string) {
-  if (!name || name === null || name === '') {
+export function splitName(name: string): {given_names: string; family_names: string} {
+  if (!name) {
     return {
       given_names: '',
       family_names: ''
     }
   }
+
+  name = name.trim()
+
+  if (name.includes(', ')) {
+    const names = name.split(', ')
+
+    return {
+      given_names: names.slice(1).join(' '),
+      family_names: names[0]
+    }
+  }
+
   const names = name.split(' ')
   return {
     given_names: names[0],


### PR DESCRIPTION
## Fix parsing name

### Changes proposed in this pull request

* When the OpenID name contains `, `, assume the family names come first when creating a public profile

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=0`
* Sign in with an OpenID provider that returns your name in the form `FamilyName, FirstName` and check that your name in your profile is correct
* If this is not possible for you, check the code and the tests

closes #1676

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [x] Tests