### PR TITLE
Allow admins to delete mentions

### DIFF
--- a/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/AuthenticationIntegrationTest.java
@@ -188,6 +188,81 @@ public class AuthenticationIntegrationTest {
 			.statusCode(401);
 	}
 
+	@Test
+	void givenUnauthenticatedUser_whenDeletingMentionThroughRpc_thenNotAllowed() {
+		User user = User.create();
+		Mention mentionToDelete = Mention.createMention(user);
+		String bodyJson = "{\"mention_id\": \"%s\"}".formatted(mentionToDelete.id);
+
+		RestAssured.given()
+			.contentType(ContentType.JSON)
+			.body(bodyJson)
+			.when()
+			.post("rpc/delete_mention")
+			.then()
+			.statusCode(400);
+
+		List<?> responseArray = RestAssured.when()
+			.get("mention?id=eq." + mentionToDelete.id)
+			.then()
+			.statusCode(200)
+			.extract()
+			.as(List.class);
+		Assertions.assertEquals(1, responseArray.size());
+	}
+
+	@Test
+	void givenAuthenticatedUser_whenDeletingMentionThroughRpc_thenNotAllowed() {
+		User user = User.create();
+		Mention mentionToDelete = Mention.createMention(user);
+		String bodyJson = "{\"mention_id\": \"%s\"}".formatted(mentionToDelete.id);
+
+		RestAssured.given()
+			.header(user.authHeader)
+			.contentType(ContentType.JSON)
+			.body(bodyJson)
+			.when()
+			.post("rpc/delete_mention")
+			.then()
+			.statusCode(400);
+
+		List<?> responseArray = RestAssured.when()
+			.get("mention?id=eq." + mentionToDelete.id)
+			.then()
+			.statusCode(200)
+			.extract()
+			.as(List.class);
+		Assertions.assertEquals(1, responseArray.size());
+	}
+
+	@Test
+	void givenAdmin_whenDeletingMentionThroughRpc_thenAllowed() {
+		String bodyJson;
+		Mention mentionToDelete;
+		{
+			User user = User.create();
+			mentionToDelete = Mention.createMention(user);
+			bodyJson = "{\"mention_id\": \"%s\"}".formatted(mentionToDelete.id);
+		}
+
+		RestAssured.given()
+			.header(User.adminAuthHeader)
+			.contentType(ContentType.JSON)
+			.body(bodyJson)
+			.when()
+			.post("rpc/delete_mention")
+			.then()
+			.statusCode(204);
+
+		List<?> responseArray = RestAssured.when()
+			.get("mention?id=eq." + mentionToDelete.id)
+			.then()
+			.statusCode(200)
+			.extract()
+			.as(List.class);
+		Assertions.assertTrue(responseArray.isEmpty());
+	}
+
 	/*
 	 * ============================
 	 * === Tests for categories ===

--- a/backend-tests/src/test/java/nl/esciencecenter/Mention.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/Mention.java
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+import java.util.Objects;
+import java.util.Random;
+import java.util.UUID;
+
+public class Mention {
+
+	public final UUID id;
+	public final String title;
+	public final MentionType mentionType;
+
+	private Mention(UUID id, String title, MentionType mentionType) {
+		this.id = Objects.requireNonNull(id);
+		this.title = Objects.requireNonNull(title);
+		this.mentionType = Objects.requireNonNull(mentionType);
+	}
+
+	/**
+	 * Creates and stores mention with a random title and mention type. No DOI or OpenAlex ID are generated
+	 *
+	 * @param user the user who should create this mention
+	 *
+	 * @return the randomly generated mention that is stored in the database
+	 */
+	public static Mention createMention(User user) {
+		Objects.requireNonNull(user);
+
+		String title = UUID.randomUUID().toString();
+
+		MentionType[] mentionTypes = MentionType.values();
+		int mentionTypeSize = mentionTypes.length;
+		int randomIdx = new Random().nextInt(mentionTypeSize);
+		MentionType mentionType = mentionTypes[randomIdx];
+
+		String bodyJson = "{\"title\": \"%s\", \"mention_type\": \"%s\", \"source\": \"backend tests\"}".formatted(
+			title,
+			mentionType.name()
+		);
+
+		String mentionId = RestAssured.given()
+			.header(user.authHeader)
+			.header(Commons.requestEntry)
+			.contentType(ContentType.JSON)
+			.body(bodyJson)
+			.when()
+			.post("mention")
+			.then()
+			.statusCode(201)
+			.extract()
+			.path("[0].id");
+
+		return new Mention(UUID.fromString(mentionId), title, mentionType);
+	}
+}

--- a/backend-tests/src/test/java/nl/esciencecenter/MentionType.java
+++ b/backend-tests/src/test/java/nl/esciencecenter/MentionType.java
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package nl.esciencecenter;
+
+public enum MentionType {
+	blogPost,
+	book,
+	bookSection,
+	computerProgram,
+	conferencePaper,
+	dataset,
+	highlight,
+	interview,
+	journalArticle,
+	magazineArticle,
+	newspaperArticle,
+	poster,
+	presentation,
+	report,
+	thesis,
+	videoRecording,
+	webpage,
+	workshop,
+	other,
+}

--- a/database/111-mention-functions.sql
+++ b/database/111-mention-functions.sql
@@ -1,0 +1,33 @@
+-- SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+--
+-- SPDX-License-Identifier: Apache-2.0
+
+CREATE FUNCTION delete_mention(mention_id UUID) RETURNS VOID
+VOLATILE
+LANGUAGE plpgsql
+AS
+$$
+BEGIN
+	IF
+		(SELECT rolsuper FROM pg_roles WHERE rolname = SESSION_USER) IS DISTINCT FROM TRUE
+			AND
+		(SELECT CURRENT_SETTING('request.jwt.claims', FALSE)::json->>'role') IS DISTINCT FROM 'rsd_admin'
+	THEN
+		RAISE EXCEPTION USING MESSAGE = 'You are not allowed to delete mentions';
+	END IF;
+
+	IF mention_id IS NULL THEN
+		RAISE EXCEPTION USING MESSAGE = 'Please provide the ID of the mention to delete';
+	END IF;
+
+	DELETE FROM mention_for_software WHERE mention_for_software.mention = mention_id;
+	DELETE FROM reference_paper_for_software WHERE reference_paper_for_software.mention = mention_id;
+	DELETE FROM citation_for_mention WHERE citation_for_mention.mention = mention_id OR citation_for_mention.citation = mention_id;
+	DELETE FROM output_for_project WHERE output_for_project.mention = mention_id;
+	DELETE FROM impact_for_project WHERE impact_for_project.mention = mention_id;
+	DELETE FROM release_version WHERE release_version.mention_id = delete_mention.mention_id;
+
+	DELETE FROM mention WHERE mention.id = mention_id;
+END
+$$;

--- a/documentation/docs/03-rsd-instance/03-administration.md
+++ b/documentation/docs/03-rsd-instance/03-administration.md
@@ -221,10 +221,16 @@ fill the `provenance_iri` column. Further read [Linked Data](https://en.wikipedi
 
 ## Mentions
 
-In this section, admins can search for mentions and edit them. You an also see where the mention is used. If you enter a DOI or UUID, we search on that field only. Otherwise, we search on title, authors, journal, URL, note and OpenAlex ID.
+In this section, admins can search for mentions, edit them and delete them. You an also see where the mention is used. If you enter a DOI or UUID, we search on that field only. Otherwise, we search on title, authors, journal, URL, note and OpenAlex ID.
+
+When deleting a mention, a modal will appear to confirm that you really want to delete that mention.
 
 :::warning
 Edit mentions with care: they might be referenced to in multiple places. If you want to fully change a mention attached to e.g. a software page, you should delete it there and create a new one instead of editing it.
+:::
+
+:::warning
+When deleting a mention, all references to the mention will be deleted. Make sure to check the usages of the mention _before_ deleting it.
 :::
 
 ## Repositories

--- a/frontend/components/admin/mentions/MentionsOverviewList.tsx
+++ b/frontend/components/admin/mentions/MentionsOverviewList.tsx
@@ -9,6 +9,7 @@ import {useState} from 'react'
 import EditIcon from '@mui/icons-material/Edit'
 import IconButton from '@mui/material/IconButton'
 import HubIcon from '@mui/icons-material/Hub'
+import DeleteIcon from '@mui/icons-material/Delete'
 import Alert from '@mui/material/Alert'
 import {useSession} from '~/auth/AuthProvider'
 import {createJsonHeaders} from '~/utils/fetchHelpers'
@@ -20,6 +21,9 @@ import useSnackbar from '~/components/snackbar/useSnackbar'
 import MentionLocations from '~/components/admin/mentions/MentionLocations'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
+import TextField from '@mui/material/TextField'
+import ConfirmDeleteModal from '~/components/layout/ConfirmDeleteModal'
+import Tooltip from '@mui/material/Tooltip'
 
 function leaveOutSomeFieldsReplacer(key: string, value: any) {
   if (key === 'id' || key === 'doi_registration_date' || key === 'created_at' || key === 'updated_at') {
@@ -34,7 +38,9 @@ function AdminMention({mention, idx, onUpdate}: Readonly<{mention: MentionItemPr
   const {token} = useSession()
   const {showErrorMessage} = useSnackbar()
   const {page, rows} = usePaginationWithSearch('Find mentions')
-  const [modalOpen, setModalOpen] = useState<boolean>(false)
+  const [editModalOpen, setEditModalOpen] = useState<boolean>(false)
+  const [deleteModalOpen, setDeleteModalOpen] = useState<boolean>(false)
+  const [confirmation, setConfirmation] = useState<string>('')
 
   async function updateMention(data: MentionItemProps) {
     const id = data.id as string
@@ -45,7 +51,22 @@ function AdminMention({mention, idx, onUpdate}: Readonly<{mention: MentionItemPr
       headers: createJsonHeaders(token)
     })
     if (resp.ok) {
-      setModalOpen(false)
+      setEditModalOpen(false)
+      onUpdate()
+    } else {
+      showErrorMessage(`got status ${resp.status}:${await resp.text()}`)
+    }
+  }
+
+  async function deleteMention(mentionId: string) {
+    const body = JSON.stringify({mention_id: mentionId})
+    const resp = await fetch('/api/v1/rpc/delete_mention', {
+      method: 'POST',
+      body: body,
+      headers: createJsonHeaders(token)
+    })
+    if (resp.ok) {
+      setDeleteModalOpen(false)
       onUpdate()
     } else {
       showErrorMessage(`got status ${resp.status}:${await resp.text()}`)
@@ -54,28 +75,74 @@ function AdminMention({mention, idx, onUpdate}: Readonly<{mention: MentionItemPr
 
   return(
     <ListItem sx={{display: 'list-item'}}>
-      <div className="grid grid-cols-[1fr_auto_auto] items-center hover:bg-base-200">
+      <div className="grid grid-cols-[1fr_auto_auto_auto] gap-4 items-center hover:bg-base-200">
         <MentionViewItem item={mention} pos={page * rows + idx + 1} />
-        <IconButton onClick={() => setModalOpen(true)} ><EditIcon></EditIcon></IconButton>
-        <IconButton
-          aria-label={isOpenMentionLocations ? `Hide usages of ${mention.title}` : `Show usages of ${mention.title}`}
-          onClick={() => setIsOpenMentionLocations(!isOpenMentionLocations)}
-        >
-          <HubIcon />
-        </IconButton>
+        <Tooltip title={'Edit'} placement={'top'} >
+          <IconButton
+            onClick={() => setEditModalOpen(true)}
+            aria-label={`Edit the mention ${mention.title}`}
+          >
+            <EditIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title={'View usages'} placement={'top'} >
+          <IconButton
+            aria-label={isOpenMentionLocations ? `Hide usages of ${mention.title}` : `Show usages of ${mention.title}`}
+            onClick={() => setIsOpenMentionLocations(!isOpenMentionLocations)}
+          >
+            <HubIcon />
+          </IconButton>
+        </Tooltip>
+        <Tooltip title={'Delete'} placement={'top'} >
+          <IconButton
+            aria-label={`Delete the mention ${mention.title}; (you will be asked to confirm this before we delete it)`}
+            onClick={() => setDeleteModalOpen(!deleteModalOpen)}
+          >
+            <DeleteIcon />
+          </IconButton>
+        </Tooltip>
       </div>
       {isOpenMentionLocations ?
         <MentionLocations mentionId={mention.id as string}/>
         : null
       }
-      {modalOpen ?
+      {editModalOpen ?
         <EditMentionModal
-          title={mention.id as string ?? 'undefined'}
-          open={modalOpen}
+          title={mention.id as string}
+          open={editModalOpen}
           pos={undefined} //why does this exist?
           item={mention}
-          onCancel={() => setModalOpen(false)}
+          onCancel={() => setEditModalOpen(false)}
           onSubmit={({data}) => {updateMention(data)}}
+        />
+        : null
+      }
+      {deleteModalOpen ?
+        <ConfirmDeleteModal
+          open={deleteModalOpen}
+          title='Delete mention'
+          onCancel={() => setDeleteModalOpen(false)}
+          onDelete={() => deleteMention(mention.id!)}
+          removeDisabled={confirmation !== mention.id}
+          body={
+            <>
+              <p>
+                Are you sure you want to remove <strong>{mention.title}</strong> with ID <strong>{mention.id}</strong>?
+              </p>
+              <TextField
+                label="ID of the mention to delete"
+                helperText={
+                  <span>Type the mention ID exactly as shown above.</span>
+                }
+                value = {confirmation}
+                onChange={({target})=>setConfirmation(target.value)}
+                sx={{
+                  width: '100%',
+                  margin: '1rem 0rem'
+                }}
+              />
+            </>
+          }
         />
         : null
       }
@@ -87,7 +154,7 @@ export default function MentionsOverviewList({list, onUpdate}: {list: MentionIte
   if (list.length === 0) {
     return (
       <Alert severity="info" sx={{margin:'1rem 0rem'}}>
-        No mentions to show
+        No mentions found
       </Alert>
     )
   }

--- a/frontend/components/mention/MentionViewItem.tsx
+++ b/frontend/components/mention/MentionViewItem.tsx
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: 2022 - 2024 dv4all
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
-// SPDX-FileCopyrightText: 2023 - 2024 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2023 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 Dusan Mijatovic (dv4all) (dv4all)
 //
@@ -58,7 +58,7 @@ export default function MentionViewItem({item, pos}: {item: MentionItemProps, po
     return (
       <Link
         href={item.url}
-        className="flex-1 pr-8"
+        className="flex-1"
         target="_blank"
         rel="noreferrer"
         passHref

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Allow admins to delete mentions

### Changes proposed in this pull request

* Allow admins to delete mentions through the admin interface
* Add integration tests for the new API RPC
* Update the docs

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin
* Check the admin interface and try to delete mentions
* Check that the new tests are correct
* Try to use the new API RPC as non-admin; this should fail
* Check the updated documentation

closes #1799

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [x] Update documentation
* [x] Tests