### PR TITLE
fix: do not reset tab

### DIFF
--- a/frontend/components/home/rsd/index.tsx
+++ b/frontend/components/home/rsd/index.tsx
@@ -35,7 +35,6 @@ export default function RsdHome({counts,news}: HomeProps) {
     <main
       // a11y id to be used to skip to main content link
       id="main-content"
-      tabIndex={-1}
       className="bg-base-100 dark:bg-base-900 dark:text-base-100 outline-none"
       data-testid="rsd-home-page"
     >

--- a/frontend/components/layout/MainContent.tsx
+++ b/frontend/components/layout/MainContent.tsx
@@ -19,7 +19,6 @@ export default function MainContent({className, children, ...props}: MainContain
     <main
       // a11y id to be used to skip to main content link
       id="main-content"
-      tabIndex={-1}
       className={`flex-1 flex flex-col py-4 lg:pb-12 outline-none ${className ?? ''}`}
       {...props}
     >


### PR DESCRIPTION
# Do not reset tab

Closes #1806

Changes proposed in this pull request:
* Remove tabIndex=-1 which seem to be resetting tab to start of the page    

How to test:
* `make start` to build and generate test data
* reload page and use tab, the button "Skip to main content" should appear and work
* navigate to pages and see if the tabbing behaves as expected

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
