### PR TITLE
Increase contrast of several aspects of the web

### DIFF
--- a/frontend/components/feedback/FeedbackPanelButton.tsx
+++ b/frontend/components/feedback/FeedbackPanelButton.tsx
@@ -100,23 +100,23 @@ User Agent: ${navigator.userAgent}`
             </h2>
             <textarea
               autoFocus
-              className="placeholder:text-base-500 outline-0 p-2 w-full h-28 text-sm bg-base-700 text-base-100 border border-base-600 rounded-sm"
+              className="placeholder:text-base-200 outline-0 p-2 w-full h-28 text-sm bg-base-700 text-base-200 border border-base-600 rounded-sm"
               placeholder="Ideas on how to improve this page or report an issue?" value={text}
               onChange={e => setText(e.target.value)}>
             </textarea>
 
             {/* Location URL */}
-            <div className="text-[#888] text-sm break-all">
+            <div className="text-base-100 text-sm break-all">
               <LinkIcon className="-rotate-45"/> {typeof location !== 'undefined' && location.href}
             </div>
             {/* Browser user agent detection */}
-            <div className="text-[#888] text-sm mb-8">
+            <div className="text-base-100 text-sm mb-8">
               <WebIcon/> {browserNameAndVersion()}
             </div>
 
             <div className="flex justify-end gap-4 w-full my-2">
               <button
-                className="text-sm text-base-200 border border-base-400 opacity-60 rounded-sm px-3 py-1 hover:opacity-90 active:opacity-95"
+                className="text-sm text-base-100 border border-base-400 opacity-60 rounded-sm px-3 py-1 hover:opacity-90 active:opacity-95"
                 onClick={closeAndClean}>
                 Cancel
               </button>
@@ -131,10 +131,9 @@ User Agent: ${navigator.userAgent}`
               </a>
 
             </div>
-            <div className="text-sm mt-8 mb-6 text-[#B7B7B7]">
+            <div className="text-sm mt-8 mb-6 text-base-100">
               We will send your feedback using your default email application,
-              or you can open a new <a className="text-primary" href={issues_page_url} target="_blank" rel="noreferrer">
-                issue</a>
+              or you can <a className="text-primary" href={issues_page_url} target="_blank" rel="noreferrer"><u>open a new issue</u></a>
             </div>
           </div>
         </div>

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -41,7 +41,7 @@ export default function ImageWithPlaceholder({
     }
     return (
       <div
-        className={`flex flex-col justify-center items-center text-base-600 rounded-xs ${className ?? ''}`}
+        className={`flex flex-col justify-center items-center text-base-700 rounded-xs ${className ?? ''}`}
       >
         <PhotoSizeSelectActualOutlinedIcon
           sx={{

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -41,7 +41,7 @@ export default function ImageWithPlaceholder({
     }
     return (
       <div
-        className={`flex flex-col justify-center items-center text-base-700 rounded-xs ${className ?? ''}`}
+        className={`flex flex-col justify-center items-center text-base-600 rounded-xs ${className ?? ''}`}
       >
         <PhotoSizeSelectActualOutlinedIcon
           sx={{

--- a/frontend/components/layout/NoContent.tsx
+++ b/frontend/components/layout/NoContent.tsx
@@ -28,7 +28,7 @@ const NoContentBody = styled('div')({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
-  opacity: 0.50
+  opacity: 0.5
 })
 
 export default function NoContent({message='nothing to show'}:{message?:string}) {

--- a/frontend/components/layout/NoContent.tsx
+++ b/frontend/components/layout/NoContent.tsx
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
+// SPDX-FileCopyrightText: 2026 Imperial College London
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -26,7 +28,7 @@ const NoContentBody = styled('div')({
   flexDirection: 'column',
   justifyContent: 'center',
   alignItems: 'center',
-  opacity: 0.25
+  opacity: 0.50
 })
 
 export default function NoContent({message='nothing to show'}:{message?:string}) {


### PR DESCRIPTION
# Increase contrast of several aspects of the web

Fixes partly #1769 . No closing it, for now.

Changes proposed in this pull request:

* There are several parts of the web where contrast is not good enough, or where we are conveying information only by colours. Part of it is just changing the colour palette - deployment specific - but other things require changes in the code itself. For example, there are places where the colours are hardcoded instead of using the palette. The feedback form is specially challenging as there, the `primary` colour needs to have good enough contrast against a dark background and as a background itself for a clear font. I have not been able to solve that for Imperial palette, yet. 

How to test:

* Run `docker compose up`. We do not want content in some places as the changes here concern some placeholder text.
* Visit the `feedback` dialog and check the contrast. With the standard palette, proably either the send feedback button or open a new issue link at the bottom will raise an error when checked with the accessibility tool. This is to be fixed, in principle, by playing with the colours of the palette.
* Go to the software of projects page. There should be no complain about the background text and image saying there's no content.
* Create a new software and go to the edit page. The Click or drop to upload your logo placeholder should raise no issues concerning contrast, either. 
* I have fixed a few other issues that were purely related with the Imperial palette, but the above should be helpful for all cases. 

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
