### PR TITLE
Fix software import function

### DIFF
--- a/database/201-software-import.sql
+++ b/database/201-software-import.sql
@@ -3,7 +3,7 @@
 --
 -- SPDX-License-Identifier: Apache-2.0
 
-CREATE OR REPLACE FUNCTION software_import(
+CREATE FUNCTION software_import(
 	community_slug VARCHAR(200),
 	slug VARCHAR(200),
 	brand_name VARCHAR(200),
@@ -217,11 +217,13 @@ BEGIN
 		THEN
 			INSERT INTO category (
 				community,
+				allow_software,
 				short_name,
 				name
 			)
 			VALUES (
 				community_id,
+				TRUE,
 				top_level_category_value,
 				top_level_category_value
 			)


### PR DESCRIPTION
## Fix software import function

### Changes proposed in this pull request

* Fix the `software_import` database function so that `allow_software` for categories is set to `true`.

### How to test

* `docker compose --profile "*" down --volumes && docker compose --profile "*" build --parallel && docker compose --profile data --profile scrapers up`
* Sign in as admin, create a community with slug `nassa`, then run `docker compose exec scrapers java -cp /usr/myjava/scrapers.jar nl.esciencecenter.rsd.scraper.nassa.MainNassa`
* On the software overview of the community, the category filters should be visible
* On the software pages, the categories should be present

closes #1853

PR Checklist:

* [ ] Increase version numbers in `docker-compose.yml`
* [x] Link to a GitHub issue
* [ ] Update documentation
* [ ] Tests