### PR TITLE
1758 speech access

### DIFF
--- a/frontend/components/category/CategoryEditTreeNode.tsx
+++ b/frontend/components/category/CategoryEditTreeNode.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2024 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -83,7 +83,9 @@ export default function CategoryEditTreeNode({node, community, organisation, lab
   function getExpandIcon() {
     if (node.childrenCount() === 0) {
       return (
-        <IconButton disabled>
+        <IconButton
+          title="Disabled"
+          disabled>
           <Icon />
         </IconButton>
       )
@@ -91,6 +93,7 @@ export default function CategoryEditTreeNode({node, community, organisation, lab
     else if (expandChildren) {
       return (
         <IconButton
+          title="Close"
           disabled={showItem!=='none'}
           onClick={() => setExpandChildren(false)}
         >
@@ -100,6 +103,7 @@ export default function CategoryEditTreeNode({node, community, organisation, lab
     } else {
       return (
         <IconButton
+          title="Open"
           disabled={showItem!=='none'}
           onClick={() => setExpandChildren(true)}
         >

--- a/frontend/components/category/CategoryList.tsx
+++ b/frontend/components/category/CategoryList.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2024 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -86,6 +86,7 @@ function NodeWithChildren({
         secondaryAction={
           <IconButton
             edge="end"
+            title={open ? 'Close' : 'Open'}
             aria-label="expand"
             onClick={()=>setOpen(!open)}
           >

--- a/frontend/components/category/CategoryTree.tsx
+++ b/frontend/components/category/CategoryTree.tsx
@@ -38,6 +38,7 @@ export default function CategoryTree({onRemove,items,showLongNames,selectedList}
               </Link>
               { onRemove && selectedList?.has(category.id) ?
                 <IconButton
+                  title="Delete"
                   size='small'
                   onClick={()=>onRemove(category.id)}>
                   <CancelIcon fontSize='small'/>

--- a/frontend/components/login/LoginDialog.tsx
+++ b/frontend/components/login/LoginDialog.tsx
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2022 dv4all
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -48,7 +48,9 @@ export default function LoginDialog({providers,open, onClose}: LoginDialogProps)
         }}
       >
         Sign in with
-        <IconButton onClick={onClose}>
+        <IconButton
+          aria-label="Close dialog"
+          onClick={onClose}>
           <CloseIcon />
         </IconButton>
       </DialogTitle>

--- a/frontend/components/login/LoginProviders.tsx
+++ b/frontend/components/login/LoginProviders.tsx
@@ -8,6 +8,7 @@
 import Link from 'next/link'
 import List from '@mui/material/List'
 import ListItem from '@mui/material/ListItem'
+import ListItemButton from '@mui/material/ListItemButton'
 import ListItemText from '@mui/material/ListItemText'
 import Chip from '@mui/material/Chip'
 
@@ -59,26 +60,27 @@ export default function LoginProviders({providers,login_info_url,onClick}:LoginP
           if (provider?.accessType==='EVERYONE') color='success'
           if (provider?.accessType==='INVITE_ONLY') color='warning'
           return (
-            <Link
+            <ListItem
               key={provider.signInUrl}
-              href={provider.signInUrl}
+              alignItems="flex-start"
+              className="rounded-[0.25rem] border my-2"
+              sx={{
+                opacity: 0.75,
+                '&:hover': {
+                  opacity: 1,
+                  backgroundColor:'background.default'
+                },
+                position:'relative'
+              }}
               onClick={()=>{
                 // close modal for local account
                 if (provider.openidProvider==='local' && onClick) onClick()
               }}
-              passHref
+              disablePadding
             >
-              <ListItem
-                alignItems="flex-start"
-                className="rounded-[0.25rem] border my-2"
-                sx={{
-                  opacity: 0.75,
-                  '&:hover': {
-                    opacity: 1,
-                    backgroundColor:'background.default'
-                  },
-                  position:'relative'
-                }}
+              <ListItemButton
+                component={Link}
+                href={provider.signInUrl}
               >
                 {
                   provider?.accessType==='INVITE_ONLY' ?
@@ -108,8 +110,8 @@ export default function LoginProviders({providers,login_info_url,onClick}:LoginP
                     }
                   }}
                 />
-              </ListItem>
-            </Link>
+              </ListItemButton>
+            </ListItem>
           )
         })}
       </List>

--- a/frontend/components/login/LoginProviders.tsx
+++ b/frontend/components/login/LoginProviders.tsx
@@ -72,15 +72,15 @@ export default function LoginProviders({providers,login_info_url,onClick}:LoginP
                 },
                 position:'relative'
               }}
-              onClick={()=>{
-                // close modal for local account
-                if (provider.openidProvider==='local' && onClick) onClick()
-              }}
               disablePadding
             >
               <ListItemButton
                 component={Link}
                 href={provider.signInUrl}
+                onClick={()=>{
+                  // close modal for local account
+                  if (provider.openidProvider==='local' && onClick) onClick()
+                }}
               >
                 {
                   provider?.accessType==='INVITE_ONLY' ?

--- a/frontend/components/mention/MentionEditButtons.tsx
+++ b/frontend/components/mention/MentionEditButtons.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -27,6 +27,7 @@ export default function MentionEditButtons({item}: {item:MentionItemProps}) {
       <IconButton
         data-testid="edit-mention-btn"
         key="edit-button"
+        title="Edit"
         onClick={()=>setEditModal(item)}>
         <EditIcon />
       </IconButton>
@@ -37,6 +38,7 @@ export default function MentionEditButtons({item}: {item:MentionItemProps}) {
     <IconButton
       data-testid="delete-mention-btn"
       key="delete-button"
+      title="Delete"
       sx={{
         marginLeft:'1rem'
       }}

--- a/frontend/components/organisation/releases/OrganisationReleasesIndex.test.tsx
+++ b/frontend/components/organisation/releases/OrganisationReleasesIndex.test.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -55,7 +55,7 @@ describe('components/organisation/releases/index.tsx', () => {
     )
 
     // buttons
-    const years = screen.getAllByRole('release-year-button')
+    const years = screen.getAllByTestId('release-year-button')
     // NOTE! one period is loaded and therefore not a button hence length-1
     expect(years.length).toEqual(mockReleaseCount.length - 1)
 

--- a/frontend/components/organisation/releases/ReleaseNavButton.tsx
+++ b/frontend/components/organisation/releases/ReleaseNavButton.tsx
@@ -1,5 +1,5 @@
-// SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2023 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2023 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
@@ -27,7 +27,13 @@ export default function ReleaseNavButton({year, selected, release_cnt, link}: Re
   }
 
   return (
-    <Link role="release-year-button" scroll={false} href={link} style={{opacity: 0.6}}>
+    <Link
+      data-testId="release-year-button"
+      role="button"
+      scroll={false}
+      href={link}
+      style={{opacity: 0.7}}
+    >
       <div className="border rounded-md">
         <div className="bg-primary py-1 px-2 text-primary-content">{year}</div>
         <div className="text-center p-2 font-medium text-primary">{release_cnt}</div>

--- a/frontend/components/search/ShowItemsSelect.tsx
+++ b/frontend/components/search/ShowItemsSelect.tsx
@@ -1,12 +1,11 @@
-// SPDX-FileCopyrightText: 2025 Dusan Mijatovic (Netherlands eScience Center)
-// SPDX-FileCopyrightText: 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2025 - 2026 Dusan Mijatovic (Netherlands eScience Center)
+// SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
 //
 // SPDX-License-Identifier: Apache-2.0
 
 import FormControl from '@mui/material/FormControl'
 import Select from '@mui/material/Select'
 import MenuItem from '@mui/material/MenuItem'
-import InputLabel from '@mui/material/InputLabel'
 
 import {rowsPerPageOptions} from '~/config/pagination'
 
@@ -32,17 +31,21 @@ export default function ShowItemsSelect({items, onItemsChange}: SelectRowsProps)
       }}
       title={`Show ${items} items on page`}
     >
-      {/* need to add it for accessibility - Lighthouse audit */}
-      <InputLabel id="select-items" className="opacity-0">Items</InputLabel>
       <Select
         id="select-rows"
-        labelId="select-items"
         variant="outlined"
         value={items}
-        // label="Items"
         onChange={({target}) =>{
           // console.log('items...', target.value)
           onItemsChange(target.value)
+        }}
+        inputProps={{
+          // a11y fix for voice control
+          'aria-label': items.toString()
+        }}
+        MenuProps={{
+          // a11y CRITICAL VOICE CONTROL FIX FOR CUSTOM MENUS
+          disablePortal: true
         }}
         sx={{
           border: '1px solid #fff'


### PR DESCRIPTION
# Improve speech access

Closes #1758

Changes proposed in this pull request:
* Improve speech access for select options
* Improve a11y for login modal
* Improve a11y for mention item buttons
* Improve a11y in categories components

How to test:
* This PR is set on [dev server](https://research-software.dev/) in order to be able to test on multiple machines with different OS-es.
* Confirm that software overview can be navigated using speech:
  * confirm user can select/change number of items on the page
  * confirm user can use filters in the panel
  * confirm user can use search
* Confirm no a11y warnings (beside color contrast) in the login modal
* Confirm no a11y warnings on edit mentions

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
