### PR TITLE
1759 screen reader status messages

### DIFF
--- a/frontend/app/(container)/news/page.tsx
+++ b/frontend/app/(container)/news/page.tsx
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {Metadata} from 'next'
 import {notFound} from 'next/navigation'
 
@@ -44,8 +49,6 @@ export default async function NewsOverviewPage({
     token
   })
 
-  const numPages = Math.ceil(count / page_rows)
-
   // console.group('NewsOverviewPage')
   // console.log('count...', count)
   // console.log('page...', page)
@@ -56,7 +59,7 @@ export default async function NewsOverviewPage({
 
   return (
     <NewsOverview
-      pages={numPages}
+      count={count}
       page={page}
       rows={page_rows}
       search={search}

--- a/frontend/app/(container)/persons/page.tsx
+++ b/frontend/app/(container)/persons/page.tsx
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {Metadata} from 'next'
 import {notFound} from 'next/navigation'
 
@@ -43,8 +48,6 @@ export default async function PersonsOverviewPage({
     token
   })
 
-  const numPages = Math.ceil(count / page_rows)
-
   // console.group('PersonsOverviewPage')
   // console.log('params...', params)
   // console.log('token...', token)
@@ -58,7 +61,7 @@ export default async function PersonsOverviewPage({
   return (
     <PersonsOverviewClient
       page={page}
-      pages={numPages}
+      count={count}
       rows={page_rows}
       search={search}
       persons={persons}

--- a/frontend/components/a11y/StatusForReaders.tsx
+++ b/frontend/components/a11y/StatusForReaders.tsx
@@ -5,13 +5,23 @@
 
 import {ComponentPropsWithoutRef} from 'react'
 
+export type ScreenReaderMessage=string | {
+  // prio controls when message is read:
+  // polite -> after all other messages in the queue
+  // assertive -> interrupts and reads message immediately
+  prio: 'polite' | 'assertive',
+  text: string
+}
+
 type StatusForReadersProps = {
-  message: string
+  message: ScreenReaderMessage
 } & ComponentPropsWithoutRef<'div'>
 
 /**
- * a11y status announcer
- * provides polite status update to screen readers
+ * a11y status announcer.
+ * Provides status update to screen readers.
+ * Default priority is polite and you can use text only.
+ * To interrupt use object {prio:'assertive',text:'your important message'}
  * @param param0
  * @returns
  */
@@ -19,15 +29,23 @@ export default function StatusForReaders({message, ...props}:StatusForReadersPro
 
   if (!message) return null
 
+  // normalize whether message is a string or an object
+  const isObject = typeof message === 'object' && message !== null
+  const notification = isObject ? message.text : message
+  const priority = isObject ? message.prio : 'polite'
+
+  // Skip rendering if the message text inside the object happens to be empty
+  if (!notification) return null
+
   return (
     <div
       role="status"
-      aria-live="polite"
+      aria-live={priority}
       aria-atomic="true"
       className="sr-only"
       {...props}
     >
-      {message}
+      {notification}
     </div>
   )
 }

--- a/frontend/components/a11y/StatusForReaders.tsx
+++ b/frontend/components/a11y/StatusForReaders.tsx
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {ComponentPropsWithoutRef} from 'react'
+
+type StatusForReadersProps = {
+  message: string
+} & ComponentPropsWithoutRef<'div'>
+
+/**
+ * a11y status announcer
+ * provides polite status update to screen readers
+ * @param param0
+ * @returns
+ */
+export default function StatusForReaders({message, ...props}:StatusForReadersProps) {
+
+  if (!message) return null
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      className="sr-only"
+      {...props}
+    >
+      {message}
+    </div>
+  )
+}

--- a/frontend/components/admin/rsd-invites/index.tsx
+++ b/frontend/components/admin/rsd-invites/index.tsx
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 'use client'
-import {useState} from 'react'
 import Alert from '@mui/material/Alert'
 
 import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
@@ -13,15 +12,11 @@ import ContentLoader from '~/components/layout/ContentLoader'
 import StatusForReaders from '~/components/a11y/StatusForReaders'
 import CreateRsdInvite from './CreateRsdInvite'
 import {useRsdInvite} from './useRsdInvite'
-import {NewAccountInvite} from './apiRsdInvite'
 
 const extraLineGenerators: ((inv: Invitation) => string)[] = [inv => inv.id, inv => inv.comment ?? '']
 
 export default function AdminRsdInvites() {
-  const {loading,activeInvites,createInvite,deleteInvite} = useRsdInvite()
-  // a11y feedback notifier state for dynamic list actions
-  const [notification, setNotification] = useState('')
-
+  const {loading,activeInvites,notification,createInvite,deleteInvite} = useRsdInvite()
 
   if (loading) {
     return (
@@ -29,26 +24,6 @@ export default function AdminRsdInvites() {
         <ContentLoader />
       </section>
     )
-  }
-
-  async function handleCreateInvitation(inv:NewAccountInvite) {
-    try {
-      setNotification('Generating new invitation link...')
-      await createInvite(inv)
-      setNotification('New invitation link successfully generated and added to the list below.')
-    } catch {
-      setNotification('Failed to generate invitation link. Please try again.')
-    }
-  }
-
-  async function handleDeleteInvitation(inv: Invitation) {
-    try {
-      setNotification('Deleting invitation link...')
-      await deleteInvite(inv)
-      setNotification('Invitation link successfully deleted.')
-    } catch {
-      setNotification('Failed to delete invitation link.')
-    }
   }
 
   return (
@@ -71,7 +46,7 @@ export default function AdminRsdInvites() {
               subject="Invite to register with RSD"
               body="You are welcome to join RSD! Click on the link below and login with your credentials to complete your registration."
               invitations={activeInvites}
-              onDelete={handleDeleteInvitation}
+              onDelete={deleteInvite}
               showTitle={false}
               extraLineGenerators={extraLineGenerators}
             />
@@ -84,7 +59,7 @@ export default function AdminRsdInvites() {
         <StatusForReaders
           message={notification}
         />
-        <CreateRsdInvite createInvite={handleCreateInvitation} />
+        <CreateRsdInvite createInvite={createInvite} />
       </section>
     </div>
   )

--- a/frontend/components/admin/rsd-invites/index.tsx
+++ b/frontend/components/admin/rsd-invites/index.tsx
@@ -10,6 +10,7 @@ import Alert from '@mui/material/Alert'
 
 import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
 import ContentLoader from '~/components/layout/ContentLoader'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 import CreateRsdInvite from './CreateRsdInvite'
 import {useRsdInvite} from './useRsdInvite'
 import {NewAccountInvite} from './apiRsdInvite'
@@ -79,14 +80,10 @@ export default function AdminRsdInvites() {
       <section
         aria-label="Create new invitation"
         className="order-1 xl:order-2">
-        {/* Visually hidden live region to catch both generation and deletion states */}
-        <div
-          role="status"
-          aria-live="polite"
-          className="sr-only absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
-        >
-          {notification}
-        </div>
+        {/* a11y screen reader announcer */}
+        <StatusForReaders
+          message={notification}
+        />
         <CreateRsdInvite createInvite={handleCreateInvitation} />
       </section>
     </div>

--- a/frontend/components/admin/rsd-invites/index.tsx
+++ b/frontend/components/admin/rsd-invites/index.tsx
@@ -1,21 +1,26 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 'use client'
+import {useState} from 'react'
 import Alert from '@mui/material/Alert'
 
 import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
 import ContentLoader from '~/components/layout/ContentLoader'
 import CreateRsdInvite from './CreateRsdInvite'
 import {useRsdInvite} from './useRsdInvite'
+import {NewAccountInvite} from './apiRsdInvite'
 
 const extraLineGenerators: ((inv: Invitation) => string)[] = [inv => inv.id, inv => inv.comment ?? '']
 
 export default function AdminRsdInvites() {
   const {loading,activeInvites,createInvite,deleteInvite} = useRsdInvite()
+  // a11y feedback notifier state for dynamic list actions
+  const [notification, setNotification] = useState('')
+
 
   if (loading) {
     return (
@@ -25,8 +30,28 @@ export default function AdminRsdInvites() {
     )
   }
 
+  async function handleCreateInvitation(inv:NewAccountInvite) {
+    try {
+      setNotification('Generating new invitation link...')
+      await createInvite(inv)
+      setNotification('New invitation link successfully generated and added to the list below.')
+    } catch {
+      setNotification('Failed to generate invitation link. Please try again.')
+    }
+  }
+
+  async function handleDeleteInvitation(inv: Invitation) {
+    try {
+      setNotification('Deleting invitation link...')
+      await deleteInvite(inv)
+      setNotification('Invitation link successfully deleted.')
+    } catch {
+      setNotification('Failed to delete invitation link.')
+    }
+  }
+
   return (
-    <section className="flex-1 flex flex-col gap-8 xl:grid xl:grid-cols-[3fr_2fr]">
+    <div className="flex-1 flex flex-col gap-8 xl:grid xl:grid-cols-[3fr_2fr]">
       <div className="order-2 xl:order-1">
         <h2 className="flex pr-4 pb-4 justify-between font-medium">
           <span>Invitations</span>
@@ -45,15 +70,25 @@ export default function AdminRsdInvites() {
               subject="Invite to register with RSD"
               body="You are welcome to join RSD! Click on the link below and login with your credentials to complete your registration."
               invitations={activeInvites}
-              onDelete={deleteInvite}
+              onDelete={handleDeleteInvitation}
               showTitle={false}
               extraLineGenerators={extraLineGenerators}
             />
         }
       </div>
-      <div className="order-1 xl:order-2">
-        <CreateRsdInvite createInvite={createInvite} />
-      </div>
-    </section>
+      <section
+        aria-label="Create new invitation"
+        className="order-1 xl:order-2">
+        {/* Visually hidden live region to catch both generation and deletion states */}
+        <div
+          role="status"
+          aria-live="polite"
+          className="sr-only absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
+        >
+          {notification}
+        </div>
+        <CreateRsdInvite createInvite={handleCreateInvitation} />
+      </section>
+    </div>
   )
 }

--- a/frontend/components/admin/rsd-invites/useRsdInvite.tsx
+++ b/frontend/components/admin/rsd-invites/useRsdInvite.tsx
@@ -16,6 +16,8 @@ export function useRsdInvite(){
   const {showErrorMessage} = useSnackbar()
   const [loading, setLoading] = useState(true)
   const [activeInvites, setActiveInvites] = useState<Invitation[]>([])
+  // a11y feedback notifier state for dynamic list actions
+  const [notification, setNotification] = useState('')
 
   const getInvites = useCallback(()=>{
     setLoading(true)
@@ -39,39 +41,40 @@ export function useRsdInvite(){
 
   },[token])
 
-  const createInvite = useCallback((invite:NewAccountInvite)=>{
-    createRsdInvite({invite,token})
-      .then((resp)=>{
-        if (resp.status===201){
-          getInvites()
-        }else{
-          showErrorMessage(`Failed to create invite. ${resp.message}`)
-        }
-      })
-      .catch(e=>{
-        showErrorMessage(`Failed to create invite. ${e.message}`)
-      })
+  const createInvite = useCallback(async(invite:NewAccountInvite)=>{
+    const resp = await createRsdInvite({invite,token})
+
+    if (resp.status===201){
+      setNotification('New invitation link successfully generated and added to the list.')
+      getInvites()
+    }else{
+      showErrorMessage(`Failed to create invite. ${resp.message}`)
+      setNotification('Failed to generate invitation link. Please try again.')
+    }
+
   },[token,getInvites,showErrorMessage])
 
   const deleteInvite = useCallback(async({id}:{id:string})=>{
     const resp = await deleteRsdInvite({id,token})
 
     if (resp.status!==200){
+      setNotification('Failed to delete invitation link.')
       showErrorMessage(`Failed to delete invite. ${resp.message}`)
     }else{
+      setNotification('Invitation link successfully deleted.')
       getInvites()
     }
 
   },[token,getInvites,showErrorMessage])
 
   useEffect(()=>{
-
     if (token) getInvites()
   },[token,getInvites])
 
   return {
     loading,
     activeInvites,
+    notification,
     getInvites,
     createInvite,
     deleteInvite,

--- a/frontend/components/communities/overview/index.tsx
+++ b/frontend/components/communities/overview/index.tsx
@@ -7,10 +7,12 @@
 
 import {useUserSettings} from '~/config/UserSettingsContext'
 import useHandleQueryChange from '~/utils/useHandleQueryChange'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 import PaginationLinkApp from '~/components/layout/PaginationLinkApp'
 import SearchInput from '~/components/search/SearchInput'
 import ToggleViewGroup from '~/components/search/ToggleViewGroup'
 import ShowItemsSelect from '~/components/search/ShowItemsSelect'
+import {searchOverviewMsg} from '~/components/search/searchOverviewMsg'
 import {CommunityListProps} from '../apiCommunities'
 import CommunitiesList from './CommunitiesList'
 import CommunitiesGrid from './CommunitiesGrid'
@@ -33,6 +35,15 @@ export default function CommunitiesOverview({
   // if masonry we change to grid
   const view = rsd_page_layout === 'masonry' ? 'grid' : rsd_page_layout
 
+  const {announcement} = searchOverviewMsg({
+    name: 'organisations',
+    count,
+    page,
+    rows,
+    filterCnt:0,
+    search
+  })
+
   return (
     <>
       {/* Page title with search and pagination */}
@@ -44,6 +55,8 @@ export default function CommunitiesOverview({
           // define a11y region
           aria-label="Search community by name or short description"
           className="flex-2 flex">
+          {/* a11y screen reader announcer */}
+          <StatusForReaders message={announcement} />
           <SearchInput
             placeholder="Search community by name or short description"
             onSearch={(search: string) => handleQueryChange('search', search)}

--- a/frontend/components/filter/CategoriesFilter.tsx
+++ b/frontend/components/filter/CategoriesFilter.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -11,6 +11,9 @@ import TextField from '@mui/material/TextField'
 
 import FilterTitle from '~/components/filter/FilterTitle'
 import FilterOption from '~/components/filter/FilterOption'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
+import {screenReaderFilterMsg, ariaOptionLabel} from './screenReaderFilterMsg'
+
 
 export type CategoryOption = {
   category: string,
@@ -46,14 +49,23 @@ export default function CategoriesFilter({categories,categoryList,handleQueryCha
     setOptions(categoryList)
   },[categories,categoryList])
 
+  const message = screenReaderFilterMsg({
+    name: title,
+    selected: selected.map(item => item.category),
+    optionCnt: options?.length
+  })
+
   return (
     <>
       <FilterTitle
         title={title}
         count={categoryList.length ?? ''}
       />
+      {/* a11y screen reader announcer */}
+      <StatusForReaders message={message}/>
       <Autocomplete
         className="mt-4"
+        disabled={options?.length===0}
         value={selected}
         size="small"
         multiple
@@ -66,15 +78,25 @@ export default function CategoriesFilter({categories,categoryList,handleQueryCha
         defaultValue={[]}
         filterSelectedOptions
         // remove key from other props
-        renderOption={({key,...props}, option) => (
-          <FilterOption
-            key={key ?? option.category}
-            props={props}
-            label={option.category}
-            count={option.category_cnt}
-            capitalize={false}
-          />
-        )}
+        renderOption={({key,...props}, option) => {
+          // a11y provide descriptive audio fallback for menu lines
+          const accessibleOptionLabel = ariaOptionLabel({
+            name: option.category,
+            count: option.category_cnt
+          })
+          return (
+            <FilterOption
+              key={key ?? option.category}
+              props={{
+                ...props,
+                'aria-label': accessibleOptionLabel
+              }}
+              label={option.category}
+              count={option.category_cnt}
+              capitalize={false}
+            />
+          )
+        }}
         renderInput={(params) => (
           <TextField {...params} placeholder={title} />
         )}

--- a/frontend/components/filter/FilterHeader.tsx
+++ b/frontend/components/filter/FilterHeader.tsx
@@ -1,6 +1,6 @@
-// SPDX-FileCopyrightText: 2023 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 dv4all
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -14,6 +14,7 @@ type FilterHeaderProps = {
 }
 
 export default function FilterHeader({filterCnt,disableClear=true,resetFilters}:FilterHeaderProps) {
+  const filterLabel = filterCnt===1 ? 'Filter' : 'Filters'
   return (
     <div className="flex justify-between">
       <div className="flex justify-center items-center gap-2 mr-12">
@@ -21,7 +22,7 @@ export default function FilterHeader({filterCnt,disableClear=true,resetFilters}:
           className="rounded-full bg-base-200 h-8 w-8 flex items-center justify-center font-semibold">
           {filterCnt}
         </span>
-        {filterCnt===1 ? 'Filter' : 'Filters'}
+        {filterLabel}
       </div>
 
       <Button
@@ -30,6 +31,7 @@ export default function FilterHeader({filterCnt,disableClear=true,resetFilters}:
         disabled={disableClear}
         variant="contained"
         color="primary"
+        aria-label={`Clear all filters. ${filterCnt} active ${filterLabel}.`}
       >
         Clear
       </Button>

--- a/frontend/components/filter/FiltersPanel.tsx
+++ b/frontend/components/filter/FiltersPanel.tsx
@@ -16,18 +16,18 @@ import useSmallScreen from '~/config/useSmallScreen'
  * @param param0
  * @returns
  */
-export default function FiltersPanel({children}: {children: any}) {
+export default function FiltersPanel({children}: {children: React.ReactNode}) {
   const smallScreen = useSmallScreen()
 
   // hide filter panel on mobile
   if (smallScreen) return null
 
   return (
-    <section
+    <aside
       data-testid="filters-panel"
       aria-label="Filters"
       className="flex bg-base-100 p-4 shadow-sm rounded-md flex-col gap-8 min-w-[18rem]">
       {children}
-    </section>
+    </aside>
   )
 }

--- a/frontend/components/filter/KeywordsFilter.tsx
+++ b/frontend/components/filter/KeywordsFilter.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -11,6 +11,8 @@ import TextField from '@mui/material/TextField'
 
 import FilterTitle from '~/components/filter/FilterTitle'
 import FilterOption from '~/components/filter/FilterOption'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
+import {screenReaderFilterMsg, ariaOptionLabel} from './screenReaderFilterMsg'
 
 export type KeywordFilterOption = {
   keyword: string
@@ -33,13 +35,6 @@ export default function KeywordsFilter({keywords, keywordsList, handleQueryChang
   const [selected, setSelected] = useState<KeywordFilterOption[]>([])
   const [options, setOptions] = useState<KeywordFilterOption[]>(keywordsList)
 
-  // console.group('KeywordsFilter')
-  // console.log('keywords...', keywords)
-  // console.log('keywordsList...', keywordsList)
-  // console.log('options...', options)
-  // console.log('selected...', selected)
-  // console.groupEnd()
-
   useEffect(() => {
     if (keywords && keywordsList &&
       keywords.length > 0 && keywordsList.length > 0) {
@@ -59,14 +54,31 @@ export default function KeywordsFilter({keywords, keywordsList, handleQueryChang
     setOptions(keywordsList)
   },[keywords,keywordsList])
 
+  const message = screenReaderFilterMsg({
+    name: title,
+    selected: selected.map(item => item.keyword),
+    optionCnt: options?.length
+  })
+
+  // console.group('KeywordsFilter')
+  // console.log('keywords...', keywords)
+  // console.log('keywordsList...', keywordsList)
+  // console.log('options...', options)
+  // console.log('selected...', selected)
+  // console.log('selectionContext...', selectionContext)
+  // console.groupEnd()
+
   return (
     <>
       <FilterTitle
         title={title}
-        count={keywordsList.length ?? ''}
+        count={keywordsList.length ?? 0}
       />
+      {/* a11y screen reader announcer */}
+      <StatusForReaders message={message}/>
       <Autocomplete
         className="mt-4"
+        disabled={options?.length===0}
         value={selected}
         size="small"
         multiple
@@ -78,16 +90,29 @@ export default function KeywordsFilter({keywords, keywordsList, handleQueryChang
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={({key,...props}, option) => (
-          <FilterOption
-            key={key ?? option.keyword}
-            props={props}
-            label={option.keyword}
-            count={option.keyword_cnt}
-          />
-        )}
+        renderOption={({key,...props}, option) => {
+          // a11y provide descriptive audio fallback for menu lines
+          const accessibleOptionLabel = ariaOptionLabel({
+            name: option.keyword,
+            count: option.keyword_cnt
+          })
+          return (
+            <FilterOption
+              key={key ?? option.keyword}
+              props={{
+                ...props,
+                'aria-label': accessibleOptionLabel
+              }}
+              label={option.keyword}
+              count={option.keyword_cnt}
+            />
+          )
+        }}
         renderInput={(params) => (
-          <TextField {...params} placeholder={title} />
+          <TextField
+            {...params}
+            placeholder={title}
+          />
         )}
         onChange={(event, newValue) => {
           // extract values into string[] for url query

--- a/frontend/components/filter/LicensesFilter.tsx
+++ b/frontend/components/filter/LicensesFilter.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -9,6 +9,8 @@ import {useEffect, useState} from 'react'
 
 import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
+import {screenReaderFilterMsg, ariaOptionLabel} from './screenReaderFilterMsg'
 import FilterTitle from './FilterTitle'
 import FilterOption from './FilterOption'
 
@@ -40,14 +42,23 @@ export default function LicensesFilter({licenses, licensesList,handleQueryChange
     setOptions(licensesList)
   },[licenses,licensesList])
 
+  const message = screenReaderFilterMsg({
+    name: title,
+    selected: selected.map(item => item.license),
+    optionCnt: options?.length
+  })
+
   return (
     <>
       <FilterTitle
         title={title}
         count={licensesList.length ?? ''}
       />
+      {/* a11y screen reader announcer */}
+      <StatusForReaders message={message}/>
       <Autocomplete
         className="mt-4"
+        disabled={options?.length===0}
         value={selected}
         size="small"
         multiple
@@ -59,14 +70,24 @@ export default function LicensesFilter({licenses, licensesList,handleQueryChange
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={({key,...props}, option) => (
-          <FilterOption
-            key={key ?? option.license}
-            props={props}
-            label={option.license}
-            count={option.license_cnt}
-          />
-        )}
+        renderOption={({key,...props}, option) => {
+          // a11y provide descriptive audio fallback for menu lines
+          const accessibleOptionLabel = ariaOptionLabel({
+            name: option.license,
+            count: option.license_cnt
+          })
+          return (
+            <FilterOption
+              key={key ?? option.license}
+              props={{
+                ...props,
+                'aria-label': accessibleOptionLabel
+              }}
+              label={option.license}
+              count={option.license_cnt}
+            />
+          )
+        }}
         renderInput={(params) => (
           <TextField {...params} placeholder={title} />
         )}

--- a/frontend/components/filter/ProgrammingLanguagesFilter.tsx
+++ b/frontend/components/filter/ProgrammingLanguagesFilter.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -9,8 +9,13 @@ import {useEffect, useState} from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
 
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 import FilterTitle from './FilterTitle'
 import FilterOption from './FilterOption'
+import {
+  screenReaderFilterMsg,
+  ariaOptionLabel
+} from './screenReaderFilterMsg'
 
 export type LanguagesFilterOption = {
   prog_language: string
@@ -40,14 +45,23 @@ export default function ProgrammingLanguagesFilter({prog_lang,languagesList,hand
     setOptions(languagesList)
   },[prog_lang,languagesList])
 
+  const message = screenReaderFilterMsg({
+    name: title,
+    selected: selected.map(item => item.prog_language),
+    optionCnt: options?.length
+  })
+
   return (
     <>
       <FilterTitle
         title={title}
         count={languagesList.length ?? ''}
       />
+      {/* a11y screen reader announcer */}
+      <StatusForReaders message={message}/>
       <Autocomplete
         className="mt-4"
+        disabled={options?.length===0}
         value={selected}
         size="small"
         multiple
@@ -59,14 +73,24 @@ export default function ProgrammingLanguagesFilter({prog_lang,languagesList,hand
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={({key, ...props}, option) => (
-          <FilterOption
-            key={key ?? option.prog_language}
-            props={props}
-            label={option.prog_language}
-            count={option.prog_language_cnt}
-          />
-        )}
+        renderOption={({key, ...props}, option) => {
+          // a11y provide descriptive audio fallback for menu lines
+          const accessibleOptionLabel = ariaOptionLabel({
+            name: option.prog_language,
+            count: option.prog_language_cnt
+          })
+          return (
+            <FilterOption
+              key={key ?? option.prog_language}
+              props={{
+                ...props,
+                'aria-label': accessibleOptionLabel
+              }}
+              label={option.prog_language}
+              count={option.prog_language_cnt}
+            />
+          )
+        }}
         renderInput={(params) => (
           <TextField {...params} placeholder={title} />
         )}

--- a/frontend/components/filter/ResearchDomainFilter.tsx
+++ b/frontend/components/filter/ResearchDomainFilter.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 //
@@ -9,8 +9,11 @@ import {useEffect, useState} from 'react'
 import Autocomplete from '@mui/material/Autocomplete'
 import TextField from '@mui/material/TextField'
 
+import StatusForReaders from '~/components/a11y/StatusForReaders'
+import {screenReaderFilterMsg, ariaOptionLabel} from './screenReaderFilterMsg'
 import FilterTitle from '~/components/filter/FilterTitle'
 import FilterOption from '~/components/filter/FilterOption'
+
 
 export type ResearchDomainOption = {
   key: string
@@ -47,14 +50,23 @@ export default function ResearchDomainFilter({domains, domainsList,handleQueryCh
     setOptions(domainsList)
   },[domains,domainsList])
 
+  const message = screenReaderFilterMsg({
+    name: title,
+    selected: selected.map(item => item.domain),
+    optionCnt: options?.length
+  })
+
   return (
     <>
       <FilterTitle
         title={title}
         count={domainsList.length ?? ''}
       />
+      {/* a11y screen reader announcer */}
+      <StatusForReaders message={message}/>
       <Autocomplete
         className="mt-4"
+        disabled={options?.length===0}
         value={selected}
         size="small"
         multiple
@@ -66,14 +78,24 @@ export default function ResearchDomainFilter({domains, domainsList,handleQueryCh
         }}
         defaultValue={[]}
         filterSelectedOptions
-        renderOption={({key, ...props}, option) => (
-          <FilterOption
-            key={key ?? option.domain}
-            props={props}
-            label={option.domain}
-            count={option.domain_cnt}
-          />
-        )}
+        renderOption={({key, ...props}, option) => {
+          // a11y provide descriptive audio fallback for menu lines
+          const accessibleOptionLabel = ariaOptionLabel({
+            name: option.domain,
+            count: option.domain_cnt
+          })
+          return (
+            <FilterOption
+              key={key ?? option.domain}
+              props={{
+                ...props,
+                'aria-label': accessibleOptionLabel
+              }}
+              label={option.domain}
+              count={option.domain_cnt}
+            />
+          )
+        }}
         renderInput={(params) => (
           <TextField {...params} placeholder={title} />
         )}

--- a/frontend/components/filter/screenReaderFilterMsg.ts
+++ b/frontend/components/filter/screenReaderFilterMsg.ts
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+type FilterScreenReaderMsgProps={
+  name: string,
+  selected: string[],
+  optionCnt: number
+}
+
+export function screenReaderFilterMsg({name,selected=[],optionCnt=0}:FilterScreenReaderMsgProps){
+
+  if (!name) return ''
+
+  if (selected?.length===0){
+    return `${name}: No options selected. ${optionCnt} options available.`
+  }
+
+  return `${name}: ${selected.length} of ${optionCnt} options selected. Selected options: ${selected.join(', ')}. Use Backspace to remove last selected option.`
+}
+
+export function ariaOptionLabel({name,count}:{name?:string,count?:number}){
+  if (name && count){
+    return `${name}, ${count} matches available`
+  }
+
+  if (name){
+    return `${name}, ${count} matches available`
+  }
+
+  if (count){
+    return `${count} matches available`
+  }
+
+  return ''
+}

--- a/frontend/components/form/AsyncAutocompleteSC.tsx
+++ b/frontend/components/form/AsyncAutocompleteSC.tsx
@@ -76,7 +76,7 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
   const searchFor = useDebounce(newInputValue, 700)
   const [processing, setProcessing] = useState('')
   //a11y screen reader live announcement management
-  const [srAnnouncement, setSrAnnouncement] = useState('')
+  const [announcement, setAnnouncement] = useState('')
   const {loading, foundFor} = status
 
   useEffect(() => {
@@ -90,12 +90,12 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
       newInputValue!==''
     ) {
       // debugger
+      // announce search initiation politely
+      setAnnouncement(`Searching for ${searchFor} ...`)
       // issue search request using trimmed value
       onSearch(searchFor)
       // set raw value as processing
       setProcessing(searchFor)
-      // announce search initiation politely
-      setSrAnnouncement(`Searching for ${searchFor}...`)
     }
   }, [searchFor, foundFor, processing, newInputValue, config.minLength, onSearch])
 
@@ -103,14 +103,15 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
   useEffect(() => {
     if (!loading && foundFor) {
       if (options.length === 0) {
-        setSrAnnouncement(`No results found for ${foundFor}.`)
+        setAnnouncement(`No results found for ${foundFor}.`)
       } else {
-        setSrAnnouncement(
+        setAnnouncement(
           `${options.length} suggestion${options.length === 1 ? '' : 's'} found for ${foundFor}. Use up and down arrow keys to navigate.`
         )
       }
     }
   }, [options, loading, foundFor])
+
   // console.group('AsyncAutocompleteSC')
   // console.log('loading...', loading)
   // console.log('options...', options)
@@ -129,8 +130,8 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
       loading === false && onCreate) {
       // we send trimmed value
       onCreate(value)
-      // announce creation confirmation
-      setSrAnnouncement(`Created and added new entry: ${value}`)
+      // announce creation confirmation - too early
+      // setAnnouncement(`Created and added new entry: ${value}`)
       if (config?.reset) {
         // reset selected value to nothing
         setSelected(null)
@@ -142,8 +143,8 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
   function requestAdd(item: AutocompleteOption<T>) {
     // console.log('requestAdd...', item)
     onAdd(item)
-    // announce selection addition confirmation
-    setSrAnnouncement(`Added ${item.label}`)
+    // announce selection addition confirmation - too early
+    // setAnnouncement(`Added ${item.label}`)
     if (config?.reset) {
       // reset selected value to nothing
       setSelected(null)
@@ -250,7 +251,7 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
     <div className="w-full relative">
       {/* a11y screen reader announcer */}
       <StatusForReaders
-        message={srAnnouncement}
+        message={announcement}
       />
       <Autocomplete
         freeSolo={config.freeSolo}

--- a/frontend/components/form/AsyncAutocompleteSC.tsx
+++ b/frontend/components/form/AsyncAutocompleteSC.tsx
@@ -17,6 +17,7 @@ import {FilterOptionsState} from '@mui/material/useAutocomplete'
 import TextField from '@mui/material/TextField'
 
 import {useDebounce} from '~/utils/useDebounce'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 
 export type AutocompleteOption<T> = {
   key: string
@@ -247,15 +248,10 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
 
   return (
     <div className="w-full relative">
-      {/* Visually Hidden Live Announcement Box */}
-      <div
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
-        className="sr-only absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
-      >
-        {srAnnouncement}
-      </div>
+      {/* a11y screen reader announcer */}
+      <StatusForReaders
+        message={srAnnouncement}
+      />
       <Autocomplete
         freeSolo={config.freeSolo}
         id="async-autocomplete"

--- a/frontend/components/form/AsyncAutocompleteSC.tsx
+++ b/frontend/components/form/AsyncAutocompleteSC.tsx
@@ -74,6 +74,8 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
   const [selected, setSelected] = useState<AutocompleteOption<T>|null>(null)
   const searchFor = useDebounce(newInputValue, 700)
   const [processing, setProcessing] = useState('')
+  //a11y screen reader live announcement management
+  const [srAnnouncement, setSrAnnouncement] = useState('')
   const {loading, foundFor} = status
 
   useEffect(() => {
@@ -91,9 +93,23 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
       onSearch(searchFor)
       // set raw value as processing
       setProcessing(searchFor)
+      // announce search initiation politely
+      setSrAnnouncement(`Searching for ${searchFor}...`)
     }
   }, [searchFor, foundFor, processing, newInputValue, config.minLength, onSearch])
 
+  // a11y monitor results array changes to announce results length updates
+  useEffect(() => {
+    if (!loading && foundFor) {
+      if (options.length === 0) {
+        setSrAnnouncement(`No results found for ${foundFor}.`)
+      } else {
+        setSrAnnouncement(
+          `${options.length} suggestion${options.length === 1 ? '' : 's'} found for ${foundFor}. Use up and down arrow keys to navigate.`
+        )
+      }
+    }
+  }, [options, loading, foundFor])
   // console.group('AsyncAutocompleteSC')
   // console.log('loading...', loading)
   // console.log('options...', options)
@@ -112,6 +128,8 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
       loading === false && onCreate) {
       // we send trimmed value
       onCreate(value)
+      // announce creation confirmation
+      setSrAnnouncement(`Created and added new entry: ${value}`)
       if (config?.reset) {
         // reset selected value to nothing
         setSelected(null)
@@ -123,6 +141,8 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
   function requestAdd(item: AutocompleteOption<T>) {
     // console.log('requestAdd...', item)
     onAdd(item)
+    // announce selection addition confirmation
+    setSrAnnouncement(`Added ${item.label}`)
     if (config?.reset) {
       // reset selected value to nothing
       setSelected(null)
@@ -226,7 +246,16 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
   }
 
   return (
-    <>
+    <div className="w-full relative">
+      {/* Visually Hidden Live Announcement Box */}
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
+      >
+        {srAnnouncement}
+      </div>
       <Autocomplete
         freeSolo={config.freeSolo}
         id="async-autocomplete"
@@ -334,6 +363,6 @@ export default function AsyncAutocompleteSC<T>({status, options, config,
           )}}
         renderOption={onRenderOption}
       />
-    </>
+    </div>
   )
 }

--- a/frontend/components/layout/SortableList.tsx
+++ b/frontend/components/layout/SortableList.tsx
@@ -74,6 +74,42 @@ export default function SortableList<T extends RequiredListProps>({
       onDragEnd={onDragEnd}
       sensors={sensors}
       modifiers={[restrictToVerticalAxis,restrictToParentElement]}
+      // a11y improved screen reader communication during d-n-d
+      accessibility={{
+        announcements: {
+          onDragStart({active}) {
+            const index = items.findIndex(item => item.id === active.id)
+            return `Picked up item at position ${index + 1} of ${items.length}. Use up and down arrow keys to reorder.`
+          },
+          onDragMove({active, over}) {
+            if (over) {
+              const activeIndex = items.findIndex(item => item.id === active.id)
+              const overIndex = items.findIndex(item => item.id === over.id)
+              return `Item moved from position ${activeIndex + 1} to position ${overIndex + 1} of ${items.length}.`
+            }
+            return 'Item is being dragged.'
+          },
+          onDragOver({over}) {
+            if (over) {
+              // const activeIndex = items.findIndex(item => item.id === active.id)
+              const overIndex = items.findIndex(item => item.id === over.id)
+              return `Item is hovering over position ${overIndex + 1} of ${items.length}.`
+            }
+            return 'Item is over a non-droppable area.'
+          },
+          onDragEnd({active, over}) {
+            if (over) {
+              const activeIndex = items.findIndex(item => item.id === active.id)
+              const overIndex = items.findIndex(item => item.id === over.id)
+              return `Dropped item. Reordered from position ${activeIndex + 1} to final position ${overIndex + 1}.`
+            }
+            return 'Dropped item.'
+          },
+          onDragCancel() {
+            return 'Dragging cancelled. Item returned to its original position.'
+          }
+        }
+      }}
     >
       <SortableContext
         items={items.map(item=>({id: item.id ?? ''}))}

--- a/frontend/components/maintainers/GenerateInviteLink.tsx
+++ b/frontend/components/maintainers/GenerateInviteLink.tsx
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import Button from '@mui/material/Button'
+import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
+
+import StatusForReaders from '~/components/a11y/StatusForReaders'
+import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
+
+type GenerateInviteLinkProps=Readonly<{
+  email:{
+    subject: string
+    body: string
+  },
+  notification: string,
+  invitations: Invitation[],
+  createInvitation: ()=>Promise<void>
+  deleteInvitation: (invitation:Invitation)=>Promise<void>
+}>
+
+export default function GenerateInviteLink(props:GenerateInviteLinkProps) {
+  // destructure props
+  const {email,notification,invitations,createInvitation,deleteInvitation} = props
+
+  return (
+    <div className="grid gap-4 justify-items-start">
+      {/* a11y screen reader announcer */}
+      <StatusForReaders
+        message={notification}
+        className="absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
+      />
+      <Button
+        variant='contained'
+        sx={{
+          margin: '1rem 0rem',
+          display: 'flex',
+          alignItems: 'center'
+        }}
+        // hide decorative icon from speech engines
+        startIcon={<AutoFixHighIcon aria-hidden="true"/>}
+        onClick={createInvitation}
+      >
+        Generate invite link
+      </Button>
+      <InvitationList
+        subject={email.subject}
+        body={email.body}
+        invitations={invitations}
+        onDelete={deleteInvitation}
+      />
+    </div>
+  )
+
+}

--- a/frontend/components/maintainers/InvitationList.tsx
+++ b/frontend/components/maintainers/InvitationList.tsx
@@ -116,11 +116,13 @@ export default function InvitationList({
   if(invitations.length === 0) return null
 
   return (
-    <>
+    <section
+      aria-label={`${invitations?.length} unused invitations`}
+    >
       {showTitle ?
         <EditSectionTitle
-          title={'Unused invitations'}
-          subtitle={'These invitations are not used yet'}
+          title="Unused invitations"
+          subtitle="These invitations are not used yet"
         />
         : null
       }
@@ -179,6 +181,6 @@ export default function InvitationList({
           )
         })}
       </List>
-    </>
+    </section>
   )
 }

--- a/frontend/components/mention/MentionItemBase.tsx
+++ b/frontend/components/mention/MentionItemBase.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -44,7 +44,7 @@ export default function MentionItemBase({item,pos,nav,type,role='find'}:MentionI
     return null
   }
   return (
-    <article
+    <div
       data-testid="mention-item-base"
       className="flex-1"
     >
@@ -79,7 +79,7 @@ export default function MentionItemBase({item,pos,nav,type,role='find'}:MentionI
         role={role}
       />
       <MentionNote note={item.note ?? null} />
-    </article>
+    </div>
   )
 }
 

--- a/frontend/components/news/overview/index.tsx
+++ b/frontend/components/news/overview/index.tsx
@@ -6,29 +6,40 @@
 'use client'
 
 import useHandleQueryChange from '~/utils/useHandleQueryChange'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 import PaginationLinkApp from '~/components/layout/PaginationLinkApp'
 import {useUserSettings} from '~/config/UserSettingsContext'
 import SearchInput from '~/components/search/SearchInput'
 import ToggleViewGroup from '~/components/search/ToggleViewGroup'
 import ShowItemsSelect from '~/components/search/ShowItemsSelect'
+import {searchOverviewMsg} from '~/components/search/searchOverviewMsg'
 import {NewsListItemProps} from '~/components/news/apiNews'
 import NewsList from './list'
 import NewsGrid from './NewsGrid'
 
 type NewsOverviewProps = Readonly<{
   page: number,
-  pages: number,
+  count: number,
   rows: number,
   news: NewsListItemProps[],
   search?: string|null,
 }>
 
-export default function NewsOverview({pages,page,rows,search,news}:NewsOverviewProps) {
+export default function NewsOverview({count,page,rows,search,news}:NewsOverviewProps) {
   const {handleQueryChange} = useHandleQueryChange()
   const {rsd_page_layout,setPageLayout,setPageRows} = useUserSettings()
-
+  const numPages = Math.ceil(count / rows)
   // if masonry we change to grid
   const view = rsd_page_layout === 'masonry' ? 'grid' : rsd_page_layout
+
+  const {announcement} = searchOverviewMsg({
+    name: 'news items',
+    count: rows,
+    page,
+    rows,
+    filterCnt:0,
+    search
+  })
 
   return (
     <>
@@ -40,6 +51,8 @@ export default function NewsOverview({pages,page,rows,search,news}:NewsOverviewP
           // define a11y region
           aria-label="Search news items by title, summary or author"
           className="flex-2 flex">
+          {/* a11y screen reader announcer */}
+          <StatusForReaders message={announcement} />
           <SearchInput
             placeholder="Search news items by title, summary or author"
             onSearch={(search: string) => handleQueryChange('search', search)}
@@ -71,7 +84,7 @@ export default function NewsOverview({pages,page,rows,search,news}:NewsOverviewP
 
       {/* Pagination */}
       <PaginationLinkApp
-        count={pages}
+        count={numPages}
         page={page}
       />
     </>

--- a/frontend/components/organisation/overview/index.tsx
+++ b/frontend/components/organisation/overview/index.tsx
@@ -8,9 +8,11 @@
 import {useUserSettings} from '~/config/UserSettingsContext'
 import {OrganisationListProps} from '~/types/Organisation'
 import useHandleQueryChange from '~/utils/useHandleQueryChange'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 import SearchInput from '~/components/search/SearchInput'
 import ToggleViewGroup from '~/components/search/ToggleViewGroup'
 import ShowItemsSelect from '~/components/search/ShowItemsSelect'
+import {searchOverviewMsg} from '~/components/search/searchOverviewMsg'
 import OrganisationListView from '~/components/organisation/overview/OrganisationList'
 import OrganisationGrid from '~/components/organisation/overview/OrganisationGrid'
 import PaginationLinkApp from '~/components/layout/PaginationLinkApp'
@@ -34,6 +36,15 @@ export default function OrganisationsOverviewClient({
   // if masonry we change to grid
   const view = rsd_page_layout === 'masonry' ? 'grid' : rsd_page_layout
 
+  const {announcement} = searchOverviewMsg({
+    name: 'organisations',
+    count,
+    page,
+    rows,
+    filterCnt:0,
+    search
+  })
+
   return (
     <>
       <div className="flex flex-wrap mt-4 py-8 px-4 rounded-lg bg-base-100 lg:sticky top-0 border border-base-200 z-11">
@@ -44,6 +55,8 @@ export default function OrganisationsOverviewClient({
           // define a11y region
           aria-label="Search organisation by name, ROR name or website"
           className="flex-2 flex">
+          {/* a11y screen reader announcer */}
+          <StatusForReaders message={announcement} />
           <SearchInput
             placeholder="Search organisation by name, ROR name or website"
             onSearch={(search: string) => handleQueryChange('search', search)}

--- a/frontend/components/person/AggregatedPersonModal.tsx
+++ b/frontend/components/person/AggregatedPersonModal.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -116,6 +116,7 @@ export default function AggregatedPersonModal({
         id={formId}
         onSubmit={handleSubmit((data) => onSubmit(data))}
         autoComplete="off"
+        aria-label={title}
       >
         {/* hidden inputs */}
         <input type="hidden"

--- a/frontend/components/person/AggregatedPersonOption.tsx
+++ b/frontend/components/person/AggregatedPersonOption.tsx
@@ -23,7 +23,11 @@ export default function AggregatedPersonOption({option}: {option: AutocompleteOp
       return (
         <div className="grid grid-cols-[3fr_2fr] gap-2">
           {affiliation_options.join('; ')}
-          <div className="pl-4 text-right">{orcid}</div>
+          <div
+            className="pl-4 text-right"
+            aria-label={`ORCID ID ${orcid}`}>
+            {orcid}
+          </div>
         </div>
       )
     }
@@ -31,37 +35,44 @@ export default function AggregatedPersonOption({option}: {option: AutocompleteOp
       return (
         <div className="grid grid-cols-[3fr_2fr] gap-2">
           <div className="flex-1"></div>
-          <div className="pl-4 text-right">{option.data?.orcid}</div>
+          <div
+            className="pl-4 text-right"
+            aria-label={`ORCID ID ${orcid}`}>
+            {orcid}
+          </div>
         </div>
       )
     }
     if (affiliation_options) {
       return (
         <div className="flex-1">
-          {option.data?.affiliation_options.join('; ')}
+          {affiliation_options.join('; ')}
         </div>
       )
     }
   }
 
   return (
-    <article className="flex-1 flex">
+    <div className="flex-1 flex gap-2">
       <ContributorAvatar
         avatarUrl={getImageUrl(option.data?.avatar_options[0] ?? null) ?? ''}
         displayName={displayName ?? ''}
         displayInitials={displayInitials}
       />
-      <section className="flex-1">
+      <div className="flex-1">
         <div className="grid grid-cols-[3fr_1fr] gap-2">
           <div className="flex items-center">
             <strong><span className="flex-1">{option.label}</span></strong>
           </div>
-          <span className="text-right">{option.data?.sources.join(', ')}</span>
+          <span
+            className="text-right"
+            aria-label={`Source ${option.data?.sources.join(', ')}`}
+          >{option.data?.sources.join(', ')}</span>
         </div>
         <div className="py-1 text-[0.75rem]">
           {renderSecondRow()}
         </div>
-      </section>
-    </article>
+      </div>
+    </div>
   )
 }

--- a/frontend/components/profile/overview/index.tsx
+++ b/frontend/components/profile/overview/index.tsx
@@ -6,28 +6,41 @@
 'use client'
 
 import useHandleQueryChange from '~/utils/useHandleQueryChange'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 import {useUserSettings} from '~/config/UserSettingsContext'
 import SearchInput from '~/components/search/SearchInput'
 import PaginationLinkApp from '~/components/layout/PaginationLinkApp'
 import ShowItemsSelect from '~/components/search/ShowItemsSelect'
 import ToggleViewGroup from '~/components/search/ToggleViewGroup'
+import {searchOverviewMsg} from '~/components/search/searchOverviewMsg'
 import {PersonsOverview} from './apiPersonsOverview'
 import PersonsList from './PersonsList'
 import PersonsGrid from './PersonsGrid'
 
 type PersonsOverviewProps = Readonly<{
   page: number,
-  pages: number,
+  count: number,
   rows: number,
   persons: PersonsOverview[],
   search?: string|null,
 }>
 
-export default function PersonsOverviewClient({pages,page,rows,search,persons}:PersonsOverviewProps) {
+export default function PersonsOverviewClient({count,page,rows,search,persons}:PersonsOverviewProps) {
   const {handleQueryChange} = useHandleQueryChange()
   const {rsd_page_layout,setPageLayout,setPageRows} = useUserSettings()
+  const numPages = Math.ceil(count / rows)
+
   // if masonry we change to grid
   const view = rsd_page_layout === 'masonry' ? 'grid' : rsd_page_layout
+
+  const {announcement} = searchOverviewMsg({
+    name: 'organisations',
+    count,
+    page,
+    rows,
+    filterCnt:0,
+    search
+  })
 
   return (
     <>
@@ -37,6 +50,8 @@ export default function PersonsOverviewClient({pages,page,rows,search,persons}:P
           Persons
         </h1>
         <div className="flex-2 flex">
+          {/* a11y screen reader announcer */}
+          <StatusForReaders message={announcement} />
           <SearchInput
             placeholder="Search person by name or affiliation"
             onSearch={(search: string) => handleQueryChange('search', search)}
@@ -66,7 +81,7 @@ export default function PersonsOverviewClient({pages,page,rows,search,persons}:P
       }
       {/* Pagination */}
       <PaginationLinkApp
-        count={pages}
+        count={numPages}
         page={page}
       />
     </>

--- a/frontend/components/projects/edit/information/ProjectInformationForm.tsx
+++ b/frontend/components/projects/edit/information/ProjectInformationForm.tsx
@@ -55,7 +55,9 @@ export default function ProjectInformationForm({editProject}: {editProject: Edit
         <input type="hidden"
           {...register('id',{required:'id is required'})}
         />
-        <EditSection className='xl:grid xl:grid-cols-[3fr_1fr] xl:px-0 xl:gap-[3rem]'>
+        <EditSection
+          aria-label="Project description items"
+          className='xl:grid xl:grid-cols-[3fr_1fr] xl:px-0 xl:gap-[3rem]'>
           {/* middle panel */}
           <div className="py-2 overflow-hidden">
             <EditSectionTitle

--- a/frontend/components/projects/edit/maintainers/ProjectMaintainerLinks.tsx
+++ b/frontend/components/projects/edit/maintainers/ProjectMaintainerLinks.tsx
@@ -8,8 +8,9 @@ import Button from '@mui/material/Button'
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 
 import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
-import {useProjectInvitations} from './useProjectInvitations'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 import useProjectContext from '../context/useProjectContext'
+import {useProjectInvitations} from './useProjectInvitations'
 
 export default function ProjectMaintainerLinks() {
   const {project} = useProjectContext()
@@ -44,14 +45,11 @@ export default function ProjectMaintainerLinks() {
 
   return (
     <>
-      {/* Visually hidden live region to catch both generation and deletion states */}
-      <div
-        role="status"
-        aria-live="polite"
-        className="sr-only absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
-      >
-        {notification}
-      </div>
+      {/* a11y screen reader announcer */}
+      <StatusForReaders
+        message={notification}
+        className="absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
+      />
       <Button
         variant='contained'
         sx={{

--- a/frontend/components/projects/edit/maintainers/ProjectMaintainerLinks.tsx
+++ b/frontend/components/projects/edit/maintainers/ProjectMaintainerLinks.tsx
@@ -3,73 +3,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useState} from 'react'
-import Button from '@mui/material/Button'
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
-
-import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
-import StatusForReaders from '~/components/a11y/StatusForReaders'
+import GenerateInviteLink from '~/components/maintainers/GenerateInviteLink'
 import useProjectContext from '../context/useProjectContext'
 import {useProjectInvitations} from './useProjectInvitations'
 
 export default function ProjectMaintainerLinks() {
   const {project} = useProjectContext()
-  const {unusedInvitations,createInvitation,deleteInvitation} = useProjectInvitations({project:project.id})
-  // a11y feedback notifier state for dynamic list actions
-  const [notification, setNotification] = useState('')
-
-  // console.group('ProjectMaintainerLinks')
-  // console.log('project...', project)
-  // console.log('unusedInvitations...', unusedInvitations)
-  // console.groupEnd()
-
-  async function handleCreateInvitation() {
-    try {
-      setNotification('Generating new invitation link...')
-      await createInvitation()
-      setNotification('New invitation link successfully generated and added to the list below.')
-    } catch {
-      setNotification('Failed to generate invitation link. Please try again.')
-    }
-  }
-
-  async function handleDeleteInvitation(inv: Invitation) {
-    try {
-      setNotification('Deleting invitation link...')
-      await deleteInvitation(inv)
-      setNotification('Invitation link successfully deleted.')
-    } catch {
-      setNotification('Failed to delete invitation link.')
-    }
-  }
+  const {unusedInvitations,notification,createInvitation,deleteInvitation} = useProjectInvitations({project:project.id})
 
   return (
-    <>
-      {/* a11y screen reader announcer */}
-      <StatusForReaders
-        message={notification}
-        className="absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
-      />
-      <Button
-        variant='contained'
-        sx={{
-          margin: '1rem 0rem',
-          display: 'flex',
-          alignItems: 'center'
-        }}
-        // hide decorative icon from speech engines
-        startIcon={<AutoFixHighIcon aria-hidden="true"/>}
-        onClick={handleCreateInvitation}
-      >
-        Generate invite link
-      </Button>
-      <div className="py-4"></div>
-      <InvitationList
-        subject={`Maintainer invite for project ${encodeURIComponent(project.title ?? '')}`}
-        body={`Please use the following link to become a maintainer of ${encodeURIComponent(project.title ?? '')} project.`}
-        invitations={unusedInvitations}
-        onDelete={handleDeleteInvitation}
-      />
-    </>
+    <GenerateInviteLink
+      email={{
+        subject: `Maintainer invite for project ${encodeURIComponent(project.title ?? '')}`,
+        body: `Please use the following link to become a maintainer of ${encodeURIComponent(project.title ?? '')} project.`
+      }}
+      notification={notification}
+      invitations={unusedInvitations}
+      createInvitation={createInvitation}
+      deleteInvitation={deleteInvitation}
+    />
   )
 }

--- a/frontend/components/projects/edit/maintainers/ProjectMaintainerLinks.tsx
+++ b/frontend/components/projects/edit/maintainers/ProjectMaintainerLinks.tsx
@@ -1,26 +1,57 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {useState} from 'react'
 import Button from '@mui/material/Button'
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 
-import InvitationList from '~/components/maintainers/InvitationList'
+import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
 import {useProjectInvitations} from './useProjectInvitations'
 import useProjectContext from '../context/useProjectContext'
 
 export default function ProjectMaintainerLinks() {
   const {project} = useProjectContext()
   const {unusedInvitations,createInvitation,deleteInvitation} = useProjectInvitations({project:project.id})
+  // a11y feedback notifier state for dynamic list actions
+  const [notification, setNotification] = useState('')
 
   // console.group('ProjectMaintainerLinks')
   // console.log('project...', project)
   // console.log('unusedInvitations...', unusedInvitations)
   // console.groupEnd()
 
+  async function handleCreateInvitation() {
+    try {
+      setNotification('Generating new invitation link...')
+      await createInvitation()
+      setNotification('New invitation link successfully generated and added to the list below.')
+    } catch {
+      setNotification('Failed to generate invitation link. Please try again.')
+    }
+  }
+
+  async function handleDeleteInvitation(inv: Invitation) {
+    try {
+      setNotification('Deleting invitation link...')
+      await deleteInvitation(inv)
+      setNotification('Invitation link successfully deleted.')
+    } catch {
+      setNotification('Failed to delete invitation link.')
+    }
+  }
+
   return (
     <>
+      {/* Visually hidden live region to catch both generation and deletion states */}
+      <div
+        role="status"
+        aria-live="polite"
+        className="sr-only absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
+      >
+        {notification}
+      </div>
       <Button
         variant='contained'
         sx={{
@@ -28,8 +59,9 @@ export default function ProjectMaintainerLinks() {
           display: 'flex',
           alignItems: 'center'
         }}
-        startIcon={<AutoFixHighIcon />}
-        onClick={createInvitation}
+        // hide decorative icon from speech engines
+        startIcon={<AutoFixHighIcon aria-hidden="true"/>}
+        onClick={handleCreateInvitation}
       >
         Generate invite link
       </Button>
@@ -38,7 +70,7 @@ export default function ProjectMaintainerLinks() {
         subject={`Maintainer invite for project ${encodeURIComponent(project.title ?? '')}`}
         body={`Please use the following link to become a maintainer of ${encodeURIComponent(project.title ?? '')} project.`}
         invitations={unusedInvitations}
-        onDelete={deleteInvitation}
+        onDelete={handleDeleteInvitation}
       />
     </>
   )

--- a/frontend/components/projects/edit/maintainers/index.tsx
+++ b/frontend/components/projects/edit/maintainers/index.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -60,8 +60,11 @@ export default function ProjectMaintainers() {
 
   return (
     <>
-      <EditSection className='xl:grid xl:grid-cols-[1fr_1fr] xl:px-0 xl:gap-[3rem]'>
-        <div className="py-4">
+      <EditSection
+        className='xl:grid xl:grid-cols-[1fr_1fr] xl:px-0 xl:gap-[3rem]'>
+        <section
+          aria-label={`${maintainers?.length} ${config.title}`}
+          className="py-4">
           <EditSectionTitle
             title={config.title}
           />
@@ -69,14 +72,16 @@ export default function ProjectMaintainers() {
             onDelete={onDeleteMaintainer}
             maintainers={maintainers}
           />
-        </div>
-        <div className="py-4 min-w-[21rem] xl:my-0">
+        </section>
+        <section
+          aria-label={config.inviteLink.title}
+          className="py-4 xl:my-0">
           <EditSectionTitle
             title={config.inviteLink.title}
             subtitle={config.inviteLink.subtitle}
           />
           <ProjectMaintainerLinks />
-        </div>
+        </section>
       </EditSection>
       <ConfirmDeleteModal
         open={modal.open}

--- a/frontend/components/projects/edit/maintainers/useProjectInvitations.tsx
+++ b/frontend/components/projects/edit/maintainers/useProjectInvitations.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -16,6 +16,8 @@ export function useProjectInvitations({project}:{project?:string}) {
   const {showErrorMessage} = useSnackbar()
   const [unusedInvitations,setUnusedInvitations] = useState<Invitation[]>([])
   const [magicLink, setMagicLink] = useState(null)
+  // a11y feedback notifier state for dynamic list actions
+  const [notification, setNotification] = useState('')
 
   const loadUnusedInvitations = useCallback(()=>{
     // get unused invitation
@@ -42,6 +44,7 @@ export function useProjectInvitations({project}:{project?:string}) {
 
   const createInvitation = useCallback(async()=>{
     if (project && user?.account){
+      setNotification('Generating new invitation link...')
       const resp = await createMaintainerLink({
         project,
         account:user?.account,
@@ -50,10 +53,13 @@ export function useProjectInvitations({project}:{project?:string}) {
       if (resp.status===201){
         // set magic link prop to new link
         setMagicLink(resp.message)
+        // update notification
+        setNotification('New invitation link successfully generated and added to the list.')
         // reload unused invitations
         loadUnusedInvitations()
       }else{
         showErrorMessage(`Failed to create invitation. ${resp.message}`)
+        setNotification('Failed to generate invitation link. Please try again.')
       }
     }
   // IGNORE showErrorMessage dependency
@@ -61,14 +67,17 @@ export function useProjectInvitations({project}:{project?:string}) {
   },[project,user?.account,token,loadUnusedInvitations])
 
   const deleteInvitation = useCallback(async(invitation:Invitation)=>{
+    setNotification('Deleting invitation link...')
     const resp = await deleteMaintainerLink({
       invitation,
       token
     })
     if (resp.status===200){
+      setNotification('Invitation link successfully deleted.')
       loadUnusedInvitations()
     }else{
       showErrorMessage(`Failed to delete invitation. ${resp.message}`)
+      setNotification('Failed to delete invitation link.')
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   },[token,loadUnusedInvitations])
@@ -76,6 +85,7 @@ export function useProjectInvitations({project}:{project?:string}) {
   return {
     magicLink,
     unusedInvitations,
+    notification,
     deleteInvitation,
     createInvitation
   }

--- a/frontend/components/projects/edit/mentions/impact/index.tsx
+++ b/frontend/components/projects/edit/mentions/impact/index.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,7 +27,9 @@ export default function ProjectImpactTab() {
           <div className="py-2" />
           <MentionEditSection />
         </div>
-        <div className="pt-4 pb-8">
+        <section
+          aria-label={config.findMention.title}
+          className="pt-4 pb-8">
           <FindMentionSection
             id={project.id}
             config={{
@@ -40,7 +42,7 @@ export default function ProjectImpactTab() {
           />
           <BulkImportImpact/>
           <AddImpact />
-        </div>
+        </section>
       </EditSection>
     </EditImpactProvider>
   )

--- a/frontend/components/projects/edit/mentions/index.tsx
+++ b/frontend/components/projects/edit/mentions/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,7 +11,9 @@ import ProjectMentionTabs from './ProjectMentionTabs'
 export default function ProjectMentions() {
 
   return (
-    <section className="flex-1">
+    <section
+      aria-label="Project output, citations and impact"
+      className="flex-1">
       <ProjectMentionProvider>
         <ProjectMentionTabs />
       </ProjectMentionProvider>

--- a/frontend/components/projects/edit/mentions/output/index.tsx
+++ b/frontend/components/projects/edit/mentions/output/index.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -28,7 +28,9 @@ export default function ProjectOutputTab() {
           <div className="py-2" />
           <MentionEditSection />
         </div>
-        <div className="pt-4 pb-8">
+        <section
+          aria-label={config.findMention.title}
+          className="pt-4 pb-8">
           <FindMentionSection
             id={project.id}
             config={{
@@ -42,7 +44,7 @@ export default function ProjectOutputTab() {
           <ImportProjectOutput/>
           <AddOutput />
           <ScrapersInfo />
-        </div>
+        </section>
       </EditSection>
     </EditOutputProvider>
   )

--- a/frontend/components/projects/edit/organisations/config.ts
+++ b/frontend/components/projects/edit/organisations/config.ts
@@ -1,9 +1,10 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -13,7 +14,7 @@ export const cfgOrganisations = {
     title: 'Add organisation',
     subtitle: 'We search by name in the RSD and the ROR databases',
     label: 'Find or add organisation',
-    help: 'At least the first 2 letters of the organisation name',
+    help: 'Type at least first 2 letters of the organisation name',
     validation: {
       // custom validation rule, not in use by react-hook-form
       minLength: 2,

--- a/frontend/components/projects/edit/organisations/index.tsx
+++ b/frontend/components/projects/edit/organisations/index.tsx
@@ -359,7 +359,9 @@ export default function ProjectOrganisations() {
   return (
     <>
       <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
-        <section className="py-4">
+        <section
+          aria-label={`${organisations?.length} ${config.title}`}
+          className="py-4">
           <h2 className="flex pr-4 pb-4 justify-between">
             <span>{config.title}</span>
             <span>{organisations?.length}</span>
@@ -372,7 +374,9 @@ export default function ProjectOrganisations() {
             onCategory={onCategoryEdit}
           />
         </section>
-        <section className="py-4">
+        <section
+          aria-label={config.findOrganisation.title}
+          className="py-4">
           <EditSectionTitle
             title={config.findOrganisation.title}
             subtitle={config.findOrganisation.subtitle}

--- a/frontend/components/projects/edit/related-projects/RelatedProjectList.tsx
+++ b/frontend/components/projects/edit/related-projects/RelatedProjectList.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +21,7 @@ import {maxText} from '~/utils/maxText'
 import {getImageUrl} from '~/utils/editImage'
 import {OrganisationStatus} from '~/types/Organisation'
 
-type RelatedProjectProps = {
+export type RelatedProjectProps = {
   slug: string
   title: string
   subtitle: string | null

--- a/frontend/components/projects/edit/related-projects/RelatedProjectSection.tsx
+++ b/frontend/components/projects/edit/related-projects/RelatedProjectSection.tsx
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {SearchProject} from '~/types/Project'
+import EditSection from '~/components/layout/EditSection'
+import EditSectionTitle from '~/components/layout/EditSectionTitle'
+import {relatedProject as config} from './config'
+import FindRelatedProject from './FindRelatedProject'
+import RelatedProjectList, {RelatedProjectProps} from './RelatedProjectList'
+
+type RelatedProjectSectionProp=Readonly<{
+  projectId: string,
+  token: string,
+  relatedProject?: RelatedProjectProps[],
+  onRemove:(pos:number)=>void
+  onAdd: (item: SearchProject) => void
+  onCreate?: (keyword: string) => void
+}>
+
+export default function RelatedProjectSection(props:RelatedProjectSectionProp){
+  // destructure props
+  const {relatedProject,projectId,token,onRemove,onAdd,onCreate} = props
+
+  return (
+    <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
+      <section
+        aria-label={`${relatedProject?.length ?? 0} ${config.title}`}
+        className="py-4">
+        <EditSectionTitle
+          title={config.title}
+        >
+          {/* add count to title */}
+          {relatedProject && relatedProject.length > 0 ?
+            <div className="pl-4 text-2xl">{relatedProject.length}</div>
+            : null
+          }
+        </EditSectionTitle>
+        <RelatedProjectList
+          projects={relatedProject}
+          onRemove={onRemove}
+        />
+      </section>
+      <section
+        aria-label={config.findTitle}
+        className="py-4">
+        <EditSectionTitle
+          title={config.findTitle}
+          subtitle={config.findSubtitle}
+        />
+        <FindRelatedProject
+          project={projectId}
+          token={token}
+          config={{
+            freeSolo: false,
+            minLength: config.validation.minLength,
+            label: config.label,
+            help: config.help,
+            reset: true
+          }}
+          onAdd={onAdd}
+          onCreate={onCreate}
+        />
+      </section>
+    </EditSection>
+  )
+}

--- a/frontend/components/projects/edit/related-projects/index.tsx
+++ b/frontend/components/projects/edit/related-projects/index.tsx
@@ -9,19 +9,15 @@
 import {useEffect, useState} from 'react'
 
 import {useSession} from '~/auth/AuthProvider'
-import {getRelatedProjectsForProject} from '~/components/projects/apiProjects'
-import {addRelatedProject, deleteRelatedProject} from '~/components/projects/edit/apiEditProject'
 import {sortOnStrProp} from '~/utils/sortFn'
 import {extractErrorMessages} from '~/utils/fetchHelpers'
 import {ProjectStatusKey, RelatedProjectForProject, SearchProject} from '~/types/Project'
 import {OrganisationStatus} from '~/types/Organisation'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import EditSectionTitle from '~/components/layout/EditSectionTitle'
-import EditSection from '~/components/layout/EditSection'
-import {relatedProject as config} from './config'
-import FindRelatedProject from './FindRelatedProject'
+import {getRelatedProjectsForProject} from '~/components/projects/apiProjects'
+import {addRelatedProject, deleteRelatedProject} from '~/components/projects/edit/apiEditProject'
 import useProjectContext from '../context/useProjectContext'
-import RelatedProjectList from './RelatedProjectList'
+import RelatedProjectSection from './RelatedProjectSection'
 
 export default function RelatedProjectsForProject() {
   const {token} = useSession()
@@ -125,45 +121,13 @@ export default function RelatedProjectsForProject() {
   }
 
   return (
-    <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
-      <section
-        aria-label={`${relatedProject?.length ?? 0} ${config.title}`}
-        className="py-4">
-        <EditSectionTitle
-          title={config.title}
-          // subtitle={config.subtitle}
-        >
-          {/* add count to title */}
-          {relatedProject && relatedProject.length > 0 ?
-            <div className="pl-4 text-2xl">{relatedProject.length}</div>
-            : null
-          }
-        </EditSectionTitle>
-        <RelatedProjectList
-          projects={relatedProject}
-          onRemove={onRemove}
-        />
-      </section>
-      <section
-        aria-label={config.findTitle}
-        className="py-4">
-        <EditSectionTitle
-          title={config.findTitle}
-          subtitle={config.findSubtitle}
-        />
-        <FindRelatedProject
-          project={project.id}
-          token={token}
-          config={{
-            freeSolo: false,
-            minLength: config.validation.minLength,
-            label: config.label,
-            help: config.help,
-            reset: true
-          }}
-          onAdd={onAdd}
-        />
-      </section>
-    </EditSection>
+    <RelatedProjectSection
+      projectId={project.id}
+      token={token}
+      relatedProject={relatedProject}
+      onRemove={onRemove}
+      onAdd={onAdd}
+    />
   )
+
 }

--- a/frontend/components/projects/edit/related-projects/index.tsx
+++ b/frontend/components/projects/edit/related-projects/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -126,7 +126,9 @@ export default function RelatedProjectsForProject() {
 
   return (
     <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
-      <section className="py-4">
+      <section
+        aria-label={`${relatedProject?.length ?? 0} ${config.title}`}
+        className="py-4">
         <EditSectionTitle
           title={config.title}
           // subtitle={config.subtitle}
@@ -142,7 +144,9 @@ export default function RelatedProjectsForProject() {
           onRemove={onRemove}
         />
       </section>
-      <section className="py-4">
+      <section
+        aria-label={config.findTitle}
+        className="py-4">
         <EditSectionTitle
           title={config.findTitle}
           subtitle={config.findSubtitle}

--- a/frontend/components/projects/edit/related-software/RelatedSoftwareList.tsx
+++ b/frontend/components/projects/edit/related-software/RelatedSoftwareList.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -20,7 +20,7 @@ import LockIcon from '@mui/icons-material/Lock'
 import {maxText} from '~/utils/maxText'
 import {OrganisationStatus} from '~/types/Organisation'
 
-type SoftwareItem = {
+export type RelatedSoftwareProps = {
   id: string
   slug: string
   brand_name: string
@@ -29,12 +29,12 @@ type SoftwareItem = {
 }
 
 type SoftwareListProps = {
-  software: SoftwareItem[] | undefined
+  software: RelatedSoftwareProps[] | undefined
   onRemove:(pos:number)=>void
 }
 
 type SoftwareItemProps = {
-  software: SoftwareItem
+  software: RelatedSoftwareProps
   onDelete:()=>void
 }
 

--- a/frontend/components/projects/edit/related-software/RelatedSoftwareSection.tsx
+++ b/frontend/components/projects/edit/related-software/RelatedSoftwareSection.tsx
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import {SearchSoftware} from '~/types/SoftwareTypes'
+import EditSectionTitle from '~/components/layout/EditSectionTitle'
+import EditSection from '~/components/layout/EditSection'
+import {relatedSoftware as config} from '~/components/software/edit/related-software/config'
+import FindRelatedSoftware from './FindRelatedSoftware'
+import RelatedSoftwareList,{RelatedSoftwareProps} from './RelatedSoftwareList'
+
+type RelatedSoftwareSectionProp=Readonly<{
+  softwareId: string,
+  token: string,
+  relatedSoftware?: RelatedSoftwareProps[],
+  onRemove:(pos:number)=>void
+  onAdd: (item: SearchSoftware) => void
+  onCreate?: (keyword: string) => void
+}>
+
+export default function RelatedSoftwareSection(props:RelatedSoftwareSectionProp){
+  // destructure props
+  const {relatedSoftware,softwareId,token,onRemove,onAdd,onCreate} = props
+
+  return (
+    <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
+      <section
+        aria-label={`${relatedSoftware?.length ?? 0} ${config.title}`}
+        className="py-4">
+        <EditSectionTitle
+          title={config.title}
+        >
+          {/* add count to title */}
+          {relatedSoftware && relatedSoftware.length > 0 ?
+            <div className="pl-4 text-2xl">{relatedSoftware.length}</div>
+            : null
+          }
+        </EditSectionTitle>
+        <RelatedSoftwareList
+          software={relatedSoftware}
+          onRemove={onRemove}
+        />
+      </section>
+      <section
+        aria-label={config.findTitle}
+        className="py-4">
+        <EditSectionTitle
+          title={config.findTitle}
+          subtitle={config.findSubTitle}
+        />
+        <FindRelatedSoftware
+          software={softwareId}
+          token={token}
+          config={{
+            freeSolo: false,
+            minLength: config.validation.minLength,
+            label: config.label,
+            help: config.help,
+            reset: true
+          }}
+          onAdd={onAdd}
+          onCreate={onCreate}
+        />
+      </section>
+    </EditSection>
+  )
+}

--- a/frontend/components/projects/edit/related-software/index.tsx
+++ b/frontend/components/projects/edit/related-software/index.tsx
@@ -15,12 +15,8 @@ import {sortOnStrProp} from '~/utils/sortFn'
 import {RelatedSoftwareOfProject, SearchSoftware} from '~/types/SoftwareTypes'
 import {OrganisationStatus} from '~/types/Organisation'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import EditSectionTitle from '~/components/layout/EditSectionTitle'
-import EditSection from '~/components/layout/EditSection'
-import FindRelatedSoftware from './FindRelatedSoftware'
-import {relatedSoftware as config} from '~/components/software/edit/related-software/config'
 import useProjectContext from '../context/useProjectContext'
-import RelatedSoftwareList from './RelatedSoftwareList'
+import RelatedSoftwareSection from './RelatedSoftwareSection'
 
 export default function RelatedSoftwareForProject() {
   const {token} = useSession()
@@ -107,45 +103,13 @@ export default function RelatedSoftwareForProject() {
   }
 
   return (
-    <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
-      <section
-        aria-label={`${relatedSoftware?.length ?? 0} ${config.title}`}
-        className="py-4">
-        <EditSectionTitle
-          title={config.title}
-          // subtitle={config.subtitle}
-        >
-          {/* add count to title */}
-          {relatedSoftware && relatedSoftware.length > 0 ?
-            <div className="pl-4 text-2xl">{relatedSoftware.length}</div>
-            : null
-          }
-        </EditSectionTitle>
-        <RelatedSoftwareList
-          software={relatedSoftware}
-          onRemove={onRemove}
-        />
-      </section>
-      <section
-        aria-label={config.findTitle}
-        className="py-4">
-        <EditSectionTitle
-          title={config.findTitle}
-          subtitle={config.findSubTitle}
-        />
-        <FindRelatedSoftware
-          software={''}
-          token={token}
-          config={{
-            freeSolo: false,
-            minLength: config.validation.minLength,
-            label: config.label,
-            help: config.help,
-            reset: true
-          }}
-          onAdd={onAdd}
-        />
-      </section>
-    </EditSection>
+    <RelatedSoftwareSection
+      softwareId=''
+      token={token}
+      relatedSoftware={relatedSoftware}
+      onAdd={onAdd}
+      onRemove={onRemove}
+    />
   )
+
 }

--- a/frontend/components/projects/edit/related-software/index.tsx
+++ b/frontend/components/projects/edit/related-software/index.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -108,7 +108,9 @@ export default function RelatedSoftwareForProject() {
 
   return (
     <EditSection className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
-      <section className="py-4">
+      <section
+        aria-label={`${relatedSoftware?.length ?? 0} ${config.title}`}
+        className="py-4">
         <EditSectionTitle
           title={config.title}
           // subtitle={config.subtitle}
@@ -124,7 +126,9 @@ export default function RelatedSoftwareForProject() {
           onRemove={onRemove}
         />
       </section>
-      <section className="py-4">
+      <section
+        aria-label={config.findTitle}
+        className="py-4">
         <EditSectionTitle
           title={config.findTitle}
           subtitle={config.findSubTitle}

--- a/frontend/components/projects/edit/team/config.ts
+++ b/frontend/components/projects/edit/team/config.ts
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2022 - 2024 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 - 2025 dv4all
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -18,7 +18,7 @@ export const cfgTeamMembers = {
       return 'We search by name or ORCID in RSD database'
     },
     label: 'Find or add team member',
-    help: 'At least 2 letters, use pattern {First name} {Last name} or 0000-0000-0000-0000',
+    help: 'Type at least 2 letters, use first, last name or ORCID iD',
     validation: {
       // custom validation rule, not in use by react-hook-form
       minLength: 2,

--- a/frontend/components/projects/edit/team/index.tsx
+++ b/frontend/components/projects/edit/team/index.tsx
@@ -179,8 +179,11 @@ export default function ProjectTeam() {
 
   return (
     <>
-      <EditSection className='md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]'>
-        <div className="py-4">
+      <EditSection
+        className='md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]'>
+        <section
+          aria-label={`${members?.length} ${cfgTeamMembers.title}`}
+          className="py-4">
           <h2 className="flex pr-4 pb-4 justify-between">
             <span>{cfgTeamMembers.title}</span>
             <span>{members?.length}</span>
@@ -191,8 +194,10 @@ export default function ProjectTeam() {
             onDelete={onDeleteMember}
             onSorted={sortedMembers}
           />
-        </div>
-        <div className="py-4 min-w-[21rem] xl:my-0">
+        </section>
+        <section
+          aria-label={cfgTeamMembers.find.title}
+          className="py-4 min-w-[21rem] xl:my-0">
           <EditSectionTitle
             title={cfgTeamMembers.find.title}
             subtitle={cfgTeamMembers.find.subtitle(host?.orcid_search)}
@@ -211,7 +216,7 @@ export default function ProjectTeam() {
             }}
           />
           <ContributorPrivacyHint />
-        </div>
+        </section>
       </EditSection>
 
       {modal.edit.open && modal.edit.member ?

--- a/frontend/components/projects/edit/testimonials/index.tsx
+++ b/frontend/components/projects/edit/testimonials/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -135,7 +135,9 @@ export default function ProjectTestimonials() {
   )
 
   return (
-    <section className="flex-1">
+    <section
+      aria-label="Testimonials"
+      className="flex-1">
       <EditSection>
         <div className="py-4">
           <EditSectionTitle

--- a/frontend/components/projects/overview/search/ProjectSearchSection.tsx
+++ b/frontend/components/projects/overview/search/ProjectSearchSection.tsx
@@ -15,10 +15,12 @@ import {useUserSettings} from '~/config/UserSettingsContext'
 import {getPageRange} from '~/utils/pagination'
 import useSmallScreen from '~/config/useSmallScreen'
 import useHandleQueryChange from '~/utils/useHandleQueryChange'
-import SearchInput from '~/components/search/SearchInput'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 import FiltersModal from '~/components/filter/FiltersModal'
+import SearchInput from '~/components/search/SearchInput'
 import ToggleViewGroup from '~/components/search/ToggleViewGroup'
 import ShowItemsSelect from '~/components/search/ShowItemsSelect'
+import {searchOverviewMsg} from '~/components/search/searchOverviewMsg'
 import useProjectParams from '~/components/projects/overview/useProjectParams'
 
 type SearchSectionProps = {
@@ -35,7 +37,14 @@ export default function ProjectSearchSection({
   const {handleQueryChange} = useHandleQueryChange()
   const [modal, setModal] = useState(false)
 
-  const placeholder = filterCnt > 0 ? 'Find within selection' : 'Find project'
+  const {placeholder,announcement} = searchOverviewMsg({
+    name: 'project items',
+    count,
+    page,
+    rows,
+    filterCnt,
+    search
+  })
 
   // console.group('ProjectSearchSection')
   // console.log('page...', page)
@@ -47,6 +56,8 @@ export default function ProjectSearchSection({
     <section
       aria-label="Find project"
       data-testid="search-section">
+      {/* a11y screen reader announcer */}
+      <StatusForReaders message={announcement} />
       <div className="flex border rounded-md shadow-xs bg-base-100 p-2">
         <SearchInput
           placeholder={placeholder}

--- a/frontend/components/search/searchOverviewMsg.ts
+++ b/frontend/components/search/searchOverviewMsg.ts
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+type SearchOverviewMsg={
+  name: string
+  count: number
+  page: number
+  rows: number
+  filterCnt: number
+  search?: string | null
+}
+export function searchOverviewMsg({name,count,page,rows,search,filterCnt}:SearchOverviewMsg){
+
+  let announcement = `${count} ${name}. Page ${page} of ${Math.ceil(count / rows)}. ${rows} items per page.`
+  let placeholder = `Find ${name.split(' ')[0]}`
+
+  if (search) {
+    announcement += ` Filtered by search term ${search}.`
+  }
+
+  if (filterCnt > 0) {
+    announcement += ` ${filterCnt} filters active.`
+    placeholder = 'Find within selection'
+  }
+
+  return {
+    placeholder,
+    announcement
+  }
+}

--- a/frontend/components/software/edit/communities/config.ts
+++ b/frontend/components/software/edit/communities/config.ts
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +9,7 @@ export const cfg = {
     title: 'Join community',
     subtitle: 'We search by community name in the RSD',
     label: 'Find RSD community',
-    help: 'At least the first 2 letters of the community name',
+    help: 'Type at least first 2 letters of the community name',
     validation: {
       // custom validation rule, not in use by react-hook-form
       minLength: 2,

--- a/frontend/components/software/edit/contributors/index.tsx
+++ b/frontend/components/software/edit/contributors/index.tsx
@@ -33,6 +33,7 @@ import useSoftwareContext from '../context/useSoftwareContext'
 import GetContributorsFromDoi from './GetContributorsFromDoi'
 import useSoftwareContributors from './useSoftwareContributors'
 import SortableContributorsList from './SortableContributorsList'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 
 type EditContributorModal = ModalProps & {
   contributor?: Person
@@ -43,8 +44,8 @@ export default function EditSoftwareContributors() {
   const {software} = useSoftwareContext()
   const {showInfoMessage} = useSnackbar()
   const {
-    loading,contributors,addContributor,
-    updateContributor,deleteContributor,
+    loading,contributors,notification,
+    addContributor,updateContributor,deleteContributor,
     sortedContributors, setContributors
   } = useSoftwareContributors()
   const [modal, setModal] = useState<ModalStates<EditContributorModal>>({
@@ -62,6 +63,7 @@ export default function EditSoftwareContributors() {
   // console.log('loading...', loading)
   // console.log('orcid...', orcid)
   // console.log('options...', options)
+  // console.log('notification...', notification)
   // console.groupEnd()
 
   function hideModals() {
@@ -186,6 +188,7 @@ export default function EditSoftwareContributors() {
       <EditSection
         className='md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]'
       >
+        <StatusForReaders message={notification}/>
         <section
           aria-label={`${contributors?.length ?? 0} contributors`}
           className="py-4"

--- a/frontend/components/software/edit/contributors/useSoftwareContributors.tsx
+++ b/frontend/components/software/edit/contributors/useSoftwareContributors.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -63,6 +63,7 @@ export default function useSoftwareContributors() {
   const [contributors, setContributors] = useState<Contributor[]>([])
   const [loading, setLoading] = useState(true)
   const [loadedSoftware, setLoadedSoftware] = useState<string>('')
+  const [notification, setNotification] = useState<string>('')
 
   const addContributor = useCallback(async(person:FormPerson)=>{
     if (software.id){
@@ -85,7 +86,7 @@ export default function useSoftwareContributors() {
       const contributor = {
         ...getPropsFromObject(person,PersonProps,true),
         software: software.id
-      }
+      } as Contributor
       // new contributor to add
       const resp = await postContributor({
         contributor,
@@ -109,8 +110,10 @@ export default function useSoftwareContributors() {
           ]
           setContributors(newList)
         }
+        setNotification(`${contributor.given_names} added to contributors list.`)
       } else {
         showErrorMessage(`Failed to add contributor. ${resp.message}`)
+        setNotification('Failed to add contributor. Try again later.')
       }
     }
   // ignore showErrorMessage as dependency
@@ -156,8 +159,10 @@ export default function useSoftwareContributors() {
       if (resp.status === 200) {
         const newList = resetContactPersons(contributor,contributors,token)
         setContributors(newList)
+        setNotification(`${contributor.given_names} successfully updated.`)
       } else {
         showErrorMessage(`Failed to update contributor. ${resp.message}`)
+        setNotification('Failed to update contributor. Try again later.')
       }
     }
   // ignore showErrorMessage as dependency
@@ -180,9 +185,11 @@ export default function useSoftwareContributors() {
         setContributors(oldList)
         // show error message
         showErrorMessage(`Failed to update contributor positions. ${resp.message}`)
+        setNotification('Failed to update contributor positions. Try again later.')
       }
     } else {
       setContributors([])
+      setNotification('Contributor position in the list successfully changed.')
     }
   // ignore showErrorMessage as dependency
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -208,8 +215,10 @@ export default function useSoftwareContributors() {
           .sort((a,b)=>sortOnNumProp(a,b,'position'))
         // now patch the positions
         sortedContributors(newList)
+        setNotification(`${contributor.given_names} removed from contributors`)
       } else {
         showErrorMessage(`Failed to remove ${getDisplayName(contributor)}. Error: ${resp.message}`)
+        setNotification(`Failed to remove ${contributor.given_names}. Try again later.`)
       }
       // try to remove member avatar
       // without waiting for result
@@ -221,6 +230,7 @@ export default function useSoftwareContributors() {
       }
     } else {
       showErrorMessage(`Failed to remove ${getDisplayName(contributor)}. Error: contributor id missing`)
+      setNotification(`Failed to remove ${contributor.given_names}. Try again later.`)
     }
   // ignore showErrorMessage as dependency
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -239,6 +249,7 @@ export default function useSoftwareContributors() {
       setContributors(data ?? [])
       setLoadedSoftware(software)
       setLoading(false)
+      setNotification(`Contributors list loaded. List contains ${data?.length} items.`)
     }
     if (software?.id && token &&
       software.id !== loadedSoftware) {
@@ -250,6 +261,7 @@ export default function useSoftwareContributors() {
   return {
     loading,
     contributors,
+    notification,
     addContributor,
     updateContributor,
     deleteContributor,

--- a/frontend/components/software/edit/contributors/useSoftwareContributors.tsx
+++ b/frontend/components/software/edit/contributors/useSoftwareContributors.tsx
@@ -12,6 +12,8 @@ import {Contributor, PatchContributor, PersonProps} from '~/types/Contributor'
 import {deleteImage, saveBase64Image} from '~/utils/editImage'
 import {getDisplayName} from '~/utils/getDisplayName'
 import {sortOnNumProp} from '~/utils/sortFn'
+import {getPropsFromObject} from '~/utils/getPropsFromObject'
+import {ScreenReaderMessage} from '~/components/a11y/StatusForReaders'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import useSoftwareContext from '../context/useSoftwareContext'
 import {
@@ -20,7 +22,6 @@ import {
   deleteContributorsById
 } from './apiContributors'
 import {FormPerson} from '~/components/person/AggregatedPersonModal'
-import {getPropsFromObject} from '~/utils/getPropsFromObject'
 
 /**
  * Replace contributor item and reset contact person flag on other items in the list
@@ -63,7 +64,7 @@ export default function useSoftwareContributors() {
   const [contributors, setContributors] = useState<Contributor[]>([])
   const [loading, setLoading] = useState(true)
   const [loadedSoftware, setLoadedSoftware] = useState<string>('')
-  const [notification, setNotification] = useState<string>('')
+  const [notification, setNotification] = useState<ScreenReaderMessage>('')
 
   const addContributor = useCallback(async(person:FormPerson)=>{
     if (software.id){
@@ -110,10 +111,16 @@ export default function useSoftwareContributors() {
           ]
           setContributors(newList)
         }
-        setNotification(`${contributor.given_names} added to contributors list.`)
+        setNotification({
+          prio: 'assertive',
+          text: `${contributor.given_names} added to contributors list.`
+        })
       } else {
         showErrorMessage(`Failed to add contributor. ${resp.message}`)
-        setNotification('Failed to add contributor. Try again later.')
+        setNotification({
+          prio: 'assertive',
+          text: 'Failed to add contributor. Try again later.'
+        })
       }
     }
   // ignore showErrorMessage as dependency
@@ -187,9 +194,9 @@ export default function useSoftwareContributors() {
         showErrorMessage(`Failed to update contributor positions. ${resp.message}`)
         setNotification('Failed to update contributor positions. Try again later.')
       }
+      setNotification('Contributor position in the list successfully changed.')
     } else {
       setContributors([])
-      setNotification('Contributor position in the list successfully changed.')
     }
   // ignore showErrorMessage as dependency
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/components/software/edit/editSoftwareConfig.tsx
+++ b/frontend/components/software/edit/editSoftwareConfig.tsx
@@ -104,7 +104,7 @@ export const contributorInformation = {
       return 'We search by name or ORCID in RSD database'
     },
     label: 'Find or add contributor',
-    help: 'At least 2 letters, use pattern {First name} {Last name} or 0000-0000-0000-0000',
+    help: 'Type at least 2 letters, use first name, last name or ORCID iD',
     validation: {
       // custom validation rule, not in use by react-hook-form
       minLength: 2,
@@ -130,7 +130,7 @@ export const organisationInformation = {
     title: 'Add organisation',
     subtitle: 'We search by name in the RSD and the ROR databases',
     label: 'Find or add organisation',
-    help: 'At least the first 2 letters of the organisation name',
+    help: 'Type at least first 2 letters of the organisation name',
     validation: {
       // custom validation rule, not in use by react-hook-form
       minLength: 2,

--- a/frontend/components/software/edit/maintainers/SoftwareMaintainerLinks.tsx
+++ b/frontend/components/software/edit/maintainers/SoftwareMaintainerLinks.tsx
@@ -3,78 +3,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {useState} from 'react'
-import Button from '@mui/material/Button'
-import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
-
-import StatusForReaders from '~/components/a11y/StatusForReaders'
-import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
+import GenerateInviteLink from '~/components/maintainers/GenerateInviteLink'
 import useSoftwareContext from '~/components/software/edit/context/useSoftwareContext'
 import {useSoftwareInvitations} from './useSoftwareInvitations'
 
 export default function SoftwareMaintainerLinks() {
   const {software} = useSoftwareContext()
-  const {unusedInvitations,createInvitation,deleteInvitation} = useSoftwareInvitations({software:software.id})
-  // a11y feedback notifier state for dynamic list actions
-  const [notification, setNotification] = useState('')
-
-  // console.group('ProjectMaintainerLinks')
-  // console.log('project...', project)
-  // console.log('unusedInvitations...', unusedInvitations)
-  // console.groupEnd()
-
-  async function handleCreateInvitation() {
-    try {
-      setNotification('Generating new invitation link...')
-      await createInvitation()
-      setNotification('New invitation link successfully generated and added to the list below.')
-    } catch {
-      setNotification('Failed to generate invitation link. Please try again.')
-    }
-  }
-
-  async function handleDeleteInvitation(inv: Invitation) {
-    try {
-      setNotification('Deleting invitation link...')
-      await deleteInvitation(inv)
-      setNotification('Invitation link successfully deleted.')
-    } catch {
-      setNotification('Failed to delete invitation link.')
-    }
-  }
-
-  // console.group('SoftwareMaintainerLinks')
-  // console.log('software...', software)
-  // console.log('magicLink...', magicLink)
-  // console.log('unusedInvitations...', unusedInvitations)
-  // console.groupEnd()
+  const {unusedInvitations,notification,createInvitation,deleteInvitation} = useSoftwareInvitations({software:software.id})
 
   return (
-    <>
-      {/* a11y screen reader announcer */}
-      <StatusForReaders
-        message={notification}
-        className="absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
-      />
-      <Button
-        variant='contained'
-        sx={{
-          margin: '1rem 0rem',
-          display: 'flex',
-          alignItems: 'center'
-        }}
-        startIcon={<AutoFixHighIcon aria-hidden="true"/>}
-        onClick={handleCreateInvitation}
-      >
-        Generate invite link
-      </Button>
-      <div className="py-4"></div>
-      <InvitationList
-        subject={`Maintainer invite for software ${encodeURIComponent(software.brand_name ?? '')}`}
-        body={`Please use the following link to become a maintainer of ${encodeURIComponent(software.brand_name ?? '')} software.`}
-        invitations={unusedInvitations}
-        onDelete={handleDeleteInvitation}
-      />
-    </>
+    <GenerateInviteLink
+      email={{
+        subject: `Maintainer invite for software ${encodeURIComponent(software.brand_name ?? '')}`,
+        body: `Please use the following link to become a maintainer of ${encodeURIComponent(software.brand_name ?? '')} software.`
+      }}
+      notification={notification}
+      invitations={unusedInvitations}
+      createInvitation={createInvitation}
+      deleteInvitation={deleteInvitation}
+    />
   )
 }

--- a/frontend/components/software/edit/maintainers/SoftwareMaintainerLinks.tsx
+++ b/frontend/components/software/edit/maintainers/SoftwareMaintainerLinks.tsx
@@ -7,6 +7,7 @@ import {useState} from 'react'
 import Button from '@mui/material/Button'
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 
+import StatusForReaders from '~/components/a11y/StatusForReaders'
 import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
 import useSoftwareContext from '~/components/software/edit/context/useSoftwareContext'
 import {useSoftwareInvitations} from './useSoftwareInvitations'
@@ -50,14 +51,11 @@ export default function SoftwareMaintainerLinks() {
 
   return (
     <>
-      {/* Visually hidden live region to catch both generation and deletion states */}
-      <div
-        role="status"
-        aria-live="polite"
-        className="sr-only absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
-      >
-        {notification}
-      </div>
+      {/* a11y screen reader announcer */}
+      <StatusForReaders
+        message={notification}
+        className="absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
+      />
       <Button
         variant='contained'
         sx={{

--- a/frontend/components/software/edit/maintainers/SoftwareMaintainerLinks.tsx
+++ b/frontend/components/software/edit/maintainers/SoftwareMaintainerLinks.tsx
@@ -1,18 +1,46 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
+import {useState} from 'react'
 import Button from '@mui/material/Button'
 import AutoFixHighIcon from '@mui/icons-material/AutoFixHigh'
 
-import InvitationList from '~/components/maintainers/InvitationList'
-import useSoftwareContext from '../context/useSoftwareContext'
+import InvitationList, {Invitation} from '~/components/maintainers/InvitationList'
+import useSoftwareContext from '~/components/software/edit/context/useSoftwareContext'
 import {useSoftwareInvitations} from './useSoftwareInvitations'
 
 export default function SoftwareMaintainerLinks() {
   const {software} = useSoftwareContext()
   const {unusedInvitations,createInvitation,deleteInvitation} = useSoftwareInvitations({software:software.id})
+  // a11y feedback notifier state for dynamic list actions
+  const [notification, setNotification] = useState('')
+
+  // console.group('ProjectMaintainerLinks')
+  // console.log('project...', project)
+  // console.log('unusedInvitations...', unusedInvitations)
+  // console.groupEnd()
+
+  async function handleCreateInvitation() {
+    try {
+      setNotification('Generating new invitation link...')
+      await createInvitation()
+      setNotification('New invitation link successfully generated and added to the list below.')
+    } catch {
+      setNotification('Failed to generate invitation link. Please try again.')
+    }
+  }
+
+  async function handleDeleteInvitation(inv: Invitation) {
+    try {
+      setNotification('Deleting invitation link...')
+      await deleteInvitation(inv)
+      setNotification('Invitation link successfully deleted.')
+    } catch {
+      setNotification('Failed to delete invitation link.')
+    }
+  }
 
   // console.group('SoftwareMaintainerLinks')
   // console.log('software...', software)
@@ -22,6 +50,14 @@ export default function SoftwareMaintainerLinks() {
 
   return (
     <>
+      {/* Visually hidden live region to catch both generation and deletion states */}
+      <div
+        role="status"
+        aria-live="polite"
+        className="sr-only absolute w-px h-px p-0 -m-px overflow-hidden clip whitespace-nowrap border-0"
+      >
+        {notification}
+      </div>
       <Button
         variant='contained'
         sx={{
@@ -29,8 +65,8 @@ export default function SoftwareMaintainerLinks() {
           display: 'flex',
           alignItems: 'center'
         }}
-        startIcon={<AutoFixHighIcon />}
-        onClick={createInvitation}
+        startIcon={<AutoFixHighIcon aria-hidden="true"/>}
+        onClick={handleCreateInvitation}
       >
         Generate invite link
       </Button>
@@ -39,7 +75,7 @@ export default function SoftwareMaintainerLinks() {
         subject={`Maintainer invite for software ${encodeURIComponent(software.brand_name ?? '')}`}
         body={`Please use the following link to become a maintainer of ${encodeURIComponent(software.brand_name ?? '')} software.`}
         invitations={unusedInvitations}
-        onDelete={deleteInvitation}
+        onDelete={handleDeleteInvitation}
       />
     </>
   )

--- a/frontend/components/software/edit/maintainers/index.tsx
+++ b/frontend/components/software/edit/maintainers/index.tsx
@@ -61,7 +61,9 @@ export default function EditSoftwareMaintainers() {
       <EditSection
         aria-label={config.title}
         className='xl:grid xl:grid-cols-[1fr_1fr] xl:px-0 xl:gap-[3rem]'>
-        <div className="py-4">
+        <section
+          aria-label={`${maintainers?.length} ${config.title}`}
+          className="py-4">
           <EditSectionTitle
             title={config.title}
           />
@@ -69,10 +71,10 @@ export default function EditSoftwareMaintainers() {
             onDelete={onDeleteMaintainer}
             maintainers={maintainers}
           />
-        </div>
+        </section>
         <section
           aria-label={config.inviteLink.title}
-          className="py-4 min-w-[21rem] xl:my-0">
+          className="py-4 xl:my-0">
           <EditSectionTitle
             title={config.inviteLink.title}
             subtitle={config.inviteLink.subtitle}

--- a/frontend/components/software/edit/maintainers/useSoftwareInvitations.tsx
+++ b/frontend/components/software/edit/maintainers/useSoftwareInvitations.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -15,7 +15,8 @@ export function useSoftwareInvitations({software}:{software?:string}) {
   const {token,user} = useSession()
   const {showErrorMessage} = useSnackbar()
   const [unusedInvitations,setUnusedInvitations] = useState<Invitation[]>([])
-  // const [magicLink, setMagicLink] = useState(null)
+  // a11y feedback notifier state for dynamic list actions
+  const [notification, setNotification] = useState('')
 
   const loadUnusedInvitations = useCallback(()=>{
     // get unused invitation
@@ -48,10 +49,13 @@ export function useSoftwareInvitations({software}:{software?:string}) {
         token
       })
       if (resp.status===201){
+        // update notification
+        setNotification('New invitation link successfully generated and added to the list.')
         // reload unused invitation list
         loadUnusedInvitations()
       }else{
         showErrorMessage(`Failed to create invitation. ${resp.message}`)
+        setNotification('Failed to generate invitation link. Please try again.')
       }
     }
   // IGNORE showErrorMessage dependency
@@ -64,15 +68,18 @@ export function useSoftwareInvitations({software}:{software?:string}) {
       token
     })
     if (resp.status===200){
+      setNotification('Invitation link successfully deleted.')
       loadUnusedInvitations()
     }else{
       showErrorMessage(`Failed to delete invitation. ${resp.message}`)
+      setNotification('Failed to delete invitation link.')
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
   },[token,loadUnusedInvitations])
 
   return {
     unusedInvitations,
+    notification,
     deleteInvitation,
     createInvitation
   }

--- a/frontend/components/software/edit/mentions/output/index.tsx
+++ b/frontend/components/software/edit/mentions/output/index.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,7 +27,9 @@ export default function SoftwareOutputTab() {
           <div className="py-2" />
           <MentionEditSection />
         </div>
-        <div className="pt-4 pb-8">
+        <section
+          aria-label={config.findMention.title}
+          className="pt-4 pb-8">
           <FindMentionSection
             id={software.id}
             config={{
@@ -40,7 +42,7 @@ export default function SoftwareOutputTab() {
           />
           <ImportRelatedOutput/>
           <AddRelatedOutput />
-        </div>
+        </section>
       </EditSection>
     </EditRelatedOutputProvider>
   )

--- a/frontend/components/software/edit/mentions/reference-papers/index.tsx
+++ b/frontend/components/software/edit/mentions/reference-papers/index.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,7 +23,9 @@ export default function ReferencePapersTab() {
           <div className="py-2" />
           <MentionEditSection />
         </div>
-        <div className="pt-4 pb-8">
+        <section
+          aria-label={config.findMention.title}
+          className="pt-4 pb-8">
           <FindMentionSection
             id={software.id}
             config={{
@@ -35,7 +37,7 @@ export default function ReferencePapersTab() {
             findPublicationByTitle={findPublicationByTitle}
           />
           <ScrapersInfo />
-        </div>
+        </section>
       </EditSection>
     </EditReferencePapersProvider>
   )

--- a/frontend/components/software/edit/organisations/FindOrganisationItem.tsx
+++ b/frontend/components/software/edit/organisations/FindOrganisationItem.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2023 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,7 +23,7 @@ export default function FindOrganisationItem({...org}:FindOrganisationItemProps)
   }
 
   return (
-    <article
+    <div
       // information used by e2e tests
       data-testid="organisation-list-item"
       // information used by e2e tests
@@ -40,13 +41,13 @@ export default function FindOrganisationItem({...org}:FindOrganisationItemProps)
         }
         {
           org.website &&
-          <div>{org.website}</div>
+          <div aria-label={`website ${org.website}`}>{org.website}</div>
         }
         {
           org.ror_id &&
-          <div>{org.ror_id}</div>
+          <div aria-label={'ror id ${org.ror_id}'}>{org.ror_id}</div>
         }
       </div>
-    </article>
+    </div>
   )
 }

--- a/frontend/components/software/edit/related-projects/index.tsx
+++ b/frontend/components/software/edit/related-projects/index.tsx
@@ -15,11 +15,7 @@ import {sortOnStrProp} from '~/utils/sortFn'
 import {OrganisationStatus} from '~/types/Organisation'
 import {SearchProject} from '~/types/Project'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import FindRelatedProject from '~/components/projects/edit/related-projects/FindRelatedProject'
-import EditSectionTitle from '~/components/layout/EditSectionTitle'
-import RelatedProjectList from '~/components/projects/edit/related-projects/RelatedProjectList'
-import EditSection from '~/components/layout/EditSection'
-import {relatedProject as config} from '~/components/projects/edit/related-projects/config'
+import RelatedProjectSection from '~/components/projects/edit/related-projects/RelatedProjectSection'
 import useSoftwareContext from '../context/useSoftwareContext'
 
 export default function RelatedProjectsForSoftware() {
@@ -104,46 +100,13 @@ export default function RelatedProjectsForSoftware() {
   }
 
   return (
-    <EditSection
-      className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
-      <section
-        aria-label={`${relatedProject?.length ?? 0} ${config.title}`}
-        className="py-4">
-        <EditSectionTitle
-          title={config.title}
-          // subtitle={config.subtitle}
-        >
-          {/* add count to title */}
-          {relatedProject && relatedProject.length > 0 ?
-            <div className="pl-4 text-2xl">{relatedProject.length}</div>
-            : null
-          }
-        </EditSectionTitle>
-        <RelatedProjectList
-          projects={relatedProject}
-          onRemove={onRemove}
-        />
-      </section>
-      <section
-        aria-label={config.findTitle}
-        className="py-4">
-        <EditSectionTitle
-          title={config.findTitle}
-          subtitle={config.findSubtitle}
-        />
-        <FindRelatedProject
-          project={''}
-          token={token}
-          config={{
-            freeSolo: false,
-            minLength: config.validation.minLength,
-            label: config.label,
-            help: config.help,
-            reset: true
-          }}
-          onAdd={onAdd}
-        />
-      </section>
-    </EditSection>
+    <RelatedProjectSection
+      projectId={''}
+      token={token}
+      relatedProject={relatedProject}
+      onRemove={onRemove}
+      onAdd={onAdd}
+    />
   )
+
 }

--- a/frontend/components/software/edit/related-projects/index.tsx
+++ b/frontend/components/software/edit/related-projects/index.tsx
@@ -105,9 +105,10 @@ export default function RelatedProjectsForSoftware() {
 
   return (
     <EditSection
-      aria-label={config.title}
       className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
-      <section className="py-4">
+      <section
+        aria-label={`${relatedProject?.length ?? 0} ${config.title}`}
+        className="py-4">
         <EditSectionTitle
           title={config.title}
           // subtitle={config.subtitle}

--- a/frontend/components/software/edit/related-software/index.tsx
+++ b/frontend/components/software/edit/related-software/index.tsx
@@ -14,13 +14,8 @@ import {addRelatedSoftware, deleteRelatedSoftware, getRelatedSoftwareForSoftware
 import {RelatedSoftwareOfSoftware, SearchSoftware} from '~/types/SoftwareTypes'
 import {OrganisationStatus} from '~/types/Organisation'
 import useSnackbar from '~/components/snackbar/useSnackbar'
-import FindRelatedSoftware from '~/components/projects/edit/related-software/FindRelatedSoftware'
-import RelatedSoftwareList from '~/components/projects/edit/related-software/RelatedSoftwareList'
-import EditSectionTitle from '~/components/layout/EditSectionTitle'
-import EditSection from '~/components/layout/EditSection'
+import RelatedSoftwareSection from '~/components/projects/edit/related-software/RelatedSoftwareSection'
 import useSoftwareContext from '../context/useSoftwareContext'
-import {relatedSoftware as config} from './config'
-
 
 export default function RelatedSoftwareForSoftware() {
   const {token} = useSession()
@@ -110,45 +105,13 @@ export default function RelatedSoftwareForSoftware() {
   }
 
   return (
-    <EditSection
-      aria-label={config.title}
-      className="flex-1 md:flex md:flex-col-reverse md:justify-end xl:grid xl:grid-cols-[3fr_2fr] xl:px-0 xl:gap-[3rem]">
-      <section className="py-4">
-        <EditSectionTitle
-          title={config.title}
-        // subtitle={config.subtitle}
-        >
-          {/* add count to title */}
-          {relatedSoftware && relatedSoftware.length > 0 ?
-            <div className="pl-4 text-2xl">{relatedSoftware.length}</div>
-            : null
-          }
-        </EditSectionTitle>
-        <RelatedSoftwareList
-          software={relatedSoftware}
-          onRemove={onRemove}
-        />
-      </section>
-      <section
-        aria-label={config.findTitle}
-        className="py-4">
-        <EditSectionTitle
-          title={config.findTitle}
-          subtitle={config.findSubTitle}
-        />
-        <FindRelatedSoftware
-          software={software.id ?? ''}
-          token={token}
-          config={{
-            freeSolo: false,
-            minLength: config.validation.minLength,
-            label: config.label,
-            help: config.help,
-            reset: true
-          }}
-          onAdd={onAdd}
-        />
-      </section>
-    </EditSection>
+    <RelatedSoftwareSection
+      softwareId={software.id}
+      token={token}
+      relatedSoftware={relatedSoftware}
+      onAdd={onAdd}
+      onRemove={onRemove}
+    />
   )
+
 }

--- a/frontend/components/software/overview/search/SoftwareSearchSection.tsx
+++ b/frontend/components/software/overview/search/SoftwareSearchSection.tsx
@@ -14,10 +14,12 @@ import {getPageRange} from '~/utils/pagination'
 import useHandleQueryChange from '~/utils/useHandleQueryChange'
 import useSmallScreen from '~/config/useSmallScreen'
 import {useUserSettings} from '~/config/UserSettingsContext'
+import StatusForReaders from '~/components/a11y/StatusForReaders'
+import FiltersModal from '~/components/filter/FiltersModal'
 import SearchInput from '~/components/search/SearchInput'
 import ToggleViewGroup from '~/components/search/ToggleViewGroup'
 import ShowItemsSelect from '~/components/search/ShowItemsSelect'
-import FiltersModal from '~/components/filter/FiltersModal'
+import {searchOverviewMsg} from '~/components/search/searchOverviewMsg'
 import useSoftwareParams from '~/components/software/overview/useSoftwareParams'
 
 type SearchSectionProps = {
@@ -34,12 +36,22 @@ export default function SoftwareSearchSection({
   const {search,page,rows,view,filterCnt} = useSoftwareParams()
   const [modal, setModal] = useState(false)
 
-  const placeholder = filterCnt > 0 ? 'Find within selection' : 'Find software'
+  // a11y screen reader announcements and placeholder
+  const {announcement,placeholder} = searchOverviewMsg({
+    name: 'software items',
+    count,
+    page,
+    rows,
+    filterCnt,
+    search
+  })
 
   return (
     <section
       aria-label="Find software"
       data-testid="search-section">
+      {/* a11y screen reader announcer */}
+      <StatusForReaders message={announcement} />
       <div className="flex border rounded-md shadow-xs bg-base-100 p-2">
         <SearchInput
           placeholder={placeholder}


### PR DESCRIPTION
# a11y notifications for screen readers

Closes #1759

Changes proposed in this pull request:
* Add notification messages for screen readers based on audit feedback    
* Added additional landmarks to edit software and edit project pages 
* Refactored code to get through SonarQube checks (mainly duplicated code target < 3%)
* Improved screen reader communication during drag-n-drop of contributor item

How to test:
* `make start` to build and generate test data
* login as rsd-admin
* create new software or edit existing software
    *  navigate to contributors. Enable screen reader and add new contributor. Confirm that search status is passed and the found items are communicated.
    * navigate to organisation. Enable screen reader. Add new organisation. Confirm that search results are passed to screen reader and that you can add organisation
    * navigate to mentions section. Add new reference paper using search. Confirm that search results are communicated to screen reader
    * navigate to related projects. Confirm you can use search results using screen reader
    * navigate to related software. Confirm you can use search results using screen reader
    * navigate to maintainers. Confirm you can invite maintainer using screen reader
* create new or edit existing project. Do similair checks on team members, organisations, mentions and maintainer invites
* navigate to admin / invites page. Confirm that invite status is communicated to screen readers  
* navigate to software overview page. Use screen reader to navigate filters and search. Confirm the amount of found items is announced to screen readers.
* navigate to project overview page. Use screen reader to navigate filters and search. Confirm the amount of found items is announced to screen readers.
* navigate to organisation overview page. Confirm the amount of find items is announced to screen readers.
* navigate to commuinties overview page. Confirm the amount of find items is announced to screen readers.
* navigate to news overview page. Confirm the amount of find items is is announced to screen readers.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
