### PR TITLE
Use PostgREST ready flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,6 +45,7 @@ POSTGRES_USER=rsd
 PGRST_DB_ANON_ROLE=rsd_web_anon
 PGRST_DB_SCHEMA=public
 PGRST_SERVER_PORT=3500
+PGRST_ADMIN_SERVER_PORT=3501
 
 # postgREST API
 # consumed by services: authentication,frontend,auth-tests, scrapers, codemeta

--- a/backend-postgrest/Dockerfile
+++ b/backend-postgrest/Dockerfile
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgrest/postgrest:v14.6
+FROM postgrest/postgrest:v14.12

--- a/backend-tests/docker-compose.yml
+++ b/backend-tests/docker-compose.yml
@@ -40,12 +40,21 @@ services:
       - PGRST_DB_URI=postgres://rsd_authenticator:simplepassword@database:5432/rsd-db
       - PGRST_DB_ANON_ROLE=rsd_web_anon
       - PGRST_DB_SCHEMA=public
+      - PGRST_SERVER_HOST=backend
       - PGRST_SERVER_PORT=3500
+      - PGRST_ADMIN_SERVER_PORT=3501
       - PGRST_JWT_SECRET=normally_this_is_a_secret_string_that_none_knows_BUT_this_is_just_a_test
     depends_on:
       - "database"
     networks:
       - net-test
+    healthcheck:
+        test: [ "CMD", "postgrest", "--ready" ]
+        interval: 5s
+        retries: 2
+        timeout: 5s
+        start_period: 60s
+        start_interval: 1s
 
   codemeta:
     container_name: codemeta-test
@@ -92,8 +101,8 @@ services:
       - AUTH_URL=http://auth:7000/auth
       - API_V2_URL=http://auth:7000/api/v2
     depends_on:
-      - "database"
-      - "backend"
+      backend:
+        condition: service_healthy
     networks:
       - net-test
 

--- a/backend-tests/docker-compose.yml
+++ b/backend-tests/docker-compose.yml
@@ -66,7 +66,8 @@ services:
     environment:
       - POSTGREST_URL
     depends_on:
-      - "database"
+      backend:
+        condition: service_healthy
     networks:
       - net-test
 
@@ -82,8 +83,8 @@ services:
       - PGRST_JWT_SECRET=normally_this_is_a_secret_string_that_none_knows_BUT_this_is_just_a_test
       - RSD_API_ACCESS_TOKEN_ENABLED=true
     depends_on:
-      - "database"
-      - "backend"
+      backend:
+        condition: service_healthy
     networks:
       - net-test
 
@@ -103,6 +104,10 @@ services:
     depends_on:
       backend:
         condition: service_healthy
+      auth:
+        condition: service_started
+      codemeta:
+        condition: service_started
     networks:
       - net-test
 

--- a/backend-tests/src/test/java/nl/esciencecenter/SetupAllTests.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/SetupAllTests.java
@@ -9,11 +9,6 @@ import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import io.restassured.RestAssured;
 import io.restassured.http.Header;
-import java.io.IOException;
-import java.net.URI;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
 import java.util.Date;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
@@ -21,53 +16,11 @@ import org.junit.jupiter.api.extension.ExtensionContext;
 public class SetupAllTests implements BeforeAllCallback {
 
 	@Override
-	public void beforeAll(ExtensionContext extensionContext) throws Exception {
-		checkBackendAvailable();
+	public void beforeAll(ExtensionContext extensionContext) {
 		setupRestAssured();
 	}
 
 	public static Header adminAuthHeader;
-
-	public static void checkBackendAvailable() throws InterruptedException {
-		URI backendUri = URI.create(System.getenv("POSTGREST_URL"));
-		HttpClient client = HttpClient.newBuilder().followRedirects(HttpClient.Redirect.NORMAL).build();
-		HttpRequest request = HttpRequest.newBuilder(backendUri).build();
-		int maxTries = 30;
-		for (int i = 1; i <= maxTries; i++) {
-			try {
-				HttpResponse<Void> response = client.send(request, HttpResponse.BodyHandlers.discarding());
-				if (response.statusCode() == 200) {
-					System.out.println(
-						"Attempt %d/%d to connect to the backend on %s succeeded, continuing with the tests".formatted(
-							i,
-							maxTries,
-							backendUri
-						)
-					);
-					client.close();
-					return;
-				}
-				System.out.println(
-					"Attempt %d/%d to connect to the backend on %s failed, trying again in 1 second".formatted(
-						i,
-						maxTries,
-						backendUri
-					)
-				);
-				Thread.sleep(1000);
-			} catch (IOException e) {
-				System.out.println(
-					"Attempt %d/%d to connect to the backend on %s failed, trying again in 1 second".formatted(
-						i,
-						maxTries,
-						backendUri
-					)
-				);
-				Thread.sleep(1000);
-			}
-		}
-		throw new RuntimeException("Unable to make connection to the backend with URI: " + backendUri);
-	}
 
 	public static void setupRestAssured() {
 		RestAssured.baseURI = System.getenv("POSTGREST_URL");

--- a/data-generation/Dockerfile
+++ b/data-generation/Dockerfile
@@ -12,4 +12,4 @@ COPY ./img /usr/app/img
 COPY ./images.js /usr/app
 COPY ./real-data.js /usr/app
 COPY ./main.js /usr/app
-CMD npx wait-on --timeout 60s $POSTGREST_URL && node main.js
+CMD node main.js

--- a/data-generation/package-lock.json
+++ b/data-generation/package-lock.json
@@ -8,14 +8,14 @@
 			"name": "data-generator",
 			"version": "1.0.0",
 			"dependencies": {
-				"@faker-js/faker": "10.3.0",
+				"@faker-js/faker": "10.4.0",
 				"jsonwebtoken": "9.0.3"
 			}
 		},
 		"node_modules/@faker-js/faker": {
-			"version": "10.3.0",
-			"resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.3.0.tgz",
-			"integrity": "sha512-It0Sne6P3szg7JIi6CgKbvTZoMjxBZhcv91ZrqrNuaZQfB5WoqYYbzCUOq89YR+VY8juY9M1vDWmDDa2TzfXCw==",
+			"version": "10.4.0",
+			"resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-10.4.0.tgz",
+			"integrity": "sha512-sDBWI3yLy8EcDzgobvJTWq1MJYzAkQdpjXuPukga9wXonhpMRvd1Izuo2Qgwey2OiEoRIBr35RMU9HJRoOHzpw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -155,9 +155,9 @@
 			"license": "MIT"
 		},
 		"node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+			"integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"

--- a/data-generation/package-lock.json
+++ b/data-generation/package-lock.json
@@ -9,8 +9,7 @@
 			"version": "1.0.0",
 			"dependencies": {
 				"@faker-js/faker": "10.3.0",
-				"jsonwebtoken": "9.0.3",
-				"wait-on": "9.0.5"
+				"jsonwebtoken": "9.0.3"
 			}
 		},
 		"node_modules/@faker-js/faker": {
@@ -29,130 +28,11 @@
 				"npm": ">=10"
 			}
 		},
-		"node_modules/@hapi/address": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
-			"integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^11.0.2"
-			},
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@hapi/formula": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
-			"integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@hapi/hoek": {
-			"version": "11.0.7",
-			"resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
-			"integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@hapi/pinpoint": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
-			"integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==",
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/@hapi/tlds": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
-			"integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=14.0.0"
-			}
-		},
-		"node_modules/@hapi/topo": {
-			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
-			"integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/hoek": "^11.0.2"
-			}
-		},
-		"node_modules/@standard-schema/spec": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-			"license": "MIT"
-		},
-		"node_modules/asynckit": {
-			"version": "0.4.0",
-			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-			"license": "MIT"
-		},
-		"node_modules/axios": {
-			"version": "1.15.2",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-			"integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
-			"license": "MIT",
-			"dependencies": {
-				"follow-redirects": "^1.15.11",
-				"form-data": "^4.0.5",
-				"proxy-from-env": "^2.1.0"
-			}
-		},
 		"node_modules/buffer-equal-constant-time": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
 			"integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/call-bind-apply-helpers": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-			"integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/combined-stream": {
-			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"license": "MIT",
-			"dependencies": {
-				"delayed-stream": "~1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/delayed-stream": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.4.0"
-			}
-		},
-		"node_modules/dunder-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
-			"integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"gopd": "^1.2.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
 		},
 		"node_modules/ecdsa-sig-formatter": {
 			"version": "1.0.11",
@@ -161,202 +41,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"safe-buffer": "^5.0.1"
-			}
-		},
-		"node_modules/es-define-property": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-			"integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-errors": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-object-atoms": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-			"integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/es-set-tostringtag": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
-			"integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-			"license": "MIT",
-			"dependencies": {
-				"es-errors": "^1.3.0",
-				"get-intrinsic": "^1.2.6",
-				"has-tostringtag": "^1.0.2",
-				"hasown": "^2.0.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/follow-redirects": {
-			"version": "1.16.0",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-			"funding": [
-				{
-					"type": "individual",
-					"url": "https://github.com/sponsors/RubenVerborgh"
-				}
-			],
-			"license": "MIT",
-			"engines": {
-				"node": ">=4.0"
-			},
-			"peerDependenciesMeta": {
-				"debug": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-			"license": "MIT",
-			"dependencies": {
-				"asynckit": "^0.4.0",
-				"combined-stream": "^1.0.8",
-				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
-			},
-			"engines": {
-				"node": ">= 6"
-			}
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
-			"integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-intrinsic": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
-			"integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-			"license": "MIT",
-			"dependencies": {
-				"call-bind-apply-helpers": "^1.0.2",
-				"es-define-property": "^1.0.1",
-				"es-errors": "^1.3.0",
-				"es-object-atoms": "^1.1.1",
-				"function-bind": "^1.1.2",
-				"get-proto": "^1.0.1",
-				"gopd": "^1.2.0",
-				"has-symbols": "^1.1.0",
-				"hasown": "^2.0.2",
-				"math-intrinsics": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/get-proto": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
-			"integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-			"license": "MIT",
-			"dependencies": {
-				"dunder-proto": "^1.0.1",
-				"es-object-atoms": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/gopd": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-			"integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-symbols": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
-			"integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/has-tostringtag": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
-			"integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-			"license": "MIT",
-			"dependencies": {
-				"has-symbols": "^1.0.3"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/hasown": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-			"license": "MIT",
-			"dependencies": {
-				"function-bind": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/joi": {
-			"version": "18.1.2",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-			"integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@hapi/address": "^5.1.1",
-				"@hapi/formula": "^3.0.2",
-				"@hapi/hoek": "^11.0.7",
-				"@hapi/pinpoint": "^2.0.1",
-				"@hapi/tlds": "^1.1.1",
-				"@hapi/topo": "^6.0.2",
-				"@standard-schema/spec": "^1.1.0"
-			},
-			"engines": {
-				"node": ">= 20"
 			}
 		},
 		"node_modules/jsonwebtoken": {
@@ -402,12 +86,6 @@
 				"safe-buffer": "^5.0.1"
 			}
 		},
-		"node_modules/lodash": {
-			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-			"license": "MIT"
-		},
 		"node_modules/lodash.includes": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
@@ -450,68 +128,11 @@
 			"integrity": "sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==",
 			"license": "MIT"
 		},
-		"node_modules/math-intrinsics": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
-			"integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
-		"node_modules/mime-db": {
-			"version": "1.52.0",
-			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/mime-types": {
-			"version": "2.1.35",
-			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "1.52.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-			"integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/ms": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
 			"license": "MIT"
-		},
-		"node_modules/proxy-from-env": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
-			"integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/rxjs": {
-			"version": "7.8.2",
-			"resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
-			"integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
-			"license": "Apache-2.0",
-			"dependencies": {
-				"tslib": "^2.1.0"
-			}
 		},
 		"node_modules/safe-buffer": {
 			"version": "5.2.1",
@@ -543,31 +164,6 @@
 			},
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/tslib": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-			"integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-			"license": "0BSD"
-		},
-		"node_modules/wait-on": {
-			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/wait-on/-/wait-on-9.0.5.tgz",
-			"integrity": "sha512-qgnbHDfDTRIp73ANEJNRW/7kn8CrDUcvZz18xotJQku/P4saTGkbIzvnMZebPmVvVNUiRq1qWAPyqCH+W4H8KA==",
-			"license": "MIT",
-			"dependencies": {
-				"axios": "^1.15.0",
-				"joi": "^18.1.2",
-				"lodash": "^4.18.1",
-				"minimist": "^1.2.8",
-				"rxjs": "^7.8.2"
-			},
-			"bin": {
-				"wait-on": "bin/wait-on"
-			},
-			"engines": {
-				"node": ">=20.0.0"
 			}
 		}
 	}

--- a/data-generation/package.json
+++ b/data-generation/package.json
@@ -1,6 +1,6 @@
 {
 	"dependencies": {
-		"@faker-js/faker": "10.3.0",
+		"@faker-js/faker": "10.4.0",
 		"jsonwebtoken": "9.0.3"
 	},
 	"name": "data-generator",

--- a/data-generation/package.json
+++ b/data-generation/package.json
@@ -1,8 +1,7 @@
 {
 	"dependencies": {
 		"@faker-js/faker": "10.3.0",
-		"jsonwebtoken": "9.0.3",
-		"wait-on": "9.0.5"
+		"jsonwebtoken": "9.0.3"
 	},
 	"name": "data-generator",
 	"version": "1.0.0",

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -55,7 +55,8 @@ services:
       - PGRST_ADMIN_SERVER_PORT
       - PGRST_JWT_SECRET
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     networks:
       - net
     restart: unless-stopped
@@ -104,8 +105,8 @@ services:
       - RSD_API_ACCESS_TOKEN_ENABLED
       - HOST_URL
     depends_on:
-      - database
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - net
     restart: unless-stopped
@@ -121,7 +122,8 @@ services:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     networks:
       - net
     restart: unless-stopped
@@ -145,9 +147,8 @@ services:
     expose:
       - 3000
     depends_on:
-      - database
-      - backend
-      - auth
+      backend:
+        condition: service_healthy
     networks:
       - net
     restart: unless-stopped
@@ -172,8 +173,8 @@ services:
       - CROSSREF_CONTACT_EMAIL
       - LIBRARIES_IO_ACCESS_TOKEN
     depends_on:
-      - database
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - net
     restart: unless-stopped
@@ -188,7 +189,8 @@ services:
       - POSTGREST_URL
       - PGRST_JWT_SECRET
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - net
     restart: unless-stopped
@@ -201,6 +203,9 @@ services:
     environment:
       - API_URL=${POSTGREST_URL_EXTERNAL}
       - SUPPORTED_SUBMIT_METHODS=[]
+    depends_on:
+      backend:
+        condition: service_healthy
     networks:
       - net
     restart: unless-stopped

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -50,13 +50,22 @@ services:
       - PGRST_DB_URI=postgres://rsd_authenticator:${POSTGRES_AUTHENTICATOR_PASSWORD}@${POSTGRES_DB_HOST}:${POSTGRES_DB_HOST_PORT}/${POSTGRES_DB}
       - PGRST_DB_ANON_ROLE
       - PGRST_DB_SCHEMA
+      - PGRST_SERVER_HOST=backend
       - PGRST_SERVER_PORT
+      - PGRST_ADMIN_SERVER_PORT
       - PGRST_JWT_SECRET
     depends_on:
       - database
     networks:
       - net
     restart: unless-stopped
+    healthcheck:
+      test: [ "CMD", "postgrest", "--ready" ]
+      interval: 5s
+      retries: 2
+      timeout: 5s
+      start_period: 60s
+      start_interval: 1s
 
   auth:
     container_name: auth

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,9 @@ services:
       - PGRST_DB_URI=postgres://rsd_authenticator:${POSTGRES_AUTHENTICATOR_PASSWORD}@${POSTGRES_DB_HOST}:${POSTGRES_DB_HOST_PORT}/${POSTGRES_DB}
       - PGRST_DB_ANON_ROLE
       - PGRST_DB_SCHEMA
+      - PGRST_SERVER_HOST=backend
       - PGRST_SERVER_PORT
+      - PGRST_ADMIN_SERVER_PORT
       - PGRST_JWT_SECRET
       - PGRST_DB_POOL=30
       - PGRST_DB_POOL_ACQUISITION_TIMEOUT=30
@@ -59,6 +61,13 @@ services:
       - database
     networks:
       - net
+    healthcheck:
+      test: [ "CMD", "postgrest", "--ready" ]
+      interval: 5s
+      retries: 2
+      timeout: 5s
+      start_period: 60s
+      start_interval: 1s
 
   auth:
     build: ./authentication
@@ -326,7 +335,8 @@ services:
       - PGRST_JWT_SECRET
       - POSTGREST_URL
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - net
     deploy:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,8 @@ services:
       - PGRST_DB_POOL=30
       - PGRST_DB_POOL_ACQUISITION_TIMEOUT=30
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     networks:
       - net
     healthcheck:
@@ -108,8 +109,8 @@ services:
       - RSD_API_ACCESS_TOKEN_ENABLED
       - HOST_URL
     depends_on:
-      - database
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - net
     entrypoint:
@@ -130,7 +131,8 @@ services:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
     depends_on:
-      - database
+      database:
+        condition: service_healthy
     networks:
       - net
 
@@ -161,9 +163,8 @@ services:
     expose:
       - 3000
     depends_on:
-      - database
-      - backend
-      - auth
+      backend:
+        condition: service_healthy
     volumes:
       - ./frontend/public:/app/public
     #   - ./deployment/hmz/styles:/app/public/styles
@@ -192,8 +193,8 @@ services:
       - CROSSREF_CONTACT_EMAIL
       - LIBRARIES_IO_ACCESS_TOKEN
     depends_on:
-      - database
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - net
 
@@ -207,7 +208,8 @@ services:
       - POSTGREST_URL
       - PGRST_JWT_SECRET
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
     networks:
       - net
 
@@ -218,6 +220,9 @@ services:
     environment:
       - API_URL=${POSTGREST_URL_EXTERNAL}
       - SUPPORTED_SUBMIT_METHODS=[]
+    depends_on:
+      backend:
+        condition: service_healthy
     networks:
       - net
 

--- a/e2e/.env.e2e
+++ b/e2e/.env.e2e
@@ -29,6 +29,7 @@ POSTGRES_USER=rsd
 PGRST_DB_ANON_ROLE=rsd_web_anon
 PGRST_DB_SCHEMA=public
 PGRST_SERVER_PORT=3500
+PGRST_ADMIN_SERVER_PORT=3501
 
 # postgREST API
 # consumed by services: authentication,frontend,auth-tests, scrapers


### PR DESCRIPTION
## Use PostgREST ready flag

### Changes proposed in this pull request

* Use PostgREST's new [ready flag](https://docs.postgrest.org/en/v14/references/cli.html#ready-flag) to mark the backend container as healthy
* Both the data-generation and the backend-test module now use this healthcheck to determine when they should start (`wait-on` for the data-generatio module was removed)
* Upgrade Faker from `10.3.0` to `10.4.0` ([release notes](https://github.com/faker-js/faker/releases))
* Upgrade PostgREST from `v14.6` to `v14.12` ([release notes](https://github.com/PostgREST/postgrest/releases))

### How to test

* **Add the new env variable from `.env.example` to your `.env` and `.env.local`**
* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* The data-generation script should start within one second of the backend container being ready
* Not sure why, but the data-generation script should run much faster than before (even in the commit before PostgREST was upgraded). UPDATE: this is probably because `wait-on` was making a request to the slow Swagger endpoint four times per second, which was taking up the connections from the connection pool.
* Check if the RSD still works
* Stop the containers and remove them (`docker compose down --volumes`)
* Check if the backend tests still pass (follow the instructions from `backend-tests/README.md`)
* Carefully check if the changes to the Docker Compose files (especially `deployment/docker-compose.yml`) are correct and if I didn't forget any changes in these or other files

closes #1805

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests