### PR TITLE
Upgrade Postgres and PostgREST

### DIFF
--- a/backend-postgrest/Dockerfile
+++ b/backend-postgrest/Dockerfile
@@ -4,4 +4,4 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgrest/postgrest:v14.12
+FROM postgrest/postgrest:v14.17

--- a/database/Dockerfile
+++ b/database/Dockerfile
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-FROM postgres:17.9
+FROM postgres:17.11
 RUN chmod a+rwx /docker-entrypoint-initdb.d
 COPY --chown=postgres:postgres *.sh /docker-entrypoint-initdb.d/
 COPY --chown=postgres:postgres *.sql /docker-entrypoint-initdb.d/


### PR DESCRIPTION
## Upgrade Postgres and PostgREST

### Changes proposed in this pull request

* Upgrade Postgres from 17.9 to 17.11 to [fix security issues](https://www.postgresql.org/about/news/postgresql-186-1711-1615-1519-1424-and-19-beta-3-released-3365/)
* Upgrade PostgREST from v14.12 to v14.17 [to fix bugs](https://github.com/PostgREST/postgrest/releases)

### How to test

* `docker compose --profile "*" down --volumes && docker compose --profile "*" build --parallel && docker compose --profile data up`
* Check if everything still works
* If the mention counts are present on the software overview page (might take a minute), the background services still work
* Check the Postgres release notes for [17.10](https://www.postgresql.org/docs/release/17.10/) and [17.11](https://www.postgresql.org/docs/release/17.11/) to see that no manual steps are needed
* Run the backend tests as in `backend-tests/README.md` to see if they still pass

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [ ] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests