### PR TITLE
feat: update github actions for authentication and background-services

### DIFF
--- a/.github/workflows/_java_sonar.yml
+++ b/.github/workflows/_java_sonar.yml
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: reusable java sonar
+
+on:
+  workflow_call:
+    inputs:
+      head_sha:
+        required: true
+        type: string
+      head_branch:
+        required: true
+        type: string
+      working_directory:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+      sonar_project_key:
+        required: true
+        type: string
+      workflow_run_id:
+        required: true
+        type: string
+    secrets:
+      SONAR_TOKEN:
+        required: true
+
+jobs:
+  # 1. Fetch PR info in order to determine where Sonar check should run
+  resolve-pr:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/_pr_info.yml
+    with:
+      head_sha: ${{ inputs.head_sha }}
+
+  # 2. Run Sonar analysis using inputs and reslove-pr step
+  scan:
+    name: Java Sonar Scanner
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-24.04
+    needs: resolve-pr
+    steps:
+      - name: Checkout Code Securely
+        uses: actions/checkout@v6
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ inputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
+
+      - name: Download Target Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.working_directory }}/target/
+          run-id: ${{ inputs.workflow_run_id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v4
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Run Sonar Analysis (PR Mode)
+        if: ${{ needs.resolve-pr.outputs.is_pr == 'true' }}
+        working-directory: ${{ inputs.working_directory }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+            -Dsonar.projectKey=${{ inputs.sonar_project_key }} \
+            -Dsonar.pullrequest.key=${{ needs.resolve-pr.outputs.pr_number }} \
+            -Dsonar.pullrequest.base=${{ needs.resolve-pr.outputs.pr_base }} \
+            -Dsonar.pullrequest.branch=${{ inputs.head_branch }}
+
+      - name: Run Sonar Analysis (Branch Mode)
+        if: ${{ needs.resolve-pr.outputs.is_pr == 'false' }}
+        working-directory: ${{ inputs.working_directory }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: |
+          mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar \
+            -Dsonar.projectKey=${{ inputs.sonar_project_key }} \
+            -Dsonar.branch.name=${{ inputs.head_branch }}

--- a/.github/workflows/_java_tests.yml
+++ b/.github/workflows/_java_tests.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: reusable JUnit & JaCoCo test runner
+
+on:
+  workflow_call:
+    inputs:
+      working_directory:
+        required: true
+        type: string
+      artifact_name:
+        required: true
+        type: string
+
+jobs:
+  java-tests:
+    name: Maven JUnit tests and JaCoCo test report
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+        with:
+          # Shallow clones should be disabled for a better relevancy of analysis
+          fetch-depth: 0
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          # new cache feature directly available in java-setup action
+          cache: 'maven'
+
+      - name: Execute Tests and Generate Reports
+        working-directory: ${{ inputs.working_directory }}
+        run: mvn -B clean verify
+
+      - name: Upload Target Artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact_name }}
+          path: ${{ inputs.working_directory }}/target/
+          retention-days: 1

--- a/.github/workflows/_pr_info.yml
+++ b/.github/workflows/_pr_info.yml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: reusable pr info module
+
+on:
+  workflow_call:
+    inputs:
+      head_sha:
+        required: true
+        type: string
+    outputs:
+      is_pr:
+        description: "Returns true if an active PR is found"
+        value: ${{ jobs.lookup.outputs.is_pr }}
+      pr_number:
+        description: "The discovered Pull Request Number"
+        value: ${{ jobs.lookup.outputs.pr_number }}
+      pr_base:
+        description: "The target base branch of the PR"
+        value: ${{ jobs.lookup.outputs.pr_base }}
+
+jobs:
+  lookup:
+    runs-on: ubuntu-24.04
+    outputs:
+      is_pr: ${{ steps.process.outputs.is_pr }}
+      pr_number: ${{ steps.process.outputs.pr_number }}
+      pr_base: ${{ steps.process.outputs.pr_base }}
+    steps:
+      # AI suggested: dynamically discover the PR number using the Commit SHA (Works for Forks + Local PRs)
+      - name: Fetch PR Info via Commit SHA
+        id: process
+        run: |
+          # Fetch the raw JSON array from GitHub REST API using the input SHA
+          API_RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ inputs.head_sha }}/pulls")
+
+          # Isolate the first item cleanly to extract both variables safely
+          PR_NUMBER=$(echo "$API_RESPONSE" | jq -r '.[0].number // empty')
+          PR_BASE=$(echo "$API_RESPONSE" | jq -r '.[0].base.ref // empty')
+
+          if [ -n "$PR_NUMBER" ] && [ "$PR_NUMBER" != "null" ]; then
+            echo "is_pr=true" >> $GITHUB_OUTPUT
+            echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "pr_base=$PR_BASE" >> $GITHUB_OUTPUT
+            echo "SUCCESS: Found Pull Request #$PR_NUMBER linking to base branch $PR_BASE"
+          else
+            echo "is_pr=false" >> $GITHUB_OUTPUT
+            echo "No active Pull Request found for commit ${{ inputs.head_sha }}"
+          fi

--- a/.github/workflows/authentication_sonar.yml
+++ b/.github/workflows/authentication_sonar.yml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: authentication sonar
+
+on:
+  workflow_run:
+    workflows: ["authentication tests"]
+    types:
+      - completed
+
+jobs:
+  auth-sonar:
+    name: authentication sonar
+    uses: ./.github/workflows/_java_sonar.yml
+    with:
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+      head_branch: ${{ github.event.workflow_run.head_branch }}
+      working_directory: "authentication"
+      # get artifacts saved in authentication_tests action (use same name)
+      artifact_name: "authentication-target-dir"
+      sonar_project_key: "nl.research-software:authentication"
+      workflow_run_id: ${{ github.event.workflow_run.id }}
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/authentication_tests.yml
+++ b/.github/workflows/authentication_tests.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,34 +21,8 @@ on:
 
 jobs:
   authentication-tests:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: "Maven JUnit tests and JaCoCo test report"
-        working-directory: authentication
-        run: |
-          mvn verify
-      - name: SonarCloud Scan authentication
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        working-directory: authentication
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=nl.research-software:authentication -Pcoverage
+    name: authentication tests
+    uses: ./.github/workflows/_java_tests.yml
+    with:
+      working_directory: "authentication"
+      artifact_name: "authentication-target-dir"

--- a/.github/workflows/background_services_sonar.yml
+++ b/.github/workflows/background_services_sonar.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: background-services sonar
+
+on:
+  workflow_run:
+    workflows: ["background-services tests"]
+    types:
+      - completed
+
+jobs:
+  background-services-sonar:
+    name: background-services sonar
+    uses: ./.github/workflows/_java_sonar.yml
+    with:
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+      head_branch: ${{ github.event.workflow_run.head_branch }}
+      working_directory: "background-services"
+      # get artifacts saved in background_services_tests action (use same name)
+      artifact_name: "background-services-target-dir"
+      sonar_project_key: "nl.esciencecenter:background-services"
+      workflow_run_id: ${{ github.event.workflow_run.id }}
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/background_services_tests.yml
+++ b/.github/workflows/background_services_tests.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,34 +21,8 @@ on:
 
 jobs:
   background-services-tests:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: "Maven JUnit tests and JaCoCo test report"
-        working-directory: background-services
-        run: |
-          mvn verify
-      - name: SonarCloud Scan background-services
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        working-directory: background-services
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=rsd-background-services -Pcoverage
+    name: background-services tests
+    uses: ./.github/workflows/_java_tests.yml
+    with:
+      working_directory: "background-services"
+      artifact_name: "background-services-target-dir"

--- a/.github/workflows/e2e_tests_firefox.yml
+++ b/.github/workflows/e2e_tests_firefox.yml
@@ -67,4 +67,3 @@ jobs:
             e2e/state/
             .env
           retention-days: 30
-

--- a/.github/workflows/frontend_sonar.yml
+++ b/.github/workflows/frontend_sonar.yml
@@ -17,8 +17,17 @@ on:
       - completed
 
 jobs:
+  # 1. Reuse the exact same PR lookup engine
+  resolve-pr:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    uses: ./.github/workflows/_pr_info.yml
+    with:
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+
+  # 2. Run your frontend analysis using the shared outputs
   fe-sonar:
     name: "fe-sonar"
+    needs: resolve-pr
     # Ensure it only runs if the primary frontend testing pipeline succeeded
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-24.04
@@ -26,35 +35,16 @@ jobs:
       # 1. Checkout the code branch safely using isolated environment variables
       - name: Checkout target branch
         uses: actions/checkout@v6
+        env:
+          # Isolates the code string inside a hard token context to block injection tricks
+          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           # Use the safe string variable below
           ref: ${{ env.HEAD_BRANCH }}
           fetch-depth: 0
-        env:
-          # Isolates the code string inside a hard token context to block injection tricks
-          HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
 
-      # 2. AI suggested: dynamically discover the PR number using the Commit SHA (Works for Forks + Local PRs)
-      - name: "get pull request number"
-        id: pr_info
-        run: |
-          # Fetch the raw JSON array from GitHub REST API
-          API_RESPONSE=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" "${{ github.api_url }}/repos/${{ github.repository }}/commits/${{ github.event.workflow_run.head_sha }}/pulls")
-          
-          # Extract the PR ID cleanly from the first item of the array
-          PR_NUMBER=$(echo "$API_RESPONSE" | jq '.[0].number')
-          
-          if [ "$PR_NUMBER" != "null" ] && [ -n "$PR_NUMBER" ]; then
-            echo "PR_NUM=$PR_NUMBER" >> $GITHUB_ENV
-            echo "SUCCESS: Found Pull Request ID #$PR_NUMBER"
-          else
-            echo "API Diagnostics: Here is the raw response returned by GitHub:"
-            echo "$API_RESPONSE"
-            echo "ERROR: No active Pull Request found for this commit SHA."
-          fi
-
-      # 3. DOWNLOAD ARTIFACT CROSS-WORKFLOW (test-coverage)
+      # 2. DOWNLOAD ARTIFACT CROSS-WORKFLOW (test-coverage)
       - name: "download coverage artifact"
         uses: actions/download-artifact@v7
         with:
@@ -75,15 +65,15 @@ jobs:
       # 4. Run the Scan
       - name: SonarCloud Scan frontend
         uses: SonarSource/sonarqube-scan-action@v8
-        with:
-          projectBaseDir: frontend
-          # AI suggested: use verified PR number from our API query if it exists
-          args: >
-            -Dsonar.pullrequest.key=${{ env.PR_NUM }}
-            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
-            -Dsonar.pullrequest.base=${{ github.event.workflow_run.base_ref }}
-
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # This secret is now safely accessible!
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          projectBaseDir: frontend
+          # AI suggested: use verified PR number from our API query if it exists
+          args: >
+            -Dsonar.pullrequest.key=${{ needs.resolve-pr.outputs.pr_number }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.head_branch }}
+            -Dsonar.pullrequest.base=${{ needs.resolve-pr.outputs.pr_base }}
+

--- a/.github/workflows/scrapers_sonar.yml
+++ b/.github/workflows/scrapers_sonar.yml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+# SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
+# SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
+# SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: scrapers sonar
+
+on:
+  workflow_run:
+    workflows: ["scrapers tests"]
+    types:
+      - completed
+
+jobs:
+  scrapers-sonar:
+    name: scrapers sonar
+    uses: ./.github/workflows/_java_sonar.yml
+    with:
+      head_sha: ${{ github.event.workflow_run.head_sha }}
+      head_branch: ${{ github.event.workflow_run.head_branch }}
+      working_directory: "scrapers"
+      # get artifacts saved in background_services_tests action (use same name)
+      artifact_name: "scrapers-target-dir"
+      sonar_project_key: "nl.esciencecenter:scrapers"
+      workflow_run_id: ${{ github.event.workflow_run.id }}
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/scrapers_tests.yml
+++ b/.github/workflows/scrapers_tests.yml
@@ -2,6 +2,7 @@
 # SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 # SPDX-FileCopyrightText: 2022 Dusan Mijatovic (dv4all)
 # SPDX-FileCopyrightText: 2022 dv4all
+# SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
 #
 # SPDX-License-Identifier: Apache-2.0
 
@@ -20,34 +21,8 @@ on:
 
 jobs:
   scrapers-tests:
-    runs-on: ubuntu-24.04
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
-      - uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: '21'
-      - name: Cache SonarCloud packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-      - name: Cache Maven packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.m2
-          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
-          restore-keys: ${{ runner.os }}-m2
-      - name: "Maven JUnit tests and JaCoCo test report"
-        working-directory: scrapers
-        run: |
-          mvn -X verify
-      - name: SonarCloud Scan scrapers
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        working-directory: scrapers
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=nl.research-software:scrapers -Pcoverage
+    name: scrapers tests
+    uses: ./.github/workflows/_java_tests.yml
+    with:
+      working_directory: "scrapers"
+      artifact_name: "scrapers-target-dir"


### PR DESCRIPTION
# GitHub Actions CI pipeline for the Java directories

Here is a quick summary, generated by AI, describing changes to help with your code review:

### 1. Split-File Architecture (Fork-Safe Sonar Checks)
* **The Problem:** Standard SonarCloud steps crash instantly on fork PRs because GitHub prevents forks from accessing our repository secrets (`SONAR_TOKEN`).
* **The Solution:** Decoupled our builds into a secure two-step pipeline:
  1. **Primary Workflow (`pull_request`):** Compiles code, executes tests, and uploads the compiled target folder binaries as a safe runner artifact. This step has no privileges and runs flawlessly on forks.
  2. **Sonar Workflow (`workflow_run`):** Triggers automatically on the `main` branch after the primary workflow finishes successfully. Because it executes in our main context, it securely reads `SONAR_TOKEN`, downloads the test artifacts, and publishes metrics to SonarCloud.

### 2. Standardized Reusable Workflows
Instead of copying boilerplate shell scripts across multiple files, everything is abstracted into three centralized workflow engines located under `.github/workflows/`:
* `_pr_info.yml`: Dynamically resolves the active Pull Request context (ID, source branch, and target base branch) via a GitHub REST API query using the unique Commit SHA. This completely fixes edge cases where the fork branch metadata is empty.
* `_java_tests.yml`: Centralizes our standard Java 21 environment setups and executes `mvn clean verify`.
* `_java_sonar.yml`: Orchestrates checking out the detached merge commit securely, mapping the parsed PR inputs, and running the `sonar-maven-plugin`.

### 3. Dependency Caching Optimization
* Removed our standalone `actions/cache@v4` steps for tracking `~/.m2`.
* Migrated to the native language integration feature inside `actions/setup-java@v5` using `cache: 'maven'`. This eliminates boilerplate lines and handles automated path cleanup to prevent build caches from becoming corrupted during parallel module actions.

### 4. Items for You to Verify/Fix (Java Specifics)
I need you to verify two things in our `pom.xml` configs:
* **Missing JaCoCo Coverage:** I noticed `authentication/pom.xml` explicitly defines the `jacoco-maven-plugin` to generate XML reports, but `background-services/pom.xml` does not. Could you add the plugin block to the background services POM? Otherwise, SonarCloud won't be able to calculate or track test coverage metrics for that module.
* **Sonar Project Keys Verification:** I set the keys based on our current workflows, but please double-check them against the SonarCloud Web UI. By default, the Maven plugin builds the key as `groupId:artifactId`. 
  * `authentication` uses `nl.research-software:authentication` (matches its POM).
  * `background-services` currently passes `rsd-background-services`. If the project dashboard in SonarCloud is actually named `nl.esciencecenter:background-services` (matching its POM's groupId), please synchronize it in the `background-services-sonar.yml` or add a `<sonar.projectKey>` property to its POM.

*Note for Review:* Because `workflow_run` events evaluate tasks explicitly from our default branch context, this entire optimization will fully activate on PR branches only after these shared workflow configurations are merged into `main`.
PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [ ] Link to a GitHub issue
*   [ ] Update documentation
*   [ ] Tests
