### PR TITLE
feat: split frontend checks

### DIFF
--- a/.github/workflows/_cff.yml
+++ b/.github/workflows/_cff.yml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 # SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
-# SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -50,7 +50,7 @@ jobs:
 
       - name: commit CITATION.cff
         # https://github.com/stefanzweifel/git-auto-commit-action
-        uses: stefanzweifel/git-auto-commit-action@v5
+        uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: ${{inputs.commit_message}}
           file_pattern: CITATION.cff

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -19,41 +19,92 @@ on:
     paths:
       - "frontend/**"
 
+defaults:
+  run:
+    working-directory: frontend
+
 jobs:
-  fe-tests:
+  # CHECK 1: Linter
+  fe-lint:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - name: "install node v22.13 and cache npm"
+      - name: "install node and cache npm"
         uses: actions/setup-node@v6
         with:
           node-version: 24.14
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - name: "install dependencies"
-        working-directory: frontend
         run: npm ci
       - name: "run eslint check"
-        working-directory: frontend
         run: npm run lint
+
+  # CHECK 2: Unit Tests
+  fe-test:
+    name: "fe-test"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: "install node and cache npm"
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.14
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: "install dependencies"
+        run: npm ci
       - name: "run unit test"
-        working-directory: frontend
         run: npm run test:coverage
+
+  # CHECK 3: Build Verification
+  fe-build:
+    name: "fe-build"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - name: "install node and cache npm"
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.14
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: "install dependencies"
+        run: npm ci
+      - name: "run build test"
+        run: npm run build
+
+  # CHECK 4: SonarCloud Scan
+  fe-sonar:
+    name: "fe-sonar"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: "install node and cache npm"
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.14
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: "install dependencies"
+        run: npm ci
+
+      # UPGRADED v4 -> v5 (Provides full Node.js 24 compatibility)
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+
+      # UPGRADED v6 -> v8 (Official SonarSource security & scanning updates)
       - name: SonarCloud Scan frontend
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@v8
         with:
           projectBaseDir: frontend
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      - name: "run build test"
-        working-directory: frontend
-        run: npm run build

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -58,6 +58,15 @@ jobs:
       - name: "run unit test"
         run: npm run test:coverage
 
+       # Upload the coverage folder for SonarCloud (fe-sonar) to use
+      - name: "upload coverage artifact"
+        uses: actions/upload-artifact@v7
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          # Automatically clean up after 24 hours
+          retention-days: 1
+
   # CHECK 3: Build Verification
   fe-build:
     name: "fe-build"
@@ -78,6 +87,7 @@ jobs:
   # CHECK 4: SonarCloud Scan
   fe-sonar:
     name: "fe-sonar"
+    needs: [fe-test]
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
@@ -91,6 +101,13 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - name: "install dependencies"
         run: npm ci
+
+       # Download the coverage folder back into frontend/coverage/
+      - name: "download coverage artifact"
+        uses: actions/download-artifact@v7
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
 
       # UPGRADED v4 -> v5 (Provides full Node.js 24 compatibility)
       - name: Cache SonarCloud packages

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 # SPDX-FileCopyrightText: 2022 dv4all
-# SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 # SPDX-FileCopyrightText: 2023 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 #
@@ -32,7 +32,7 @@ jobs:
       - name: calculate new version and create changelog content
         id: changelog
         # https://github.com/TriPSs/conventional-changelog-action
-        uses: TriPSs/conventional-changelog-action@v5
+        uses: TriPSs/conventional-changelog-action@v6
         with:
           # you can also create separate token to trace action
           github-token: "${{secrets.GITHUB_TOKEN}}"
@@ -260,7 +260,7 @@ jobs:
 
       - name: create release draft
         # https://github.com/softprops/action-gh-release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         env:
           # The token is provided by Actions, you do not need to create your own token
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,7 @@
     "build": "next build",
     "build:turbo": "next build --turbopack",
     "start": "next start",
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "lint:fix": "eslint --fix .",
     "test": "jest",
     "test:watch": "jest --watch --detectOpenHandles",


### PR DESCRIPTION
# Split frontend checks and update actions

Close #1781

Changes proposed in this pull request:
* Split frontend checks in 4 separate checks to directly see where is the problem. The checks are fe-lint, fe-test, fe-build, fe-sonar.  
* Sonar actions are upgraded to latest versions
* Release action dependencies upgraded to avoid Node version warnings

How to test:
* This can be only tested by creating PR with some errors.
* I tested it by purposely creating lint warning which should be signaled in checks
* I saw the warning from SonarCube too, similair to linter warning
* I tested build and unit test failures.
* **Release action upgrades can be only tested by making a release. We need to factor this in by our next release**. 

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
