### PR TITLE
Fix drop-and-drag border and unnecessary tab

### DIFF
--- a/frontend/components/form/ImageDropZone.tsx
+++ b/frontend/components/form/ImageDropZone.tsx
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -30,17 +30,17 @@ export default function ImageDropZone(props:ImageDropZoneProps) {
       type="button"
       aria-label={props.ariaLabel}
       // Tailwind utility resets default button styles and handles focus
-      className="text-left block bg-transparent border-0 p-0.5 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary transition-all cursor-pointer"
+      className="text-left block bg-transparent border-0 p-0.5 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary"
       onClick={props.onClick}
       onDragOver={(e: any) => {
         e.preventDefault()
-        e.currentTarget.style.border = '2px dashed grey'
+        e.currentTarget.style.outline = '2px dashed var(--rsd-base-content, grey)'
       }}
       onDragLeave={(e: any) => {
-        e.currentTarget.style.border = 'inherit'
+        e.currentTarget.style.outline = 'inherit'
       }}
       onDrop={(e: any) => {
-        e.currentTarget.style.border = 'inherit'
+        e.currentTarget.style.outline = 'inherit'
         e.preventDefault()
         if (e.dataTransfer.files.length) {
           props.onImageDrop({target: {files: e.dataTransfer.files}})

--- a/frontend/components/form/LogoDropZone.tsx
+++ b/frontend/components/form/LogoDropZone.tsx
@@ -1,5 +1,5 @@
+// SPDX-FileCopyrightText: 2025 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2025 - 2026 Netherlands eScience Center
-// SPDX-FileCopyrightText: 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 //
 // SPDX-License-Identifier: Apache-2.0
@@ -25,13 +25,13 @@ export default function LogoDropZone(props: Readonly<ImageDropZoneProps>) {
     <div
       onDragOver={(e: any) => {
         e.preventDefault()
-        e.currentTarget.style.border = '3px dashed grey'
+        e.currentTarget.style.outline = '2px dashed var(--rsd-base-content, grey)'
       }}
       onDragLeave={(e: any) => {
-        e.currentTarget.style.border = 'inherit'
+        e.currentTarget.style.outline = 'inherit'
       }}
       onDrop={(e: any) => {
-        e.currentTarget.style.border = 'inherit'
+        e.currentTarget.style.outline = 'inherit'
         e.preventDefault()
         const reader = new FileReader()
 

--- a/frontend/components/layout/SortableListItem.tsx
+++ b/frontend/components/layout/SortableListItem.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2023 - 2026 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2023 Dusan Mijatovic (dv4all)
 // SPDX-FileCopyrightText: 2023 dv4all
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -29,8 +30,9 @@ export default function SortableListItem<T extends RequiredListProps>({
     transform,transition,isDragging
   } = useSortable({id: item.id ?? ''})
 
-  //a11y FIX: Destructure "role" out of attributes so it doesn't apply to the <li> element
-  const {role, ...cleanedAttributes} = attributes
+  //a11y FIX: Destructure "role" and "tabIndex" out of attributes so it doesn't apply to the <li> element
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const {role, tabIndex, ...cleanedAttributes} = attributes
 
   return (
     <ListItem

--- a/frontend/components/projects/edit/information/ProjectInformationForm.tsx
+++ b/frontend/components/projects/edit/information/ProjectInformationForm.tsx
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2023 dv4all
 // SPDX-FileCopyrightText: 2024 - 2026 Dusan Mijatovic (Netherlands eScience Center)
 // SPDX-FileCopyrightText: 2024 - 2026 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -59,7 +60,7 @@ export default function ProjectInformationForm({editProject}: {editProject: Edit
           aria-label="Project description items"
           className='xl:grid xl:grid-cols-[3fr_1fr] xl:px-0 xl:gap-[3rem]'>
           {/* middle panel */}
-          <div className="py-2 overflow-hidden">
+          <div className="py-2">
             <EditSectionTitle
               title={config.sectionTitle}
             />


### PR DESCRIPTION
## Fix drop-and-drag border and unnecessary tab

### Changes proposed in this pull request

* When dragging and dropping an image, the border does not animate any more; neither does it cause a content shift any more
* Remove extra tab that focuses a draggable list element without interactive semantics

### How to test

* `docker compose down --volumes && docker compose build --parallel && docker compose up --scale data-generation=1`
* Sign in as admin
* Drag and drop images in various places
* Try tab navigating a sortable list, e.g. the organisations of software

closes #1819
closes #1820

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests