### PR TITLE
1755 link purpose & 1763 autocomplete

### DIFF
--- a/e2e/helpers/software.ts
+++ b/e2e/helpers/software.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -67,16 +67,9 @@ export async function editSoftwareMetadata(page: Page, mockSoftware: MockedSoftw
     element: getStarted,
     value: mockSoftware.repoUrl
   })
-  // add repository url
-  // const repoUrl = page.getByLabel('Repository URL')
-  // await repoUrl.fill(mockSoftware.repoUrl)
-  // await Promise.all([
-  //   repoUrl.blur(),
-  //   // wait for POST
-  //   page.waitForResponse(/\/repository_url/),
-  // ])
   // add Concept DOI
-  const doi = await page.getByLabel('Software DOI')
+  const doi = await page.getByRole('textbox',{name:'Software DOI'})
+  // getByLabel('Software DOI')
   await fillAutosaveInput({
     page,
     element: doi,

--- a/frontend/components/layout/EditSectionTitle.tsx
+++ b/frontend/components/layout/EditSectionTitle.tsx
@@ -9,6 +9,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {ElementType} from 'react'
 import Link from '@mui/material/Link'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 
@@ -17,57 +18,69 @@ type EditSectionTitleProps = {
   subtitle?: string,
   children?: any,
   hlevel?: number,
-  infoLink?: string,
+  infoLink?: {
+    url: string,
+    ariaLabel: string
+  },
   className?: string
 }
 
-export default function EditSectionTitle({title, subtitle = '', children, hlevel = 2, infoLink, className='font-medium'}:EditSectionTitleProps) {
+function InfoLink({infoLink}:Readonly<{infoLink:EditSectionTitleProps['infoLink']}>){
 
-  const HeadingTag: any = `h${hlevel}`
+  if (!infoLink) return null
 
-  function getSubtitle() {
-    if (subtitle) {
-      return (
-        <p className="mb-4"
-          dangerouslySetInnerHTML={{__html: subtitle}}>
-        </p>
-      )
-    }
-  }
+  return (
+    <Link
+      aria-label={infoLink.ariaLabel}
+      href={infoLink.url}
+      target="_blank"
+      rel="noreferrer"
+      className="flex"
+    >
+      <InfoOutlinedIcon fontSize="small"/>
+    </Link>
+  )
+}
 
-  if (children) {
+function SubTitle({subtitle}:Readonly<{subtitle:EditSectionTitleProps['subtitle']}>){
+  if (!subtitle) return null
+
+  return(
+    <p className="mb-4"
+      dangerouslySetInnerHTML={{__html: subtitle}}>
+    </p>
+  )
+}
+
+
+export default function EditSectionTitle({
+  title, subtitle = '', children, hlevel = 2, infoLink, className='font-medium'
+}:EditSectionTitleProps) {
+
+  const HeadingTag = `h${hlevel}` as ElementType
+
+  if (children){
     return (
       <>
         <div className="flex">
-          <HeadingTag className={`flex-1 ${className ?? ''}`}>{title} {
-            infoLink &&
-            <Link
-              aria-label="Link to info page"
-              href={infoLink} target="_blank" rel="noreferrer">
-              <InfoOutlinedIcon fontSize="small"/>
-            </Link>
-          }
+          <HeadingTag className={`flex-1 flex ${className ?? ''}`}>
+            {title}
+            <InfoLink infoLink={infoLink}/>
           </HeadingTag>
           {children}
         </div>
-        {getSubtitle()}
+        <SubTitle subtitle={subtitle} />
       </>
     )
   }
 
   return (
     <>
-      <HeadingTag className={`${className ?? ''}`}>{title} {
-        infoLink &&
-          <Link
-            aria-label="Link to info page"
-            href={infoLink} target="_blank" rel="noreferrer">
-            <InfoOutlinedIcon fontSize="small"/>
-          </Link>
-      }
+      <HeadingTag className={`flex-1 flex ${className ?? ''}`}>
+        {title}
+        <InfoLink infoLink={infoLink}/>
       </HeadingTag>
-      {getSubtitle()}
+      <SubTitle subtitle={subtitle} />
     </>
   )
-
 }

--- a/frontend/components/layout/EditSectionTitle.tsx
+++ b/frontend/components/layout/EditSectionTitle.tsx
@@ -13,7 +13,7 @@ import {ElementType} from 'react'
 import Link from '@mui/material/Link'
 import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined'
 
-type EditSectionTitleProps = {
+type EditSectionTitleProps = Readonly<{
   title: string,
   subtitle?: string,
   children?: any,
@@ -23,7 +23,7 @@ type EditSectionTitleProps = {
     ariaLabel: string
   },
   className?: string
-}
+}>
 
 function InfoLink({infoLink}:Readonly<{infoLink:EditSectionTitleProps['infoLink']}>){
 

--- a/frontend/components/layout/OrcidLink.tsx
+++ b/frontend/components/layout/OrcidLink.tsx
@@ -17,16 +17,17 @@ export default function OrcidLink({orcid}:{orcid?:string|null}) {
       target="_blank"
       rel="noreferrer"
       style={{whiteSpace:'nowrap'}}
+      className="flex gap-1 items-end"
       // 1. a11y link explanation MUST start with same value as in visible text
       aria-label={`${orcid}, Personal ORCID page, opens in a new tab`}
     >
       {/* 2. SVG hidden from screen readers since it's decorative */}
       <LogoOrcid
         aria-hidden="true"
-        className="inline max-w-[1.125rem] mr-1"
+        className="max-w-[1.5rem]"
       />
       {/* 3. Visible text for everyone */}
-      <span className="text-sm align-bottom">{orcid}</span>
+      <span className="text-sm">{orcid}</span>
     </a>
   )
 }

--- a/frontend/components/layout/OrcidLink.tsx
+++ b/frontend/components/layout/OrcidLink.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,10 +12,20 @@ export default function OrcidLink({orcid}:{orcid?:string|null}) {
   const url =`https://orcid.org/${orcid}`
   // show orcid link
   return (
-    <a href={url} target="_blank" rel="noreferrer"
+    <a
+      href={url}
+      target="_blank"
+      rel="noreferrer"
       style={{whiteSpace:'nowrap'}}
+      // 1. a11y link explanation MUST start with same value as in visible text
+      aria-label={`${orcid}, Personal ORCID page, opens in a new tab`}
     >
-      <LogoOrcid className="inline max-w-[1.125rem] mr-1" />
+      {/* 2. SVG hidden from screen readers since it's decorative */}
+      <LogoOrcid
+        aria-hidden="true"
+        className="inline max-w-[1.125rem] mr-1"
+      />
+      {/* 3. Visible text for everyone */}
       <span className="text-sm align-bottom">{orcid}</span>
     </a>
   )

--- a/frontend/components/projects/edit/information/config.ts
+++ b/frontend/components/projects/edit/information/config.ts
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
 // SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
 //
@@ -85,7 +85,10 @@ export const projectInformation = {
   research_domain: {
     title: 'Research domains',
     subtitle: 'ERC classification.',
-    infoLink: 'https://erc.europa.eu/news/new-erc-panel-structure-2021-and-2022',
+    infoLink: {
+      url:'https://erc.europa.eu/news/new-erc-panel-structure-2021-and-2022',
+      ariaLabel: 'ERC classification, link to page opens in new tab'
+    },
     label: 'Select main research domain and field'
   },
   keywords: {

--- a/frontend/components/software/ContactPersonCard.tsx
+++ b/frontend/components/software/ContactPersonCard.tsx
@@ -1,64 +1,72 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import EmailIcon from '@mui/icons-material/Email'
-import Avatar from '@mui/material/Avatar'
 import LaunchIcon from '@mui/icons-material/Launch'
 
 import {Person} from '~/types/Contributor'
 import {getImageUrl} from '~/utils/editImage'
 import {getDisplayName, getDisplayInitials} from '~/utils/getDisplayName'
-import LogoOrcid from '~/assets/logos/logo-orcid.svg'
+import PersonalInfo from './PersonalInfo'
+import ContributorAvatar from './ContributorAvatar'
+
+type MailToType=Readonly<{
+  email_address: Person['email_address'],
+  given_names: Person['given_names'],
+}>
+
+export function MailToLink({email_address,given_names}:MailToType){
+  if (email_address) {
+    return (
+      <a className="flex-1 flex gap-1 items-end text-sm"
+        href={`mailto:${email_address}`}
+        target="_blank" rel="noreferrer"
+      >
+        <EmailIcon sx={{
+          '&:hover': {
+            opacity: 'inherit'
+          }
+        }} color="primary" />
+        Mail {given_names}
+      </a>
+    )
+  }
+  return null
+}
+
+type ContactPersonCardProps=Readonly<{
+  person: Person|null,
+  section:'software'|'projects'
+}>
 
 
-export default function ContactPersonCard({person,section='software'}: {person: Person|null,section:'software'|'projects'}) {
+export default function ContactPersonCard({person,section='software'}:ContactPersonCardProps) {
   // what to render if no contact person?
   if (!person) return null
   const displayName = getDisplayName(person)
 
-  function renderEmail() {
-    if (person?.email_address) {
-      return (
-        <a className="flex items-start pt-4"
-          href={`mailto:${person?.email_address}`}
-          target="_blank" rel="noreferrer"
-        >
-          <EmailIcon sx={{
-            mr: 1,
-            '&:hover': {
-              opacity: 'inherit'
-            }
-          }} color="primary" />
-          Mail {person?.given_names}
-        </a>
-      )
-    }
-  }
-
   return (
-    <article className="flex flex-col bg-base-100 max-w-md">
-      <h3 className="text-center font-medium px-6 py-4 uppercase bg-primary text-base-100 md:text-left">Contact person</h3>
+    <section
+      aria-label="Contact person"
+      className="flex flex-col bg-base-100 max-w-md">
+      <h3 className="text-center font-medium px-6 py-4 uppercase bg-primary text-base-100 md:text-left">
+        Contact person
+      </h3>
       <div className="flex flex-col p-8 gap-8 md:flex-row 2xl:flex-col">
-        <Avatar
-          alt={displayName ?? ''}
-          src={getImageUrl(person.avatar_id) ?? ''}
+        <ContributorAvatar
+          avatarUrl={getImageUrl(person.avatar_id) ?? ''}
+          displayName={displayName}
+          displayInitials={getDisplayInitials(person)}
+          size={7}
           sx={{
-            width: '7rem',
-            height: '7rem',
-            fontSize: '2rem',
             alignSelf: 'center'
           }}
-        >
-          {displayName ?
-            getDisplayInitials(person)
-            :null
-          }
-        </Avatar>
+        />
         <div className="flex-1 flex flex-col items-start">
           <h4 className="text-primary text-2xl">
             {person?.is_public ?
@@ -69,26 +77,11 @@ export default function ContactPersonCard({person,section='software'}: {person: 
               <>{displayName}</>
             }
           </h4>
-          {person?.role && <h5 className="pt-1">
-            {person?.role}
-          </h5>
-          }
-          {
-            person?.affiliation && <h5 className="pt-1">
-              {person?.affiliation}
-            </h5>
-          }
-          {person?.orcid && <h5 className="pt-1">
-            <a href={'https://orcid.org/' + person.orcid} target="_blank" rel="noreferrer"
-              style={{whiteSpace:'nowrap'}}
-            >
-              <LogoOrcid className="inline max-w-[1.5rem] mr-2" />
-              <span className="align-bottom">{person.orcid}</span>
-            </a>
-          </h5>}
-          {renderEmail()}
+          <PersonalInfo {...person}>
+            <MailToLink {...person}/>
+          </PersonalInfo>
         </div>
       </div>
-    </article>
+    </section>
   )
 }

--- a/frontend/components/software/ContributorAvatar.tsx
+++ b/frontend/components/software/ContributorAvatar.tsx
@@ -1,13 +1,23 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import Avatar from '@mui/material/Avatar'
 
-export default function ContributorAvatar({displayName, displayInitials, avatarUrl, size=3}: {
-  displayName:string,displayInitials:string,avatarUrl:string,size?:number
-}) {
+type ContributorAvatarProps=Readonly<{
+  displayName:string|null,
+  displayInitials:string,
+  avatarUrl:string,
+  size?:number,
+  sx?: any
+}>
+
+export default function ContributorAvatar({
+  displayName, displayInitials, avatarUrl, size=3, sx
+}:ContributorAvatarProps) {
   return (
     <Avatar
       alt={displayName ?? 'Unknown'}
@@ -16,8 +26,9 @@ export default function ContributorAvatar({displayName, displayInitials, avatarU
         width: `${size}rem`,
         height: `${size}rem`,
         fontSize: `${size/3}rem`,
-        marginRight: '1rem'
-      }}
+        ...sx
+      }
+      }
     >
       {displayInitials}
     </Avatar>

--- a/frontend/components/software/ContributorsList.tsx
+++ b/frontend/components/software/ContributorsList.tsx
@@ -89,13 +89,15 @@ export default function ContributorsList({contributors,section='software'}: {con
 
   return (
     <>
-      <div className="gap-4 mt-12 md:grid md:grid-cols-2 hd:grid-cols-3 2xl:mt-0">
+      <section
+        aria-label="Contributors list"
+        className="gap-4 mt-12 md:grid md:grid-cols-2 hd:grid-cols-3 2xl:mt-0">
         {persons.map(item => {
           const displayName = getDisplayName(item)
           const avatarUrl = getImageUrl(item.avatar_id) ?? ''
           if (displayName) {
             return (
-              <div key={displayName} className="flex py-4 pr-4 md:pr-8 2xl:pr-12 2xl:pb-8">
+              <div key={displayName} className="flex gap-4 py-4 pr-4 md:pr-8 2xl:pr-12 2xl:pb-8">
                 <ContributorAvatar
                   avatarUrl={avatarUrl}
                   displayName={displayName}
@@ -119,7 +121,7 @@ export default function ContributorsList({contributors,section='software'}: {con
           return null
         })
         }
-      </div>
+      </section>
       <ShowButton
         showAll={hasMore}
         showLess={contributors.length > topItems}

--- a/frontend/components/software/PersonalInfo.tsx
+++ b/frontend/components/software/PersonalInfo.tsx
@@ -1,26 +1,29 @@
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import OrcidLink from '../layout/OrcidLink'
+import {ReactElement} from 'react'
+import OrcidLink from '~/components/layout/OrcidLink'
 
 type PersonalInfoProps = Readonly<{
   role?: string | null
   affiliation?: string | null
   orcid?: string | null
+  children?: ReactElement
 }>
 
-export default function PersonalInfo({role, affiliation, orcid}:PersonalInfoProps) {
-  if(role || affiliation || orcid){
+export default function PersonalInfo({role, affiliation, orcid, children}:PersonalInfoProps) {
+  if(role || affiliation || orcid || children){
     return (
-      <div className="grid gap-2">
-        {role && <div>{role}</div>}
-        {affiliation && <div>{affiliation}</div>}
-        {orcid && <div><OrcidLink orcid={orcid} /></div>}
+      <div className="grid gap-1 pt-1">
+        {role ? <div>{role}</div> : null}
+        {affiliation ? <div>{affiliation}</div> : null}
+        {orcid ? <OrcidLink orcid={orcid} /> : null}
+        {children ?? null}
       </div>
     )
   }

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -1,12 +1,11 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2022 - 2024 dv4all
 // SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2025 dv4all
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2022 Matthias Rüster (GFZ) <matthias.ruester@gfz-potsdam.de>
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
@@ -51,7 +50,10 @@ export const softwareInformation = {
   // field for markdown
   description: {
     label: 'Description',
-    help: '/documentation/users/adding-software/#description',
+    help: {
+      url: '/documentation/users/adding-software/#description',
+      ariaLabel: 'Description, link to documentation page opens in new tab'
+    },
     validation: {
       // we do not show error message for this one, we use only maxLength value
       maxLength: {value: 10000, message: 'Maximum length is 10000'},
@@ -111,7 +113,10 @@ export const contributorInformation = {
   importContributors: {
     title: 'Import contributors',
     subtitle: 'We use your Software DOI and DataCite.org API',
-    infoLink: '/documentation/users/adding-software/#contributors',
+    infoLink: {
+      url:'/documentation/users/adding-software/#contributors',
+      ariaLabel: 'Import contributors, link to documentation page opens in new tab'
+    },
     label: 'Import contributors',
     message: (doi: string) => `Import contributors from datacite.org using DOI ${doi}`
   }

--- a/frontend/components/software/edit/links/config.tsx
+++ b/frontend/components/software/edit/links/config.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Felix Mühlbauer (GFZ) <felix.muehlbauer@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
@@ -24,7 +24,10 @@ export const config={
     subtitle: 'Provide the DOI of your software. This DOI will be used to import metadata about the software.',
     label: 'Software DOI',
     help: '',
-    infoLink: '/documentation/users/adding-software/#software-doi',
+    infoLink: {
+      url:'/documentation/users/adding-software/#software-doi',
+      ariaLabel: 'Software DOI, link to documentation page opens in new tab'
+    },
     validation: {
       minLength: {value: 7, message: 'Minimum length is 7'},
       maxLength: {value: 100, message: 'Maximum length is 100'},

--- a/frontend/components/user/settings/profile/ProfileInput.tsx
+++ b/frontend/components/user/settings/profile/ProfileInput.tsx
@@ -35,7 +35,8 @@ export default function ProfileInput() {
             name: 'given_names',
             label: modalConfig.given_names.label,
             useNull: true,
-            // defaultValue: profile.given_names,
+            // enable autocomplete context
+            autoComplete: 'given-name',
             helperTextMessage: modalConfig.given_names.help,
             helperTextCnt: `${given_names?.length ?? 0}/${modalConfig.given_names.validation.maxLength.value}`,
           }}
@@ -46,7 +47,8 @@ export default function ProfileInput() {
             name: 'family_names',
             label: modalConfig.family_names.label,
             useNull: true,
-            // defaultValue: profile.family_names,
+            // enable autocomplete context
+            autoComplete: 'family-name',
             helperTextMessage: modalConfig.family_names.help,
             helperTextCnt: `${family_names?.length ?? 0}/${modalConfig.family_names.validation.maxLength.value}`,
           }}
@@ -59,7 +61,8 @@ export default function ProfileInput() {
             name: 'role',
             label: modalConfig.role.label,
             useNull: true,
-            // defaultValue: profile.role,
+            // enable autocomplete context
+            autoComplete: 'organization-title',
             helperTextMessage: 'Type in your current role',
             helperTextCnt: `${role?.length ?? 0}/${modalConfig.role.validation.maxLength.value}`,
           }}
@@ -70,7 +73,8 @@ export default function ProfileInput() {
             name: 'affiliation',
             label: modalConfig.affiliation.label,
             useNull: true,
-            // defaultValue: profile.affiliation,
+            // enable autocomplete context
+            autoComplete: 'organization',
             helperTextMessage: 'Type in your current affiliation',
             helperTextCnt: `${affiliation?.length ?? 0}/${modalConfig.affiliation.validation.maxLength.value}`,
           }}
@@ -83,7 +87,8 @@ export default function ProfileInput() {
             name: 'email_address',
             label: modalConfig.email_address.label,
             useNull: true,
-            // defaultValue: profile.email_address,
+            // enable autocomplete context
+            autoComplete: 'email',
             helperTextMessage: 'Type in your contact email',
             helperTextCnt: `${email_address?.length ?? 0}/${modalConfig.email_address.validation(false).maxLength.value}`,
           }}

--- a/frontend/components/user/settings/profile/index.tsx
+++ b/frontend/components/user/settings/profile/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,9 +27,7 @@ export default function UserProfilePage() {
         className="pb-8 font-medium"
       />
       <FormProvider {...methods}>
-        <form
-          autoComplete="off"
-        >
+        <form>
           {/* hidden inputs */}
           <input type="hidden"
             {...methods.register('account')}


### PR DESCRIPTION
# Add aria-label to info links on edit software pages

Closes #1755
Closes #1763

Changes proposed in this pull request:
* Add aria-label to info link in the Edit title component (#1755)
* Add autocomplete options to user profile inputs (#1763)
* Refactor ORCID and PersonalInfo components and use it on multiple places

How to test:
* `make start` to build and generate some test data
* login as rsd-admin to be able to edit existing item or create new software item
* navigate to edit software description, confirm that info link in Description title has aria-label. You can test it with screen reader to confirm that provides more information about the link purpose
* navigate to Link & metadata and confirm that Software DOI info link has also information about the link
* view software page, navigate to contributors with ORCID. Confirm that ORCID link has aria-label with description what it means
* navigate to user profile and confirm that profile inputs have autocomplete options:
   * autoComplete: 'given-name',
   * autoComplete: 'family-name',
   * autoComplete: 'organization-title',
   * autoComplete: 'organization',
   * autoComplete: 'email'

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
