### PR TITLE
Ensure sonarqube action can be runned by fork PR's

### DIFF
--- a/.github/workflows/frontend_sonar.yml
+++ b/.github/workflows/frontend_sonar.yml
@@ -35,19 +35,7 @@ jobs:
           # Isolates the code string inside a hard token context to block injection tricks
           HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
 
-      # 2. Re-create the folder structure
-      - name: "install node and cache npm"
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.14
-          cache: 'npm'
-
-      - name: "install dependencies"
-        run: |
-          cd frontend
-          npm ci
-
-      # 3. DOWNLOAD ARTIFACT CROSS-WORKFLOW (test-coverage)
+      # 2. DOWNLOAD ARTIFACT CROSS-WORKFLOW (test-coverage)
       - name: "download coverage artifact"
         uses: actions/download-artifact@v7
         with:
@@ -57,7 +45,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # 4. Cache Sonar packages natively
+      # 3. Cache Sonar packages natively
       - name: Cache SonarCloud packages
         uses: actions/cache@v5
         with:
@@ -65,7 +53,7 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
 
-      # 5. Run the Scan
+      # 4. Run the Scan
       - name: SonarCloud Scan frontend
         uses: SonarSource/sonarqube-scan-action@v8
         with:

--- a/.github/workflows/frontend_sonar.yml
+++ b/.github/workflows/frontend_sonar.yml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# Run SonarCloud Safely using workflow_run
+# The workflow_run event executes within the security context of your main branch,
+# granting it access to ${{ secrets.SONAR_TOKEN }} even when processing contributions from a fork.
+
+name: frontend sonar
+
+on:
+  workflow_run:
+    # Must match the exact 'name' string of frontend_tests.yml
+    workflows: ["frontend tests"]
+    types:
+      - completed
+
+jobs:
+  fe-sonar:
+    name: "fe-sonar"
+    # Ensure it only runs if the primary frontend testing pipeline succeeded
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    steps:
+      # 1. Checkout the code branch safely using isolated environment variables
+      - name: Checkout target branch
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          # Use the safe string variable below
+          ref: ${{ env.HEAD_BRANCH }}
+          fetch-depth: 0
+        env:
+          # Isolates the code string inside a hard token context to block injection tricks
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+
+      # 2. Re-create the folder structure
+      - name: "install node and cache npm"
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24.14
+          cache: 'npm'
+
+      - name: "install dependencies"
+        run: |
+          cd frontend
+          npm ci
+
+      # 3. DOWNLOAD ARTIFACT CROSS-WORKFLOW (test-coverage)
+      - name: "download coverage artifact"
+        uses: actions/download-artifact@v7
+        with:
+          name: frontend-coverage
+          path: frontend/coverage/
+          # Explicitly targets the parent workflow run to fetch its files
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # 4. Cache Sonar packages natively
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v5
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      # 5. Run the Scan
+      - name: SonarCloud Scan frontend
+        uses: SonarSource/sonarqube-scan-action@v8
+        with:
+          projectBaseDir: frontend
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # This secret is now safely accessible!
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/frontend_tests.yml
+++ b/.github/workflows/frontend_tests.yml
@@ -58,7 +58,7 @@ jobs:
       - name: "run unit test"
         run: npm run test:coverage
 
-       # Upload the coverage folder for SonarCloud (fe-sonar) to use
+      # Upload the coverage folder for SonarCloud (fe-sonar) to use
       - name: "upload coverage artifact"
         uses: actions/upload-artifact@v7
         with:
@@ -83,45 +83,3 @@ jobs:
         run: npm ci
       - name: "run build test"
         run: npm run build
-
-  # CHECK 4: SonarCloud Scan
-  fe-sonar:
-    name: "fe-sonar"
-    needs: [fe-test]
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-      - name: "install node and cache npm"
-        uses: actions/setup-node@v6
-        with:
-          node-version: 24.14
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-      - name: "install dependencies"
-        run: npm ci
-
-       # Download the coverage folder back into frontend/coverage/
-      - name: "download coverage artifact"
-        uses: actions/download-artifact@v7
-        with:
-          name: frontend-coverage
-          path: frontend/coverage/
-
-      # UPGRADED v4 -> v5 (Provides full Node.js 24 compatibility)
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v5
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      # UPGRADED v6 -> v8 (Official SonarSource security & scanning updates)
-      - name: SonarCloud Scan frontend
-        uses: SonarSource/sonarqube-scan-action@v8
-        with:
-          projectBaseDir: frontend
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/frontend/components/software/ContactPersonCard.tsx
+++ b/frontend/components/software/ContactPersonCard.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
# SonarQube and PR's from fork repos

Changes proposed in this pull request:
* Split frontend test and sonar qube action in order to run sonarqube within local repo environment
* Sonar is separate action and runs after all other checks are done passed successfully.

How to test:
* This PR should be used for testing. All tests should run including SonarQube which will run after frontend tests.
* I tested linter failure/warnings
* I tested build failure
* I tested unit test failure
* The sonarqube action can be only tested after reaching main branch. **GitHub imposes a strict security restriction on the workflow_run event trigger: The workflow file must exist on the default branch (main) before it can ever be triggered. In order to test this change completely we need to merge this PR and then use next frontend PR to confirm that SonarQube action works properly.**
 

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
