### PR TITLE
On first login: create user profile in authenticator module

### DIFF
--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
@@ -3,6 +3,7 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
 // SPDX-FileCopyrightText: 2024 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 // SPDX-FileCopyrightText: 2025 Paula Stock (GFZ) <paula.stock@gfz.de>
+// SPDX-FileCopyrightText: 2026 Matthias Volk (GFZ) <matthias.volk@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
@@ -21,6 +21,8 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
@@ -146,6 +148,7 @@ public class PostgrestAccount implements Account {
 
 			UUID accountId = UUID.fromString(newAccountId);
 			createLoginForAccount(accountId, openIdInfo, provider, backendUri, token);
+			createUserProfileForLogin(accountId, openIdInfo, backendUri, token);
 
 			boolean isAdmin = createAdminIfDevAndNoAdminsExist(backendUri, token, accountId);
 
@@ -290,6 +293,62 @@ public class PostgrestAccount implements Account {
 				response.body(),
 				"Could not create login for account"
 			);
+		}
+	}
+
+	static List<String> splitName(String fullName) {
+		String givenNames = "";
+		String familyNames = "";
+
+		if (fullName != null && fullName.length() > 0) {
+			List<String> parts;
+
+			fullName = fullName.trim();
+			if (fullName.contains(", ")) {
+				parts = Arrays.asList(fullName.split(", ")).reversed();
+			} else {
+				parts = Arrays.asList(fullName.split(" "));
+			}
+
+			givenNames = parts.get(0);
+			familyNames = String.join(" ", parts.subList(1, parts.size()));
+		}
+
+		return Arrays.asList(givenNames, familyNames);
+	}
+
+	private void createUserProfileForLogin(
+			UUID accountId,
+			OpenIdInfo openIdInfo,
+			String backendUri,
+			String adminJwt)
+			throws IOException, InterruptedException, RsdResponseException, RsdAuthenticationException {
+
+		List<String> nameParts = splitName(openIdInfo.name());
+
+		JsonObject userProfileData = new JsonObject();
+		userProfileData.addProperty("account", accountId.toString());
+		userProfileData.addProperty("given_names", nameParts.get(0));
+		userProfileData.addProperty("family_names", nameParts.get(1));
+		userProfileData.addProperty("email_address", openIdInfo.email());
+		userProfileData.addProperty("affiliation", openIdInfo.organisation());
+		userProfileData.addProperty("is_public", false);
+
+		URI createLoginUri = URI.create(backendUri + "/user_profile");
+
+		HttpResponse<String> response = postJsonAsAdminWithResponse(
+				createLoginUri,
+				userProfileData.toString(),
+				adminJwt);
+
+		if (response.statusCode() == 409) {
+			throw new RsdAuthenticationException("A user profile already exists for this account");
+		} else if (response.statusCode() >= 300) {
+			throw new RsdResponseException(
+					response.statusCode(),
+					response.uri(),
+					response.body(),
+					"Could not create user profile login for login.");
 		}
 	}
 

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
@@ -318,13 +318,8 @@ public class PostgrestAccount implements Account {
 		return Arrays.asList(givenNames, familyNames);
 	}
 
-	private void createUserProfileForLogin(
-			UUID accountId,
-			OpenIdInfo openIdInfo,
-			String backendUri,
-			String adminJwt)
-			throws IOException, InterruptedException, RsdResponseException, RsdAuthenticationException {
-
+	private void createUserProfileForLogin(UUID accountId, OpenIdInfo openIdInfo, String backendUri, String adminJwt)
+		throws IOException, InterruptedException, RsdResponseException, RsdAuthenticationException {
 		List<String> nameParts = splitName(openIdInfo.name());
 
 		JsonObject userProfileData = new JsonObject();
@@ -338,18 +333,20 @@ public class PostgrestAccount implements Account {
 		URI createLoginUri = URI.create(backendUri + "/user_profile");
 
 		HttpResponse<String> response = postJsonAsAdminWithResponse(
-				createLoginUri,
-				userProfileData.toString(),
-				adminJwt);
+			createLoginUri,
+			userProfileData.toString(),
+			adminJwt
+		);
 
 		if (response.statusCode() == 409) {
 			throw new RsdAuthenticationException("A user profile already exists for this account");
 		} else if (response.statusCode() >= 300) {
 			throw new RsdResponseException(
-					response.statusCode(),
-					response.uri(),
-					response.body(),
-					"Could not create user profile login for login.");
+				response.statusCode(),
+				response.uri(),
+				response.body(),
+				"Could not create user profile login for login."
+			);
 		}
 	}
 

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
@@ -313,7 +313,7 @@ public class PostgrestAccount implements Account {
 		String givenNames = "";
 		String familyNames = "";
 
-		if (fullName != null && fullName.length() > 0) {
+		if (fullName != null && !fullName.isEmpty()) {
 			List<String> parts;
 
 			fullName = fullName.trim();
@@ -348,7 +348,7 @@ public class PostgrestAccount implements Account {
 			createLoginUri,
 			userProfileData.toString(),
 			adminJwt,
-			"Prefer",
+			PREFER_HEADER_KEY,
 			"resolution=ignore-duplicates"
 		);
 

--- a/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
+++ b/authentication/src/main/java/nl/esciencecenter/rsd/authentication/PostgrestAccount.java
@@ -130,14 +130,16 @@ public class PostgrestAccount implements Account {
 		throws IOException, InterruptedException, RsdResponseException {
 		Optional<AccountInfo> maybeExistingAccount = getAccountIfExists(openIdInfo, provider);
 
+		JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
+		String token = jwtCreator.createAdminJwt();
+		AccountInfo accountInfo;
+
 		if (maybeExistingAccount.isPresent()) {
-			return maybeExistingAccount.get();
+			accountInfo = maybeExistingAccount.get();
 		}
 		// The login credentials do no exist yet, create a new account and return it.
 		else {
 			// create account
-			JwtCreator jwtCreator = new JwtCreator(Config.jwtSigningSecret());
-			String token = jwtCreator.createAdminJwt();
 			URI createAccountEndpoint = URI.create(backendUri + "/account");
 			String newAccountJson = postJsonAsAdmin(createAccountEndpoint, "{}", token);
 			String newAccountId = JsonParser.parseString(newAccountJson)
@@ -149,13 +151,23 @@ public class PostgrestAccount implements Account {
 
 			UUID accountId = UUID.fromString(newAccountId);
 			createLoginForAccount(accountId, openIdInfo, provider, backendUri, token);
-			createUserProfileForLogin(accountId, openIdInfo, backendUri, token);
 
 			boolean isAdmin = createAdminIfDevAndNoAdminsExist(backendUri, token, accountId);
 
 			// a new account cannot be locked
-			return new AccountInfo(accountId, openIdInfo.name(), isAdmin, openIdInfo.data(), false, Optional.empty());
+			accountInfo = new AccountInfo(
+				accountId,
+				openIdInfo.name(),
+				isAdmin,
+				openIdInfo.data(),
+				false,
+				Optional.empty()
+			);
 		}
+
+		createUserProfileForLogin(accountInfo.account(), openIdInfo, backendUri, token);
+
+		return accountInfo;
 	}
 
 	public AccountInfo useInviteToCreateAccount(UUID inviteId, OpenIdInfo openIdInfo, OpenidProvider provider)
@@ -335,12 +347,12 @@ public class PostgrestAccount implements Account {
 		HttpResponse<String> response = postJsonAsAdminWithResponse(
 			createLoginUri,
 			userProfileData.toString(),
-			adminJwt
+			adminJwt,
+			"Prefer",
+			"resolution=ignore-duplicates"
 		);
 
-		if (response.statusCode() == 409) {
-			throw new RsdAuthenticationException("A user profile already exists for this account");
-		} else if (response.statusCode() >= 300) {
+		if (response.statusCode() >= 300) {
 			throw new RsdResponseException(
 				response.statusCode(),
 				response.uri(),

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
@@ -1,5 +1,6 @@
 // SPDX-FileCopyrightText: 2024 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 // SPDX-FileCopyrightText: 2024 - 2025 Netherlands eScience Center
+// SPDX-FileCopyrightText: 2026 Matthias Volk (GFZ) <matthias.volk@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
@@ -6,6 +6,7 @@
 package nl.esciencecenter.rsd.authentication;
 
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.UUID;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
@@ -114,5 +115,37 @@ class PostgrestAccountTest {
 		Assertions.assertThrowsExactly(RsdAccountInviteException.class, () ->
 			PostgrestAccount.checkInviteResponseGetUsesLeft(UUID.randomUUID(), json)
 		);
+	}
+
+	@Test
+	void givenSpaceSeparatedFullName_whenSplit_thenPartsAreReturned() {
+		String fullName = "first middle last   ";
+		Assertions.assertEquals(
+				Arrays.asList("first", "middle last"),
+				PostgrestAccount.splitName(fullName));
+	}
+
+	@Test
+	void givenCommaSeparatedFullName_whenSplit_thenPartsAreReturned() {
+		String fullName = "last, first middle";
+		Assertions.assertEquals(
+				Arrays.asList("first middle", "last"),
+				PostgrestAccount.splitName(fullName));
+	}
+
+	@Test
+	void givenNull_whenSplit_thenEmptyStringsAreReturned() {
+		String fullName = null;
+		Assertions.assertEquals(
+				Arrays.asList("", ""),
+				PostgrestAccount.splitName(fullName));
+	}
+
+	@Test
+	void givenEmptyString_whenSplit_thenEmptyStringsAreReturned() {
+		String fullName = "";
+		Assertions.assertEquals(
+				Arrays.asList("", ""),
+				PostgrestAccount.splitName(fullName));
 	}
 }

--- a/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
+++ b/authentication/src/test/java/nl/esciencecenter/rsd/authentication/PostgrestAccountTest.java
@@ -121,32 +121,24 @@ class PostgrestAccountTest {
 	@Test
 	void givenSpaceSeparatedFullName_whenSplit_thenPartsAreReturned() {
 		String fullName = "first middle last   ";
-		Assertions.assertEquals(
-				Arrays.asList("first", "middle last"),
-				PostgrestAccount.splitName(fullName));
+		Assertions.assertEquals(Arrays.asList("first", "middle last"), PostgrestAccount.splitName(fullName));
 	}
 
 	@Test
 	void givenCommaSeparatedFullName_whenSplit_thenPartsAreReturned() {
 		String fullName = "last, first middle";
-		Assertions.assertEquals(
-				Arrays.asList("first middle", "last"),
-				PostgrestAccount.splitName(fullName));
+		Assertions.assertEquals(Arrays.asList("first middle", "last"), PostgrestAccount.splitName(fullName));
 	}
 
 	@Test
 	void givenNull_whenSplit_thenEmptyStringsAreReturned() {
 		String fullName = null;
-		Assertions.assertEquals(
-				Arrays.asList("", ""),
-				PostgrestAccount.splitName(fullName));
+		Assertions.assertEquals(Arrays.asList("", ""), PostgrestAccount.splitName(fullName));
 	}
 
 	@Test
 	void givenEmptyString_whenSplit_thenEmptyStringsAreReturned() {
 		String fullName = "";
-		Assertions.assertEquals(
-				Arrays.asList("", ""),
-				PostgrestAccount.splitName(fullName));
+		Assertions.assertEquals(Arrays.asList("", ""), PostgrestAccount.splitName(fullName));
 	}
 }

--- a/frontend/components/user/settings/profile/apiUserProfile.ts
+++ b/frontend/components/user/settings/profile/apiUserProfile.ts
@@ -2,13 +2,13 @@
 // SPDX-FileCopyrightText: 2025 Dusan Mijatovic (dv4all) (dv4all)
 // SPDX-FileCopyrightText: 2025 Netherlands eScience Center
 // SPDX-FileCopyrightText: 2025 dv4all
+// SPDX-FileCopyrightText: 2026 Matthias Volk (GFZ) <matthias.volk@gfz.de>
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
-import {splitName} from '~/utils/getDisplayName'
+import { createJsonHeaders, extractReturnMessage, getBaseUrl } from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
-import {getLoginForAccount, LoginForAccount} from './apiLoginForAccount'
+import { getLoginForAccount } from './apiLoginForAccount'
 
 export type UserProfile = {
   account: string,
@@ -36,38 +36,6 @@ export async function loadUserProfile({account,token}:{account?:string,token?:st
       getUserProfile({account,token}),
       getLoginForAccount({account,token})
     ])
-    // const profile = await
-    // console.log('loadUserProfile...profile...', profile)
-    // return profile if found
-    if (profile!==null) return {
-      profile,
-      logins
-    }
-    // get logins
-    // const logins = await getLoginForAccount({account,token})
-    // console.log('getLoginForAccount...logins...', logins)
-    if (logins.length>0){
-      const profile = convertLoginToProfile(logins)
-      // console.log('convertLoginToProfile...profile...', profile)
-      if (profile){
-        const resp = await insertUserProfile({profile,token})
-        if (resp?.status===200){
-          return {
-            profile,
-            logins
-          }
-        }
-        logger(`loadUserProfile.insertUserProfile: ${resp?.status}: ${resp?.message}`,'error')
-        return {
-          profile,
-          logins
-        }
-      }
-      return {
-        profile,
-        logins
-      }
-    }
     return {
       profile,
       logins
@@ -136,43 +104,6 @@ export async function patchUserProfile({account,data,token}:UpdateUserProfilePro
       status: 500,
       message: e?.message
     }
-  }
-}
-
-export function convertLoginToProfile(logins:LoginForAccount[]){
-  try{
-    const login = logins[0]
-    const profile: UserProfile = {
-      account: login.account,
-      ...splitName(login.name),
-      email_address: login.email,
-      affiliation: login.home_organisation,
-      role: null,
-      is_public: false,
-      avatar_id: null,
-      description: null
-    }
-    return profile
-  }catch(e:any){
-    logger(`convertLoginToProfile: ${e.message}`,'error')
-    return null
-  }
-}
-
-export async function insertUserProfile({profile,token}:{profile:UserProfile,token:string}){
-  try{
-    const url = `${getBaseUrl()}/user_profile`
-    const resp = await fetch(url, {
-      method: 'POST',
-      headers: {
-        ...createJsonHeaders(token)
-      },
-      body: JSON.stringify(profile)
-    })
-    return extractReturnMessage(resp)
-  }catch(e:any){
-    logger(`insertUserProfile: ${e.message}`,'error')
-    return null
   }
 }
 

--- a/frontend/components/user/settings/profile/apiUserProfile.ts
+++ b/frontend/components/user/settings/profile/apiUserProfile.ts
@@ -6,9 +6,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { createJsonHeaders, extractReturnMessage, getBaseUrl } from '~/utils/fetchHelpers'
+import {createJsonHeaders, extractReturnMessage, getBaseUrl} from '~/utils/fetchHelpers'
 import logger from '~/utils/logger'
-import { getLoginForAccount } from './apiLoginForAccount'
+import {getLoginForAccount} from './apiLoginForAccount'
 
 export type UserProfile = {
   account: string,


### PR DESCRIPTION
# On first login: create user profile in authenticator module

Fixes #1828

Changes proposed in this pull request:

* Create a row in the `user_profile` table when a user logs in for the first time. Currently this happens when the user visits the user profile settings page for the first time.

How to test:

* Login and create a maintainer invite link for a software.
* Logout (or open a private window) and paste the invite link.
* Follow the prompt and sign in as a user *without existing* account.
* Confirm the message that the invite link was processed.
* Do *not* open the user profile page. Instead, verify in the database that there is an row in `user_profile` for the new user.

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [ ] Update documentation
*   [x] Tests
