### PR TITLE
fix: remove disableScrollLock

### DIFF
--- a/frontend/components/AppHeader/AddMenu.tsx
+++ b/frontend/components/AppHeader/AddMenu.tsx
@@ -81,8 +81,6 @@ export default function AddMenu() {
         onClose={() => handleClose()}
         transformOrigin={{horizontal: 'right', vertical: 'top'}}
         anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
-        // disable adding styles to body (overflow:hidden & padding-right)
-        disableScrollLock={true}
         slotProps={{
           list: {'aria-labelledby': 'menu-button'}
         }}

--- a/frontend/components/AppHeader/ResponsiveMenu.tsx
+++ b/frontend/components/AppHeader/ResponsiveMenu.tsx
@@ -56,8 +56,6 @@ export default function ResponsiveMenu({activePath}:{activePath:string}) {
         onClose={handleCloseResponsiveMenu}
         transformOrigin={{horizontal: 'right', vertical: 'top'}}
         anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
-        // disable adding styles to body (overflow:hidden & padding-right)
-        disableScrollLock = {true}
       >
         {menuItems.map(item => {
           const isActive = isActiveMenuItem({item, activePath})

--- a/frontend/components/feedback/FeedbackPanelButton.tsx
+++ b/frontend/components/feedback/FeedbackPanelButton.tsx
@@ -89,7 +89,6 @@ User Agent: ${navigator.userAgent}`
         open={open}
         onClose={handleClose}
         aria-labelledby="feedback-dialog-title"
-        disableScrollLock={true}
       >
         <div className="h-full w-full bg-base-700 p-5 ">
           <div className="mx-auto max-w-[500px]">

--- a/frontend/components/layout/UserMenu.tsx
+++ b/frontend/components/layout/UserMenu.tsx
@@ -128,8 +128,6 @@ export default function UserMenu() {
         onClose={handleClose}
         transformOrigin={{horizontal: 'right', vertical: 'top'}}
         anchorOrigin={{horizontal: 'right', vertical: 'bottom'}}
-        // disable adding styles to body (overflow:hidden & padding-right)
-        disableScrollLock = {true}
       >
         {renderMenuOptions()}
       </Menu>


### PR DESCRIPTION
# Revert back to original component behavior

Closes #1823

Changes proposed in this pull request:
* Remove disableScrollLock to go back to original components behavior
* The "fix" I produced previously was triggered by Chrome plugin for voice control I installed. This plugin was injecting additional css styles :-(.      

How to test:
* `make start` to build and generate test data.
* login as rsd-admin
* confirm:
    * no layout shift occurs when using Feedback modal. You will not be able to scroll even if the page is longer than the screen while modal is open. This is desired behaviour.
    * no layout shift when using Add menu. You won't be able to scroll page even if page is longer than screen while menu is open. This is desired behavior.
    * no layout shift when using User Menu. You won't be able to scroll page even if page is longer than the screen while menu is open.
    * no layout shift on mobile main menu.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
