### PR TITLE
Allow admins to fully change contributors and team members

### DIFF
--- a/data-generation/Dockerfile
+++ b/data-generation/Dockerfile
@@ -12,4 +12,4 @@ COPY ./img /usr/app/img
 COPY ./images.js /usr/app
 COPY ./real-data.js /usr/app
 COPY ./main.js /usr/app
-CMD npx wait-on --timeout 30s $POSTGREST_URL && node main.js
+CMD npx wait-on --timeout 60s $POSTGREST_URL && node main.js

--- a/data-generation/main.js
+++ b/data-generation/main.js
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
-// SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -1057,7 +1057,9 @@ function generateUserProfiles(accountIds) {
 	return user_profiles;
 }
 
-// start of running code, main
+// start of running code, main()
+console.log('starting data generation');
+
 const globalPromises = [];
 const orcids = generateOrcids();
 

--- a/database/005-create-relations-for-software.sql
+++ b/database/005-create-relations-for-software.sql
@@ -227,10 +227,13 @@ BEGIN
 	NEW.id = OLD.id;
 	NEW.created_at = OLD.created_at;
 	NEW.updated_at = LOCALTIMESTAMP;
-	IF OLD.account IS NOT NULL AND (CURRENT_USER = 'rsd_admin' OR (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER)) IS DISTINCT FROM TRUE THEN
-		NEW.family_names = OLD.family_names;
-		NEW.given_names = OLD.given_names;
-		NEW.orcid = OLD.orcid;
+	IF (CURRENT_USER = 'rsd_admin' OR (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER)) IS DISTINCT FROM TRUE THEN
+		NEW.account = OLD.account;
+		IF OLD.account IS NOT NULL THEN
+			NEW.family_names = OLD.family_names;
+			NEW.given_names = OLD.given_names;
+			NEW.orcid = OLD.orcid;
+		END IF;
 	END IF;
 	return NEW;
 END

--- a/database/007-create-relations-for-projects.sql
+++ b/database/007-create-relations-for-projects.sql
@@ -1,5 +1,5 @@
--- SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2022 dv4all
 -- SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
@@ -47,10 +47,13 @@ BEGIN
 	NEW.id = OLD.id;
 	NEW.created_at = OLD.created_at;
 	NEW.updated_at = LOCALTIMESTAMP;
-	IF OLD.account IS NOT NULL AND (CURRENT_USER = 'rsd_admin' OR (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER)) IS DISTINCT FROM TRUE THEN
-		NEW.family_names = OLD.family_names;
-		NEW.given_names = OLD.given_names;
-		NEW.orcid = OLD.orcid;
+	IF (CURRENT_USER = 'rsd_admin' OR (SELECT rolsuper FROM pg_roles WHERE rolname = CURRENT_USER)) IS DISTINCT FROM TRUE THEN
+		NEW.account = OLD.account;
+		IF OLD.account IS NOT NULL THEN
+			NEW.family_names = OLD.family_names;
+			NEW.given_names = OLD.given_names;
+			NEW.orcid = OLD.orcid;
+		END IF;
 	END IF;
 	return NEW;
 END

--- a/database/104-person-views.sql
+++ b/database/104-person-views.sql
@@ -22,7 +22,7 @@ CREATE FUNCTION unique_person_entries() RETURNS TABLE (
 ) LANGUAGE sql STABLE AS
 $$
 SELECT DISTINCT
-	(CONCAT(contributor.given_names,' ',contributor.family_names)) AS display_name,
+	CONCAT(contributor.given_names, ' ', contributor.family_names) AS display_name,
 	contributor.given_names,
 	contributor.family_names,
 	contributor.email_address,
@@ -35,7 +35,7 @@ FROM
 	contributor
 UNION
 SELECT DISTINCT
-	(CONCAT(team_member.given_names,' ',team_member.family_names)) AS display_name,
+	CONCAT(team_member.given_names, ' ', team_member.family_names) AS display_name,
 	team_member.given_names,
 	team_member.family_names,
 	team_member.email_address,
@@ -98,6 +98,7 @@ CREATE FUNCTION person_mentions() RETURNS TABLE (
 	id UUID,
 	given_names VARCHAR,
 	family_names VARCHAR,
+	display_name VARCHAR,
 	email_address VARCHAR,
 	affiliation VARCHAR,
 	"role" VARCHAR,
@@ -115,6 +116,7 @@ SELECT
 	contributor.id,
 	contributor.given_names,
 	contributor.family_names,
+	CONCAT(contributor.given_names, ' ', contributor.family_names) AS display_name,
 	contributor.email_address,
 	contributor.affiliation,
 	contributor.role,
@@ -141,6 +143,7 @@ SELECT
 	team_member.id,
 	team_member.given_names,
 	team_member.family_names,
+	CONCAT(team_member.given_names, ' ', team_member.family_names) AS display_name,
 	team_member.email_address,
 	team_member.affiliation,
 	team_member.role,

--- a/database/104-person-views.sql
+++ b/database/104-person-views.sql
@@ -1,8 +1,8 @@
 -- SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
--- SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 -- SPDX-FileCopyrightText: 2023 dv4all
--- SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2024 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 --
 -- SPDX-License-Identifier: Apache-2.0
 
@@ -106,6 +106,7 @@ CREATE FUNCTION person_mentions() RETURNS TABLE (
 	origin VARCHAR,
 	slug VARCHAR,
 	public_orcid_profile VARCHAR,
+	account VARCHAR,
 	avatars_by_name VARCHAR[],
 	avatars_by_orcid VARCHAR[]
 ) LANGUAGE sql STABLE AS
@@ -122,6 +123,7 @@ SELECT
 	'contributor' AS origin,
 	software.slug,
 	public_profile.orcid as public_orcid_profile,
+	contributor.account,
 	person_avatars_by_name.avatars AS avatars_by_name,
 	person_avatars_by_orcid.avatars	AS avatars_by_orcid
 FROM
@@ -134,7 +136,7 @@ LEFT JOIN
 	person_avatars_by_name() ON person_avatars_by_name.display_name = CONCAT(contributor.given_names,' ',contributor.family_names)
 LEFT JOIN
 	person_avatars_by_orcid() ON person_avatars_by_orcid.orcid = contributor.orcid
-UNION
+UNION ALL
 SELECT
 	team_member.id,
 	team_member.given_names,
@@ -147,6 +149,7 @@ SELECT
 	'team_member' AS origin,
 	project.slug,
 	public_profile.orcid as public_orcid_profile,
+	team_member.account,
 	person_avatars_by_name.avatars AS avatars_by_name,
 	person_avatars_by_orcid.avatars	AS avatars_by_orcid
 FROM

--- a/frontend/components/admin/rsd-contributors/apiRsdContributors.ts
+++ b/frontend/components/admin/rsd-contributors/apiRsdContributors.ts
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,7 +22,7 @@ export async function getContributors({page, rows, token, searchFor, orderBy}: A
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
       const encodedSearch = encodeURIComponent(searchFor)
-      query+=`&or=(given_names.ilike."*${encodedSearch}*",family_names.ilike."*${encodedSearch}*",email_address.ilike."*${encodedSearch}*",orcid.ilike."*${encodedSearch}*")`
+      query+=`&or=(given_names.ilike."*${encodedSearch}*",family_names.ilike."*${encodedSearch}*",email_address.ilike."*${encodedSearch}*",orcid.ilike."*${encodedSearch}*",account.ilike."*${encodedSearch}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy.column}.${orderBy.direction}`

--- a/frontend/components/admin/rsd-contributors/apiRsdContributors.ts
+++ b/frontend/components/admin/rsd-contributors/apiRsdContributors.ts
@@ -22,7 +22,7 @@ export async function getContributors({page, rows, token, searchFor, orderBy}: A
     let query = paginationUrlParams({rows, page})
     if (searchFor) {
       const encodedSearch = encodeURIComponent(searchFor)
-      query+=`&or=(given_names.ilike."*${encodedSearch}*",family_names.ilike."*${encodedSearch}*",email_address.ilike."*${encodedSearch}*",orcid.ilike."*${encodedSearch}*",account.ilike."*${encodedSearch}*")`
+      query+=`&or=(display_name.ilike."*${encodedSearch}*",email_address.ilike."*${encodedSearch}*",orcid.ilike."*${encodedSearch}*",account.ilike."*${encodedSearch}*")`
     }
     if (orderBy) {
       query+=`&order=${orderBy.column}.${orderBy.direction}`

--- a/frontend/components/admin/rsd-contributors/config.tsx
+++ b/frontend/components/admin/rsd-contributors/config.tsx
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2023 - 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -87,6 +88,18 @@ export function createColumns(token: string) {
   }, {
     key: 'orcid',
     label: 'ORCID',
+    type: 'string',
+    sx: {
+      width: '11rem',
+      padding: '0.5rem'
+    },
+    patchFn: async (props) => patchPerson({
+      ...props,
+      token
+    })
+  }, {
+    key: 'account',
+    label: 'Account',
     type: 'string',
     sx: {
       width: '11rem',

--- a/frontend/components/admin/rsd-contributors/useContributors.tsx
+++ b/frontend/components/admin/rsd-contributors/useContributors.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -23,6 +24,7 @@ export type RsdContributor = {
   origin: 'contributor' | 'team_member'
   slug: string
   public_orcid_profile: null | string
+  account: string | null
   avatars: null | string[]
 }
 

--- a/frontend/components/person/AggregatedPersonModal.tsx
+++ b/frontend/components/person/AggregatedPersonModal.tsx
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -22,6 +23,7 @@ import ControlledAutocomplete from '~/components/form/ControlledAutocomplete'
 import AvatarOptionsPerson, {RequiredAvatarProps} from '~/components/person/AvatarOptionsPerson'
 import useAggregatedPerson from './useAggregatedPerson'
 import {modalConfig} from './config'
+import {useSession} from '~/auth/AuthProvider'
 
 type InputProps={
   label:string
@@ -30,6 +32,7 @@ type InputProps={
 }
 
 type AggregatedPersonModalConfig={
+  account: InputProps,
   is_contact_person: Omit<InputProps,'validation'>,
   given_names: InputProps,
   family_names: InputProps,
@@ -61,6 +64,8 @@ export default function AggregatedPersonModal({
   title='Profile',config=modalConfig
 }: AggregatedPersonModalProps) {
   const {loading, options} = useAggregatedPerson(person?.orcid)
+  const session = useSession()
+  const isAdmin = session?.user?.role === 'rsd_admin'
   const smallScreen = useMediaQuery('(max-width:640px)')
   const {handleSubmit, watch, formState, control, register, setValue, trigger} = useForm<FormPerson>({
     mode: 'onChange',
@@ -89,6 +94,7 @@ export default function AggregatedPersonModal({
   // console.log('formData...', formData)
   // console.log('loading...', loading)
   // console.log('options...', options)
+  // console.log('person...', person)
   // console.groupEnd()
 
   function handleCancel(e?:any, reason?:'backdropClick' | 'escapeKeyDown') {
@@ -122,9 +128,11 @@ export default function AggregatedPersonModal({
         <input type="hidden"
           {...register('id')}
         />
-        <input type="hidden"
-          {...register('account')}
-        />
+        {!isAdmin &&
+          <input type="hidden"
+            {...register('account')}
+          />
+        }
         <input type="hidden"
           {...register('position')}
         />
@@ -149,7 +157,7 @@ export default function AggregatedPersonModal({
               control={control}
               options={{
                 // user cannot edit specific public profile information (account!==null)
-                disabled: formData.account!==null,
+                disabled: formData.account!==null && !isAdmin,
                 name: 'given_names',
                 label: config.given_names.label,
                 useNull: true,
@@ -163,7 +171,7 @@ export default function AggregatedPersonModal({
               control={control}
               options={{
                 // user cannot edit specific public profile information (account!==null)
-                disabled: formData.account!==null,
+                disabled: formData.account!==null && !isAdmin,
                 name: 'family_names',
                 label: config.family_names.label,
                 useNull: true,
@@ -189,7 +197,7 @@ export default function AggregatedPersonModal({
             <ControlledTextField
               options={{
                 // user cannot edit specific public profile information (account!==null)
-                disabled: formData.account!==null,
+                disabled: formData.account!==null && !isAdmin,
                 name: 'orcid',
                 label: config.orcid.label,
                 useNull: true,
@@ -216,14 +224,25 @@ export default function AggregatedPersonModal({
               helperTextMessage={config.affiliation.help}
               rules={config.affiliation.validation}
             />
-          </section>
-          <section>
             <ControlledSwitch
               name="is_contact_person"
               label={config.is_contact_person.label}
               control={control}
               defaultValue={false}
             />
+            {isAdmin &&
+              <ControlledTextField
+                control={control}
+                options={{
+                  name: 'account',
+                  label: config.account.label,
+                  useNull: true,
+                  defaultValue: person?.account,
+                  helperTextMessage: config.account.help,
+                }}
+                rules={config?.account.validation}
+              />
+            }
           </section>
         </DialogContent>
         <DialogActions sx={{

--- a/frontend/components/person/config.ts
+++ b/frontend/components/person/config.ts
@@ -1,10 +1,20 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 export const modalConfig = {
+  account: {
+    label: 'Account ID',
+    help: 'Connect an account to this person',
+    validation: {
+      pattern: {
+        value: /^\w{8}-\w{4}-\w{4}-\w{4}-\w{12}$/,
+        message: 'Should be a UUID'
+      }
+    }
+  },
   is_contact_person: {
     label: 'Contact person',
     help: 'Is this the main contact person?'

--- a/frontend/components/person/searchForPerson.ts
+++ b/frontend/components/person/searchForPerson.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2025 dv4all
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (dv4all) (dv4all)
 //
@@ -11,7 +11,7 @@ import {sortBySearchFor} from '~/utils/sortFn'
 import logger from '~/utils/logger'
 import {searchORCID} from '~/utils/getORCID'
 import {TeamMember} from '~/types/Project'
-import {Contributor} from '~/types/Contributor'
+import {Contributor, Person} from '~/types/Contributor'
 import {rsdPublicProfiles, rsdUniquePersonEntries, UniqueRsdPerson} from './findRSDPerson'
 import {AggregatedPerson, groupByOrcid, personsToAutocompleteOptions} from './groupByOrcid'
 
@@ -99,7 +99,7 @@ function joinPublicProfiles({aggPersons,profiles}:{
   return persons
 }
 
-export function personAlreadyPresent(collection:TeamMember[]|Contributor[],person:AggregatedPerson){
+export function personAlreadyPresent(collection:TeamMember[]|Contributor[]|Person[],person:AggregatedPerson){
   const found = collection.find(item=>{
     if (item.account && person.account){
       return item.account === person.account

--- a/frontend/components/projects/apiProjects.ts
+++ b/frontend/components/projects/apiProjects.ts
@@ -2,7 +2,7 @@
 // SPDX-FileCopyrightText: 2021 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2025 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,9 +10,15 @@ import {OrganisationRole} from '~/types/Organisation'
 import {mentionColumns, MentionItemProps} from '~/types/Mention'
 import {
   KeywordForProject,
-  OrganisationsOfProject, Project,
-  ProjectLink, ProjectListItem, ProjectStatusKey, RelatedProjectForProject,
-  ResearchDomain, SearchProject, TeamMember
+  OrganisationsOfProject,
+  Project,
+  ProjectLink,
+  ProjectListItem,
+  ProjectStatusKey,
+  RelatedProjectForProject,
+  ResearchDomain,
+  SearchProject,
+  TeamMember
 } from '~/types/Project'
 import {RelatedSoftwareOfProject} from '~/types/SoftwareTypes'
 import {CategoryPath} from '~/types/Category'
@@ -21,6 +27,7 @@ import {extractCountFromHeader} from '~/utils/extractCountFromHeader'
 import {createJsonHeaders, getBaseUrl} from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
 import {ProjectStatusLabels} from '~/components/projects/overview/filters/ProjectStatusFilter'
+import {Person} from '~/types/Contributor'
 
 export async function getProjectList({url, token}: {url: string, token?: string}) {
   try {
@@ -293,7 +300,7 @@ export async function getImpactByProject({project, token}:
 }
 
 export async function getTeamForProject({project, token}:
-{project: string, token?: string}) {
+{project: string, token?: string}): Promise<TeamMember[]> {
   try {
     // build url
     const query = `project_id=${project}&order=position.asc,given_names.asc`
@@ -315,6 +322,34 @@ export async function getTeamForProject({project, token}:
     return []
   } catch (e: any) {
     logger(`getTeamForProject: ${e?.message}`, 'error')
+    return []
+  }
+}
+
+export async function getRawTeamMembers({project, token}:
+{project: string, token?: string}): Promise<Person[]> {
+  try {
+    // build url
+    const selectList = 'id,is_contact_person,email_address,family_names,given_names,affiliation,role,orcid,position,avatar_id,account'
+    const query = `select=${selectList}&project=eq.${project}&order=position.asc,given_names.asc`
+    const url = `${getBaseUrl()}/team_member?${query}`
+
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+      }
+    })
+
+    if (resp.status === 200) {
+      const data: TeamMember[] = await resp.json()
+      return data
+    }
+    logger(`getRawTeamMembers: ${resp.status} ${resp.statusText} [${url}]`, 'warn')
+    // / query not found
+    return []
+  } catch (e: any) {
+    logger(`getRawTeamMembers: ${e?.message}`, 'error')
     return []
   }
 }

--- a/frontend/components/projects/edit/team/EditProjectTeamIndex.test.tsx
+++ b/frontend/components/projects/edit/team/EditProjectTeamIndex.test.tsx
@@ -1,8 +1,9 @@
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (dv4all) (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 - 2025 dv4all
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -18,11 +19,11 @@ import {modalConfig} from '~/components/person/config'
 import {cfgTeamMembers} from './config'
 import ProjectTeam from './index'
 
-// MOCK getTeamForProject
+// MOCK getRawTeamMembers
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockGetTeamForProject = jest.fn(props => Promise.resolve([] as any))
+const mockGetRawTeamMembers = jest.fn(props => Promise.resolve([] as any))
 jest.mock('~/components/projects/apiProjects', () => ({
-  getTeamForProject: jest.fn(props=>mockGetTeamForProject(props))
+  getRawTeamMembers: jest.fn(props=>mockGetRawTeamMembers(props))
 }))
 
 // MOCK searchForPerson
@@ -104,7 +105,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
 
   it('renders no team members message', async () => {
     // mock no members
-    mockGetTeamForProject.mockResolvedValueOnce([])
+    mockGetRawTeamMembers.mockResolvedValueOnce([])
     // render component
     render(
       <WithAppContext options={{session: mockSession}}>
@@ -123,7 +124,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
 
   it('renders members list', async() => {
     // mock no members
-    mockGetTeamForProject.mockResolvedValueOnce(mockTeamMembers)
+    mockGetRawTeamMembers.mockResolvedValueOnce(mockTeamMembers)
 
     // render component
     render(
@@ -151,7 +152,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
     const memberId='new-team-member-id'
     const searchMember = `${newPerson.given_names} ${newPerson.family_names}`
     // mock no members
-    mockGetTeamForProject.mockResolvedValueOnce([])
+    mockGetRawTeamMembers.mockResolvedValueOnce([])
     // mock searchForPerson response
     mockSearchForPerson.mockResolvedValueOnce(mockSearchOptions)
     // mock post response
@@ -273,7 +274,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
 
   it('can remove team member', async() => {
     // mock no members
-    mockGetTeamForProject.mockResolvedValueOnce(mockTeamMembers)
+    mockGetRawTeamMembers.mockResolvedValueOnce(mockTeamMembers)
 
     // render component
     render(
@@ -337,7 +338,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
       project: editProjectState.id
     }
     // mock no members
-    mockGetTeamForProject.mockResolvedValueOnce(mockTeamMembers)
+    mockGetRawTeamMembers.mockResolvedValueOnce(mockTeamMembers)
     // mock patch
     mockPatchTeamMember.mockResolvedValueOnce({
       status: 200,
@@ -393,7 +394,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
   })
   it('can CANCEL modal changes', async () => {
     // mock no members
-    mockGetTeamForProject.mockResolvedValueOnce(mockTeamMembers)
+    mockGetRawTeamMembers.mockResolvedValueOnce(mockTeamMembers)
     // mock patch
     mockPatchTeamMember.mockResolvedValueOnce({
       status: 200,
@@ -461,7 +462,7 @@ describe('frontend/components/projects/edit/team/index.tsx', () => {
       avatar_id: newAvatarId
     }
     // mock no members
-    mockGetTeamForProject.mockResolvedValueOnce(mockTeamMembers)
+    mockGetRawTeamMembers.mockResolvedValueOnce(mockTeamMembers)
     // mock patch
     mockPatchTeamMember.mockResolvedValueOnce({
       status: 200,

--- a/frontend/components/projects/edit/team/SortableTeamMemberList.tsx
+++ b/frontend/components/projects/edit/team/SortableTeamMemberList.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
@@ -11,15 +11,15 @@
 import Alert from '@mui/material/Alert'
 import AlertTitle from '@mui/material/AlertTitle'
 
-import {TeamMember} from '~/types/Project'
 import SortableList from '~/components/layout/SortableList'
 import SortableContributorItem from '~/components/software/edit/contributors/SortableContributorItem'
+import {Person} from '~/types/Contributor'
 
 type TeamMemberListProps = {
-  members: TeamMember[],
+  members: Person[],
   onEdit: (pos: number) => void
   onDelete: (pos: number) => void
-  onSorted: (members:TeamMember[])=>void
+  onSorted: (members:Person[])=>void
 }
 
 export default function SortableTeamMemberList({members, onEdit, onDelete, onSorted}: TeamMemberListProps) {
@@ -35,7 +35,7 @@ export default function SortableTeamMemberList({members, onEdit, onDelete, onSor
     )
   }
 
-  function onRenderItem(item:TeamMember,index:number) {
+  function onRenderItem(item:Person,index:number) {
     return <SortableContributorItem
       key={item.id ?? index}
       item={item}

--- a/frontend/components/projects/edit/team/apiTeamMembers.ts
+++ b/frontend/components/projects/edit/team/apiTeamMembers.ts
@@ -2,11 +2,12 @@
 // SPDX-FileCopyrightText: 2022 dv4all
 // SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {PatchPerson} from '~/types/Contributor'
-import {SaveTeamMember, TeamMember} from '~/types/Project'
+import {PatchPerson, Person} from '~/types/Contributor'
+import {SaveTeamMember} from '~/types/Project'
 import {createJsonHeaders, extractReturnMessage} from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
 
@@ -99,7 +100,7 @@ export async function deleteTeamMemberById({ids, token}: {ids: string[], token: 
 }
 
 export async function patchTeamMemberPositions({members, token}:
-{members: TeamMember[], token: string}) {
+{members: Person[], token: string}) {
   try {
     // create all requests
     const requests = members.map(member => {

--- a/frontend/components/projects/edit/team/useTeamMembers.tsx
+++ b/frontend/components/projects/edit/team/useTeamMembers.tsx
@@ -1,7 +1,8 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -10,8 +11,8 @@ import {useCallback, useEffect, useState} from 'react'
 
 import {useSession} from '~/auth/AuthProvider'
 import {TeamMember} from '~/types/Project'
-import {PatchPerson, PersonProps} from '~/types/Contributor'
-import {getTeamForProject} from '~/components/projects/apiProjects'
+import {PatchPerson, Person, PersonProps} from '~/types/Contributor'
+import {getRawTeamMembers} from '~/components/projects/apiProjects'
 import {deleteImage, saveBase64Image} from '~/utils/editImage'
 import {getPropsFromObject} from '~/utils/getPropsFromObject'
 import {sortOnNumProp} from '~/utils/sortFn'
@@ -31,7 +32,7 @@ import {
  * @param members
  * @returns members (updated)
  */
-function resetContactPersons(member:TeamMember,members:TeamMember[],token:string){
+function resetContactPersons(member:TeamMember,members:Person[],token:string){
   // const resetContactPersons:Contributor[] = []
   const newList = members.map(item=>{
     // if current member
@@ -62,7 +63,7 @@ export default function useTeamMembers() {
   const {token} = useSession()
   const {project} = useProjectContext()
   const {showErrorMessage} = useSnackbar()
-  const [members, setMembers] = useState<TeamMember[]>([])
+  const [members, setMembers] = useState<Person[]>([])
   const [loadedSlug, setLoadedSlug] = useState('')
   const [loading, setLoading] = useState(true)
 
@@ -166,7 +167,7 @@ export default function useTeamMembers() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   },[project.id,members,token])
 
-  const sortedMembers = useCallback(async(newList:TeamMember[])=>{
+  const sortedMembers = useCallback(async(newList:Person[])=>{
     if (newList.length > 0) {
       const oldList = [...members]
       // update ui first
@@ -190,7 +191,7 @@ export default function useTeamMembers() {
   // eslint-disable-next-line react-hooks/exhaustive-deps
   },[project.id,members,token])
 
-  const deleteMember = useCallback(async(member:TeamMember)=>{
+  const deleteMember = useCallback(async(member:Person)=>{
     if (member.id){
       // remove from database
       const ids = [member.id]
@@ -231,7 +232,7 @@ export default function useTeamMembers() {
     let abort = false
     async function getMembers() {
       setLoading(true)
-      const members = await getTeamForProject({
+      const members = await getRawTeamMembers({
         project: project.id,
         token
       })

--- a/frontend/components/software/edit/contributors/EditSoftwareContributorsIndex.test.tsx
+++ b/frontend/components/software/edit/contributors/EditSoftwareContributorsIndex.test.tsx
@@ -2,7 +2,8 @@
 // SPDX-FileCopyrightText: 2023 - 2025 dv4all
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -21,9 +22,8 @@ import SoftwareContributors from '.'
 import mockContributors from './__mocks__/softwareContributors.json'
 import mockSearchOptions from '~/components/person/__mocks__/searchForPersonOptions.json'
 
-// MOCK getContributorsForSoftware
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mockGetContributorsForSoftware = jest.fn(props => Promise.resolve([] as any))
+const mockGetRawContributorsForSoftware = jest.fn(props => Promise.resolve([] as any))
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mockPostContributor = jest.fn(props => Promise.resolve([] as any))
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -40,7 +40,7 @@ const mockPatchContributorPositions = jest.fn(props => Promise.resolve({
 }))
 jest.mock('./apiContributors', () => ({
   ...jest.requireActual('./apiContributors'),
-  getContributorsForSoftware: jest.fn(props => mockGetContributorsForSoftware(props)),
+  getRawContributorsForSoftware: jest.fn(props => mockGetRawContributorsForSoftware(props)),
   postContributor: jest.fn(props => mockPostContributor(props)),
   patchContributor: jest.fn(props => mockPatchContributor(props)),
   deleteContributorsById: jest.fn(props => mockDeleteContributorsById(props)),
@@ -111,7 +111,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
     editSoftwareState.brand_name= 'Test software title'
     editSoftwareState.concept_doi= ''
     // resolve no contributors
-    mockGetContributorsForSoftware.mockResolvedValueOnce([])
+    mockGetRawContributorsForSoftware.mockResolvedValueOnce([])
 
     render(
       <WithAppContext options={{session: mockSession}}>
@@ -136,7 +136,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
     editSoftwareState.brand_name= 'Test software title'
     editSoftwareState.concept_doi= ''
     // resolve list of contributors
-    mockGetContributorsForSoftware.mockResolvedValueOnce(mockContributors)
+    mockGetRawContributorsForSoftware.mockResolvedValueOnce(mockContributors)
 
     render(
       <WithAppContext options={{session: mockSession}}>
@@ -168,7 +168,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
     editSoftwareState.brand_name= 'Test software title'
     editSoftwareState.concept_doi= ''
     // resolve no contributors
-    mockGetContributorsForSoftware.mockResolvedValueOnce([])
+    mockGetRawContributorsForSoftware.mockResolvedValueOnce([])
     // mock search options returned
     mockSearchForPerson.mockResolvedValueOnce(mockSearchOptions)
     // mock post response
@@ -293,7 +293,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
     editSoftwareState.concept_doi= '10.5281/zenodo.6379973'
 
     // resolve no contributors
-    mockGetContributorsForSoftware.mockResolvedValueOnce([])
+    mockGetRawContributorsForSoftware.mockResolvedValueOnce([])
     // resolve import request
     mockGetContributorsFromDoi.mockResolvedValueOnce(mockContributors)
 
@@ -330,7 +330,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
     editSoftwareState.concept_doi= ''
 
     // resolve contributors
-    mockGetContributorsForSoftware.mockResolvedValueOnce(mockContributors)
+    mockGetRawContributorsForSoftware.mockResolvedValueOnce(mockContributors)
 
     render(
       <WithAppContext options={{session: mockSession}}>
@@ -402,7 +402,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
       software: editSoftwareState.id
     }
     // mock return list of contributors
-    mockGetContributorsForSoftware.mockResolvedValueOnce(mockContributors)
+    mockGetRawContributorsForSoftware.mockResolvedValueOnce(mockContributors)
     // mock patch contributor response
     mockPatchContributor.mockResolvedValueOnce({
       status: 200,
@@ -464,7 +464,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
     editSoftwareState.brand_name= 'Test software title'
     editSoftwareState.concept_doi= ''
     // mock no members
-    mockGetContributorsForSoftware.mockResolvedValueOnce(mockContributors)
+    mockGetRawContributorsForSoftware.mockResolvedValueOnce(mockContributors)
     // mock patch contributor response
     mockPatchContributor.mockResolvedValueOnce({
       status: 200,
@@ -537,7 +537,7 @@ describe('frontend/components/software/edit/contributors/index.tsx', () => {
       software: editSoftwareState.id,
     }
     // mock no members
-    mockGetContributorsForSoftware.mockResolvedValueOnce(mockContributors)
+    mockGetRawContributorsForSoftware.mockResolvedValueOnce(mockContributors)
     // mock patch
     mockPatchContributor.mockResolvedValueOnce({
       status: 200,

--- a/frontend/components/software/edit/contributors/SortableContributorItem.tsx
+++ b/frontend/components/software/edit/contributors/SortableContributorItem.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -9,7 +10,7 @@ import ListItemText from '@mui/material/ListItemText'
 import ListItemAvatar from '@mui/material/ListItemAvatar'
 
 import {combineRoleAndAffiliation, getDisplayInitials, getDisplayName} from '~/utils/getDisplayName'
-import {Contributor} from '~/types/Contributor'
+import {Contributor, Person} from '~/types/Contributor'
 import {TeamMember} from '~/types/Project'
 import {getImageUrl} from '~/utils/editImage'
 import useSmallScreen from '~/config/useSmallScreen'
@@ -18,7 +19,7 @@ import SortableListItemActions from '~/components/layout/SortableListItemActions
 import ContributorAvatar from '~/components/software/ContributorAvatar'
 
 type SortableContributorItemProps = Readonly<{
-  item: Contributor | TeamMember,
+  item: Contributor | TeamMember | Person,
   onEdit: () => void,
   onDelete: () => void,
 }>

--- a/frontend/components/software/edit/contributors/apiContributors.ts
+++ b/frontend/components/software/edit/contributors/apiContributors.ts
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2022 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -15,7 +15,7 @@ import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetch
 import {Contributor, NewContributor, PatchContributor, Person} from '~/types/Contributor'
 
 export async function getContributorsForSoftware({software, token}:
-{software: string, token?: string}) {
+{software: string, token?: string}): Promise<Person[]> {
   try {
     // build url
     const query = `software_id=${software}&order=position.asc,given_names.asc`
@@ -38,6 +38,33 @@ export async function getContributorsForSoftware({software, token}:
 
   } catch (e: any) {
     logger(`getContributorsForSoftware: ${e?.message}`, 'error')
+    return []
+  }
+}
+
+export async function getRawContributorsForSoftware({software, token}: {software: string, token?: string}): Promise<Person[]> {
+  try {
+    // build url
+    const selectList = 'id,is_contact_person,email_address,family_names,given_names,affiliation,role,orcid,position,avatar_id,account'
+    const query = `select=${selectList}&software=eq.${software}&order=position.asc,given_names.asc`
+    const url = `${getBaseUrl()}/contributor?${query}`
+
+    const resp = await fetch(url, {
+      method: 'GET',
+      headers: {
+        ...createJsonHeaders(token),
+      }
+    })
+
+    if (resp.status === 200) {
+      return await resp.json()
+    }
+    logger(`getRawContributorsForSoftware: ${resp.status} - ${resp.statusText}: [${url}]`, 'warn')
+    // query not found
+    return []
+
+  } catch (e: any) {
+    logger(`getRawContributorsForSoftware: ${e?.message}`, 'error')
     return []
   }
 }

--- a/frontend/components/software/edit/contributors/useSoftwareContributors.tsx
+++ b/frontend/components/software/edit/contributors/useSoftwareContributors.tsx
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all) (dv4all)
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -17,7 +18,7 @@ import {ScreenReaderMessage} from '~/components/a11y/StatusForReaders'
 import useSnackbar from '~/components/snackbar/useSnackbar'
 import useSoftwareContext from '../context/useSoftwareContext'
 import {
-  getContributorsForSoftware, postContributor,
+  getRawContributorsForSoftware, postContributor,
   patchContributor, patchContributorPositions,
   deleteContributorsById
 } from './apiContributors'
@@ -69,7 +70,7 @@ export default function useSoftwareContributors() {
   const addContributor = useCallback(async(person:FormPerson)=>{
     if (software.id){
       // new base64 image to upload
-      if (person.avatar_id && person.avatar_id.startsWith('data:')===true){
+      if (person?.avatar_id?.startsWith('data:')){
         const upload = await saveBase64Image({
           base64: person.avatar_id,
           token
@@ -130,7 +131,7 @@ export default function useSoftwareContributors() {
   const updateContributor = useCallback(async(person:FormPerson)=>{
     if (software.id){
       // new base64 image to upload
-      if (person.avatar_id && person.avatar_id.startsWith('data:')===true){
+      if (person?.avatar_id?.startsWith('data:')){
         const upload = await saveBase64Image({
           base64: person.avatar_id,
           token
@@ -247,7 +248,7 @@ export default function useSoftwareContributors() {
     let abort = false
     const getContributors = async (software: string, token: string) => {
       setLoading(true)
-      const data = await getContributorsForSoftware({
+      const data = await getRawContributorsForSoftware({
         software,
         token
       }) as Contributor[]

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/frontend/types/Contributor.ts
+++ b/frontend/types/Contributor.ts
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: 2022 - 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 - 2023 dv4all
 // SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
 /**
- * Table definitions in 003-create-relations-for-software.sql
+ * Table definitions in 005-create-relations-for-software.sql
  */
 
 export type Person = {


### PR DESCRIPTION
## Allow admins to fully change contributors and team members

### Changes proposed in this pull request

* Change row level security so that only admins can change the account of a contributor or team member
* Allow admins to see and change the account of a contributor or team member in the admin interface
* Allow admins to see and change the account of a contributor or team member in edit modal of a software or project page
* Allow admins to find users by given _and_ family names

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin
* Go to the contributor overview in the admin interface. Accounts can be seen and edited.
* If someone is called "FirstName LastName", you can now find them by this string.
* Go to a software or project page and edit a contributor or team member. Accounts should be editable and be saved when you do so. When there is an account, only an admin should be able to edit the account, ORCID and name fields.
* Check if existing avatars are still chosable when adding an existing contributor to a new page
* Check if I edited the tests correctly

closes #1791

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests