### PR TITLE
Fixed issue #1852, fixing the API documentation

### DIFF
--- a/documentation/docs/02-API/01-rest-api.md
+++ b/documentation/docs/02-API/01-rest-api.md
@@ -96,8 +96,7 @@ print(response.json())
         data = {"slug": "test-software", "brand_name": "TEST-Software", "description": "My new software entry"}
         headers = {
             'Authorization': f'Bearer {accessToken}',
-            'Content-Type': "application/json",
-            "Prefer": "return=representation"
+            'Content-Type': "application/json"
             }
 
         response = requests.post(url, json=data, headers=headers)

--- a/documentation/docs/02-API/01-rest-api.md
+++ b/documentation/docs/02-API/01-rest-api.md
@@ -100,7 +100,7 @@ print(response.json())
             }
 
         response = requests.post(url, json=data, headers=headers)
-        print(response.json())
+        print(response.text)
         ```
     </TabItem>
 </Tabs>


### PR DESCRIPTION
Fixing python API documentation

Fixes #1852 

Changes proposed in this pull request:

*    Removed the Prefer: return=representation header from the Python example, which was not present in the equivalent curl request and was producing an error. The two examples now perform the same call.

How to test:

* Run the Python snippet

PR Checklist:

*   [ ] Increase version numbers in `docker-compose.yml`
*   [x] Link to a GitHub issue
*   [x] Update documentation
*   [ ] Tests
