### PR TITLE
Fix programming languages filter

### DIFF
--- a/database/100-create-api-views.sql
+++ b/database/100-create-api-views.sql
@@ -2,8 +2,8 @@
 -- SPDX-FileCopyrightText: 2021 - 2023 dv4all
 -- SPDX-FileCopyrightText: 2022 - 2023 Christian Meeßen (GFZ) <christian.meessen@gfz-potsdam.de>
 -- SPDX-FileCopyrightText: 2022 - 2023 Helmholtz Centre Potsdam - GFZ German Research Centre for Geosciences
--- SPDX-FileCopyrightText: 2022 - 2025 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
--- SPDX-FileCopyrightText: 2022 - 2025 Netherlands eScience Center
+-- SPDX-FileCopyrightText: 2022 - 2026 Ewan Cahen (Netherlands eScience Center) <e.cahen@esciencecenter.nl>
+-- SPDX-FileCopyrightText: 2022 - 2026 Netherlands eScience Center
 -- SPDX-FileCopyrightText: 2023 - 2025 Dusan Mijatovic (Netherlands eScience Center)
 --
 -- SPDX-License-Identifier: Apache-2.0
@@ -105,10 +105,10 @@ CREATE FUNCTION prog_lang_filter_for_software() RETURNS TABLE (
 $$
 	SELECT
 		repository_url_for_software.software,
-		ARRAY_AGG(DISTINCT p_lang)
+		ARRAY_AGG(DISTINCT p_lang.lang)
 	FROM
 		repository_url_for_software,
-		LATERAL (SELECT JSONB_OBJECT_KEYS(repository_url.languages) FROM repository_url WHERE repository_url.id = repository_url_for_software.repository_url) AS p_lang
+		LATERAL (SELECT JSONB_OBJECT_KEYS(repository_url.languages) FROM repository_url WHERE repository_url.id = repository_url_for_software.repository_url) AS p_lang(lang)
 	GROUP BY repository_url_for_software.software;
 $$;
 


### PR DESCRIPTION
## Fix programming languages filter

### Changes proposed in this pull request

* Fix programming languages filter

### How to test

* `docker compose --profile "*" down --volumes && docker compose --profile "*" build --parallel && docker compose --profile data --profile scrapers up`
* Wait for the harvester or run `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.git.MainProgrammingLanguages`
* The programmig languages filter dropdown should not contain any parantheses or quotes
* Selecting any of them should work.
* Als try out a language with white space in it (probably `Go Template` is available)
* Programming languages on software cards should also not have parentheses anymore

closes #1848

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests