### PR TITLE
Upgrade Java

### DIFF
--- a/.github/workflows/_java_sonar.yml
+++ b/.github/workflows/_java_sonar.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2026 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -42,11 +43,11 @@ jobs:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ inputs.head_sha }}
           fetch-depth: 0
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25.0.3'
           cache: 'maven'
 
       - name: Download PR Artifacts

--- a/.github/workflows/_java_tests.yml
+++ b/.github/workflows/_java_tests.yml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2026 Dusan Mijatovic (Netherlands eScience Center)
+# SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
 # SPDX-FileCopyrightText: 2026 Netherlands eScience Center
 #
 # SPDX-License-Identifier: Apache-2.0
@@ -26,11 +27,11 @@ jobs:
           # Shallow clones should be disabled for a better relevancy of analysis
           fetch-depth: 0
 
-      - name: Set up JDK 21
+      - name: Set up JDK 25
         uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25.0.3'
           # new cache feature directly available in java-setup action
           cache: 'maven'
 

--- a/.github/workflows/all_tests.yml
+++ b/.github/workflows/all_tests.yml
@@ -48,7 +48,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '25.0.3'
       - name: "Maven JUnit tests"
         working-directory: scrapers
         run: |

--- a/authentication/Dockerfile
+++ b/authentication/Dockerfile
@@ -7,7 +7,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.9.16-eclipse-temurin-21 AS builder
+FROM maven:3.9.16-eclipse-temurin-25-noble AS builder
 WORKDIR /usr/mymaven
 RUN mkdir src
 COPY pom.xml .
@@ -15,7 +15,7 @@ RUN mvn dependency:go-offline
 COPY ./src ./src
 RUN mvn package --offline
 
-FROM eclipse-temurin:21.0.11_10-jre-noble
+FROM eclipse-temurin:25.0.3_9-jre-noble
 WORKDIR /usr/myjava
 COPY --from=builder /usr/mymaven/target/*-jar-with-dependencies.jar auth.jar
 CMD java -cp auth.jar nl.esciencecenter.rsd.authentication.Main

--- a/authentication/pom.xml
+++ b/authentication/pom.xml
@@ -23,8 +23,8 @@ SPDX-License-Identifier: Apache-2.0
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>25</maven.compiler.source>
+		<maven.compiler.target>25</maven.compiler.target>
 		<sonar.organization>research-software-directory</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>

--- a/backend-tests/Dockerfile
+++ b/backend-tests/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.9.16-eclipse-temurin-21
+FROM maven:3.9.16-eclipse-temurin-25-noble
 WORKDIR /usr/mymaven
 RUN mkdir src
 COPY pom.xml .

--- a/backend-tests/pom.xml
+++ b/backend-tests/pom.xml
@@ -19,8 +19,8 @@ SPDX-License-Identifier: Apache-2.0
 	<version>1.0-SNAPSHOT</version>
 
 	<properties>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>25</maven.compiler.source>
+		<maven.compiler.target>25</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 

--- a/background-services/Dockerfile
+++ b/background-services/Dockerfile
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.9.16-eclipse-temurin-21 AS builder
+FROM maven:3.9.16-eclipse-temurin-25-noble AS builder
 WORKDIR /usr/mymaven
 RUN mkdir src
 COPY pom.xml .
@@ -13,7 +13,7 @@ RUN mvn dependency:go-offline
 COPY ./src ./src
 RUN mvn package --offline
 
-FROM eclipse-temurin:21.0.11_10-jre-noble
+FROM eclipse-temurin:25.0.3_9-jre-noble
 WORKDIR /usr/myjava
 COPY --from=builder /usr/mymaven/target/*-jar-with-dependencies.jar background-services.jar
 CMD java -cp background-services.jar nl.esciencecenter.rsd.Main

--- a/background-services/pom.xml
+++ b/background-services/pom.xml
@@ -17,8 +17,8 @@ SPDX-License-Identifier: Apache-2.0
 	<version>1.0-SNAPSHOT</version>
 
 	<properties>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>25</maven.compiler.source>
+		<maven.compiler.target>25</maven.compiler.target>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<sonar.organization>research-software-directory</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>

--- a/frontend/app/(container)/login/local/couple/page.tsx
+++ b/frontend/app/(container)/login/local/couple/page.tsx
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {Metadata} from 'next'
 
 import Button from '@mui/material/Button'
@@ -26,6 +31,7 @@ export default async function CoupleLocalAccountPage() {
         >
           <TextField
             required
+            autoFocus={true}
             slotProps={{
               htmlInput: {pattern: '\\w+'}} // NOSONAR
             }

--- a/frontend/app/(container)/login/local/page.tsx
+++ b/frontend/app/(container)/login/local/page.tsx
@@ -1,3 +1,8 @@
+// SPDX-FileCopyrightText: 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+// SPDX-FileCopyrightText: 2026 Netherlands eScience Center
+//
+// SPDX-License-Identifier: Apache-2.0
+
 import {Metadata} from 'next'
 
 import Button from '@mui/material/Button'
@@ -26,6 +31,7 @@ export default async function LocalLoginPage() {
         >
           <TextField
             required
+            autoFocus={true}
             slotProps={{
               htmlInput: {pattern: '\\w+'}} // NOSONAR
             }

--- a/scrapers/Dockerfile
+++ b/scrapers/Dockerfile
@@ -5,7 +5,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM maven:3.9.16-eclipse-temurin-21 AS builder
+FROM maven:3.9.16-eclipse-temurin-25-noble AS builder
 WORKDIR /usr/mymaven
 RUN mkdir ./src
 COPY pom.xml .
@@ -13,7 +13,7 @@ RUN mvn dependency:go-offline
 COPY ./src ./src
 RUN mvn package --offline
 
-FROM eclipse-temurin:21.0.11_10-jre-noble
+FROM eclipse-temurin:25.0.3_9-jre-noble
 WORKDIR /usr/myjava
 RUN apt-get update && apt-get --yes install cron nano
 COPY jobs.cron /etc/cron.d/jobs.cron

--- a/scrapers/pom.xml
+++ b/scrapers/pom.xml
@@ -24,8 +24,8 @@ SPDX-License-Identifier: Apache-2.0
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<maven.compiler.source>21</maven.compiler.source>
-		<maven.compiler.target>21</maven.compiler.target>
+		<maven.compiler.source>25</maven.compiler.source>
+		<maven.compiler.target>25</maven.compiler.target>
 		<sonar.organization>research-software-directory</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>


### PR DESCRIPTION
## Upgrade Java

### Changes proposed in this pull request

* Upgrade java from 21 to 25
* Add autofocus to the local account sign in and coupling page

### How to test

* `docker compose --profile "*" down --volumes && docker compose --profile "*" build --parallel && docker compose --profile data --profile scrapers up`
* Check if signing in still work
* Check if  the scrapers still work by waiting and seeing if data got harvested
* If you do Java development, upgrade to the same version as in the `Dockerfile`s (tip: use [SDKMAN!](https://sdkman.io/) to manage your Java versions)
* When signing in with a local account or coupling a local account, the text field should be focuses when you enter the page
* `docker compose --profile "*" down --volumes`
* Follow the instructions of the backend-tests README to check if those tests still pass

closes #1833

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests