### PR TITLE
1761&1766 a11 fixes

### DIFF
--- a/frontend/components/AppHeader/index.tsx
+++ b/frontend/components/AppHeader/index.tsx
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Jesús García Gonzalez (Netherlands eScience Center) <j.g.gonzalez@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (Imperial College London) <d.alonso-alvarez@imperial.ac.uk>
 // SPDX-FileCopyrightText: 2026 Dusan Mijatovic (NLEsc) <d.mijatovic@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Imperial College London
@@ -44,9 +44,8 @@ export default function AppHeader() {
       className="z-12 py-4 min-h-[88px] bg-secondary text-primary-content flex items-center flex-wrap"
     >
       {/* keep these styles in sync with main in MainContent.tsx */}
-      <div
-        className="flex-1 flex flex-col px-4 xl:flex-row items-start lg:container lg:mx-auto">
-        <div className="w-full flex-1 flex items-center justify-between">
+      <div className="flex-1 flex flex-col px-4 xl:flex-row items-start lg:container lg:mx-auto">
+        <div className="flex-1 w-full flex flex-col flex-wrap items-center justify-between sm:flex-row">
           <Link href="/" passHref className="hover:text-inherit" aria-label="Link to home page">
             <LogoApp
               className="hidden 2xl:block"
@@ -68,10 +67,13 @@ export default function AppHeader() {
           <GlobalSearchAutocomplete className="hidden xl:block ml-12 mr-6"/>
 
           {/* Large menu*/}
-          <nav aria-label="Main Navigation" className="flex-1 flex items-center">
+          <nav
+            aria-label="Main Navigation"
+            className="flex-1 flex items-center"
+          >
             <DesktopMenu activePath={pathname ?? '/'}/>
 
-            <div className="flex-1 flex gap-2 justify-end items-center min-w-[8rem] text-right ml-4 text-primary-content">
+            <div className="flex-1 flex flex-wrap gap-2 justify-end items-center min-w-[8rem] text-right xl:ml-4 text-primary-content">
               {/* FEEDBACK panel */}
               {host.feedback?.enabled
                 ? <FeedbackPanelButton

--- a/frontend/components/communities/overview/index.tsx
+++ b/frontend/components/communities/overview/index.tsx
@@ -43,7 +43,7 @@ export default function CommunitiesOverview({
         <section
           // define a11y region
           aria-label="Search community by name or short description"
-          className="flex-2 flex min-w-[20rem]">
+          className="flex-2 flex">
           <SearchInput
             placeholder="Search community by name or short description"
             onSearch={(search: string) => handleQueryChange('search', search)}

--- a/frontend/components/layout/SortableList.tsx
+++ b/frontend/components/layout/SortableList.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -9,10 +9,16 @@
 import {JSX} from 'react'
 import {
   DndContext, DragEndEvent, useSensor,
-  useSensors, TouchSensor, MouseSensor
+  useSensors, TouchSensor, MouseSensor,
+  KeyboardSensor
 } from '@dnd-kit/core'
 import {restrictToParentElement, restrictToVerticalAxis} from '@dnd-kit/modifiers'
-import {arrayMove, SortableContext, verticalListSortingStrategy} from '@dnd-kit/sortable'
+import {
+  arrayMove,
+  SortableContext,
+  verticalListSortingStrategy,
+  sortableKeyboardCoordinates
+} from '@dnd-kit/sortable'
 import List from '@mui/material/List'
 
 
@@ -31,12 +37,9 @@ export default function SortableList<T extends RequiredListProps>({
   items, onSorted, onRenderItem}: SortableListProps<T>) {
   const sensors = useSensors(
     useSensor(TouchSensor),
-    useSensor(MouseSensor,{
-      // required to enable click events
-      // on draggable items with buttons
-      // activationConstraint: {
-      //   distance: 8,
-      // }
+    useSensor(MouseSensor),
+    useSensor(KeyboardSensor, {
+      coordinateGetter: sortableKeyboardCoordinates,
     })
   )
 

--- a/frontend/components/layout/SortableListItem.tsx
+++ b/frontend/components/layout/SortableListItem.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -8,6 +8,7 @@
 import {ReactNode} from 'react'
 import {SxProps, Theme} from '@mui/material/styles'
 import ListItem from '@mui/material/ListItem'
+import IconButton from '@mui/material/IconButton'
 import DragIndicatorIcon from '@mui/icons-material/DragIndicator'
 import {useSortable} from '@dnd-kit/sortable'
 import {CSS} from '@dnd-kit/utilities'
@@ -24,15 +25,20 @@ export default function SortableListItem<T extends RequiredListProps>({
   item, children, sx, secondaryAction, ...props}: SortableListItemProps<T>) {
   const {
     attributes,listeners,setNodeRef,
+    setActivatorNodeRef,
     transform,transition,isDragging
   } = useSortable({id: item.id ?? ''})
+
+  //a11y FIX: Destructure "role" out of attributes so it doesn't apply to the <li> element
+  const {role, ...cleanedAttributes} = attributes
 
   return (
     <ListItem
       data-testid="sortable-list-item"
       // draggable
       ref={setNodeRef}
-      {...attributes}
+      // Apply all other ARIA tags (like aria-describedby) without breaking semantic HTML structure
+      {...cleanedAttributes}
       secondaryAction={secondaryAction}
       disablePadding={true}
       disableGutters={true}
@@ -66,15 +72,25 @@ export default function SortableListItem<T extends RequiredListProps>({
       {...props}
     >
       <div className="flex-1 flex gap-2 items-center justify-center overflow-hidden">
-        {/* drag-n-drop icon/button */}
-        <div
+        {/* drag-n-drop button a11y compatible */}
+        <IconButton
+          // add ref for keyboard activation
+          ref={setActivatorNodeRef}
+          // pass the destructured role directly to your interactive handle button
+          role={role}
           title="Drag to change position"
-          aria-label="drag to change position"
+          aria-label="Drag handle, press Space to reorder"
+          edge="start"
           className="hover:cursor-move text-base-content-disabled"
+          sx={{
+            marginLeft:0,
+            cursor: isDragging ? 'move' : 'inherit'
+          }}
+          // Keep listeners attached specifically here
           {...listeners}
         >
           <DragIndicatorIcon />
-        </div>
+        </IconButton>
         {children}
       </div>
     </ListItem>

--- a/frontend/components/news/overview/index.tsx
+++ b/frontend/components/news/overview/index.tsx
@@ -39,7 +39,7 @@ export default function NewsOverview({pages,page,rows,search,news}:NewsOverviewP
         <section
           // define a11y region
           aria-label="Search news items by title, summary or author"
-          className="flex-2 flex min-w-[20rem]">
+          className="flex-2 flex">
           <SearchInput
             placeholder="Search news items by title, summary or author"
             onSearch={(search: string) => handleQueryChange('search', search)}

--- a/frontend/components/organisation/overview/index.tsx
+++ b/frontend/components/organisation/overview/index.tsx
@@ -43,7 +43,7 @@ export default function OrganisationsOverviewClient({
         <section
           // define a11y region
           aria-label="Search organisation by name, ROR name or website"
-          className="flex-2 flex min-w-[20rem]">
+          className="flex-2 flex">
           <SearchInput
             placeholder="Search organisation by name, ROR name or website"
             onSearch={(search: string) => handleQueryChange('search', search)}

--- a/frontend/components/profile/overview/index.tsx
+++ b/frontend/components/profile/overview/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -36,7 +36,7 @@ export default function PersonsOverviewClient({pages,page,rows,search,persons}:P
         <h1 className="mr-4 lg:flex-1">
           Persons
         </h1>
-        <div className="flex-2 flex min-w-[20rem]">
+        <div className="flex-2 flex">
           <SearchInput
             placeholder="Search person by name or affiliation"
             onSearch={(search: string) => handleQueryChange('search', search)}

--- a/frontend/components/search/SearchResultsClient.tsx
+++ b/frontend/components/search/SearchResultsClient.tsx
@@ -1,5 +1,6 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Jesse Gonzalez (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -85,7 +86,7 @@ export default function SearchResultsClient({
           <h1 className="mr-4 lg:flex-1">
             Search Results
           </h1>
-          <div className="flex-2 flex min-w-[20rem]">
+          <div className="flex-2 flex">
             <SearchInput
               placeholder="Search for software, projects, organisations..."
               onSearch={handleSearch}

--- a/frontend/components/software/edit/information/EditSoftwareDescriptionInputs.tsx
+++ b/frontend/components/software/edit/information/EditSoftwareDescriptionInputs.tsx
@@ -94,7 +94,7 @@ export default function EditSoftwareDescriptionInputs() {
         {/* add white space at the bottom */}
         {/* <div className="xl:py-3"></div> */}
       </div>
-      <div className="py-2 min-w-[21rem]">
+      <div className="py-2">
         <AutosaveSoftwarePageStatus />
         <div className="py-6"></div>
         <AutosaveSoftwareLogo />

--- a/frontend/styles/global.css
+++ b/frontend/styles/global.css
@@ -3,7 +3,7 @@
  * SPDX-FileCopyrightText: 2021 - 2023 dv4all
  * SPDX-FileCopyrightText: 2022 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
  * SPDX-FileCopyrightText: 2022 Marc Hanisch (GFZ) <marc.hanisch@gfz-potsdam.de>
- * SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+ * SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
  * SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
  * SPDX-FileCopyrightText: 2025 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
  * SPDX-FileCopyrightText: 2026 Diego Alonso Alvarez (ICL) <d.alonso-alvarez@imperial.ac.uk>
@@ -111,12 +111,6 @@ html {
 
 body {
   font-size: 1rem;
-  /* minimal with to have logo,
-  add button, mobile menu and profile.
-  NOTE ! when changing this value we need to update
-  useDisableScrollLock hook in utils folder too.
-  */
-  min-width: 30rem;
   /* fix jumping scrollbar */
   overflow: auto;
   --scrollbar-thumb: #e4e4e7;


### PR DESCRIPTION
# Drag & drop with keyboard and 400% zoom

Closes #1761 
Closes #1766 

Changes proposed in this pull request:
* implement keyboard drag & drop options on list items for reordering
* remove min-widths from elements to remove horizontal scrolling on very small screens (320) and high zoom 400%    

How to test:
* `make start` to build and generate test data
* login as rsd admin
* select software from list to edit
* navigate to contributors page. Try to change order using keyboard: you need to tab until focus is on drag icon/button. Then use space and up-down arrows to change the position of the item. 
* This feature should work on all list with drag-drop option: organisation, testimonials, package managers etc. Also in the projects pages.
* To test #1766, scale window to 1280px and increase zoom to 400%. Confirm there is no horizontal scrolling on home page, software page, projects page etc. There might be some areas where horizontal scrolling might be present due to the size of the content but that is acceptable.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
