### PR TITLE
fix: enable keyboard image upload

### DIFF
--- a/frontend/components/form/ControlledImageInput.tsx
+++ b/frontend/components/form/ControlledImageInput.tsx
@@ -1,10 +1,10 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEvent} from 'react'
+import {ChangeEvent, useRef} from 'react'
 
 import Avatar from '@mui/material/Avatar'
 import Button from '@mui/material/Button'
@@ -16,8 +16,8 @@ import {useSession} from '~/auth/AuthProvider'
 import {deleteImage, getImageUrl} from '~/utils/editImage'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {handleFileUpload} from '~/utils/handleFileUpload'
-import ImageInput from './ImageInput'
 import ImageDropZone from '~/components/form/ImageDropZone'
+import ImageInput from './ImageInput'
 
 export type FormInputsForImage={
   logo_id: string|null
@@ -35,6 +35,7 @@ type ImageInputProps={
 export default function ControlledImageInput({name,logo_b64,logo_id,setValue}:ImageInputProps) {
   const {token} = useSession()
   const {showWarningMessage,showErrorMessage} = useSnackbar()
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   async function onFileUpload(e: ChangeEvent<HTMLInputElement> | {target: {files: FileList | Blob[]}} | undefined): Promise<void> {
     if (e === undefined) {
@@ -83,32 +84,32 @@ export default function ControlledImageInput({name,logo_b64,logo_id,setValue}:Im
 
   return (
     <div>
-      <ImageDropZone onImageDrop={onFileUpload}>
-        <label htmlFor="upload-avatar-image"
-          style={{cursor:'pointer'}}
-          title="Click or drop to upload an image"
+      <ImageDropZone
+        ariaLabel = "Upload avatar, press enter or space to choose a file"
+        onImageDrop={onFileUpload}
+        onClick={()=>fileInputRef.current?.click()}
+      >
+        <Avatar
+          alt={name ?? ''}
+          src={logo_b64 ?? getImageUrl(logo_id ?? null) ?? undefined}
+          sx={{
+            width: '8rem',
+            height: '8rem',
+            fontSize: '3rem',
+            marginRight: '0rem',
+            '& img': {
+              height:'auto'
+            }
+          }}
+          variant="square"
         >
-          <Avatar
-            alt={name ?? ''}
-            src={logo_b64 ?? getImageUrl(logo_id ?? null) ?? undefined}
-            sx={{
-              width: '8rem',
-              height: '8rem',
-              fontSize: '3rem',
-              marginRight: '0rem',
-              '& img': {
-                height:'auto'
-              }
-            }}
-            variant="square"
-          >
-            {name ? name.slice(0,3) : ''}
-          </Avatar>
-        </label>
+          {name ? name.slice(0,3) : ''}
+        </Avatar>
       </ImageDropZone>
       <ImageInput
         id="upload-avatar-image"
         onChange={onFileUpload}
+        inputRef={fileInputRef}
       />
       <div className="flex pt-4">
         <Button

--- a/frontend/components/form/ImageDropZone.tsx
+++ b/frontend/components/form/ImageDropZone.tsx
@@ -1,24 +1,40 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import logger from '~/utils/logger'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 
-export type ImageDropZoneProps = {
+export type ImageDropZoneProps = Readonly<{
   children: React.ReactNode,
-  onImageDrop: (targetLike: {target: {files: FileList | Blob[]}}) => void
-}
+  ariaLabel: string,
+  onImageDrop: (targetLike: {target: {files: FileList | Blob[]}}) => void,
+  onClick: () => void
+}>
 
-export default function ImageDropZone(props: Readonly<ImageDropZoneProps>) {
+/**
+ * This component should be used in the areas where no additional menu is required.
+ * The component enables upload for everyone. If you need image upload component
+ * which dynamically shows upload menu use <Logo> component!
+ * @param props
+ * @returns
+ */
+export default function ImageDropZone(props:ImageDropZoneProps) {
   const {showErrorMessage} = useSnackbar()
 
   return (
-    <div
+    <button
+      // Critical for focus and button functionality
+      type="button"
+      aria-label={props.ariaLabel}
+      // Tailwind utility resets default button styles and handles focus
+      className="text-left block bg-transparent border-0 p-0.5 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary transition-all cursor-pointer"
+      onClick={props.onClick}
       onDragOver={(e: any) => {
         e.preventDefault()
-        e.currentTarget.style.border = '3px dashed grey'
+        e.currentTarget.style.border = '2px dashed grey'
       }}
       onDragLeave={(e: any) => {
         e.currentTarget.style.border = 'inherit'
@@ -39,6 +55,6 @@ export default function ImageDropZone(props: Readonly<ImageDropZoneProps>) {
         }
       }}>
       {props.children}
-    </div>
+    </button>
   )
 }

--- a/frontend/components/form/ImageInput.tsx
+++ b/frontend/components/form/ImageInput.tsx
@@ -1,18 +1,22 @@
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {InputHTMLAttributes} from 'react'
+import {InputHTMLAttributes, RefObject} from 'react'
 import {allowedImageMimeTypes} from '~/utils/handleFileUpload'
 
-type ImageInputProps = Omit<InputHTMLAttributes<HTMLInputElement>,'accept'|'style'|'type'>
+type ImageInputProps = Readonly<Omit<InputHTMLAttributes<HTMLInputElement>, 'accept' | 'style' | 'type'> & {
+  // Add inputRef type
+  inputRef: RefObject<HTMLInputElement | null>
+}>
 
-export default function ImageInput(props:Readonly<ImageInputProps>) {
+export default function ImageInput({inputRef, ...props}:ImageInputProps) {
   return (
     <input
       id="image-input"
       type="file"
+      ref={inputRef}
       style={{display:'none'}}
       accept={allowedImageMimeTypes}
       {...props}

--- a/frontend/components/form/LogoDropZone.tsx
+++ b/frontend/components/form/LogoDropZone.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -12,6 +13,11 @@ export type ImageDropZoneProps = {
   onImageDrop: (image: ImageDataProps) => any
 }
 
+/**
+ * This component is used with Logo component
+ * @param props
+ * @returns
+ */
 export default function LogoDropZone(props: Readonly<ImageDropZoneProps>) {
   const {showErrorMessage} = useSnackbar()
 

--- a/frontend/components/layout/ImageWithPlaceholder.tsx
+++ b/frontend/components/layout/ImageWithPlaceholder.tsx
@@ -41,7 +41,7 @@ export default function ImageWithPlaceholder({
     }
     return (
       <div
-        className={`flex flex-col justify-center items-center text-base-600 rounded-xs ${className ?? ''}`}
+        className={`flex flex-col justify-center items-center text-base-600 rounded-xs p-4 ${className ?? ''}`}
       >
         <PhotoSizeSelectActualOutlinedIcon
           sx={{

--- a/frontend/components/layout/Logo.tsx
+++ b/frontend/components/layout/Logo.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -26,6 +26,12 @@ type LogoProps = Readonly<{
   props?: any
 }>
 
+/**
+ * This component is used for images where admin should be able to edit image.
+ * Interactively the menu option for editing image/logo/avatar is shown.
+ * @param param0
+ * @returns
+ */
 export default function Logo({
   name,logo,onAddLogo,onRemoveLogo,
   canEdit=false,src,sx,

--- a/frontend/components/news/edit/AutosaveNewsImage.tsx
+++ b/frontend/components/news/edit/AutosaveNewsImage.tsx
@@ -5,11 +5,11 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEvent} from 'react'
+import {ChangeEvent, useRef} from 'react'
 import Button from '@mui/material/Button'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {useFormContext} from 'react-hook-form'
@@ -21,10 +21,10 @@ import EditSectionTitle from '~/components/layout/EditSectionTitle'
 import ImageWithPlaceholder from '~/components/layout/ImageWithPlaceholder'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import CopyToClipboard from '~/components/layout/CopyToClipboard'
-import {NewsImageProps,NewsItem,addNewsImage,deleteNewsImage} from '../apiNews'
-import {newsConfig as config} from './config'
 import ImageInput from '~/components/form/ImageInput'
 import ImageDropZone from '~/components/form/ImageDropZone'
+import {NewsImageProps,NewsItem,addNewsImage,deleteNewsImage} from '../apiNews'
+import {newsConfig as config} from './config'
 
 type UploadedImageProps={
   imgUrl: string|null,
@@ -75,6 +75,7 @@ export default function AutosaveNewsImage() {
   const {token} = useSession()
   const {showWarningMessage, showErrorMessage, showInfoMessage} = useSnackbar()
   const {watch, setValue} = useFormContext<NewsItem>()
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [
     form_id, image_for_news, description
@@ -184,25 +185,25 @@ export default function AutosaveNewsImage() {
         })
       }
 
-      <ImageDropZone onImageDrop={onFileUpload}>
-        <label htmlFor='upload-article-image'
-          style={{cursor: 'pointer'}}
-          title="Click or drop to upload an image"
-        >
-          <ImageWithPlaceholder
-            placeholder="Click or drop to upload image < 2MB"
-            src={null}
-            alt={'image'}
-            bgSize={'scale-down'}
-            bgPosition={'left center'}
-            className="w-full h-[9rem]"
-          />
-        </label>
+      <ImageDropZone
+        ariaLabel = "Upload news image, press enter or space to choose a file"
+        onImageDrop={onFileUpload}
+        onClick={()=>fileInputRef.current?.click()}
+      >
+        <ImageWithPlaceholder
+          placeholder="Click or drop to upload image < 2MB"
+          src={null}
+          alt={'image'}
+          bgSize={'scale-down'}
+          bgPosition={'left center'}
+          className="h-[9rem]"
+        />
       </ImageDropZone>
 
       <ImageInput
         id="upload-article-image"
         onChange={onFileUpload}
+        inputRef={fileInputRef}
       />
     </>
   )

--- a/frontend/components/organisation/units/ResearchUnitModal.tsx
+++ b/frontend/components/organisation/units/ResearchUnitModal.tsx
@@ -8,7 +8,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEvent, useEffect, useState} from 'react'
+import {ChangeEvent, useEffect, useRef, useState} from 'react'
 import Button from '@mui/material/Button'
 import Dialog from '@mui/material/Dialog'
 import DialogActions from '@mui/material/DialogActions'
@@ -22,17 +22,16 @@ import DeleteIcon from '@mui/icons-material/Delete'
 import {useForm} from 'react-hook-form'
 
 import {useSession} from '~/auth/AuthProvider'
-import useSnackbar from '../../snackbar/useSnackbar'
-import ControlledTextField from '../../form/ControlledTextField'
-import {EditOrganisation} from '~/types/Organisation'
-import config from '../settings/general/generalSettingsConfig'
 import {deleteImage, getImageUrl} from '~/utils/editImage'
 import {handleFileUpload} from '~/utils/handleFileUpload'
 import {getSlugFromString} from '~/utils/getSlugFromString'
-import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
+import {EditOrganisation} from '~/types/Organisation'
+import useSnackbar from '~/components/snackbar/useSnackbar'
+import ControlledTextField from '~/components/form/ControlledTextField'
 import ImageInput from '~/components/form/ImageInput'
 import ImageDropZone from '~/components/form/ImageDropZone'
-
+import SubmitButtonWithListener from '~/components/form/SubmitButtonWithListener'
+import config from '~/components/organisation/settings/general/generalSettingsConfig'
 
 type EditOrganisationModalProps = {
   open: boolean,
@@ -54,6 +53,7 @@ export default function ResearchUnitModal({
   const {showWarningMessage,showErrorMessage} = useSnackbar()
   const smallScreen = useMediaQuery('(max-width:600px)')
   const [baseUrl, setBaseUrl] = useState('')
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const {
     handleSubmit, watch, formState, reset, control, register, setValue
   } = useForm<EditOrganisation>({
@@ -185,32 +185,32 @@ export default function ResearchUnitModal({
         }}>
           <section className="grid grid-cols-[1fr_3fr] gap-8">
             <div>
-              <ImageDropZone onImageDrop={onFileUpload}>
-                <label htmlFor="upload-avatar-image-modal"
-                  style={{cursor:'pointer'}}
-                  title="Click or drop to upload an image"
+              <ImageDropZone
+                ariaLabel = "Upload image, press enter or space to choose a file"
+                onImageDrop={onFileUpload}
+                onClick={()=>fileInputRef.current?.click()}
+              >
+                <Avatar
+                  alt={formData.name ?? ''}
+                  src={formData.logo_b64 ?? getImageUrl(formData?.logo_id) ?? undefined}
+                  sx={{
+                    width: '8rem',
+                    height: '8rem',
+                    fontSize: '3rem',
+                    marginRight: '0rem',
+                    '& img': {
+                      height:'auto'
+                    }
+                  }}
+                  variant="square"
                 >
-                  <Avatar
-                    alt={formData.name ?? ''}
-                    src={formData.logo_b64 ?? getImageUrl(formData?.logo_id) ?? undefined}
-                    sx={{
-                      width: '8rem',
-                      height: '8rem',
-                      fontSize: '3rem',
-                      marginRight: '0rem',
-                      '& img': {
-                        height:'auto'
-                      }
-                    }}
-                    variant="square"
-                  >
-                    {formData.name ? formData.name.slice(0,3) : ''}
-                  </Avatar>
-                </label>
+                  {formData.name ? formData.name.slice(0,3) : ''}
+                </Avatar>
               </ImageDropZone>
               <ImageInput
                 id="upload-avatar-image-modal"
                 onChange={onFileUpload}
+                inputRef={fileInputRef}
               />
               <div className="flex pt-4">
                 <Button

--- a/frontend/components/person/AvatarOptions.tsx
+++ b/frontend/components/person/AvatarOptions.tsx
@@ -1,12 +1,12 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEvent} from 'react'
+import {ChangeEvent, useRef} from 'react'
 import Box from '@mui/material/Box'
 import Avatar from '@mui/material/Avatar'
 import IconButton from '@mui/material/IconButton'
@@ -31,6 +31,7 @@ type AvatarOptionsProps = {
 export default function AvatarOptions(props: AvatarOptionsProps) {
   const {given_names, family_names, avatar_id, avatar_options, loading} = props
   const {onFileUpload, onNoAvatar, onSelectAvatar} = props
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   let avatar:string|undefined
   if (avatar_id){
@@ -50,35 +51,29 @@ export default function AvatarOptions(props: AvatarOptionsProps) {
   return (
     <div className="grid grid-cols-[1fr_3fr] gap-4">
       <div>
-        <ImageDropZone onImageDrop={onFileUpload}>
-          <label htmlFor="upload-avatar-image"
-            title="Click or drop to upload new image"
-            style={{
-              display: 'flex',
-              cursor: 'pointer',
-              padding: '0.5rem',
-              justifyContent: 'center',
-              alignItems: 'center'
+        <ImageDropZone
+          ariaLabel = "Upload avatar image, press enter or space to choose a file"
+          onImageDrop={onFileUpload}
+          onClick={()=>fileInputRef.current?.click()}
+        >
+          <Avatar
+            alt={getDisplayName({given_names, family_names}) ?? 'Unknown'}
+            src={avatar}
+            sx={{
+              width: '8rem',
+              height: '8rem',
+              fontSize: '3rem',
+              margin: '1rem'
             }}
           >
-            <Avatar
-              alt={getDisplayName({given_names, family_names}) ?? 'Unknown'}
-              src={avatar}
-              sx={{
-                width: '8rem',
-                height: '8rem',
-                fontSize: '3rem',
-                margin: '1rem'
-              }}
-            >
-              {getDisplayInitials({given_names, family_names}) ?? ''}
-            </Avatar>
-          </label>
+            {getDisplayInitials({given_names, family_names}) ?? ''}
+          </Avatar>
         </ImageDropZone>
         <ImageInput
           data-testid="upload-avatar-input"
           id="upload-avatar-image"
           onChange={onFileUpload}
+          inputRef={fileInputRef}
         />
       </div>
       <div>

--- a/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
+++ b/frontend/components/projects/edit/information/AutosaveProjectImage.tsx
@@ -1,14 +1,14 @@
 // SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {ChangeEvent, useRef} from 'react'
 import DeleteIcon from '@mui/icons-material/Delete'
 import IconButton from '@mui/material/IconButton'
-
 import {useFormContext} from 'react-hook-form'
 
 import {useSession} from '~/auth/AuthProvider'
@@ -16,20 +16,20 @@ import ImageAsBackground from '~/components/layout/ImageAsBackground'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import {EditProject} from '~/types/Project'
 import {getImageUrl} from '~/utils/editImage'
+import {upsertImage,deleteImage} from '~/utils/editImage'
+import {handleFileUpload} from '~/utils/handleFileUpload'
+import ImageInput from '~/components/form/ImageInput'
+import ImageDropZone from '~/components/form/ImageDropZone'
 import AutosaveProjectTextField from './AutosaveProjectTextField'
 import AutosaveProjectSwitch from './AutosaveProjectSwitch'
 import {projectInformation as config} from './config'
 import {patchProjectTable} from './patchProjectInfo'
-import {upsertImage,deleteImage} from '~/utils/editImage'
-import {ChangeEvent} from 'react'
-import {handleFileUpload} from '~/utils/handleFileUpload'
-import ImageInput from '~/components/form/ImageInput'
-import ImageDropZone from '~/components/form/ImageDropZone'
 
 export default function AutosaveProjectImage() {
   const {token} = useSession()
   const {showWarningMessage, showErrorMessage} = useSnackbar()
   const {watch, setValue, resetField} = useFormContext<EditProject>()
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [
     form_id, form_image_id, form_image_b64, form_image_mime_type, form_image_caption, form_image_contain
@@ -152,7 +152,7 @@ export default function AutosaveProjectImage() {
     }
     return (
       <>
-        <div className="flex pt-4">
+        <div className="flex gap-4">
           <AutosaveProjectTextField
             project_id={form_id}
             options={{
@@ -173,7 +173,7 @@ export default function AutosaveProjectImage() {
             }}
           />
 
-          <div className="flex items-center pl-4">
+          <div className="flex items-center">
             <IconButton
               color="primary"
               aria-label="remove picture"
@@ -186,39 +186,37 @@ export default function AutosaveProjectImage() {
           </div>
         </div>
 
-        <div className="flex pb-3">
-          <AutosaveProjectSwitch
-            project_id={form_id}
-            name='image_contain'
-            label={config.image_contain.label}
-            defaultValue={form_image_contain}
-          />
-        </div>
+        <AutosaveProjectSwitch
+          project_id={form_id}
+          name='image_contain'
+          label={config.image_contain.label}
+          defaultValue={form_image_contain}
+        />
       </>
     )
   }
 
   return (
-    <div>
-      <ImageDropZone onImageDrop={onFileUpload}>
-        <label htmlFor="upload-avatar-image"
-          style={{cursor: 'pointer'}}
-          title="Click or drop to upload an image"
-        >
-          <ImageAsBackground
-            src={imageUrl()}
-            alt={form_image_caption ?? 'image'}
-            bgSize={form_image_contain ? 'contain' : 'cover'}
-            bgPosition={form_image_contain ? 'center' : 'center center'}
-            className="w-full h-[23rem]"
-            noImgMsg="Click or drop to upload image < 2MB"
-          />
-        </label>
+    <div className="grid gap-2 mb-4">
+      <ImageDropZone
+        ariaLabel = "Upload project image, press enter or space to choose a file"
+        onImageDrop={onFileUpload}
+        onClick={()=>fileInputRef.current?.click()}
+      >
+        <ImageAsBackground
+          src={imageUrl()}
+          alt={form_image_caption ?? 'image'}
+          bgSize={form_image_contain ? 'contain' : 'cover'}
+          bgPosition={form_image_contain ? 'center' : 'center center'}
+          className="h-[23rem]"
+          noImgMsg="Click or drop to upload image < 2MB"
+        />
       </ImageDropZone>
 
       <ImageInput
         id="upload-avatar-image"
         onChange={onFileUpload}
+        inputRef={fileInputRef}
       />
 
       {renderImageAttributes()}

--- a/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
+++ b/frontend/components/software/edit/information/AutosaveSoftwareLogo.tsx
@@ -9,7 +9,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {ChangeEvent} from 'react'
+import {ChangeEvent,useRef} from 'react'
 import Button from '@mui/material/Button'
 import DeleteIcon from '@mui/icons-material/Delete'
 import {useFormContext} from 'react-hook-form'
@@ -30,6 +30,7 @@ export default function AutosaveSoftwareLogo() {
   const {token} = useSession()
   const {showWarningMessage, showErrorMessage} = useSnackbar()
   const {watch, setValue} = useFormContext<EditSoftwareItem>()
+  const fileInputRef = useRef<HTMLInputElement>(null)
 
   const [
     form_id, form_image_id, form_image_b64, form_image_mime_type
@@ -159,25 +160,25 @@ export default function AutosaveSoftwareLogo() {
         subtitle={config.logo.help}
       />
 
-      <ImageDropZone onImageDrop={onFileUpload}>
-        <label htmlFor='upload-software-logo'
-          style={{cursor: 'pointer'}}
-          title="Click or drop to upload a logo"
-        >
-          <ImageWithPlaceholder
-            placeholder="Click or drop to upload a logo < 2MB"
-            src={imageUrl()}
-            alt={'logo'}
-            bgSize={'contain'}
-            bgPosition={'left center'}
-            className="w-full h-[9rem]"
-          />
-        </label>
+      <ImageDropZone
+        ariaLabel = "Upload software logo, press enter or space to choose a file"
+        onImageDrop={onFileUpload}
+        onClick={()=>fileInputRef.current?.click()}
+      >
+        <ImageWithPlaceholder
+          placeholder="Click or drop to upload a logo < 2MB"
+          src={imageUrl()}
+          alt={'logo'}
+          bgSize={'contain'}
+          bgPosition={'left center'}
+          className="h-[9rem]"
+        />
       </ImageDropZone>
 
       <ImageInput
         id="upload-software-logo"
         onChange={onFileUpload}
+        inputRef={fileInputRef}
       />
 
       {renderImageAttributes()}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
# Software logo upload via keyword

Closes #1764

Changes proposed in this pull request:
* Enable software logo upload via keyboard    

How to test:
* `make start` to build and create test data
* login as rsd-admin
* create new software item or edit existing one
    * try to upload software logo using keyboard only
    * on "contributors" page confirm that avatar can be uploaded via keyboar
    * on "participating organisation" add new organisation and confirm that organisation logo can be uploaded via keyboard
    * check a11y with screen reader it should also work
* edit project or create new project 
    * confirm that project image upload via keyboard is supported
    * on team page edit team member and confirm that avatar can be uploaded via keyboard
* organisation page: select an organisation and confirm you can upload/change organisation logo using keyboard (top left)
* community page: select an community and confirm you can upload/change organisation logo using keyboard (top left)
* edit news image and confirm that image upload via keyboard is supported
* confirm that user avatar also can be uploaded with keyboard and has proper a11y for screen reader

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
