### PR TITLE
1751 name role value

### DIFF
--- a/e2e/helpers/userAgreement.ts
+++ b/e2e/helpers/userAgreement.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -64,7 +64,7 @@ export async function acceptUserAgreement(page:Page,baseURL?:string){
   await page.waitForSelector("#user-agreements-form",{state:"attached"})
 
   // get terms switch
-  const termsCheckbox = await page.getByRole('switch', { name: 'I agree to the Terms of' })
+  const termsCheckbox = await page.getByRole('switch', { name: 'I agree to the' })
   if (await termsCheckbox.isVisible()){
     // accept if not accepted
     if (await termsCheckbox.isChecked()===false){
@@ -73,7 +73,7 @@ export async function acceptUserAgreement(page:Page,baseURL?:string){
   }
 
   // get privacy checkbox
-  const privacyCheckbox = await page.getByRole('switch', { name: 'I have read the Privacy' })
+  const privacyCheckbox = await page.getByRole('switch', { name: 'I have read the' })
   if (await privacyCheckbox.isVisible()){
     // accept if not accepted
     if (await privacyCheckbox.isChecked()===false){

--- a/frontend/app/(container)/user/layout.tsx
+++ b/frontend/app/(container)/user/layout.tsx
@@ -1,5 +1,7 @@
 // SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2026 Imperial College London
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -81,7 +83,9 @@ export default async function UserPageLayout({
         {/* TABS */}
         <UserTabs counts={counts} />
         {/* TAB CONTENT */}
-        <section className="flex md:min-h-[45rem]">
+        <section
+          aria-label="User specific content"
+          className="flex md:min-h-[45rem]">
           {children}
         </section>
       </UserContextProvider>

--- a/frontend/components/cards/KeywordList.tsx
+++ b/frontend/components/cards/KeywordList.tsx
@@ -15,7 +15,9 @@ export default function KeywordList({keywords=[], visibleNumberOfKeywords = 3}: 
   if (!keywords || keywords.length===0) return null
 
   return (
-    <ul className="flex flex-wrap items-start gap-1 text-base-content text-xs">
+    <ul
+      aria-label={`${keywords?.length} keywords`}
+      className="flex flex-wrap items-start gap-1 text-base-content text-xs">
       {// limits the keywords to 'visibleNumberOfKeywords' per software.
         keywords?.slice(0, visibleNumberOfKeywords)
           .map((keyword:string) => (
@@ -30,7 +32,15 @@ export default function KeywordList({keywords=[], visibleNumberOfKeywords = 3}: 
         (keywords?.length > 0)
         && (keywords?.length > visibleNumberOfKeywords)
         && (keywords?.length - visibleNumberOfKeywords > 0)
-        && <li>{`+ ${keywords?.length - visibleNumberOfKeywords}`}</li>
+          ?
+          // Added a meaningful aria-label to the overflow count so it reads out clearly
+          <li
+            aria-label={`${keywords.length - visibleNumberOfKeywords} more keywords`}
+            title={`${keywords.length - visibleNumberOfKeywords} more keywords`}
+          >
+            {`+ ${keywords?.length - visibleNumberOfKeywords}`}
+          </li>
+          : null
       }
     </ul>
   )

--- a/frontend/components/layout/EditSection.tsx
+++ b/frontend/components/layout/EditSection.tsx
@@ -5,7 +5,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export default function EditSection({children,className='',...props}:{children:any,className?:string,props?:any}) {
+import {ComponentPropsWithoutRef, ReactNode} from 'react'
+
+type EditSectionProps = ComponentPropsWithoutRef<'section'> & {
+  children: ReactNode;
+}
+
+export default function EditSection({
+  children,
+  className='',
+  ...props
+}:EditSectionProps) {
   return (
     <section className={`flex-1 ${className}`} {...props}>
       {children}

--- a/frontend/components/layout/EditSection.tsx
+++ b/frontend/components/layout/EditSection.tsx
@@ -1,11 +1,13 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-export default function EditSection({children,className=''}:{children:any,className?:string}) {
+export default function EditSection({children,className='',...props}:{children:any,className?:string,props?:any}) {
   return (
-    <section className={`flex-1 ${className}`}>
+    <section className={`flex-1 ${className}`} {...props}>
       {children}
     </section>
   )

--- a/frontend/components/software/edit/communities/index.tsx
+++ b/frontend/components/software/edit/communities/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -96,7 +96,9 @@ export default function EditSoftwareCommunities() {
 
   return (
     <>
-      <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
+      <EditSection
+        aria-label={config.title}
+        className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
         <section className="py-4">
           <h2 className="flex pr-4 pb-4 justify-between">
             <span>{config.title}</span>
@@ -108,7 +110,9 @@ export default function EditSoftwareCommunities() {
             onEdit={onOpenEditCategories}
           />
         </section>
-        <section className="py-4">
+        <section
+          aria-label={config.findCommunity.title}
+          className="py-4">
           <EditSectionTitle
             title={config.findCommunity.title}
             subtitle={config.findCommunity.subtitle}

--- a/frontend/components/software/edit/contributors/index.tsx
+++ b/frontend/components/software/edit/contributors/index.tsx
@@ -4,8 +4,8 @@
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -183,8 +183,13 @@ export default function EditSoftwareContributors() {
 
   return (
     <>
-      <EditSection className='md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]'>
-        <section className="py-4">
+      <EditSection
+        className='md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]'
+      >
+        <section
+          aria-label={`${contributors?.length ?? 0} contributors`}
+          className="py-4"
+        >
           <h2 className="flex pr-4 pb-4 justify-between">
             <span>Contributors</span>
             <span>{contributors?.length}</span>
@@ -196,7 +201,9 @@ export default function EditSoftwareContributors() {
             onSorted={sortedContributors}
           />
         </section>
-        <section className="py-4">
+        <section
+          aria-label="Add contributor"
+          className="py-4">
           <EditSectionTitle
             title={config.findContributor.title}
             subtitle={config.findContributor.subtitle(host?.orcid_search)}

--- a/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
@@ -1,11 +1,11 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -153,7 +153,7 @@ export default function AutosaveSoftwareLogo() {
   }
 
   return (
-    <>
+    <section aria-label="Software logo">
       <EditSectionTitle
         title={config.logo.label}
         subtitle={config.logo.help}
@@ -181,6 +181,6 @@ export default function AutosaveSoftwareLogo() {
       />
 
       {renderImageAttributes()}
-    </>
+    </section>
   )
 }

--- a/frontend/components/software/edit/information/AutosaveSoftwarePageStatus.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwarePageStatus.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +24,7 @@ export default function AutosaveSoftwarePageStatus() {
   // console.groupEnd()
 
   return (
-    <>
+    <section aria-label="Software RSD status">
       <EditSectionTitle
         title={config.pageStatus.title}
         subtitle={config.pageStatus.subtitle}
@@ -49,6 +49,6 @@ export default function AutosaveSoftwarePageStatus() {
           <Link href="/user/software">your profile</Link>
         </strong> page.
       </Alert>
-    </>
+    </section>
   )
 }

--- a/frontend/components/software/edit/information/EditSoftwareDescriptionInputs.tsx
+++ b/frontend/components/software/edit/information/EditSoftwareDescriptionInputs.tsx
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -36,7 +36,10 @@ export default function EditSoftwareDescriptionInputs() {
   // console.groupEnd()
 
   return (
-    <EditSection className='md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_1fr] xl:px-0 xl:gap-[3rem]'>
+    <EditSection
+      aria-label="Software description items"
+      className='md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_1fr] xl:px-0 xl:gap-[3rem]'
+    >
       <div className="py-2">
         {user?.role === 'rsd_admin' ?
           <>

--- a/frontend/components/software/edit/links/EditSoftwareMetadataForm.tsx
+++ b/frontend/components/software/edit/links/EditSoftwareMetadataForm.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -35,6 +35,7 @@ export default function EditSoftwareMetadataForm({data}:{data:EditSoftwareItem})
   return (
     <FormProvider {...methods}>
       <form
+        aria-label="Links & metadata"
         data-testid="software-information-form"
         id="software-information"
       >

--- a/frontend/components/software/edit/maintainers/index.tsx
+++ b/frontend/components/software/edit/maintainers/index.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -58,7 +58,9 @@ export default function EditSoftwareMaintainers() {
 
   return (
     <>
-      <EditSection className='xl:grid xl:grid-cols-[1fr_1fr] xl:px-0 xl:gap-[3rem]'>
+      <EditSection
+        aria-label={config.title}
+        className='xl:grid xl:grid-cols-[1fr_1fr] xl:px-0 xl:gap-[3rem]'>
         <div className="py-4">
           <EditSectionTitle
             title={config.title}
@@ -68,13 +70,15 @@ export default function EditSoftwareMaintainers() {
             maintainers={maintainers}
           />
         </div>
-        <div className="py-4 min-w-[21rem] xl:my-0">
+        <section
+          aria-label={config.inviteLink.title}
+          className="py-4 min-w-[21rem] xl:my-0">
           <EditSectionTitle
             title={config.inviteLink.title}
             subtitle={config.inviteLink.subtitle}
           />
           <SoftwareMaintainerLinks />
-        </div>
+        </section>
       </EditSection>
       <ConfirmDeleteModal
         open={modal.open}

--- a/frontend/components/software/edit/mentions/SoftwareMentionTabs.tsx
+++ b/frontend/components/software/edit/mentions/SoftwareMentionTabs.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -47,7 +47,9 @@ export default function SoftwareMentionTabs(){
   // console.groupEnd()
 
   return (
-    <section>
+    <section
+      aria-label="Reference papers, citations and related output"
+    >
       <Tabs
         value={tab}
         onChange={(_,value)=>setTab(value)}

--- a/frontend/components/software/edit/organisations/index.tsx
+++ b/frontend/components/software/edit/organisations/index.tsx
@@ -378,7 +378,9 @@ export default function SoftwareOrganisations() {
   return (
     <>
       <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
-        <section className="py-4">
+        <section
+          aria-label={`${organisations?.length ?? 0} ${config.title}`}
+          className="py-4">
           <h2 className="flex pr-4 pb-4 justify-between">
             <span>{config.title}</span>
             <span>{organisations?.length}</span>
@@ -391,7 +393,9 @@ export default function SoftwareOrganisations() {
             onCategory={onCategoryEdit}
           />
         </section>
-        <section className="py-4">
+        <section
+          aria-label={config.findOrganisation.title}
+          className="py-4">
           <EditSectionTitle
             title={config.findOrganisation.title}
             subtitle={config.findOrganisation.subtitle}

--- a/frontend/components/software/edit/package-managers/index.tsx
+++ b/frontend/components/software/edit/package-managers/index.tsx
@@ -60,7 +60,9 @@ export default function EditPackageManagers() {
 
   return (
     <>
-      <EditSection className="py-4">
+      <EditSection
+        aria-label="Package managers"
+        className="py-4">
         <EditSectionTitle
           title="Package managers"
           subtitle="From which package managers can your software be downloaded?"

--- a/frontend/components/software/edit/related-projects/index.tsx
+++ b/frontend/components/software/edit/related-projects/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -104,7 +104,9 @@ export default function RelatedProjectsForSoftware() {
   }
 
   return (
-    <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
+    <EditSection
+      aria-label={config.title}
+      className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
       <section className="py-4">
         <EditSectionTitle
           title={config.title}
@@ -121,7 +123,9 @@ export default function RelatedProjectsForSoftware() {
           onRemove={onRemove}
         />
       </section>
-      <section className="py-4">
+      <section
+        aria-label={config.findTitle}
+        className="py-4">
         <EditSectionTitle
           title={config.findTitle}
           subtitle={config.findSubtitle}

--- a/frontend/components/software/edit/related-software/index.tsx
+++ b/frontend/components/software/edit/related-software/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -110,7 +110,9 @@ export default function RelatedSoftwareForSoftware() {
   }
 
   return (
-    <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
+    <EditSection
+      aria-label={config.title}
+      className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
       <section className="py-4">
         <EditSectionTitle
           title={config.title}
@@ -127,7 +129,9 @@ export default function RelatedSoftwareForSoftware() {
           onRemove={onRemove}
         />
       </section>
-      <section className="py-4">
+      <section
+        aria-label={config.findTitle}
+        className="py-4">
         <EditSectionTitle
           title={config.findTitle}
           subtitle={config.findSubTitle}

--- a/frontend/components/software/edit/repositories/index.tsx
+++ b/frontend/components/software/edit/repositories/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -41,7 +41,10 @@ export default function SoftwareRepositories() {
 
   return (
     <>
-      <EditSection className="py-4">
+      <EditSection
+        aria-label="Source code repositories"
+        className="py-4"
+      >
         <EditSectionTitle
           title="Source code repositories"
           subtitle="Where can the source code of this software be found?"

--- a/frontend/components/software/edit/software-heritage/index.tsx
+++ b/frontend/components/software/edit/software-heritage/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -112,7 +112,9 @@ export default function SoftwareHeritagePage() {
 
   return (
     <>
-      <EditSection className="py-4">
+      <EditSection
+        aria-label={cfg.title}
+        className="py-4">
         <EditSectionTitle
           title={cfg.title}
           subtitle={cfg.subtitle}

--- a/frontend/components/software/edit/testimonials/index.tsx
+++ b/frontend/components/software/edit/testimonials/index.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -128,7 +128,9 @@ export default function SoftwareTestimonials() {
   }
 
   return (
-    <section className="flex-1">
+    <section
+      aria-label="Testimonials"
+      className="flex-1">
       <EditSection>
         <div className="py-4">
           <EditSectionTitle

--- a/frontend/components/software/overview/cards/ProgrammingLanguageList.tsx
+++ b/frontend/components/software/overview/cards/ProgrammingLanguageList.tsx
@@ -13,14 +13,25 @@ type ProgrammingLanguageListProps = {
 export default function ProgrammingLanguageList({
   prog_lang = [], visibleNumberOfProgLang = 3}: ProgrammingLanguageListProps
 ) {
+
+  if (!prog_lang || prog_lang?.length ===0) return null
+
+  // console.group('ProgrammingLanguageList')
+  // console.log('prog_lang...', prog_lang)
+  // console.groupEnd()
+
   return (
     <ul
       aria-label={`${prog_lang?.length} programming languages`}
-      className="text-base-content-secondary text-sm flex flex-wrap gap-1">
+      className="flex-1 flex flex-wrap text-base-content-secondary text-sm">
       {// limits the prog lang to 'visibleNumberOfProgLang' per software.
         prog_lang?.slice(0, visibleNumberOfProgLang)
-          .map((lang:string, index: number) => (
-            <li className="px-1 m-0" key={lang ?? index}>{lang}</li>
+          .map((lang:string) => (
+            <li
+              title={lang}
+              key={lang}
+              className="pr-1 m-0"
+            >{lang}</li>
           ))}
       { //  Show the number of keywords that are not visible.
         (prog_lang?.length > 0)

--- a/frontend/components/software/overview/cards/ProgrammingLanguageList.tsx
+++ b/frontend/components/software/overview/cards/ProgrammingLanguageList.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -14,8 +14,10 @@ export default function ProgrammingLanguageList({
   prog_lang = [], visibleNumberOfProgLang = 3}: ProgrammingLanguageListProps
 ) {
   return (
-    <ul className="text-base-content-secondary text-sm flex flex-wrap gap-1">
-      {// limits the keywords to 'visibleNumberOfProgLang' per software.
+    <ul
+      aria-label={`${prog_lang?.length} programming languages`}
+      className="text-base-content-secondary text-sm flex flex-wrap gap-1">
+      {// limits the prog lang to 'visibleNumberOfProgLang' per software.
         prog_lang?.slice(0, visibleNumberOfProgLang)
           .map((lang:string, index: number) => (
             <li className="px-1 m-0" key={lang ?? index}>{lang}</li>
@@ -24,7 +26,15 @@ export default function ProgrammingLanguageList({
         (prog_lang?.length > 0)
         && (prog_lang?.length > visibleNumberOfProgLang)
         && (prog_lang?.length - visibleNumberOfProgLang > 0)
-        && <li>{`+ ${prog_lang?.length - visibleNumberOfProgLang}`}</li>
+          ?
+          // Added a meaningful aria-label to the overflow count so it reads out clearly
+          <li
+            aria-label={`${prog_lang?.length - visibleNumberOfProgLang} more programming language(s)`}
+            title={`${prog_lang?.length - visibleNumberOfProgLang} more programming language(s)`}
+          >
+            {`+ ${prog_lang?.length - visibleNumberOfProgLang}`}
+          </li>
+          : null
       }
     </ul>
   )

--- a/frontend/components/software/overview/cards/SoftwareCardContent.tsx
+++ b/frontend/components/software/overview/cards/SoftwareCardContent.tsx
@@ -59,7 +59,7 @@ export default function SoftwareCardContent(item:SoftwareCardContentProps) {
           />
         </div>
 
-        <div className="flex gap-2 justify-between mt-4">
+        <div className="flex gap-2 justify-end mt-4">
           {/* Languages */}
           <ProgrammingLanguageList
             prog_lang={item.prog_lang ?? undefined}

--- a/frontend/components/user/metadata/index.tsx
+++ b/frontend/components/user/metadata/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,7 +10,9 @@ import UserInfo from './UserInfo'
 
 export default function UserMetadata() {
   return (
-    <section className="grid md:grid-cols-[1fr_3fr] xl:grid-cols-[1fr_5fr] gap-4 mt-8">
+    <section
+      aria-label="User metadata"
+      className="grid md:grid-cols-[1fr_3fr] xl:grid-cols-[1fr_5fr] gap-4 mt-8">
       <BaseSurfaceRounded className="flex justify-center p-4 overflow-hidden relative">
         <UserAvatar />
       </BaseSurfaceRounded>

--- a/frontend/components/user/settings/agreements/RemoveAccount.tsx
+++ b/frontend/components/user/settings/agreements/RemoveAccount.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -87,7 +87,7 @@ export default function RemoveAccount() {
 
   if (user?.account) {
     return (
-      <>
+      <section aria-label="Remove account">
         <h2 className="pt-8">Remove account</h2>
 
         <RemoveAccountAlert disabled={disabled} />
@@ -118,7 +118,7 @@ export default function RemoveAccount() {
           }}
           onDelete={deleteAccount}
         />
-      </>
+      </section>
     )
   }
   // do not show if no account

--- a/frontend/components/user/settings/agreements/index.tsx
+++ b/frontend/components/user/settings/agreements/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -46,6 +46,7 @@ export default function UserAgreementsPage() {
       </p>
       <FormProvider {...methods}>
         <form
+          aria-label="User agreements"
           id="user-agreements-form"
           className='flex-1 flex flex-col gap-2 my-8'
         >
@@ -55,7 +56,17 @@ export default function UserAgreementsPage() {
             control={methods.control}
             onSave={setAgreeTerms}
             label={
-              <span>I agree to the <Link className="underline" target='_blank' href={host?.terms_of_service_url ?? ''}>Terms of Service</Link>.</span>
+              <span>
+                I agree to the
+                <Link
+                  className="underline ml-2"
+                  target='_blank'
+                  href={host?.terms_of_service_url ?? ''}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  Terms of Service
+                </Link>.
+              </span>
             }
           />
 
@@ -65,7 +76,17 @@ export default function UserAgreementsPage() {
             control={methods.control}
             onSave={setPrivacyStatement}
             label={
-              <span>I have read the <Link className='underline' target='_blank' href={host?.privacy_statement_url ?? ''}>Privacy Statement</Link>.</span>
+              <span>
+                I have read the
+                <Link
+                  className="underline ml-2"
+                  target='_blank'
+                  href={host?.privacy_statement_url ?? ''}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  Privacy Statement
+                </Link>.
+              </span>
             }
           />
           {/* use FormProvider to check for user agreement values */}

--- a/frontend/components/user/settings/index.tsx
+++ b/frontend/components/user/settings/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
@@ -24,6 +24,8 @@ export default function UserSettings() {
       {/* dynamic load of settings page */}
       <BaseSurfaceRounded
         className="p-8"
+        type='section'
+        aria-label = "Main content"
       >
         <UserSettingsContent />
       </BaseSurfaceRounded>

--- a/frontend/components/user/settings/nav/index.tsx
+++ b/frontend/components/user/settings/nav/index.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -31,7 +31,6 @@ export default function UserSettingsNav() {
     >
       {settingsMenu.map((item, pos) => {
         const selected = settings === settingsMenu[pos].id
-        // const selected = router.query['id'] ?? organisationMenu[0].id
         return (
           <ListItemButton
             data-testid="user-settings-nav-item"
@@ -39,6 +38,8 @@ export default function UserSettingsNav() {
             selected={selected}
             href={`${pathname}?settings=${item.id}`}
             LinkComponent={Link}
+            // 3. Inform screen readers which page is active
+            aria-current={selected ? 'page' : undefined}
             sx={editMenuItemButtonSx}
           >
             <ListItemIcon>

--- a/frontend/components/user/settings/profile/AuthenticationMethods.tsx
+++ b/frontend/components/user/settings/profile/AuthenticationMethods.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +23,9 @@ export default function AuthenticationMethods() {
   })
 
   return (
-    <div>
+    <section
+      aria-label="Authentication methods"
+    >
       <h3>Authentication methods</h3>
       <List dense={true}>
         {logins.map(account=>{
@@ -68,6 +70,6 @@ export default function AuthenticationMethods() {
           }
         }}
       />
-    </div>
+    </section>
   )
 }

--- a/frontend/components/user/settings/profile/LinkAccounts.tsx
+++ b/frontend/components/user/settings/profile/LinkAccounts.tsx
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -27,7 +27,7 @@ export default function LinkAccounts() {
   }
 
   return (
-    <div>
+    <section aria-label="Link your accounts">
       <h3 className="mb-4">Link your accounts</h3>
       <Stack
         spacing={2}
@@ -46,6 +46,6 @@ export default function LinkAccounts() {
           )
         })}
       </Stack>
-    </div>
+    </section>
   )
 }

--- a/frontend/components/user/settings/profile/ProfileInput.tsx
+++ b/frontend/components/user/settings/profile/ProfileInput.tsx
@@ -1,7 +1,7 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 // SPDX-FileCopyrightText: 2025 dv4all
 //
@@ -25,7 +25,10 @@ export default function ProfileInput() {
   ])
 
   return (
-    <div className="flex flex-col gap-4">
+    <section
+      aria-label="Profile information"
+      className="flex flex-col gap-4"
+    >
       <div className="grid lg:grid-cols-2 gap-8">
         <AutosaveProfileTextField
           options={{
@@ -102,6 +105,6 @@ export default function ProfileInput() {
           }
         </div>
       </div>
-    </div>
+    </section>
   )
 }

--- a/frontend/components/user/tabs/UserTabs.tsx
+++ b/frontend/components/user/tabs/UserTabs.tsx
@@ -65,14 +65,24 @@ export default function UserTabs({counts}:UserTabsProps) {
             modules: activeModules,
             isMaintainer
           })) {
-            return <TabAsLink
-              icon={item.icon}
-              key={key}
-              label={item.label(counts)}
-              value={key}
-              href={key}
-              scroll={false}
-            />
+            // construct label with counts and aria-label
+            const label = item.label(counts)
+            let ariaLabel = label
+            if (label.includes('(')){
+              // remove parenthesis for aria and add word items
+              ariaLabel = `${label.replaceAll('(','').replaceAll(')','')} items`
+            }
+            return (
+              <TabAsLink
+                icon={item.icon}
+                key={key}
+                label={label}
+                value={key}
+                href={key}
+                scroll={false}
+                aria-label={ariaLabel}
+              />
+            )
           }})}
       </Tabs>
     </BaseSurfaceRounded>

--- a/frontend/components/user/tabs/UserTabs.tsx
+++ b/frontend/components/user/tabs/UserTabs.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -52,12 +52,12 @@ export default function UserTabs({counts}:UserTabsProps) {
     <BaseSurfaceRounded
       className="my-4 p-2"
       type="section"
+      aria-label="User specific pages"
     >
       <Tabs
         variant="scrollable"
         allowScrollButtonsMobile
         value={select_tab}
-        aria-label="User profile tabs"
       >
         {tabItems.map(key => {
           const item = userTabItems[key]


### PR DESCRIPTION
# A11y User and software pages navigation

Closes #1751

Changes proposed in this pull request:
* Card announcement of keywords and programming languages is improved
* User settings navigation is improved and additional landmarks are created
* Aria label added to tabs to explain item count
* Additional landmarks added to edit software pages for better announcement and navigation. Current page announcement was already improved when addressing `nav>ul>li` structure of navigation. However it seem that Linux Mint and Orca screen reader are not able to announce current page as this is the case in Windows/Mac OS. Technically solution applied should announce the page (aria-current="page")

How to test:
* `make start` to build and generate test data. If you used `make start` you need to restart to activate scrapers to get keywords and programming languages (docker compose down && docker compose up -d).
* navigate to software overview and activate screen reader on the cards. On Linux Mint Orca screen reader should be available by default, use `Window + Alt + S`  to activate/deactivate screen reader. Confirm that keywords are announced in the card. Using arrows you can navigate through keywords. Same should be true for programming languages.
* Login as rsd admin.
* Navigate to user pages. 
    * Confirm that screen reader reads the counts properly now (using additional aria-labels assigned to tabs).
    * Confirm that current page is properly announced. I was not able to confirm this "clearly" on Linux Mint / Orca / Chrome however a proper aria is used on nav item indicating current page. You can confirm this using F12 -> inspect element -> confirm `aria-current="page"` is present only on the link of current page.
   * Additional landmarks are added for easier navigation (see image)
* Create new software
   * Confirm that current page is properly announced.
   * Additional landmarks are added for easier navigation between page sections 

## Additional landmarks on user settings page
<img width="1647" height="1287" alt="image" src="https://github.com/user-attachments/assets/d0386079-439d-4570-9498-dd0059a361d4" />

## Additional landmarks edit software
<img width="1651" height="989" alt="image" src="https://github.com/user-attachments/assets/e2b65f66-a624-4958-884c-7b1ff3e075e3" />

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
